### PR TITLE
ci: don't login to RBE for clang-tidy and gn-check

### DIFF
--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -135,7 +135,7 @@ jobs:
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Run Clang-Tidy
       run: |
-        e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH}
+        e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH} --remote-build none
 
         export GN_EXTRA_ARGS="target_cpu=\"${TARGET_ARCH}\""
         if [ "${{ inputs.target-platform }}" = "win" ]; then

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         for target_cpu in ${{ inputs.target-archs }}
         do
-          e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu $target_cpu
+          e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu $target_cpu --remote-build none
           cd src
           export GN_EXTRA_ARGS="target_cpu=\"$target_cpu\""
           if [ "${{ inputs.target-platform }}" = "linux" ]; then


### PR DESCRIPTION
#### Description of Change
The clang-tidy job logs into RBE, but doesn't actually do a build, so we should skip this login.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
