### PR TITLE
fix: intermittent CI failure is-not-alwaysOnTop

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -321,8 +321,8 @@ void BaseWindow::OnWindowLeaveHtmlFullScreen() {
   Emit("leave-html-full-screen");
 }
 
-void BaseWindow::OnWindowAlwaysOnTopChanged() {
-  Emit("always-on-top-changed", IsAlwaysOnTop());
+void BaseWindow::OnWindowAlwaysOnTopChanged(const bool is_always_on_top) {
+  Emit("always-on-top-changed", is_always_on_top);
 }
 
 void BaseWindow::OnExecuteAppCommand(const std::string_view command_name) {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -91,7 +91,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowLeaveFullScreen() override;
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
-  void OnWindowAlwaysOnTopChanged() override;
+  void OnWindowAlwaysOnTopChanged(bool is_always_on_top) override;
   void OnExecuteAppCommand(std::string_view command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictValue& details) override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -596,8 +596,9 @@ void NativeWindow::NotifyWindowLeaveHtmlFullScreen() {
   observers_.Notify(&NativeWindowObserver::OnWindowLeaveHtmlFullScreen);
 }
 
-void NativeWindow::NotifyWindowAlwaysOnTopChanged() {
-  observers_.Notify(&NativeWindowObserver::OnWindowAlwaysOnTopChanged);
+void NativeWindow::NotifyWindowAlwaysOnTopChanged(const bool is_always_on_top) {
+  observers_.Notify(&NativeWindowObserver::OnWindowAlwaysOnTopChanged,
+                    is_always_on_top);
 }
 
 void NativeWindow::NotifyWindowExecuteAppCommand(

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -332,7 +332,7 @@ class NativeWindow : public views::WidgetDelegate {
   virtual void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
-  void NotifyWindowAlwaysOnTopChanged();
+  void NotifyWindowAlwaysOnTopChanged(bool is_always_on_top);
   void NotifyWindowExecuteAppCommand(std::string_view command_name);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      base::DictValue details);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -974,10 +974,9 @@ void NativeWindowMac::SetWindowLevel(int unbounded_level) {
   // a bug of Cocoa or macOS.
   SetMaximizable(was_maximizable_);
 
-  // This must be notified at the very end or IsAlwaysOnTop
-  // will not yet have been updated to reflect the new status
   if (did_z_order_level_change)
-    NativeWindow::NotifyWindowAlwaysOnTopChanged();
+    NativeWindow::NotifyWindowAlwaysOnTopChanged(z_order_level !=
+                                                 ui::ZOrderLevel::kNormal);
 }
 
 ui::ZOrderLevel NativeWindowMac::GetZOrderLevel() const {

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -94,7 +94,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowLeaveFullScreen() {}
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
-  virtual void OnWindowAlwaysOnTopChanged() {}
+  virtual void OnWindowAlwaysOnTopChanged(bool is_always_on_top) {}
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictValue& details) {}
   virtual void OnNewWindowForTab() {}

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1134,16 +1134,18 @@ bool NativeWindowViews::IsClosable() const {
 #endif
 }
 
-void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
+void NativeWindowViews::SetAlwaysOnTop(const ui::ZOrderLevel z_order,
                                        const std::string& level,
-                                       int relativeLevel) {
-  bool level_changed = z_order != widget()->GetZOrderLevel();
+                                       const int relativeLevel) {
+  const bool level_changed = z_order != widget()->GetZOrderLevel();
+  const bool always_on_top = z_order != ui::ZOrderLevel::kNormal;
+
   widget()->SetZOrderLevel(z_order);
 
 #if BUILDFLAG(IS_WIN)
   // Reset the placement flag.
   behind_task_bar_ = false;
-  if (z_order != ui::ZOrderLevel::kNormal) {
+  if (always_on_top) {
     // On macOS the window is placed behind the Dock for the following levels.
     // Re-use the same names on Windows to make it easier for the user.
     static constexpr auto levels = base::MakeFixedFlatSet<std::string_view>(
@@ -1153,10 +1155,8 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
 #endif
   MoveBehindTaskBarIfNeeded();
 
-  // This must be notified at the very end or IsAlwaysOnTop
-  // will not yet have been updated to reflect the new status
   if (level_changed)
-    NativeWindow::NotifyWindowAlwaysOnTopChanged();
+    NativeWindow::NotifyWindowAlwaysOnTopChanged(always_on_top);
 }
 
 ui::ZOrderLevel NativeWindowViews::GetZOrderLevel() const {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2863,6 +2863,27 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.setAlwaysOnTop(flag, level)', () => {
     let w: BrowserWindow;
+    const alwaysOnTopStressIterations = 1000;
+    const alwaysOnTopSettleTimeout = 5000;
+
+    const waitForAlwaysOnTop = async (alwaysOnTop: boolean, label: string) => {
+      try {
+        await waitUntil(() => w.isAlwaysOnTop() === alwaysOnTop, {
+          rate: 50,
+          timeout: alwaysOnTopSettleTimeout
+        });
+      } catch (error) {
+        throw new Error(`${label}: ${(error as Error).message}`);
+      }
+    };
+
+    const setAlwaysOnTopAndWaitForState = async (alwaysOnTop: boolean, label: string) => {
+      const alwaysOnTopChanged = once(w, 'always-on-top-changed') as Promise<[any, boolean]>;
+      w.setAlwaysOnTop(alwaysOnTop);
+      const [, emittedAlwaysOnTop] = await alwaysOnTopChanged;
+      expect(emittedAlwaysOnTop).to.equal(alwaysOnTop, `${label}: unexpected event payload`);
+      await waitForAlwaysOnTop(alwaysOnTop, label);
+    };
 
     afterEach(closeAllWindows);
 
@@ -2895,12 +2916,23 @@ describe('BrowserWindow module', () => {
     });
 
     it('causes the right value to be emitted on `always-on-top-changed`', async () => {
-      const alwaysOnTopChanged = once(w, 'always-on-top-changed') as Promise<[any, boolean]>;
       expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop');
-      w.setAlwaysOnTop(true);
-      const [, alwaysOnTop] = await alwaysOnTopChanged;
-      expect(alwaysOnTop).to.be.true('is not alwaysOnTop');
+      await setAlwaysOnTopAndWaitForState(true, 'single transition');
     });
+
+    ifit(process.platform === 'win32')(
+      'eventually becomes consistent with the emitted value after repeated transitions',
+      async function () {
+        this.timeout(120000);
+
+        expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop');
+
+        for (let i = 0; i < alwaysOnTopStressIterations; i++) {
+          await setAlwaysOnTopAndWaitForState(true, `iteration ${i + 1} enable`);
+          await setAlwaysOnTopAndWaitForState(false, `iteration ${i + 1} disable`);
+        }
+      }
+    );
 
     ifit(process.platform === 'darwin')('honors the alwaysOnTop level of a child window', () => {
       w = new BrowserWindow({ show: false });

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2863,7 +2863,6 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.setAlwaysOnTop(flag, level)', () => {
     let w: BrowserWindow;
-    const alwaysOnTopStressIterations = 1000;
     const alwaysOnTopSettleTimeout = 5000;
 
     const waitForAlwaysOnTop = async (alwaysOnTop: boolean, label: string) => {
@@ -2921,16 +2920,12 @@ describe('BrowserWindow module', () => {
     });
 
     ifit(process.platform === 'win32')(
-      'eventually becomes consistent with the emitted value after repeated transitions',
-      async function () {
-        this.timeout(120000);
-
+      'eventually becomes consistent with the emitted value after enable and disable transitions',
+      async () => {
         expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop');
 
-        for (let i = 0; i < alwaysOnTopStressIterations; i++) {
-          await setAlwaysOnTopAndWaitForState(true, `iteration ${i + 1} enable`);
-          await setAlwaysOnTopAndWaitForState(false, `iteration ${i + 1} disable`);
-        }
+        await setAlwaysOnTopAndWaitForState(true, 'enable');
+        await setAlwaysOnTopAndWaitForState(false, 'disable');
       }
     );
 


### PR DESCRIPTION
#### Description of Change

Fix a bug that's causing a rare test flake where browserWindow 's`always-on-top-changed` event fails with a `false` value for `alwaysOnTop` when it should be `true`.

Example of the failing test:

```
2026-04-16T16:47:09.0709515Z Failure in test: "BrowserWindow module BrowserWindow.setAlwaysOnTop(flag, level) causes the right value to be emitted on `always-on-top-changed`"
2026-04-16T16:47:09.2527662Z AssertionError: is not alwaysOnTop: expected false to be true
2026-04-16T16:47:09.2535903Z     at Context.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-browser-window-spec.ts:2705:37)
2026-04-16T16:47:09.2536975Z Retrying test (1/3)...
2026-04-16T16:47:09.2898545Z Failure in test: "BrowserWindow module BrowserWindow.setAlwaysOnTop(flag, level) causes the right value to be emitted on `always-on-top-changed`"
2026-04-16T16:47:09.2904705Z AssertionError: is not alwaysOnTop: expected false to be true
2026-04-16T16:47:09.2917258Z     at Context.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-browser-window-spec.ts:2705:37)
2026-04-16T16:47:09.2918146Z Retrying test (2/3)...
2026-04-16T16:47:09.3170389Z Failure in test: "BrowserWindow module BrowserWindow.setAlwaysOnTop(flag, level) causes the right value to be emitted on `always-on-top-changed`"
2026-04-16T16:47:09.3175687Z AssertionError: is not alwaysOnTop: expected false to be true
2026-04-16T16:47:09.3184716Z     at Context.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-browser-window-spec.ts:2705:37)
2026-04-16T16:47:09.3282882Z Retrying test (3/3)...
2026-04-16T16:47:09.3657525Z not ok 488 BrowserWindow module BrowserWindow.setAlwaysOnTop(flag, level) causes the right value to be emitted on `always-on-top-changed`
2026-04-16T16:47:09.3668563Z   is not alwaysOnTop: expected false to be true
2026-04-16T16:47:09.3691272Z   AssertionError: is not alwaysOnTop: expected false to be true
2026-04-16T16:47:09.3702970Z       at Context.<anonymous> (electron\spec\api-browser-window-spec.ts:2705:37)
```

I think it's realated to the native window calls we make on win32. `NativeWindowViews::SetAlwaysOnTop()` calls `SetZOrderLevel()` which calls `::SetWindowPos()`. It also calls `MoveBehindTaskBarIfNeeded()`, which also calls `::SetWindowPos()`. Then we immediately query the native window for its state.

This may be a followup to a previous bug: 504407c5df7c317e5647b3eb21d1cf3fa7b04309 added a comment about deferring event emission until the end of `SetAlwaysOnTop()` to ensure that IsAlwaysOnTop() 's been updated. It looks like this was a good change, but the test still fails sometimes.

This PR takes a different approach: we already know what the value will be when all of the HWND events settle, so just use that value.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed bug that could occasionally cause browserWindow's `always-on-top-changed` even to fire with incorrect values.