### PR TITLE
fix: honor webContents.print dpi horizontal/vertical options

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3399,13 +3399,13 @@ void WebContents::Print(gin::Arguments* const args) {
     // `webContents.print()` exposes `dpi: { horizontal, vertical }` in JS.
     // Keep backward compatibility with internal key names as a fallback.
     settings.Set(printing::kSettingDpiHorizontal,
-                 dpi.ValueOrDefault("horizontal",
-                                    dpi.ValueOrDefault(
-                                        printing::kSettingDpiHorizontal, 72)));
-    settings.Set(printing::kSettingDpiVertical,
-                 dpi.ValueOrDefault("vertical",
-                                    dpi.ValueOrDefault(
-                                        printing::kSettingDpiVertical, 72)));
+                 dpi.ValueOrDefault(
+                     "horizontal",
+                     dpi.ValueOrDefault(printing::kSettingDpiHorizontal, 72)));
+    settings.Set(
+        printing::kSettingDpiVertical,
+        dpi.ValueOrDefault(
+            "vertical", dpi.ValueOrDefault(printing::kSettingDpiVertical, 72)));
   }
 
   print_task_runner_->PostTaskAndReplyWithResult(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3396,10 +3396,16 @@ void WebContents::Print(gin::Arguments* const args) {
 
   // Set custom dots per inch (dpi)
   if (gin_helper::Dictionary dpi; options.Get(kDpi, &dpi)) {
+    // `webContents.print()` exposes `dpi: { horizontal, vertical }` in JS.
+    // Keep backward compatibility with internal key names as a fallback.
     settings.Set(printing::kSettingDpiHorizontal,
-                 dpi.ValueOrDefault(printing::kSettingDpiHorizontal, 72));
+                 dpi.ValueOrDefault("horizontal",
+                                    dpi.ValueOrDefault(
+                                        printing::kSettingDpiHorizontal, 72)));
     settings.Set(printing::kSettingDpiVertical,
-                 dpi.ValueOrDefault(printing::kSettingDpiVertical, 72));
+                 dpi.ValueOrDefault("vertical",
+                                    dpi.ValueOrDefault(
+                                        printing::kSettingDpiVertical, 72)));
   }
 
   print_task_runner_->PostTaskAndReplyWithResult(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -464,6 +464,8 @@ constexpr char kFooterTemplate[] = "footerTemplate";
 constexpr char kPreferCSSPageSize[] = "preferCSSPageSize";
 constexpr char kGenerateTaggedPDF[] = "generateTaggedPDF";
 constexpr char kGenerateDocumentOutline[] = "generateDocumentOutline";
+constexpr char kDpiHorizontal[] = "horizontal";
+constexpr char kDpiVertical[] = "vertical";
 #endif  // BUILDFLAG(ENABLE_PRINTING)
 
 constexpr std::string_view CursorTypeToString(
@@ -3400,12 +3402,12 @@ void WebContents::Print(gin::Arguments* const args) {
     // Keep backward compatibility with internal key names as a fallback.
     settings.Set(printing::kSettingDpiHorizontal,
                  dpi.ValueOrDefault(
-                     "horizontal",
+                     printing::kDpiHorizontal,
                      dpi.ValueOrDefault(printing::kSettingDpiHorizontal, 72)));
-    settings.Set(
-        printing::kSettingDpiVertical,
-        dpi.ValueOrDefault(
-            "vertical", dpi.ValueOrDefault(printing::kSettingDpiVertical, 72)));
+    settings.Set(printing::kSettingDpiVertical,
+                 dpi.ValueOrDefault(
+                     printing::kDpiVertical,
+                     dpi.ValueOrDefault(printing::kSettingDpiVertical, 72)));
   }
 
   print_task_runner_->PostTaskAndReplyWithResult(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3402,11 +3402,11 @@ void WebContents::Print(gin::Arguments* const args) {
     // Keep backward compatibility with internal key names as a fallback.
     settings.Set(printing::kSettingDpiHorizontal,
                  dpi.ValueOrDefault(
-                     printing::kDpiHorizontal,
+                     kDpiHorizontal,
                      dpi.ValueOrDefault(printing::kSettingDpiHorizontal, 72)));
     settings.Set(printing::kSettingDpiVertical,
                  dpi.ValueOrDefault(
-                     printing::kDpiVertical,
+                     kDpiVertical,
                      dpi.ValueOrDefault(printing::kSettingDpiVertical, 72)));
   }
 


### PR DESCRIPTION
#### Description of Change

Fixes #50785

This PR fixes a regression in silent printing where custom DPI values from webContents.print were not honored, causing incorrect output scaling in real-world print flows.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: This PR fixes a regression in silent printing where custom DPI values from webContents.print were not honored, causing incorrect output scaling in real-world print flows.<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
