### PR TITLE
fix: preserve mouse hook handle when UnhookWindowsHookEx fails

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -6,6 +6,7 @@
 #include <shellapi.h>
 #include <wrl/client.h>
 
+#include "base/logging.h"
 #include "base/win/atl.h"  // Must be before UIAutomationCore.h
 #include "base/win/registry.h"
 #include "base/win/scoped_handle.h"
@@ -684,7 +685,13 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
       if (UnhookWindowsHookEx(mouse_hook_)) {
         mouse_hook_ = nullptr;
       } else {
-        PLOG(WARNING) << "Failed to unhook low-level mouse hook";
+        const DWORD error = ::GetLastError();
+        if (error == ERROR_INVALID_HOOK_HANDLE) {
+          mouse_hook_ = nullptr;
+        } else {
+          LOG(WARNING) << "Failed to unhook low-level mouse hook: "
+                       << logging::SystemErrorCodeToString(error);
+        }
       }
     }
   }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -677,8 +677,15 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
     RemoveWindowSubclass(legacy_window_, SubclassProc, 1);
 
     if (forwarding_windows_->empty()) {
-      UnhookWindowsHookEx(mouse_hook_);
-      mouse_hook_ = nullptr;
+      // If UnhookWindowsHookEx fails, the hook is still installed in the
+      // system. Leave |mouse_hook_| pointing at the existing hook so that a
+      // subsequent SetForwardMouseMessages(true) reuses it instead of
+      // installing a duplicate hook.
+      if (UnhookWindowsHookEx(mouse_hook_)) {
+        mouse_hook_ = nullptr;
+      } else {
+        PLOG(WARNING) << "Failed to unhook low-level mouse hook";
+      }
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

`NativeWindowViews::SetForwardMouseMessages()` installs a low-level mouse hook via `SetWindowsHookEx(WH_MOUSE_LL, ...)` when mouse forwarding begins, and unhooks it once no window needs forwarding. The previous code reset the shared `mouse_hook_` handle to `nullptr` unconditionally after calling `UnhookWindowsHookEx`, even when the unhook call failed:

```cpp
if (forwarding_windows_->empty()) {
  UnhookWindowsHookEx(mouse_hook_);
  mouse_hook_ = nullptr;
}
```

Per the [UnhookWindowsHookEx documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-unhookwindowshookex), a failure (`FALSE` return) means the hook is still installed in the system. Because `mouse_hook_` was nulled out regardless, the next call to `SetForwardMouseMessages(true)` would evaluate `if (!mouse_hook_)` as true and install a second hook via `SetWindowsHookEx`, leading to duplicate `MouseHookProc` invocations for every mouse message.

This PR checks the return value of `UnhookWindowsHookEx` and only nulls `mouse_hook_` on success. When the call fails, the handle is left pointing at the still-installed hook so the next activation reuses it instead of stacking a new one on top, and the failure is logged via `PLOG(WARNING)` to surface the underlying Windows error.

Fixes #51064

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Windows where a transient `UnhookWindowsHookEx` failure in `setIgnoreMouseEvents(true, { forward: true })` teardown could cause duplicate low-level mouse hooks to be installed on the next activation.