### PR TITLE
feat: add `saveImageAt` method to webContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1585,6 +1585,20 @@ Centers the current text selection in web page.
 
 Copy the image at the given position to the clipboard.
 
+#### `contents.saveImageAt(x, y)`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/51056
+```
+-->
+
+* `x` Integer
+* `y` Integer
+
+Shows a save dialog and saves the image at the given position to disk.
+
 #### `contents.copyVideoFrameAt(x, y)`
 
 * `x` Integer

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -44,6 +44,7 @@
 #include "content/browser/renderer_host/frame_tree_node.h"  // nogncheck
 #include "content/browser/renderer_host/navigation_controller_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
+#include "content/browser/renderer_host/render_view_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
@@ -152,6 +153,7 @@
 #include "storage/browser/file_system/isolated_context.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
+#include "third_party/blink/public/common/loader/network_utils.h"
 #include "third_party/blink/public/common/messaging/transferable_message_mojom_traits.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
 #include "third_party/blink/public/common/peerconnection/webrtc_ip_handling_policy.h"
@@ -164,6 +166,7 @@
 #include "ui/base/cursor/mojom/cursor_type.mojom-shared.h"
 #include "ui/display/screen.h"
 #include "ui/events/base_event_utils.h"
+#include "ui/gfx/geometry/point_conversions.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "ui/base/cocoa/defaults_utils.h"
@@ -433,6 +436,80 @@ namespace {
 
 // Global toggle for disabling draggable regions checks.
 bool g_disable_draggable_regions = false;
+
+content::Referrer CreateSaveImageReferrer(
+    const GURL& url,
+    const GURL& frame_url,
+    network::mojom::ReferrerPolicy referrer_policy) {
+  return content::Referrer::SanitizeForRequest(
+      url, content::Referrer(frame_url.GetAsReferrer(), referrer_policy));
+}
+
+void SaveImageAtWithFallback(base::WeakPtr<WebContents> api_web_contents,
+                             content::GlobalRenderFrameHostId frame_host_id,
+                             int x,
+                             int y,
+                             // Kept alive by base::Owned until this callback fires.
+                             mojo::Remote<mojom::ElectronRenderer>*,
+                             mojom::ImageSaveInfoPtr info) {
+  if (!api_web_contents)
+    return;
+
+  auto* frame_host = content::RenderFrameHost::FromID(frame_host_id);
+  if (!frame_host)
+    return;
+
+  if (!info || info->use_save_image_at || !info->src_url.is_valid()) {
+    frame_host->SaveImageAt(x, y);
+    return;
+  }
+
+  net::HttpRequestHeaders headers;
+  headers.SetHeaderIfMissing(net::HttpRequestHeaders::kAccept,
+                             blink::network_utils::ImageAcceptHeader());
+
+  api_web_contents->GetWebContents()->SaveFrameWithHeaders(
+      info->src_url,
+      CreateSaveImageReferrer(info->src_url, info->frame_url,
+                              info->referrer_policy),
+      headers.ToString(), info->suggested_filename, frame_host,
+      /*is_subresource=*/!info->is_image_media_plugin_document);
+}
+
+void RequestImageSaveInfoAt(
+    base::WeakPtr<WebContents> api_web_contents,
+    base::WeakPtr<content::RenderWidgetHostViewBase> target_view,
+    std::optional<gfx::PointF> transformed_point) {
+  if (!api_web_contents || !target_view || !transformed_point.has_value())
+    return;
+
+  auto* target_rwh =
+      content::RenderWidgetHostImpl::From(target_view->GetRenderWidgetHost());
+  if (!target_rwh)
+    return;
+
+  auto* target_rvh = content::RenderViewHostImpl::From(target_rwh);
+  if (!target_rvh)
+    return;
+
+  auto* frame_host = target_rvh->GetMainRenderFrameHost();
+  if (!frame_host || !frame_host->IsRenderFrameLive())
+    return;
+
+  auto electron_renderer =
+      std::make_unique<mojo::Remote<mojom::ElectronRenderer>>();
+  frame_host->GetRemoteInterfaces()->GetInterface(
+      electron_renderer->BindNewPipeAndPassReceiver());
+
+  const gfx::Point frame_point = gfx::ToRoundedPoint(*transformed_point);
+  auto* raw_ptr = electron_renderer.get();
+  (*raw_ptr)->GetImageSaveInfoAt(
+      frame_point.x(), frame_point.y(),
+      base::BindOnce(&SaveImageAtWithFallback, api_web_contents,
+                     frame_host->GetGlobalId(), frame_point.x(),
+                     frame_point.y(),
+                     base::Owned(std::move(electron_renderer))));
+}
 
 #if BUILDFLAG(ENABLE_PRINTING)
 // Constants we use for printing.
@@ -3565,9 +3642,15 @@ void WebContents::CopyImageAt(int x, int y) {
 }
 
 void WebContents::SaveImageAt(int x, int y) {
-  auto* const host = web_contents()->GetPrimaryMainFrame();
-  if (host)
-    host->SaveImageAt(x, y);
+  auto* root_view = static_cast<content::RenderWidgetHostViewBase*>(
+      web_contents()->GetRenderWidgetHostView());
+  if (!root_view)
+    return;
+
+  static_cast<content::WebContentsImpl*>(web_contents())
+      ->GetRenderWidgetHostAtPointAsynchronously(
+          root_view, gfx::PointF(x, y),
+          base::BindOnce(&RequestImageSaveInfoAt, weak_factory_.GetWeakPtr()));
 }
 
 void WebContents::Focus() {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3564,6 +3564,12 @@ void WebContents::CopyImageAt(int x, int y) {
     host->CopyImageAt(x, y);
 }
 
+void WebContents::SaveImageAt(int x, int y) {
+  auto* const host = web_contents()->GetPrimaryMainFrame();
+  if (host)
+    host->SaveImageAt(x, y);
+}
+
 void WebContents::Focus() {
   // Focusing on WebContents does not automatically focus the window on macOS
   // and Linux, do it manually to match the behavior on Windows.
@@ -4704,6 +4710,7 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("showDefinitionForSelection",
                  &WebContents::ShowDefinitionForSelection)
       .SetMethod("copyImageAt", &WebContents::CopyImageAt)
+      .SetMethod("saveImageAt", &WebContents::SaveImageAt)
       .SetMethod("capturePage", &WebContents::CapturePage)
       .SetMethod("setEmbedder", &WebContents::SetEmbedder)
       .SetMethod("setDevToolsWebContents", &WebContents::SetDevToolsWebContents)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -44,7 +44,6 @@
 #include "content/browser/renderer_host/frame_tree_node.h"  // nogncheck
 #include "content/browser/renderer_host/navigation_controller_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
-#include "content/browser/renderer_host/render_view_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
@@ -488,12 +487,20 @@ void RequestImageSaveInfoAt(
   if (!target_rwh)
     return;
 
-  auto* target_rvh = content::RenderViewHostImpl::From(target_rwh);
-  if (!target_rvh)
-    return;
+  content::RenderFrameHost* frame_host = nullptr;
+  api_web_contents->GetWebContents()->ForEachRenderFrameHostWithAction(
+      [&](content::RenderFrameHost* candidate) {
+        if (!candidate->IsRenderFrameLive())
+          return content::WebContents::FrameIterationAction::kContinue;
+        if (candidate->GetView() != target_view.get())
+          return content::WebContents::FrameIterationAction::kContinue;
+        if (candidate->GetRenderWidgetHost() != target_rwh)
+          return content::WebContents::FrameIterationAction::kContinue;
 
-  auto* frame_host = target_rvh->GetMainRenderFrameHost();
-  if (!frame_host || !frame_host->IsRenderFrameLive())
+        frame_host = candidate;
+        return content::WebContents::FrameIterationAction::kStop;
+      });
+  if (!frame_host)
     return;
 
   auto electron_renderer =

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -292,6 +292,7 @@ class WebContents final : public ExclusiveAccessContext,
   void StopFindInPage(content::StopFindAction action);
   void ShowDefinitionForSelection();
   void CopyImageAt(int x, int y);
+  void SaveImageAt(int x, int y);
 
   // Focus.
   void Focus();

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -1,9 +1,20 @@
 module electron.mojom;
 
 import "mojo/public/mojom/base/string16.mojom";
+import "services/network/public/mojom/referrer_policy.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
 import "third_party/blink/public/mojom/messaging/cloneable_message.mojom";
 import "third_party/blink/public/mojom/messaging/transferable_message.mojom";
+import "url/mojom/url.mojom";
+
+struct ImageSaveInfo {
+  bool use_save_image_at;
+  url.mojom.Url src_url;
+  url.mojom.Url frame_url;
+  mojo_base.mojom.String16 suggested_filename;
+  network.mojom.ReferrerPolicy referrer_policy;
+  bool is_image_media_plugin_document;
+};
 
 interface ElectronRenderer {
   Message(
@@ -12,6 +23,8 @@ interface ElectronRenderer {
       blink.mojom.CloneableMessage arguments);
 
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
+
+  GetImageSaveInfoAt(int32 x, int32 y) => (ImageSaveInfo? info);
 
   TakeHeapSnapshot(handle file) => (bool success);
 };

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -21,24 +21,22 @@
 #include "shell/renderer/electron_ipc_native.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/renderer_client_base.h"
-#include "third_party/blink/public/common/loader/referrer_utils.h"
 #include "third_party/blink/public/mojom/frame/user_activation_notification_type.mojom-shared.h"
 #include "third_party/blink/public/platform/scheduler/web_agent_group_scheduler.h"
-#include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/blink.h"
-#include "third_party/blink/public/web/web_document.h"
 #include "third_party/blink/public/web/web_frame_widget.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_message_port_converter.h"
-#include "third_party/blink/renderer/core/dom/node.h"               // nogncheck
-#include "third_party/blink/renderer/core/frame/local_frame.h"      // nogncheck
-#include "third_party/blink/renderer/core/frame/visual_viewport.h"  // nogncheck
-#include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"  // nogncheck
-#include "third_party/blink/renderer/core/html/canvas/html_canvas_element.h"  // nogncheck
-#include "third_party/blink/renderer/core/input/event_handler.h"  // nogncheck
-#include "third_party/blink/renderer/core/layout/hit_test_location.h"  // nogncheck
-#include "third_party/blink/renderer/core/layout/hit_test_result.h"  // nogncheck
-#include "third_party/blink/renderer/core/page/page.h"  // nogncheck
+#include "third_party/blink/renderer/core/dom/document.h"
+#include "third_party/blink/renderer/core/dom/node.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
+#include "third_party/blink/renderer/core/frame/visual_viewport.h"
+#include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"
+#include "third_party/blink/renderer/core/html/canvas/html_canvas_element.h"
+#include "third_party/blink/renderer/core/input/event_handler.h"
+#include "third_party/blink/renderer/core/layout/hit_test_location.h"
+#include "third_party/blink/renderer/core/layout/hit_test_result.h"
+#include "third_party/blink/renderer/core/page/page.h"
 #include "ui/gfx/geometry/point_conversions.h"
 #include "ui/gfx/geometry/point_f.h"
 #include "url/gurl.h"
@@ -114,14 +112,11 @@ mojom::ImageSaveInfoPtr GetImageSaveInfo(content::RenderFrame* render_frame,
     return nullptr;
   }
 
-  const blink::WebDocument document = web_frame->GetDocument();
-  if (document.IsNull())
-    return nullptr;
-
+  blink::Document& document = image_node->GetDocument();
   info->frame_url = GURL(document.Url());
-  info->referrer_policy = blink::ReferrerUtils::NetToMojoReferrerPolicy(
-      document.GetReferrerPolicy());
+  info->referrer_policy = document.GetReferrerPolicy();
   info->is_image_media_plugin_document =
+      document.IsImageDocument() || document.IsMediaDocument() ||
       document.IsPluginDocument() || info->frame_url == info->src_url;
 
   return info;

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -21,14 +21,113 @@
 #include "shell/renderer/electron_ipc_native.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/renderer_client_base.h"
+#include "third_party/blink/public/common/loader/referrer_utils.h"
 #include "third_party/blink/public/mojom/frame/user_activation_notification_type.mojom-shared.h"
 #include "third_party/blink/public/platform/scheduler/web_agent_group_scheduler.h"
+#include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/blink.h"
+#include "third_party/blink/public/web/web_document.h"
+#include "third_party/blink/public/web/web_frame_widget.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_message_port_converter.h"
+#include "third_party/blink/renderer/core/dom/node.h"               // nogncheck
+#include "third_party/blink/renderer/core/frame/local_frame.h"      // nogncheck
+#include "third_party/blink/renderer/core/frame/visual_viewport.h"  // nogncheck
+#include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"  // nogncheck
+#include "third_party/blink/renderer/core/html/canvas/html_canvas_element.h"  // nogncheck
+#include "third_party/blink/renderer/core/input/event_handler.h"  // nogncheck
+#include "third_party/blink/renderer/core/layout/hit_test_location.h"  // nogncheck
+#include "third_party/blink/renderer/core/layout/hit_test_result.h"  // nogncheck
+#include "third_party/blink/renderer/core/page/page.h"  // nogncheck
+#include "ui/gfx/geometry/point_conversions.h"
+#include "ui/gfx/geometry/point_f.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
 #include "v8/include/v8-context.h"
 
 namespace electron {
+
+namespace {
+
+bool IsSaveableImageNode(blink::Node* node) {
+  return node && (blink::IsA<blink::HTMLCanvasElement>(node) ||
+                  !blink::HitTestResult::AbsoluteImageURL(node).IsEmpty());
+}
+
+blink::Node* GetSaveableImageNode(const blink::HitTestResult& result) {
+  if (blink::Node* node = result.InnerNodeOrImageMapImage();
+      IsSaveableImageNode(node)) {
+    return node;
+  }
+
+  for (const auto& raw_node : result.ListBasedTestResult()) {
+    blink::Node* node = raw_node.Get();
+    if (IsSaveableImageNode(node))
+      return node;
+  }
+
+  return nullptr;
+}
+
+mojom::ImageSaveInfoPtr GetImageSaveInfo(content::RenderFrame* render_frame,
+                                         int x,
+                                         int y) {
+  auto* web_frame = render_frame->GetWebFrame();
+  if (!web_frame)
+    return nullptr;
+
+  blink::WebFrameWidget* widget = web_frame->FrameWidget();
+  if (!widget)
+    return nullptr;
+
+  auto* frame = static_cast<blink::WebLocalFrameImpl*>(web_frame)->GetFrame();
+  if (!frame)
+    return nullptr;
+
+  const gfx::Point viewport_point =
+      gfx::ToRoundedPoint(widget->DIPsToBlinkSpace(gfx::PointF(x, y)));
+  const gfx::Point root_frame_point(
+      frame->GetPage()->GetVisualViewport().ViewportToRootFrame(
+          viewport_point));
+  blink::HitTestLocation location(
+      frame->View()->ConvertFromRootFrame(root_frame_point));
+  const auto hit_test_type = blink::HitTestRequest::kReadOnly |
+                             blink::HitTestRequest::kActive |
+                             blink::HitTestRequest::kPenetratingList |
+                             blink::HitTestRequest::kListBased;
+  blink::HitTestResult result =
+      frame->GetEventHandler().HitTestResultAtLocation(location, hit_test_type);
+  result.SetToShadowHostIfInUAShadowRoot();
+
+  blink::Node* image_node = GetSaveableImageNode(result);
+  if (!image_node)
+    return nullptr;
+
+  auto info = mojom::ImageSaveInfo::New();
+
+  if (blink::IsA<blink::HTMLCanvasElement>(image_node)) {
+    info->use_save_image_at = true;
+  } else if (!blink::HitTestResult::AbsoluteImageURL(image_node).IsEmpty()) {
+    info->src_url = GURL(blink::HitTestResult::AbsoluteImageURL(image_node));
+    info->use_save_image_at = info->src_url.SchemeIs(url::kDataScheme);
+  } else {
+    return nullptr;
+  }
+
+  const blink::WebDocument document = web_frame->GetDocument();
+  if (document.IsNull())
+    return nullptr;
+
+  info->frame_url = GURL(document.Url());
+  info->referrer_policy = blink::ReferrerUtils::NetToMojoReferrerPolicy(
+      document.GetReferrerPolicy());
+  info->is_image_media_plugin_document =
+      document.IsPluginDocument() || info->frame_url == info->src_url;
+
+  return info;
+}
+
+}  // namespace
 
 ElectronApiServiceImpl::~ElectronApiServiceImpl() = default;
 
@@ -127,6 +226,13 @@ void ElectronApiServiceImpl::ReceivePostMessage(
 
   ipc_native::EmitIPCEvent(isolate, context, false, channel, ports,
                            gin::ConvertToV8(isolate, args));
+}
+
+void ElectronApiServiceImpl::GetImageSaveInfoAt(
+    int32_t x,
+    int32_t y,
+    GetImageSaveInfoAtCallback callback) {
+  std::move(callback).Run(GetImageSaveInfo(render_frame(), x, y));
 }
 
 void ElectronApiServiceImpl::TakeHeapSnapshot(

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -37,6 +37,9 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
                blink::CloneableMessage arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
+  void GetImageSaveInfoAt(int32_t x,
+                          int32_t y,
+                          GetImageSaveInfoAtCallback callback) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,
                         TakeHeapSnapshotCallback callback) override;
   void ProcessPendingMessages();

--- a/shell/renderer/service_worker_data.cc
+++ b/shell/renderer/service_worker_data.cc
@@ -66,6 +66,14 @@ void ServiceWorkerData::ReceivePostMessage(const std::string& channel,
   NOTIMPLEMENTED();
 }
 
+void ServiceWorkerData::GetImageSaveInfoAt(
+    int32_t x,
+    int32_t y,
+    GetImageSaveInfoAtCallback callback) {
+  NOTIMPLEMENTED();
+  std::move(callback).Run(nullptr);
+}
+
 void ServiceWorkerData::TakeHeapSnapshot(mojo::ScopedHandle file,
                                          TakeHeapSnapshotCallback callback) {
   NOTIMPLEMENTED();

--- a/shell/renderer/service_worker_data.h
+++ b/shell/renderer/service_worker_data.h
@@ -45,6 +45,9 @@ class ServiceWorkerData : public mojom::ElectronRenderer {
                blink::CloneableMessage arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
+  void GetImageSaveInfoAt(int32_t x,
+                          int32_t y,
+                          GetImageSaveInfoAtCallback callback) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,
                         TakeHeapSnapshotCallback callback) override;
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Closes #45268

Adds `webContents.saveImageAt(x, y)` which uses `RenderFrameHost::SaveImageAt` for `data:` and canvas elements, and fallback to manually hit testing and saving using `WebContents::SaveFrameWithHeaders`.

I have tested that downloads work and `will-download` event of Session works as expected with Electron Fiddle, but I have no idea how to add tests for these methods which require human interaction (interacting with save dialog).

This PR was assisted with Codex.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added method `webContents.saveImageAt(x, y)` <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
