### PR TITLE
test: fixup autoupdater tests failures

### DIFF
--- a/spec/api-autoupdater-darwin-spec.ts
+++ b/spec/api-autoupdater-darwin-spec.ts
@@ -391,7 +391,8 @@ ifdescribe(shouldRunCodesignTests)('autoUpdater behavior', function () {
       );
     });
 
-    it('should hit the download endpoint when an update is available and update successfully when the zip is provided even after a different update was staged', async () => {
+    it('should hit the download endpoint when an update is available and update successfully when the zip is provided even after a different update was staged', async function () {
+      this.timeout(180000);
       await withUpdatableApp(
         {
           nextVersion: '2.0.0',
@@ -537,7 +538,8 @@ ifdescribe(shouldRunCodesignTests)('autoUpdater behavior', function () {
       );
     });
 
-    it('should keep the update directory count bounded across repeated checks', async () => {
+    it('should keep the update directory count bounded across repeated checks', async function () {
+      this.timeout(240000);
       // Verifies the orphan prune actually fires: after a second download
       // completes and rewrites ShipItState.plist, the first directory is no
       // longer referenced and must be removed when a third check begins.

--- a/spec/fixtures/auto-update/update-triple-stack/index.js
+++ b/spec/fixtures/auto-update/update-triple-stack/index.js
@@ -46,7 +46,7 @@ if (feedUrl === 'remain-open') {
     } else {
       setTimeout(() => {
         autoUpdater.checkForUpdates();
-      }, 1000);
+      }, 5000);
     }
   });
 


### PR DESCRIPTION
#### Description of Change
- Autoupdater tests on mac were failing and then succeeding on retries, but that led to extensive time being spent to the point that sometimes the mac tests timeout, even after landing #50968, as evidenced in the 41-x-y backport here: #50974
 
This PR ups the timeouts for tests that were problematic and also updates spec/fixtures/auto-update/update-triple-stack/index.js to fix a race condition.  Before this change that fixture was calling autoUpdater.checkForUpdates() every second - that 1 second gap caused a race condition where Squirrel's orphan-prune could delete a directory that a concurrent ShipIt download was still writing to, resulting in "The folder 'update-file' doesn't exist" errors.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
