### PR TITLE
refactor: avoid unnecessary `extends EventEmitter` in lib

### DIFF
--- a/lib/browser/api/message-channel.ts
+++ b/lib/browser/api/message-channel.ts
@@ -1,14 +1,11 @@
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
 
-import { EventEmitter } from 'events';
-
 const { createPair } = process._linkedBinding('electron_browser_message_port');
 
-export default class MessageChannelMain extends EventEmitter implements Electron.MessageChannelMain {
+export default class MessageChannelMain implements Electron.MessageChannelMain {
   port1: MessagePortMain;
   port2: MessagePortMain;
   constructor() {
-    super();
     const { port1, port2 } = createPair();
     this.port1 = new MessagePortMain(port1);
     this.port2 = new MessagePortMain(port2);

--- a/lib/browser/api/share-menu.ts
+++ b/lib/browser/api/share-menu.ts
@@ -1,12 +1,9 @@
 import { BrowserWindow, Menu, SharingItem, PopupOptions } from 'electron/main';
 
-import { EventEmitter } from 'events';
-
-class ShareMenu extends EventEmitter implements Electron.ShareMenu {
+class ShareMenu implements Electron.ShareMenu {
   private menu: Menu;
 
   constructor(sharingItem: SharingItem) {
-    super();
     this.menu = new (Menu as any)({ sharingItem });
   }
 


### PR DESCRIPTION
#### Description of Change

`ShareMenu` and `MesageChannel` don't need to extend `EventEmitter`. Neither of them emits anything.

Looks like this was a minor copy-paste bug that came in when f66d4c7 added better extends/implements interface info to `lib/` .

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.