### PR TITLE
fix: show 'Electron Isolated Context' in Dev Tools

### DIFF
--- a/patches/devtools_frontend/.patches
+++ b/patches/devtools_frontend/.patches
@@ -1,2 +1,3 @@
 chore_expose_ui_to_allow_electron_to_set_dock_side.patch
 feat_allow_enabling_extension_panels_on_custom_protocols.patch
+fix_context_selector_not_showing_execution_contexts.patch

--- a/patches/devtools_frontend/fix_context_selector_not_showing_execution_contexts.patch
+++ b/patches/devtools_frontend/fix_context_selector_not_showing_execution_contexts.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fedor Indutny <indutny@signal.org>
+Date: Tue, 14 Apr 2026 19:33:23 -0700
+Subject: Fix context selector not showing execution contexts
+
+When execution context's origin is `file://` - the `url.domain()` is an
+empty string and the item's subtitle becomes falsy. Since we predicated
+rendering of an item on presence of both title and subtitle - the items
+were not rendered while still taking space in the dropdown.
+
+Pending CL: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7761316
+
+diff --git a/front_end/panels/console/ConsoleContextSelector.ts b/front_end/panels/console/ConsoleContextSelector.ts
+index f933dbd6dbdfadd2ea8b78e473d9506350825037..09f590fff0263875b1727bdf7e8dd57a17603ee3 100644
+--- a/front_end/panels/console/ConsoleContextSelector.ts
++++ b/front_end/panels/console/ConsoleContextSelector.ts
+@@ -303,7 +303,7 @@ interface ViewInput {
+ type View = (input: ViewInput, output: undefined, target: HTMLElement) => void;
+ 
+ const DEFAULT_VIEW: View = (input, _output, target): void => {
+-  if (!input.title || !input.subtitle) {
++  if (!input.title && !input.subtitle) {
+     render(nothing, target);
+     return;
+   }


### PR DESCRIPTION
#### Description of Change

Because of a bug after the [upstream refactor][0] Dev Tools stopped showing 'Electron Isolated Context' in the execution context selector. 'Electron Isolated Context' runs with origin set to `file://`. Since domain name is empty for the origin the respective UI item in the context selector is created with an empty `subtitle`. However, with the upstream change items with either of `title` or `subtitle` are omitted from rendering.

Here we float an [in-review patch][1] until it is fixed upstream.

See https://github.com/electron/electron/issues/51048

[0]: https://chromium.googlesource.com/devtools/devtools-frontend.git/+/dbb61cf4b27a8ca13ac62ce7b72c22ad2664b460
[1]: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7761316

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed absent 'Electron Isolated Context' in the execution context dropdown in Dev Tools.