### PR TITLE
fix: fix types in devtools console for release

### DIFF
--- a/patches/devtools_frontend/fix_context_selector_not_showing_execution_contexts.patch
+++ b/patches/devtools_frontend/fix_context_selector_not_showing_execution_contexts.patch
@@ -11,7 +11,7 @@ were not rendered while still taking space in the dropdown.
 Pending CL: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7761316
 
 diff --git a/front_end/panels/console/ConsoleContextSelector.ts b/front_end/panels/console/ConsoleContextSelector.ts
-index f933dbd6dbdfadd2ea8b78e473d9506350825037..09f590fff0263875b1727bdf7e8dd57a17603ee3 100644
+index f933dbd6dbdfadd2ea8b78e473d9506350825037..d8aa3f9811f1857a9b30231ed8ff59e709e3383c 100644
 --- a/front_end/panels/console/ConsoleContextSelector.ts
 +++ b/front_end/panels/console/ConsoleContextSelector.ts
 @@ -303,7 +303,7 @@ interface ViewInput {
@@ -19,7 +19,7 @@ index f933dbd6dbdfadd2ea8b78e473d9506350825037..09f590fff0263875b1727bdf7e8dd57a
  
  const DEFAULT_VIEW: View = (input, _output, target): void => {
 -  if (!input.title || !input.subtitle) {
-+  if (!input.title && !input.subtitle) {
++  if (!input.title) {
      render(nothing, target);
      return;
    }


### PR DESCRIPTION
#### Description of Change

Follow up to https://github.com/electron/electron/pull/51062. On release builds, we're seeing a type error on devtools context selectors. Our current patch differs from [the upstream CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7761316), which just removed the `!input.subtitle` check entirely, leaving only if (!input.title). The && version doesn't narrow input.title from string | undefined to string, hence the error on release.                    
                                                                                                   
This PR changes the patch to match upstream — if (!input.title) — which allows TypeScript to narrow `input.title` to string in the code that follows, resolving the type error. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
