### PR TITLE
docs: note Linux performance characteristics of getApplicationNameForProtocol

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -882,6 +882,13 @@ Returns `string` - Name of the application handling the protocol, or an empty
 This method returns the application name of the default handler for the protocol
 (aka URI scheme) of a URL.
 
+> [!NOTE]
+> On Linux this method resolves the handler by spawning `xdg-mime query
+> default` and waiting for it to exit, which is significantly slower than
+> the system APIs used on macOS (`LSCopyDefaultApplicationURLForURL`) and
+> Windows (`AssocQueryString`). Callers that invoke this method on a hot
+> path should cache the result.
+
 ### `app.getApplicationInfoForProtocol(url)` _macOS_ _Windows_
 
 * `url` string - a URL with the protocol name to check. Unlike the other


### PR DESCRIPTION
#### Description of Change

The Linux implementation of [`Browser::GetApplicationNameForProtocol()`](https://github.com/electron/electron/blob/main/shell/browser/browser_linux.cc#L137-L143) invokes `xdg-mime query default` via `base::GetAppOutputWithExitCode`, which spawns a subprocess and blocks on its exit. macOS (via `LSCopyDefaultApplicationURLForURL` in `browser_mac.mm`) and Windows (via `AssocQueryString` in `browser_win.cc`) both resolve the default handler in-process through system APIs, so the Linux path is orders of magnitude slower.

This performance gap is easy to miss when development and testing happen primarily on macOS or Windows, and it can bite apps that call the API on a hot path (for example, when determining the handler for every outbound link).

This PR adds a note to the API documentation describing the difference and recommending that callers on hot paths cache the result, so app developers can avoid repeated slow invocations on Linux without needing to read the platform-specific implementations.

Refs #49727

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none