### PR TITLE
ci: build a patched siso for Windows builds

### DIFF
--- a/.github/siso-patches/0001-siso-reuse-the-outer-os.File-for-chunked-ReadAt-in-f.patch
+++ b/.github/siso-patches/0001-siso-reuse-the-outer-os.File-for-chunked-ReadAt-in-f.patch
@@ -1,0 +1,47 @@
+From 85b561ea4dbc76ba98af020b970f3aa6b20fdb9e Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sam@electronjs.org>
+Date: Wed, 8 Apr 2026 23:24:15 -0700
+Subject: [PATCH] siso: reuse the outer *os.File for chunked ReadAt in
+ fileParser.readFile
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The per-chunk goroutine currently re-opens fname to get its own handle
+for ReadAt. (*os.File).ReadAt is documented as safe for concurrent
+calls on the same File (on Windows it is ReadFile with an OVERLAPPED
+offset, so there is no shared seek state), so the extra open is
+redundant — the goroutines can share the outer f.
+
+Besides halving the CreateFileW calls per subninja, this avoids an
+intermittent 'The parameter is incorrect.' (ERROR_INVALID_PARAMETER)
+from bindflt.sys when out/ is a mapped directory inside a Windows
+container: bindflt's handle-relative NtCreateFile path races when a
+second relative open arrives while the first handle to the same target
+is still being set up. Absolute paths and single opens do not trigger
+it; see microsoft/Windows-Containers#<tbd>.
+---
+ siso/toolsupport/ninjautil/file_parser.go | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/siso/toolsupport/ninjautil/file_parser.go b/siso/toolsupport/ninjautil/file_parser.go
+index 8c18d084..63116662 100644
+--- a/siso/toolsupport/ninjautil/file_parser.go
++++ b/siso/toolsupport/ninjautil/file_parser.go
+@@ -111,13 +111,6 @@ func (p *fileParser) readFile(ctx context.Context, fname string) ([]byte, error)
+ 		eg.Go(func() error {
+ 			p.sema <- struct{}{}
+ 			defer func() { <-p.sema }()
+-			f, err := os.Open(fname)
+-			if err != nil {
+-				return err
+-			}
+-			defer func() {
+-				_ = f.Close()
+-			}()
+ 			for len(chunkBuf) > 0 {
+ 				n, err := f.ReadAt(chunkBuf, pos)
+ 				if err != nil {
+-- 
+2.53.0
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,95 +201,13 @@ jobs:
         target-platform: win
 
   # Build a patched siso binary for Windows CI in parallel with checkout-windows.
-  # Reads the siso revision from the Chromium DEPS file at the pinned chromium_version,
-  # shallow-clones chromium.googlesource.com/build at that revision, applies the patches
-  # under .github/siso-patches/, and publishes the resulting Windows amd64 binary as an
-  # artifact. The Windows build jobs download it and use it via SISO_PATH. The built
-  # binary is cached keyed on the siso revision + patch contents, so subsequent runs
-  # just restore it.
+  # The Windows build jobs download the resulting artifact and use it via SISO_PATH.
   build-siso-windows:
     needs: setup
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/pipeline-segment-build-siso-windows.yml
     permissions:
       contents: read
-    steps:
-    - name: Checkout Electron
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      with:
-        fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
-        sparse-checkout: |
-          DEPS
-          .github/siso-patches
-    - name: Resolve siso revision from Chromium DEPS
-      id: resolve
-      run: |
-        set -euo pipefail
-        CHROMIUM_VERSION=$(python3 -c "import re; print(re.search(r\"'chromium_version':\s*\n\s*'([^']+)'\", open('DEPS').read()).group(1))")
-        if ! [[ "$CHROMIUM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
-          echo "error: unexpected chromium_version format: $CHROMIUM_VERSION" >&2
-          exit 1
-        fi
-        curl -sfL "https://raw.githubusercontent.com/chromium/chromium/${CHROMIUM_VERSION}/DEPS" -o /tmp/chromium-DEPS
-        SISO_SHA=$(python3 -c "import re; print(re.search(r\"'siso_version':\s*'git_revision:([0-9a-f]+)'\", open('/tmp/chromium-DEPS').read()).group(1))")
-        if ! [[ "$SISO_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "error: unexpected siso_version SHA: $SISO_SHA" >&2
-          exit 1
-        fi
-        PATCHES_HASH=$(find .github/siso-patches -type f -name '*.patch' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-        echo "siso-sha=${SISO_SHA}" >> "$GITHUB_OUTPUT"
-        echo "patches-hash=${PATCHES_HASH}" >> "$GITHUB_OUTPUT"
-        echo "Chromium ${CHROMIUM_VERSION} pins siso at ${SISO_SHA}"
-        echo "Patches hash: ${PATCHES_HASH}"
-    - name: Restore cached siso binary
-      id: cache-siso
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-      with:
-        path: siso-out/siso.exe
-        key: siso-windows-amd64-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
-    - name: Shallow clone chromium build repo at pinned revision
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      env:
-        SISO_SHA: ${{ steps.resolve.outputs.siso-sha }}
-      run: |
-        set -euo pipefail
-        mkdir chromium-build
-        cd chromium-build
-        git init -q
-        git remote add origin https://chromium.googlesource.com/build
-        git -c protocol.version=2 fetch --depth=1 origin "$SISO_SHA"
-        git checkout --detach FETCH_HEAD
-    - name: Apply in-tree siso patches
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      run: |
-        set -euo pipefail
-        cd chromium-build
-        git -c user.name=electron-ci -c user.email=ci@electronjs.org \
-          am --3way "${GITHUB_WORKSPACE}/.github/siso-patches"/*.patch
-    - name: Set up Go
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: chromium-build/siso/go.mod
-        cache: false
-    - name: Build siso (windows/amd64)
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      working-directory: chromium-build/siso
-      env:
-        CGO_ENABLED: '0'
-        GOOS: windows
-        GOARCH: amd64
-      run: |
-        mkdir -p "${GITHUB_WORKSPACE}/siso-out"
-        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/siso.exe" .
-    - name: Upload siso artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: siso-windows-amd64
-        path: siso-out/siso.exe
-        if-no-files-found: error
-        retention-days: 1
 
   # GN Check Jobs
   macos-gn-check:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,97 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
+  # Build a patched siso binary for Windows CI in parallel with checkout-windows.
+  # Reads the siso revision from the Chromium DEPS file at the pinned chromium_version,
+  # shallow-clones chromium.googlesource.com/build at that revision, applies the patches
+  # under .github/siso-patches/, and publishes the resulting Windows amd64 binary as an
+  # artifact. The Windows build jobs download it and use it via SISO_PATH. The built
+  # binary is cached keyed on the siso revision + patch contents, so subsequent runs
+  # just restore it.
+  build-siso-windows:
+    needs: setup
+    if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 1
+        ref: ${{ github.event.pull_request.head.sha }}
+        sparse-checkout: |
+          DEPS
+          .github/siso-patches
+    - name: Resolve siso revision from Chromium DEPS
+      id: resolve
+      run: |
+        set -euo pipefail
+        CHROMIUM_VERSION=$(python3 -c "import re; print(re.search(r\"'chromium_version':\s*\n\s*'([^']+)'\", open('DEPS').read()).group(1))")
+        if ! [[ "$CHROMIUM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
+          echo "error: unexpected chromium_version format: $CHROMIUM_VERSION" >&2
+          exit 1
+        fi
+        curl -sfL "https://raw.githubusercontent.com/chromium/chromium/${CHROMIUM_VERSION}/DEPS" -o /tmp/chromium-DEPS
+        SISO_SHA=$(python3 -c "import re; print(re.search(r\"'siso_version':\s*'git_revision:([0-9a-f]+)'\", open('/tmp/chromium-DEPS').read()).group(1))")
+        if ! [[ "$SISO_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "error: unexpected siso_version SHA: $SISO_SHA" >&2
+          exit 1
+        fi
+        PATCHES_HASH=$(find .github/siso-patches -type f -name '*.patch' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+        echo "siso-sha=${SISO_SHA}" >> "$GITHUB_OUTPUT"
+        echo "patches-hash=${PATCHES_HASH}" >> "$GITHUB_OUTPUT"
+        echo "Chromium ${CHROMIUM_VERSION} pins siso at ${SISO_SHA}"
+        echo "Patches hash: ${PATCHES_HASH}"
+    - name: Restore cached siso binary
+      id: cache-siso
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: siso-out/siso.exe
+        key: siso-windows-amd64-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
+    - name: Shallow clone chromium build repo at pinned revision
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      env:
+        SISO_SHA: ${{ steps.resolve.outputs.siso-sha }}
+      run: |
+        set -euo pipefail
+        mkdir chromium-build
+        cd chromium-build
+        git init -q
+        git remote add origin https://chromium.googlesource.com/build
+        git -c protocol.version=2 fetch --depth=1 origin "$SISO_SHA"
+        git checkout --detach FETCH_HEAD
+    - name: Apply in-tree siso patches
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      run: |
+        set -euo pipefail
+        cd chromium-build
+        git -c user.name=electron-ci -c user.email=ci@electronjs.org \
+          am --3way "${GITHUB_WORKSPACE}/.github/siso-patches"/*.patch
+    - name: Set up Go
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: chromium-build/siso/go.mod
+        cache: false
+    - name: Build siso (windows/amd64)
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      working-directory: chromium-build/siso
+      env:
+        CGO_ENABLED: '0'
+        GOOS: windows
+        GOARCH: amd64
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/siso-out"
+        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/siso.exe" .
+    - name: Upload siso artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: siso-windows-amd64
+        path: siso-out/siso.exe
+        if-no-files-found: error
+        retention-days: 1
+
   # GN Check Jobs
   macos-gn-check:
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -384,7 +475,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -403,7 +494,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -422,7 +513,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -440,7 +531,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64, windows-x64, windows-x86, windows-arm64]
+    needs: [docs-only, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm, linux-arm64, build-siso-windows, windows-x64, windows-x86, windows-arm64]
     if: always() && github.repository == 'electron/electron'
     steps:
     - name: Fail if any needed job failed or was cancelled

--- a/.github/workflows/pipeline-segment-build-siso-windows.yml
+++ b/.github/workflows/pipeline-segment-build-siso-windows.yml
@@ -1,0 +1,98 @@
+name: Pipeline Segment - Build Siso (Windows)
+
+# Builds a patched siso binary for Windows CI. Reads the siso revision from
+# the Chromium DEPS file at the pinned chromium_version, shallow-clones
+# chromium.googlesource.com/build at that revision, applies the patches under
+# .github/siso-patches/, cross-compiles siso.exe for windows/amd64, and
+# publishes it as the `siso-windows-amd64` artifact. The Windows build jobs
+# download it and use it via SISO_PATH. The built binary is cached keyed on
+# the siso revision + sha256 of the patch contents, so subsequent runs just
+# restore it.
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 1
+        ref: ${{ github.event.pull_request.head.sha }}
+        sparse-checkout: |
+          DEPS
+          .github/siso-patches
+    - name: Resolve siso revision from Chromium DEPS
+      id: resolve
+      run: |
+        set -euo pipefail
+        CHROMIUM_VERSION=$(python3 -c "import re; print(re.search(r\"'chromium_version':\s*\n\s*'([^']+)'\", open('DEPS').read()).group(1))")
+        if ! [[ "$CHROMIUM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
+          echo "error: unexpected chromium_version format: $CHROMIUM_VERSION" >&2
+          exit 1
+        fi
+        curl -sfL "https://raw.githubusercontent.com/chromium/chromium/${CHROMIUM_VERSION}/DEPS" -o /tmp/chromium-DEPS
+        SISO_SHA=$(python3 -c "import re; print(re.search(r\"'siso_version':\s*'git_revision:([0-9a-f]+)'\", open('/tmp/chromium-DEPS').read()).group(1))")
+        if ! [[ "$SISO_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "error: unexpected siso_version SHA: $SISO_SHA" >&2
+          exit 1
+        fi
+        PATCHES_HASH=$(find .github/siso-patches -type f -name '*.patch' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+        echo "siso-sha=${SISO_SHA}" >> "$GITHUB_OUTPUT"
+        echo "patches-hash=${PATCHES_HASH}" >> "$GITHUB_OUTPUT"
+        echo "Chromium ${CHROMIUM_VERSION} pins siso at ${SISO_SHA}"
+        echo "Patches hash: ${PATCHES_HASH}"
+    - name: Restore cached siso binary
+      id: cache-siso
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: siso-out/siso.exe
+        key: siso-windows-amd64-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
+    - name: Shallow clone chromium build repo at pinned revision
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      env:
+        SISO_SHA: ${{ steps.resolve.outputs.siso-sha }}
+      run: |
+        set -euo pipefail
+        mkdir chromium-build
+        cd chromium-build
+        git init -q
+        git remote add origin https://chromium.googlesource.com/build
+        git -c protocol.version=2 fetch --depth=1 origin "$SISO_SHA"
+        git checkout --detach FETCH_HEAD
+    - name: Apply in-tree siso patches
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      run: |
+        set -euo pipefail
+        cd chromium-build
+        git -c user.name=electron-ci -c user.email=ci@electronjs.org \
+          am --3way "${GITHUB_WORKSPACE}/.github/siso-patches"/*.patch
+    - name: Set up Go
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: chromium-build/siso/go.mod
+        cache: false
+    - name: Build siso (windows/amd64)
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      working-directory: chromium-build/siso
+      env:
+        CGO_ENABLED: '0'
+        GOOS: windows
+        GOARCH: amd64
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/siso-out"
+        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/siso.exe" .
+    - name: Upload siso artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: siso-windows-amd64
+        path: siso-out/siso.exe
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -196,7 +196,7 @@ jobs:
       uses: ./src/electron/.github/actions/free-space-macos
     - name: Download custom siso binary (Windows)
       if: ${{ inputs.target-platform == 'win' }}
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: siso-windows-amd64
         path: ${{ runner.temp }}/siso

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -194,6 +194,22 @@ jobs:
     - name: Free up space (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos
+    - name: Download custom siso binary (Windows)
+      if: ${{ inputs.target-platform == 'win' }}
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        name: siso-windows-amd64
+        path: ${{ runner.temp }}/siso
+    - name: Set SISO_PATH (Windows)
+      if: ${{ inputs.target-platform == 'win' }}
+      run: |
+        SISO_BIN="${RUNNER_TEMP}/siso/siso.exe"
+        if [ ! -f "$SISO_BIN" ]; then
+          echo "error: expected siso binary at $SISO_BIN" >&2
+          exit 1
+        fi
+        echo "SISO_PATH=$SISO_BIN" >> "$GITHUB_ENV"
+        echo "Using custom siso binary at $SISO_BIN"
     - name: Build Electron
       if: ${{ inputs.target-platform != 'macos' || (inputs.target-variant == 'all' || inputs.target-variant == 'darwin') }}
       uses: ./src/electron/.github/actions/build-electron

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -207,6 +207,22 @@ jobs:
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos
+      - name: Download custom siso binary (Windows)
+        if: ${{ inputs.target-platform == 'win' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: siso-windows-amd64
+          path: ${{ runner.temp }}/siso
+      - name: Set SISO_PATH (Windows)
+        if: ${{ inputs.target-platform == 'win' }}
+        run: |
+          SISO_BIN="${RUNNER_TEMP}/siso/siso.exe"
+          if [ ! -f "$SISO_BIN" ]; then
+            echo "error: expected siso binary at $SISO_BIN" >&2
+            exit 1
+          fi
+          echo "SISO_PATH=$SISO_BIN" >> "$GITHUB_ENV"
+          echo "Using custom siso binary at $SISO_BIN"
       - name: Build Electron
         if: ${{ inputs.target-platform != 'macos' || (inputs.target-variant == 'all' ||
           inputs.target-variant == 'darwin') }}

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -51,6 +51,91 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
+  # Build the patched siso binary in parallel with checkout-windows; the
+  # publish-*-win jobs consume it via SISO_PATH. Keep this in sync with the
+  # matching job in build.yml.
+  build-siso-windows:
+    if: github.repository == 'electron/electron'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 1
+        sparse-checkout: |
+          DEPS
+          .github/siso-patches
+    - name: Resolve siso revision from Chromium DEPS
+      id: resolve
+      run: |
+        set -euo pipefail
+        CHROMIUM_VERSION=$(python3 -c "import re; print(re.search(r\"'chromium_version':\s*\n\s*'([^']+)'\", open('DEPS').read()).group(1))")
+        if ! [[ "$CHROMIUM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
+          echo "error: unexpected chromium_version format: $CHROMIUM_VERSION" >&2
+          exit 1
+        fi
+        curl -sfL "https://raw.githubusercontent.com/chromium/chromium/${CHROMIUM_VERSION}/DEPS" -o /tmp/chromium-DEPS
+        SISO_SHA=$(python3 -c "import re; print(re.search(r\"'siso_version':\s*'git_revision:([0-9a-f]+)'\", open('/tmp/chromium-DEPS').read()).group(1))")
+        if ! [[ "$SISO_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "error: unexpected siso_version SHA: $SISO_SHA" >&2
+          exit 1
+        fi
+        PATCHES_HASH=$(find .github/siso-patches -type f -name '*.patch' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+        echo "siso-sha=${SISO_SHA}" >> "$GITHUB_OUTPUT"
+        echo "patches-hash=${PATCHES_HASH}" >> "$GITHUB_OUTPUT"
+        echo "Chromium ${CHROMIUM_VERSION} pins siso at ${SISO_SHA}"
+        echo "Patches hash: ${PATCHES_HASH}"
+    - name: Restore cached siso binary
+      id: cache-siso
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: siso-out/siso.exe
+        key: siso-windows-amd64-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
+    - name: Shallow clone chromium build repo at pinned revision
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      env:
+        SISO_SHA: ${{ steps.resolve.outputs.siso-sha }}
+      run: |
+        set -euo pipefail
+        mkdir chromium-build
+        cd chromium-build
+        git init -q
+        git remote add origin https://chromium.googlesource.com/build
+        git -c protocol.version=2 fetch --depth=1 origin "$SISO_SHA"
+        git checkout --detach FETCH_HEAD
+    - name: Apply in-tree siso patches
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      run: |
+        set -euo pipefail
+        cd chromium-build
+        git -c user.name=electron-ci -c user.email=ci@electronjs.org \
+          am --3way "${GITHUB_WORKSPACE}/.github/siso-patches"/*.patch
+    - name: Set up Go
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: chromium-build/siso/go.mod
+        cache: false
+    - name: Build siso (windows/amd64)
+      if: steps.cache-siso.outputs.cache-hit != 'true'
+      working-directory: chromium-build/siso
+      env:
+        CGO_ENABLED: '0'
+        GOOS: windows
+        GOARCH: amd64
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/siso-out"
+        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/siso.exe" .
+    - name: Upload siso artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: siso-windows-amd64
+        path: siso-out/siso.exe
+        if-no-files-found: error
+        retention-days: 1
+
   publish-x64-win:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
     permissions:
@@ -58,7 +143,7 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     with:
       environment: production-release
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -77,7 +162,7 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     with:
       environment: production-release
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -96,7 +181,7 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    needs: checkout-windows
+    needs: [checkout-windows, build-siso-windows]
     with:
       environment: production-release
       build-runs-on: electron-arc-centralus-windows-amd64-16core

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -52,89 +52,12 @@ jobs:
         target-platform: win
 
   # Build the patched siso binary in parallel with checkout-windows; the
-  # publish-*-win jobs consume it via SISO_PATH. Keep this in sync with the
-  # matching job in build.yml.
+  # publish-*-win jobs consume it via SISO_PATH.
   build-siso-windows:
     if: github.repository == 'electron/electron'
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/pipeline-segment-build-siso-windows.yml
     permissions:
       contents: read
-    steps:
-    - name: Checkout Electron
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      with:
-        fetch-depth: 1
-        sparse-checkout: |
-          DEPS
-          .github/siso-patches
-    - name: Resolve siso revision from Chromium DEPS
-      id: resolve
-      run: |
-        set -euo pipefail
-        CHROMIUM_VERSION=$(python3 -c "import re; print(re.search(r\"'chromium_version':\s*\n\s*'([^']+)'\", open('DEPS').read()).group(1))")
-        if ! [[ "$CHROMIUM_VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
-          echo "error: unexpected chromium_version format: $CHROMIUM_VERSION" >&2
-          exit 1
-        fi
-        curl -sfL "https://raw.githubusercontent.com/chromium/chromium/${CHROMIUM_VERSION}/DEPS" -o /tmp/chromium-DEPS
-        SISO_SHA=$(python3 -c "import re; print(re.search(r\"'siso_version':\s*'git_revision:([0-9a-f]+)'\", open('/tmp/chromium-DEPS').read()).group(1))")
-        if ! [[ "$SISO_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "error: unexpected siso_version SHA: $SISO_SHA" >&2
-          exit 1
-        fi
-        PATCHES_HASH=$(find .github/siso-patches -type f -name '*.patch' | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-        echo "siso-sha=${SISO_SHA}" >> "$GITHUB_OUTPUT"
-        echo "patches-hash=${PATCHES_HASH}" >> "$GITHUB_OUTPUT"
-        echo "Chromium ${CHROMIUM_VERSION} pins siso at ${SISO_SHA}"
-        echo "Patches hash: ${PATCHES_HASH}"
-    - name: Restore cached siso binary
-      id: cache-siso
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-      with:
-        path: siso-out/siso.exe
-        key: siso-windows-amd64-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
-    - name: Shallow clone chromium build repo at pinned revision
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      env:
-        SISO_SHA: ${{ steps.resolve.outputs.siso-sha }}
-      run: |
-        set -euo pipefail
-        mkdir chromium-build
-        cd chromium-build
-        git init -q
-        git remote add origin https://chromium.googlesource.com/build
-        git -c protocol.version=2 fetch --depth=1 origin "$SISO_SHA"
-        git checkout --detach FETCH_HEAD
-    - name: Apply in-tree siso patches
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      run: |
-        set -euo pipefail
-        cd chromium-build
-        git -c user.name=electron-ci -c user.email=ci@electronjs.org \
-          am --3way "${GITHUB_WORKSPACE}/.github/siso-patches"/*.patch
-    - name: Set up Go
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version-file: chromium-build/siso/go.mod
-        cache: false
-    - name: Build siso (windows/amd64)
-      if: steps.cache-siso.outputs.cache-hit != 'true'
-      working-directory: chromium-build/siso
-      env:
-        CGO_ENABLED: '0'
-        GOOS: windows
-        GOARCH: amd64
-      run: |
-        mkdir -p "${GITHUB_WORKSPACE}/siso-out"
-        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/siso.exe" .
-    - name: Upload siso artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: siso-windows-amd64
-        path: siso-out/siso.exe
-        if-no-files-found: error
-        retention-days: 1
 
   publish-x64-win:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml


### PR DESCRIPTION
## Summary

- Adds a new `build-siso-windows` job on `ubuntu-latest` that runs in parallel with `checkout-windows` in both `build.yml` and `windows-publish.yml`. It resolves the pinned `siso_version` by reading `chromium_version` from our `DEPS` and pulling the Chromium mirror's `DEPS` at that ref, shallow-clones `chromium.googlesource.com/build` at that SHA, applies the patches under `.github/siso-patches/` via `git am --3way`, and cross-compiles `siso.exe` for `windows/amd64`.
- Caches the built binary via `actions/cache` keyed on the siso revision + `sha256` of the patch contents, so subsequent runs skip the clone/patch/Go-setup/build steps entirely on a hit. The artifact is uploaded unconditionally so downstream Windows jobs can consume it regardless.
- Windows build/publish jobs (`windows-x64`, `windows-x86`, `windows-arm64`, `publish-*-win`) now `needs: [checkout-windows, build-siso-windows]`, download the artifact into `$RUNNER_TEMP/siso/siso.exe`, and export `SISO_PATH` — which `depot_tools/siso.py` already honors — so the patched binary is used instead of the CIPD-pinned one.

## Why

Our Windows Chromium builds intermittently abort the manifest load with `'The parameter is incorrect.'` (`ERROR_INVALID_PARAMETER`) coming out of `bindflt.sys` when `out/` is a mapped directory inside the Windows container. The root cause is a handle-relative `NtCreateFile` race in `siso/toolsupport/ninjautil/file_parser.go`: each subninja is opened once in the outer goroutine and again per chunk for `ReadAt`. `(*os.File).ReadAt` is documented as safe for concurrent use (on Windows it's `ReadFile` with an `OVERLAPPED` offset, so no shared seek state), so the extra open is redundant. Removing it halves `CreateFileW` calls per subninja and eliminates the overlapping opens that trigger the bindflt race.

The patch sits in `.github/siso-patches/` so bumping it goes through normal PR review in this repo.

## Test plan

- [x] `build-siso-windows` succeeds on this PR: resolves the chromium / siso SHAs, applies the patch, cross-compiles `siso.exe`, uploads `siso-windows-amd64`.
- [x] Re-run the workflow on the same SHA and confirm the cache is restored (`cache-hit == 'true'`) and the clone/patch/go-build steps are skipped.
- [x] `windows-x64`, `windows-x86`, and `windows-arm64` all download the artifact, log `Using custom siso binary at ...`, and `depot_tools/siso.py` prints `Using Siso binary from SISO_PATH:` at the start of the build.
- [x] Confirm the `ERROR_INVALID_PARAMETER` manifest-load failures no longer reproduce on a handful of reruns of the Windows build jobs.
- [x] `node script/copy-pipeline-segment-publish.js --check` passes (the autogenerated publish pipeline stays in sync with its base).

Notes: none