### PR TITLE
test: add tab source ID tests for media handler

### DIFF
--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 
 import * as http from 'node:http';
 
+import { captureWithTabSourceId } from './lib/media-helpers';
 import { ifit, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
@@ -23,33 +24,6 @@ describe('setDisplayMediaRequestHandler', () => {
   after(() => {
     server.close();
   });
-
-  const captureWithTabSourceId = async (requestingWindow: BrowserWindow, chromeMediaSourceId: string) => {
-    return requestingWindow.webContents.executeJavaScript(`
-      navigator.mediaDevices.getUserMedia({
-        video: {
-          mandatory: {
-            chromeMediaSource: 'tab',
-            chromeMediaSourceId: ${JSON.stringify(chromeMediaSourceId)},
-          },
-        },
-      }).then((stream) => {
-        const result = {
-          ok: stream instanceof MediaStream,
-          href: location.href,
-          origin: location.origin,
-          videoTrackCount: stream.getVideoTracks().length,
-        };
-        stream.getTracks().forEach((track) => track.stop());
-        return result;
-      }, (error) => ({
-        ok: false,
-        href: location.href,
-        message: error.message,
-        origin: location.origin,
-      }))
-    `);
-  };
 
   ifit(process.platform !== 'darwin')('works when calling getDisplayMedia', async function () {
     if ((await desktopCapturer.getSources({ types: ['screen'] })).length === 0) {

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -24,6 +24,33 @@ describe('setDisplayMediaRequestHandler', () => {
     server.close();
   });
 
+  const captureWithTabSourceId = async (requestingWindow: BrowserWindow, chromeMediaSourceId: string) => {
+    return requestingWindow.webContents.executeJavaScript(`
+      navigator.mediaDevices.getUserMedia({
+        video: {
+          mandatory: {
+            chromeMediaSource: 'tab',
+            chromeMediaSourceId: ${JSON.stringify(chromeMediaSourceId)},
+          },
+        },
+      }).then((stream) => {
+        const result = {
+          ok: stream instanceof MediaStream,
+          href: location.href,
+          origin: location.origin,
+          videoTrackCount: stream.getVideoTracks().length,
+        };
+        stream.getTracks().forEach((track) => track.stop());
+        return result;
+      }, (error) => ({
+        ok: false,
+        href: location.href,
+        message: error.message,
+        origin: location.origin,
+      }))
+    `);
+  };
+
   ifit(process.platform !== 'darwin')('works when calling getDisplayMedia', async function () {
     if ((await desktopCapturer.getSources({ types: ['screen'] })).length === 0) {
       return this.skip();
@@ -451,6 +478,37 @@ describe('setDisplayMediaRequestHandler', () => {
     `);
     expect(ok).to.be.false();
     expect(message).to.equal('Invalid state');
+  });
+
+  it('works when mediaDevices.getUserMedia uses a tab source id from webContents.getMediaSourceId', async () => {
+    const sourceWindow = new BrowserWindow({ show: false });
+    const requestingWindow = new BrowserWindow({ show: false });
+    await Promise.all([sourceWindow.loadURL(serverUrl), requestingWindow.loadURL(serverUrl)]);
+
+    const sourceId = sourceWindow.webContents.getMediaSourceId(requestingWindow.webContents);
+    const { ok, message, origin, videoTrackCount } = await captureWithTabSourceId(requestingWindow, sourceId);
+
+    expect(ok).to.be.true(message);
+    expect(origin).to.equal(new URL(serverUrl).origin);
+    expect(videoTrackCount).to.equal(1);
+  });
+
+  it('rejects a tab source id when used from a different requesting webContents', async () => {
+    const sourceWindow = new BrowserWindow({ show: false });
+    const registeredRequesterWindow = new BrowserWindow({ show: false });
+    const otherRequesterWindow = new BrowserWindow({ show: false });
+    await Promise.all([
+      sourceWindow.loadURL(serverUrl),
+      registeredRequesterWindow.loadURL(serverUrl),
+      otherRequesterWindow.loadURL(serverUrl)
+    ]);
+
+    const sourceId = sourceWindow.webContents.getMediaSourceId(registeredRequesterWindow.webContents);
+    const { ok, message, origin } = await captureWithTabSourceId(otherRequesterWindow, sourceId);
+
+    expect(ok).to.be.false();
+    expect(message).to.match(/Invalid state|Error starting tab capture/);
+    expect(origin).to.equal(new URL(serverUrl).origin);
   });
 
   it('can remove a displayMediaRequestHandler', async () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 
+import { captureWithTabSourceId } from './lib/media-helpers';
 import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
 import { cleanupWebContents, closeAllWindows } from './lib/window-helpers';
 
@@ -1819,9 +1820,33 @@ describe('webContents module', () => {
 
   describe('getMediaSourceId()', () => {
     afterEach(closeAllWindows);
-    it('returns a valid stream id', () => {
-      const w = new BrowserWindow({ show: false });
-      expect(w.webContents.getMediaSourceId(w.webContents)).to.be.a('string').that.is.not.empty();
+    let server: http.Server;
+    let serverUrl: string;
+
+    before(async () => {
+      server = http.createServer((req, res) => {
+        res.setHeader('Content-Type', 'text/html');
+        res.end('');
+      });
+      serverUrl = (await listen(server)).url;
+    });
+
+    after(() => {
+      server.close();
+    });
+
+    it('returns a stream id that can be used by the registered requester', async () => {
+      const sourceWindow = new BrowserWindow({ show: false });
+      const requesterWindow = new BrowserWindow({ show: false });
+      await Promise.all([sourceWindow.loadURL(serverUrl), requesterWindow.loadURL(serverUrl)]);
+
+      const streamId = sourceWindow.webContents.getMediaSourceId(requesterWindow.webContents);
+      const { ok, message, origin, videoTrackCount } = await captureWithTabSourceId(requesterWindow, streamId);
+
+      expect(streamId).to.be.a('string').that.is.not.empty();
+      expect(ok, message).to.equal(true);
+      expect(origin).to.equal(new url.URL(serverUrl).origin);
+      expect(videoTrackCount).to.equal(1);
     });
   });
 

--- a/spec/lib/media-helpers.ts
+++ b/spec/lib/media-helpers.ts
@@ -1,0 +1,39 @@
+import { BrowserWindow } from 'electron/main';
+
+export interface TabSourceCaptureResult {
+  ok: boolean;
+  href: string;
+  message?: string;
+  origin: string;
+  videoTrackCount?: number;
+}
+
+export const captureWithTabSourceId = async (
+  requestingWindow: BrowserWindow,
+  streamId: string
+): Promise<TabSourceCaptureResult> => {
+  return requestingWindow.webContents.executeJavaScript(`
+    navigator.mediaDevices.getUserMedia({
+      video: {
+        mandatory: {
+          chromeMediaSource: 'tab',
+          chromeMediaSourceId: ${JSON.stringify(streamId)},
+        },
+      },
+    }).then((stream) => {
+      const result = {
+        ok: stream instanceof MediaStream,
+        href: location.href,
+        origin: location.origin,
+        videoTrackCount: stream.getVideoTracks().length,
+      };
+      stream.getTracks().forEach((track) => track.stop());
+      return result;
+    }, (error) => ({
+      ok: false,
+      href: location.href,
+      message: error.message,
+      origin: location.origin,
+    }));
+  `);
+};


### PR DESCRIPTION
#### Description of Change

I'm getting ready to replace some calls to deprecated API `GURL::DeprecatedGetOriginAsURL()` and realized there wasn't any test coverage for the code that I was about to change. So this is a standalone test-only PR to improve coverage before I make any changes. 

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.