### PR TITLE
test: increase test coverage for docked DevTools and attached WebContentsView

### DIFF
--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1252,6 +1252,12 @@ describe('webContents module', () => {
       const w = new BrowserWindow({ show: false, width: 800, height: 600 });
       await w.loadURL('about:blank');
 
+      // wait for it to be shown, visible
+      const shown = once(w, 'show');
+      w.show();
+      await shown;
+      await waitUntil(async () => (await w.webContents.executeJavaScript('document.visibilityState')) === 'visible');
+
       const initial = await getViewportSize(w);
 
       const devtoolsOpened = once(w.webContents, 'devtools-opened');

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1222,6 +1222,11 @@ describe('webContents module', () => {
 
   describe('openDevTools() API', () => {
     afterEach(closeAllWindows);
+
+    async function getViewportSize(w: BrowserWindow) {
+      return await w.webContents.executeJavaScript('({ width: window.innerWidth, height: window.innerHeight })');
+    }
+
     it('can show window with activation', async () => {
       const w = new BrowserWindow({ show: false });
       const focused = once(w, 'focus');
@@ -1241,6 +1246,42 @@ describe('webContents module', () => {
       w.webContents.openDevTools({ mode: 'detach', activate: false });
       await devtoolsOpened;
       expect(w.webContents.isDevToolsOpened()).to.be.true();
+    });
+
+    it('updates and restores the inspected page viewport for right-docked DevTools', async () => {
+      const w = new BrowserWindow({ show: false, width: 800, height: 600 });
+      await w.loadURL('about:blank');
+
+      const initial = await getViewportSize(w);
+
+      const devtoolsOpened = once(w.webContents, 'devtools-opened');
+      w.webContents.openDevTools({ mode: 'right', activate: false });
+      await devtoolsOpened;
+
+      await expect(
+        waitUntil(async () => {
+          const viewport = await getViewportSize(w);
+          return viewport.width < initial.width;
+        })
+      ).to.eventually.be.fulfilled();
+
+      const dockedRight = await getViewportSize(w);
+      expect(dockedRight.width).to.be.lessThan(initial.width);
+      expect(dockedRight.height).to.be.closeTo(initial.height, 50);
+
+      const devtoolsClosed = once(w.webContents, 'devtools-closed');
+      w.webContents.closeDevTools();
+      await devtoolsClosed;
+
+      await expect(
+        waitUntil(async () => {
+          const restoredViewport = await getViewportSize(w);
+          return restoredViewport.width === initial.width && restoredViewport.height === initial.height;
+        })
+      ).to.eventually.be.fulfilled();
+
+      const restoredViewport = await getViewportSize(w);
+      expect(restoredViewport).to.deep.equal(initial);
     });
 
     it('can show a DevTools window with custom title', async () => {

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -251,10 +251,17 @@ describe('WebContentsView', () => {
       // executeJavaScript calls are sequential so if this one's finished then
       // the previous one must also have been finished :)
       await v.webContents.executeJavaScript('undefined');
-      const w = new BaseWindow();
+      const w = new BaseWindow({ width: 400, height: 300 });
       w.setContentView(v);
       await p;
       expect(await v.webContents.executeJavaScript('document.visibilityState')).to.equal('visible');
+
+      const viewportSize = await v.webContents.executeJavaScript(
+        '({ width: window.innerWidth, height: window.innerHeight })'
+      );
+      const contentBounds = w.getContentBounds();
+      expect(viewportSize.width).to.equal(contentBounds.width);
+      expect(viewportSize.height).to.equal(contentBounds.height);
     });
 
     it('is initially visible if load happens after attach', async () => {


### PR DESCRIPTION
#### Description of Change

I'm getting ready to replace some calls to deprecated API `WebContentsView::DeprecatedLayoutImmediately()` and realized that I needed to improve test coverage for the areas I was about to change.

So this is a standalone test-only PR to improve coverage before making any changes. I'm going to target the deprecated API removal for 42-x-y and am PR'ing this as a standalone so that it can go back further if we want.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.