### PR TITLE
fix: handle debugger Page.reload via WebContents reload

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -12,6 +12,7 @@
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "content/public/browser/devtools_agent_host.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/web_contents.h"
 #include "gin/object_template_builder.h"
 #include "gin/per_isolate_data.h"
@@ -153,6 +154,18 @@ v8::Local<v8::Promise> Debugger::SendCommand(gin::Arguments* args) {
   std::string session_id;
   if (args->GetNext(&session_id) && session_id.empty()) {
     promise.RejectWithErrorMessage("Empty session id is not allowed");
+    return handle;
+  }
+
+  if (method == "Page.reload" && session_id.empty()) {
+    // Match DevTools frontend reload handling instead of dispatching raw CDP.
+    const bool ignore_cache =
+        command_params.FindBool("ignoreCache").value_or(false);
+    web_contents_->GetController().Reload(
+        ignore_cache ? content::ReloadType::BYPASSING_CACHE
+                     : content::ReloadType::NORMAL,
+        /* check_for_repost */ true);
+    promise.Resolve(base::DictValue());
     return handle;
   }
 

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron/main';
+import { BrowserWindow, type WebContents } from 'electron/main';
 
 import { expect } from 'chai';
 
@@ -88,6 +88,57 @@ describe('debugger module', () => {
       expect(res.result.value).to.equal(6);
 
       w.webContents.debugger.detach();
+    });
+
+    it('reloads webview guests without reloading the embedder window', async () => {
+      w.destroy();
+      w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        webPreferences: {
+          webviewTag: true
+        }
+      });
+
+      let requestCount = 0;
+      server = http.createServer((_req, res) => {
+        requestCount += 1;
+        res.setHeader('Content-Type', 'text/html');
+        res.end(`<html><body>${requestCount}</body></html>`);
+      });
+      const { url } = await listen(server);
+      const attached = once(w.webContents, 'did-attach-webview') as Promise<
+        [Electron.Event, WebContents]
+      >;
+      const hostUrl = `data:text/html,${encodeURIComponent(
+        `<webview src="${url}"></webview>`
+      )}`;
+      await w.loadURL(hostUrl);
+      const [, guest] = await attached;
+      if (guest.isLoading()) {
+        await once(guest, 'did-finish-load');
+      }
+
+      const hostMainFrameNavigations: string[] = [];
+      w.webContents.on(
+        'did-start-navigation',
+        (_event, navigationUrl, _isInPlace, isMainFrame) => {
+          if (isMainFrame) {
+            hostMainFrameNavigations.push(navigationUrl);
+          }
+        }
+      );
+
+      guest.debugger.attach();
+      const guestReloaded = once(guest, 'did-finish-load');
+      const result = await guest.debugger.sendCommand('Page.reload');
+      await guestReloaded;
+      guest.debugger.detach();
+
+      expect(result).to.deep.equal({});
+      expect(requestCount).to.equal(2);
+      expect(hostMainFrameNavigations).to.deep.equal([]);
     });
 
     it('returns response when devtools is opened', async () => {


### PR DESCRIPTION
#### Description of Change

Handle top-level `Page.reload` commands sent through `webContents.debugger.sendCommand()` with Electron's `WebContents` reload path instead of forwarding raw CDP to the target.

Electron already special-cases `Page.reload` from the DevTools frontend in `InspectableWebContents::DispatchProtocolMessageFromDevToolsFrontend`. The debugger API path bypassed that special-case and sent the raw protocol message directly through `DevToolsAgentHost::DispatchProtocolMessage`.

This matters for guest `<webview>` contents: raw CDP `Page.reload` can reload the embedder window instead of only the guest. The new handling preserves `ignoreCache` and leaves session-targeted commands unchanged.

#### Checklist

- [x] Added a regression spec for `Page.reload` against a `<webview>` guest
- [ ] Ran Electron test suite locally

#### Notes

I have not run the Electron test suite locally from this sparse checkout. This patch is based on a downstream repro where `webContents.debugger.sendCommand('Page.reload')` against a `<webview>` guest caused the embedder BrowserWindow renderer to reload, while `guestWebContents.reload()` reloaded only the guest.