### PR TITLE
fix: UAF in api::UtilityProcessWrapper

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -250,6 +250,10 @@ UtilityProcessWrapper::UtilityProcessWrapper(
 }
 
 UtilityProcessWrapper::~UtilityProcessWrapper() {
+  Dispose();
+}
+
+void UtilityProcessWrapper::Dispose() {
   content::ServiceProcessHost::RemoveObserver(this);
 }
 
@@ -279,6 +283,7 @@ void UtilityProcessWrapper::HandleTermination(uint32_t exit_code) {
     GetAllUtilityProcessWrappers().Remove(pid_);
 
   pid_ = base::kNullProcessId;
+  Dispose();
   CloseConnectorPort();
   if (killed_) {
 #if BUILDFLAG(IS_POSIX)

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -250,10 +250,6 @@ UtilityProcessWrapper::UtilityProcessWrapper(
 }
 
 UtilityProcessWrapper::~UtilityProcessWrapper() {
-  Dispose();
-}
-
-void UtilityProcessWrapper::Dispose() {
   content::ServiceProcessHost::RemoveObserver(this);
 }
 
@@ -283,7 +279,7 @@ void UtilityProcessWrapper::HandleTermination(uint32_t exit_code) {
     GetAllUtilityProcessWrappers().Remove(pid_);
 
   pid_ = base::kNullProcessId;
-  Dispose();
+  content::ServiceProcessHost::RemoveObserver(this);
   CloseConnectorPort();
   if (killed_) {
 #if BUILDFLAG(IS_POSIX)

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -22,7 +22,6 @@
 #include "shell/common/gc_plugin.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
-#include "v8/include/cppgc/prefinalizer.h"
 #include "v8/include/v8-forward.h"
 
 namespace gin {
@@ -45,8 +44,6 @@ class UtilityProcessWrapper final
       private mojo::MessageReceiver,
       public node::mojom::NodeServiceClient,
       public content::ServiceProcessHost::Observer {
-  CPPGC_USING_PRE_FINALIZER(UtilityProcessWrapper, Dispose);
-
  public:
   enum class IOHandle : size_t { STDIN = 0, STDOUT = 1, STDERR = 2 };
   enum class IOType { IO_PIPE, IO_INHERIT, IO_IGNORE };
@@ -78,8 +75,6 @@ class UtilityProcessWrapper final
       v8::Isolate* isolate) override;
 
  private:
-  void Dispose();
-
   void OnServiceProcessLaunch(const base::Process& process);
   void CloseConnectorPort();
 

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -22,6 +22,7 @@
 #include "shell/common/gc_plugin.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
+#include "v8/include/cppgc/prefinalizer.h"
 #include "v8/include/v8-forward.h"
 
 namespace gin {
@@ -44,6 +45,8 @@ class UtilityProcessWrapper final
       private mojo::MessageReceiver,
       public node::mojom::NodeServiceClient,
       public content::ServiceProcessHost::Observer {
+  CPPGC_USING_PRE_FINALIZER(UtilityProcessWrapper, Dispose);
+
  public:
   enum class IOHandle : size_t { STDIN = 0, STDOUT = 1, STDERR = 2 };
   enum class IOType { IO_PIPE, IO_INHERIT, IO_IGNORE };
@@ -75,6 +78,8 @@ class UtilityProcessWrapper final
       v8::Isolate* isolate) override;
 
  private:
+  void Dispose();
+
   void OnServiceProcessLaunch(const base::Process& process);
   void CloseConnectorPort();
 

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -224,6 +224,44 @@ describe('utilityProcess module', () => {
       expect(details.name).to.equal(name);
       expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
     });
+
+    ifit(!isWindows32Bit)('does not keep stale observers for crashed processes without JS references', async () => {
+      const v8Util = (process as any)._linkedBinding('electron_common_v8_util');
+      const logExpectedCrash = (phase: string) => {
+        console.error(
+          `[expected crash] utilityProcess regression forcing ${phase} crash; signal 11 + backtrace expected`
+        );
+      };
+      const waitForCollection = async (weakChild: WeakRef<ReturnType<typeof utilityProcess.fork>>) => {
+        for (let i = 0; i < 30; ++i) {
+          await setImmediate();
+          v8Util.requestGarbageCollectionForTesting();
+          if (weakChild.deref() === undefined) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      const name = 'Node Utility Process';
+      const firstCrash = waitForCrash(name);
+      logExpectedCrash('first');
+      let child: ReturnType<typeof utilityProcess.fork> | null = utilityProcess.fork(
+        path.join(fixturesPath, 'crash.js')
+      );
+      const weakChild = new WeakRef(child!);
+      child = null;
+
+      const firstDetails = await firstCrash;
+      expect(firstDetails.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
+      expect(await waitForCollection(weakChild)).to.equal(true);
+
+      const secondCrash = waitForCrash(name);
+      logExpectedCrash('second');
+      utilityProcess.fork(path.join(fixturesPath, 'crash.js'));
+      const secondDetails = await secondCrash;
+      expect(secondDetails.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
+    });
   });
 
   describe('app.getAppMetrics()', () => {


### PR DESCRIPTION
#### Description of Change

Detach the wrapper from ServiceProcessHost during termination instead of waiting for destruction. Add a regression test that forces GC.

This fixes a UAF error reported by ASAN: the wrapper lost its last JS reference and become collectible after emitting exit *but* before it had been removed from the global observer list.

I think this was introduced in b9e462f397 (#50955) when `UtilityProcessWrapper` was migrated to cppgc and we should probably include this fix when backporting that to 42-x-y. Marking as `no-backport` only because this fix shouldn't land separately w/o #50955.

CC @deepak1556 @dsanders11 

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.