### PR TITLE
fix: honor `ELECTRON_INSTALL_PLATFORM` in `getPlatformPath`

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -96,7 +96,7 @@ function extractFile(zipPath) {
 }
 
 function getPlatformPath() {
-  const platform = process.env.npm_config_platform || os.platform();
+  const platform = process.env.ELECTRON_INSTALL_PLATFORM || process.env.npm_config_platform || os.platform();
 
   switch (platform) {
     case 'mas':


### PR DESCRIPTION
#### Description of Change

Fixes #51027.

`npm/install.js` resolves the target platform in two places and the two disagree when the documented `ELECTRON_INSTALL_PLATFORM` env var is used.

`downloadArtifact` honors the new env var (added in #49981):

```js
const platform = process.env.ELECTRON_INSTALL_PLATFORM
  || process.env.npm_config_platform
  || process.platform;
```

But `getPlatformPath()`, which produces the executable path written to `path.txt` and compared in `isInstalled()`, was not updated and still only checks `npm_config_platform`. On, for example, a Linux host running `ELECTRON_INSTALL_PLATFORM=darwin npm install electron`, the `darwin` zip is downloaded but `path.txt` is written as `electron` (the Linux executable name) — so subsequent `isInstalled()` checks always fail (forcing redundant re-downloads) and any tool reading `path.txt` sees the wrong filename for the artifact that was actually extracted.

Bring `getPlatformPath()` in line with the download resolution by checking `ELECTRON_INSTALL_PLATFORM` first.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `ELECTRON_INSTALL_PLATFORM` being ignored when resolving the Electron executable path during postinstall, which caused `path.txt` to be written for the host platform instead of the requested target and made `isInstalled()` always re-download on subsequent installs.
