### PR TITLE
ci: only move items to Needs Review when appropriate

### DIFF
--- a/.github/workflows/pr-triage-automation.yml
+++ b/.github/workflows/pr-triage-automation.yml
@@ -36,7 +36,17 @@ jobs:
         with:
           creds: ${{ secrets.ISSUE_TRIAGE_GH_APP_CREDS }}
           org: electron
+      - name: Get project item status
+        uses: dsanders11/project-actions/get-item@5767984408ccc6742f83acc8b8d8ea5e09f329af # v2.0.0
+        id: get-item
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          project-number: 118
+          fail-if-item-not-found: false
       - name: Set status to Needs Review
+        if: >-
+          (steps.get-item.outputs.field-status == '🛑 Needs Submitter Response'
+          || steps.get-item.outputs.field-status == '🟡 WIP')
         uses: dsanders11/project-actions/edit-item@5767984408ccc6742f83acc8b8d8ea5e09f329af # v2.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
#### Description of Change
The automation for the PR triage board should only move PRs to "Needs Review" if the status was 🛑 Needs Submitter Response or 🟡 WIP.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
