### PR TITLE
fix: linux test shutdown error "AttributeError: type object 'DBusTestCase' has no attribute 'stop_dbus'"

### DIFF
--- a/script/dbus_mock.py
+++ b/script/dbus_mock.py
@@ -8,9 +8,16 @@ from dbusmock import DBusTestCase
 
 from lib.config import is_verbose_mode
 
+
 def stop():
-    DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
-    DBusTestCase.stop_dbus(DBusTestCase.session_bus_pid)
+    if hasattr(DBusTestCase, 'stop_dbus'):
+        if DBusTestCase.system_bus_pid is not None:
+            DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
+        if DBusTestCase.session_bus_pid is not None:
+            DBusTestCase.stop_dbus(DBusTestCase.session_bus_pid)
+    else:
+        DBusTestCase.tearDownClass()
+
 
 def start():
     with sys.stdout if is_verbose_mode() \
@@ -20,6 +27,7 @@ def start():
 
         DBusTestCase.start_session_bus()
         DBusTestCase.spawn_server_template('notification_daemon', None, log)
+
 
 if __name__ == '__main__':
     start()


### PR DESCRIPTION
#### Description of Change

Fix an error that occurs when running tests locally on Linux:

> [656501:0417/111056.022805:ERROR:base/process/process_posix.cc:313] Unable to terminate process 656553: No such process (3)
Traceback (most recent call last):
  File "/home/charles/electron/gn/main/src/electron/script/dbus_mock.py", line 29, in <module>
    stop()
    ~~~~^^
  File "/home/charles/electron/gn/main/src/electron/script/dbus_mock.py", line 12, in stop
    DBusTestCase.stop_dbus(DBusTestCase.system_bus_pid)
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'DBusTestCase' has no attribute 'stop_dbus'

`stop_dbus()` was removed on 2025-09-14 by https://github.com/martinpitt/python-dbusmock/commit/99c4800e9eed27f3d26c28ba827fdb4b40c7b616. I think CI isn't seeing this yet because its image has an older version, but it hits when running manually. I've patched the script s.t. it should work on both old and new versions of python-dbusmock.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed test scaffolding bug when running tests locally on Linux.