### PR TITLE
docs: remove obsolete websql from clearStorageData storages list

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -650,7 +650,7 @@ Clears the session’s HTTP cache.
     `scheme://host:port`.
   * `storages` string[] (optional) - The types of storages to clear, can be
     `cookies`, `filesystem`, `indexdb`, `localstorage`,
-    `shadercache`, `websql`, `serviceworkers`, `cachestorage`. If not
+    `shadercache`, `serviceworkers`, `cachestorage`. If not
     specified, clear all storage types.
 
 Returns `Promise<void>` - resolves when the storage data has been cleared.


### PR DESCRIPTION
#### Description of Change

The documentation for [`ses.clearStorageData([options])`](https://github.com/electron/electron/blob/main/docs/api/session.md#sesclearstoragedataoptions) lists `websql` as a valid value for the `storages` option. Passing `websql` no longer has any effect:

- WebSQL support was removed upstream in Chromium and the user-facing deprecation is captured in [`breaking-changes.md`](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) under "Removed: `WebSQL` support" (Electron 31).
- The `"websql"` key was subsequently removed from the storage-type lookup in `Session::ClearStorageData()` during the Chromium 126 bump (#41868, commit 9b0409f7c), but the matching entry in `docs/api/session.md` was left in place.

This PR removes `websql` from the documented list so the docs match the actual behavior of the API.

Refs #33900

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none