### PR TITLE
build: authenticate sudowoodo /token exchange via Actions OIDC

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -77,7 +77,6 @@ env:
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
-  SUDOWOODO_EXCHANGE_TOKEN: ${{ secrets.SUDOWOODO_EXCHANGE_TOKEN }}
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || inputs.target-platform == 'win' && '--custom-var=checkout_win=True' || '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -79,7 +79,6 @@ env:
   ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
   SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
-  SUDOWOODO_EXCHANGE_TOKEN: ${{ secrets.SUDOWOODO_EXCHANGE_TOKEN }}
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' &&
     '--custom-var=checkout_mac=True --custom-var=host_os=mac' ||
     inputs.target-platform == 'win' && '--custom-var=checkout_win=True' ||

--- a/script/release/github-token.ts
+++ b/script/release/github-token.ts
@@ -5,18 +5,36 @@ import { ElectronReleaseRepo } from './types';
 
 const cachedTokens = Object.create(null);
 
+const SUDOWOODO_OIDC_AUDIENCE = 'sudowoodo-broker';
+
+async function getActionsIdToken(): Promise<string> {
+  const { ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN } = process.env;
+  if (!ACTIONS_ID_TOKEN_REQUEST_URL || !ACTIONS_ID_TOKEN_REQUEST_TOKEN) {
+    throw new Error(
+      'ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN not set — the job needs `permissions: id-token: write` to mint an OIDC token for the sudowoodo exchange'
+    );
+  }
+  const { value } = await got(ACTIONS_ID_TOKEN_REQUEST_URL + '&audience=' + SUDOWOODO_OIDC_AUDIENCE, {
+    headers: {
+      authorization: 'Bearer ' + ACTIONS_ID_TOKEN_REQUEST_TOKEN
+    }
+  }).json<{ value: string }>();
+  return value;
+}
+
 async function ensureToken(repo: ElectronReleaseRepo) {
   if (!cachedTokens[repo]) {
     cachedTokens[repo] = await (async () => {
-      const { ELECTRON_GITHUB_TOKEN, SUDOWOODO_EXCHANGE_URL, SUDOWOODO_EXCHANGE_TOKEN } = process.env;
+      const { ELECTRON_GITHUB_TOKEN, SUDOWOODO_EXCHANGE_URL } = process.env;
       if (ELECTRON_GITHUB_TOKEN) {
         return ELECTRON_GITHUB_TOKEN;
       }
 
-      if (SUDOWOODO_EXCHANGE_URL && SUDOWOODO_EXCHANGE_TOKEN) {
+      if (SUDOWOODO_EXCHANGE_URL) {
+        const idToken = await getActionsIdToken();
         const resp = await got.post(SUDOWOODO_EXCHANGE_URL + '?repo=' + repo, {
           headers: {
-            Authorization: SUDOWOODO_EXCHANGE_TOKEN
+            Authorization: 'Bearer ' + idToken
           },
           throwHttpErrors: false
         });


### PR DESCRIPTION
Sudowoodo's `/token` endpoint (electron/sudowoodo#375) now validates the caller via a GitHub Actions OIDC token instead of the static `SUDOWOODO_EXCHANGE_TOKEN` secret. The broker checks the token's `repository`/`ref`/`workflow_ref`/`actor`/`event_name`/`run_id` claims against its allowlist and additionally verifies the `run_id` belongs to an active sudowoodo-dispatched release before minting a scoped upload token.

- `script/release/github-token.ts`: mint an OIDC token with audience `sudowoodo-broker` via the raw `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` env (so it works from any node script) and send it as `Authorization: Bearer <jwt>`. Fails with a clear message if the job lacks `id-token: write`. `ELECTRON_GITHUB_TOKEN` fallback kept.
- `pipeline-segment-electron-build.yml` (→ autogenerated `-publish.yml`): drop `SUDOWOODO_EXCHANGE_TOKEN` from the env block. `SUDOWOODO_EXCHANGE_URL` stays.

`id-token: write` was already present on the publish segment's job (for attestations) and on every `{linux,macos,windows}-publish.yml` caller, so no permission additions were needed.

---

Notes: none