### PR TITLE
fix: allow PDF viewer to show save file picker

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -32,6 +32,7 @@
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/common/constants.h"  // nogncheck
+#include "components/pdf/common/pdf_util.h"   // nogncheck
 #include "shell/common/electron_constants.h"
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 
@@ -215,6 +216,15 @@ void ElectronContentClient::AddContentDecryptionModules(
     }
 #endif  // BUILDFLAG(ENABLE_WIDEVINE)
   }
+}
+
+bool ElectronContentClient::IsFilePickerAllowedForCrossOriginSubframe(
+    const url::Origin& origin) {
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+  return IsPdfExtensionOrigin(origin);
+#else
+  return false;
+#endif
 }
 
 }  // namespace electron

--- a/shell/app/electron_content_client.h
+++ b/shell/app/electron_content_client.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "content/public/common/content_client.h"
+#include "url/origin.h"
 
 namespace electron {
 
@@ -33,6 +34,8 @@ class ElectronContentClient : public content::ContentClient {
   void AddContentDecryptionModules(
       std::vector<content::CdmInfo>* cdms,
       std::vector<media::CdmHostFilePath>* cdm_host_file_paths) override;
+  bool IsFilePickerAllowedForCrossOriginSubframe(
+      const url::Origin& origin) override;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change
 
Closes https://github.com/electron/electron/issues/51041
Refs CL:6111160

The PDF viewer's "save with changes" feature uses
`window.showSaveFilePicker()`, but the PDF extension runs in a cross-origin iframe (chrome-extension:// inside the app's origin). Chromium's File System Access API blocks cross-origin subframes from showing file pickers unless the embedder explicitly allows them via `ContentClient::IsFilePickerAllowedForCrossOriginSubframe()`.

Chrome overrides this in `ChromeContentClient` to allowlist the PDF extension origin, but Electron never did — so the picker was always blocked with a SecurityError.

This adds the same override to `ElectronContentClient`, allowing the built-in PDF extension origin to bypass the cross-origin check.

<details><summary>Screenshot</summary>
<p>

<img width="1147" height="684" alt="Screenshot 2026-04-14 at 2 33 41 PM" src="https://github.com/user-attachments/assets/bad76180-9943-493b-abe5-68ef56c19d14" />

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where saving edited PDF files would fail with a cross-origin SecurityError.