### PR TITLE
fix: setting WCO rgba(0,0,0,0) color falling back to default value

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -237,12 +237,20 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
 
   if (gin_helper::Dictionary od; options.Get(options::ktitleBarOverlay, &od)) {
     if (std::string val; od.Get(options::kOverlayButtonColor, &val)) {
-      bool success = content::ParseCssColorString(val, &overlay_button_color_);
+      SkColor overlay_button_color;
+      bool success = content::ParseCssColorString(val, &overlay_button_color);
       DCHECK(success);
+      if (success) {
+        overlay_button_color_ = overlay_button_color;
+      }
     }
     if (std::string val; od.Get(options::kOverlaySymbolColor, &val)) {
-      bool success = content::ParseCssColorString(val, &overlay_symbol_color_);
+      SkColor overlay_symbol_color;
+      bool success = content::ParseCssColorString(val, &overlay_symbol_color);
       DCHECK(success);
+      if (success) {
+        overlay_symbol_color_ = overlay_symbol_color;
+      }
     }
   }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -202,18 +202,22 @@ class NativeWindowViews : public NativeWindow,
   bool has_thick_frame() const { return thick_frame_; }
 #endif
 
-  SkColor overlay_button_color() const { return overlay_button_color_; }
-  SkColor overlay_symbol_color() const { return overlay_symbol_color_; }
+  std::optional<SkColor> overlay_button_color() const {
+    return overlay_button_color_;
+  }
+  std::optional<SkColor> overlay_symbol_color() const {
+    return overlay_symbol_color_;
+  }
 
 #if BUILDFLAG(IS_LINUX)
   views::FrameViewLinux* GetFrameViewLinux() const;
 #endif
 
  private:
-  void set_overlay_button_color(SkColor color) {
+  void set_overlay_button_color(std::optional<SkColor> color) {
     overlay_button_color_ = color;
   }
-  void set_overlay_symbol_color(SkColor color) {
+  void set_overlay_symbol_color(std::optional<SkColor> color) {
     overlay_symbol_color_ = color;
   }
 
@@ -293,8 +297,8 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   // The color to use as the theme and symbol colors respectively for WCO.
-  SkColor overlay_button_color_ = SkColor();
-  SkColor overlay_symbol_color_ = SkColor();
+  std::optional<SkColor> overlay_button_color_;
+  std::optional<SkColor> overlay_symbol_color_;
 
 #if BUILDFLAG(IS_WIN)
 

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -160,13 +160,15 @@ void ElectronFrameViewLinux::UpdateButtonColors() {
 
   // Apply custom WCO overlay colors if set.
   const bool active = ShouldPaintAsActive();
-  const SkColor symbol_color = window_->overlay_symbol_color();
-  const SkColor background_color = window_->overlay_button_color();
-  SkColor frame_color =
-      background_color == SkColor()
-          ? GetColorProvider()->GetColor(active ? ui::kColorFrameActive
-                                                : ui::kColorFrameInactive)
-          : background_color;
+  const SkColor symbol_color =
+      window_->overlay_symbol_color().value_or(SkColor());
+  const std::optional<SkColor> background_color =
+      window_->overlay_button_color();
+  // Frame color is used for blending, force it to be opaque
+  SkColor frame_color = SkColorSetA(
+      background_color.value_or(GetColorProvider()->GetColor(
+          active ? ui::kColorFrameActive : ui::kColorFrameInactive)),
+      SK_AlphaOPAQUE);
 
   for (views::Button* button : {minimize_button(), maximize_button(),
                                 restore_button(), close_button()}) {
@@ -182,9 +184,9 @@ void ElectronFrameViewLinux::UpdateButtonColors() {
 
 void ElectronFrameViewLinux::
     UpdateCaptionButtonPlaceholderContainerBackground() {
-  const SkColor obc = window_->overlay_button_color();
+  const std::optional<SkColor> obc = window_->overlay_button_color();
   SkColor bg_color;
-  if (obc == SkColor()) {
+  if (!obc.has_value()) {
     const auto* color_provider = GetColorProvider();
     if (!color_provider)
       return;
@@ -192,7 +194,7 @@ void ElectronFrameViewLinux::
                                             ? ui::kColorFrameActive
                                             : ui::kColorFrameInactive);
   } else {
-    bg_color = obc;
+    bg_color = *obc;
   }
   leading_button_container_->SetBackground(
       views::CreateSolidBackground(bg_color));

--- a/shell/browser/ui/views/win_caption_button.cc
+++ b/shell/browser/ui/views/win_caption_button.cc
@@ -68,7 +68,8 @@ void WinCaptionButton::OnPaintBackground(gfx::Canvas* canvas) {
   // Paint the background of the button (the semi-transparent rectangle that
   // appears when you hover or press the button).
 
-  const SkColor bg_color = frame_view_->window()->overlay_button_color();
+  const SkColor bg_color =
+      frame_view_->window()->overlay_button_color().value_or(SkColor());
   const SkAlpha theme_alpha = SkColorGetA(bg_color);
 
   gfx::Rect bounds = GetContentsBounds();
@@ -159,7 +160,8 @@ int WinCaptionButton::GetButtonDisplayOrderIndex() const {
 }
 
 void WinCaptionButton::PaintSymbol(gfx::Canvas* canvas) {
-  SkColor symbol_color = frame_view_->window()->overlay_symbol_color();
+  SkColor symbol_color =
+      frame_view_->window()->overlay_symbol_color().value_or(SkColor());
 
   if (button_type_ == VIEW_ID_CLOSE_BUTTON &&
       hover_animation().is_animating()) {

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -137,7 +137,8 @@ void WinCaptionButtonContainer::OnWidgetBoundsChanged(
 }
 
 void WinCaptionButtonContainer::UpdateBackground() {
-  const SkColor bg_color = frame_view_->window()->overlay_button_color();
+  const SkColor bg_color =
+      frame_view_->window()->overlay_button_color().value_or(SkColor());
   const SkAlpha theme_alpha = SkColorGetA(bg_color);
   SetBackground(views::CreateSolidBackground(bg_color));
   SetPaintToLayer();


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/51014

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed titleBarOverlay.color set to `rgba(0,0,0,0)` failing back to default frame color.
