### PR TITLE
fix: preserve return value in `deprecate.removeFunction`

### DIFF
--- a/lib/common/deprecate.ts
+++ b/lib/common/deprecate.ts
@@ -56,7 +56,7 @@ export function removeFunction<T extends Function>(fn: T, removedName: string): 
   const warn = warnOnce(`${fn.name} function`);
   return function (this: any) {
     warn();
-    fn.apply(this, arguments);
+    return fn.apply(this, arguments);
   } as unknown as typeof fn;
 }
 

--- a/spec/deprecate-spec.ts
+++ b/spec/deprecate-spec.ts
@@ -130,6 +130,19 @@ describe('deprecate', () => {
     expect(msg).to.include('oldFn');
   });
 
+  it('preserves the return value and `this` of a deprecated function with no replacement', () => {
+    deprecate.setHandler(() => {});
+
+    function oldFn(this: any, a: number, b: number) {
+      return { self: this, sum: a + b };
+    }
+    const deprecatedFn = deprecate.removeFunction(oldFn, 'oldFn');
+    const context = { name: 'ctx' };
+    const result = deprecatedFn.call(context, 2, 3);
+
+    expect(result).to.deep.equal({ self: context, sum: 5 });
+  });
+
   it('warns exactly once when a function is deprecated with a replacement', () => {
     let msg;
     deprecate.setHandler((m) => {


### PR DESCRIPTION
#### Description of Change

Fixes #51026.

`deprecate.removeFunction(fn, removedName)` wraps a function that is being removed so that calling it emits a one-shot deprecation warning. Its type signature (`<T extends Function>(fn: T, removedName: string): T`) advertises that the wrapped function's signature is preserved. The wrapper, however, does not `return` the result of `fn.apply(this, arguments)`, so it silently converts every deprecated function's return value to `undefined`. Its siblings `deprecate.renameFunction` and `deprecate.moveAPI` already `return fn.apply(...)`.

There are no in-tree callers today that observe the return value, which is why the regression has gone unnoticed, but any future use of `removeFunction` to wrap an API with a meaningful return value would break downstream callers during the deprecation window.

This PR:

- Adds the missing `return` in `lib/common/deprecate.ts`.
- Extends `spec/deprecate-spec.ts` with a test that asserts both the return value and the `this` context of the deprecated function are preserved by the wrapper.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
