### PR TITLE
build: allow non-zero exit codes locally when linting Chromium rolls

### DIFF
--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -275,7 +275,7 @@ async function main() {
   if (hasErrors) {
     console.log('  NOTE: Add "Skip-Lint: <reason>" to a commit message to skip linting that commit.');
   }
-  process.exit(hasErrors && process.env.CI ? 1 : 0);
+  process.exit(hasErrors ? 1 : 0);
 }
 
 if ((await fs.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We should be good to unflag this, there was initially some concern that a bug could leave Claude in a loop trying to fix a linting error it can't fix, but this has been running in CI for a while now just fine. I asked @samuelmaddock to unflag it locally and try it last week on the roll and didn't hear any issues, so let's do it for everyone. 👍

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
