### PR TITLE
refactor: SafeStorage never emits, so do not inherit from EventEmitter

### DIFF
--- a/shell/browser/api/electron_api_safe_storage.h
+++ b/shell/browser/api/electron_api_safe_storage.h
@@ -10,7 +10,6 @@
 
 #include "build/build_config.h"
 #include "components/os_crypt/async/common/encryptor.h"
-#include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/wrappable.h"
@@ -35,8 +34,7 @@ class Handle;
 
 namespace electron::api {
 
-class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
-                          public gin_helper::EventEmitterMixin<SafeStorage> {
+class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage> {
  public:
   static gin_helper::Handle<SafeStorage> Create(v8::Isolate* isolate);
 


### PR DESCRIPTION
#### Description of Change

Does what it says on the tin. `api::SafeStorage` never emits, so it doesn't need to inherit from `gin_helper::EventEmitter`.

That inheritance was introduced when the class first landed in bc508c611362145e746ac60d956eede0116d4c7c, but it has never emitted anything. It may have been added due to copy-paste.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.