### PR TITLE
feat: windows notification history

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -76,25 +76,37 @@ app.whenReady().then(() => {
 })
 ```
 
-#### `Notification.getHistory()` _macOS_
+#### `Notification.getHistory()` _macOS_ _Windows_
 
-Returns `Promise<Notification[]>` - Resolves with an array of `Notification` objects representing all delivered notifications still present in Notification Center.
+Returns `Promise<Notification[]>` - Resolves with an array of `Notification` objects representing all delivered notifications still present in Notification Center (macOS) or Action Center (Windows).
 
-Each returned `Notification` is a live object connected to the corresponding delivered notification. Interaction events (`click`, `reply`, `action`, `close`) will fire on these objects when the user interacts with the notification in Notification Center. This is useful after an app restart to re-attach event handlers to notifications from a previous session.
+Each returned `Notification` is a live object connected to the corresponding delivered notification. Interaction events (`click`, `reply`, `action`, `close`) will fire on these objects when the user interacts with the notification. This is useful after an app restart to re-attach event handlers to notifications from a previous session.
 
-The returned notifications have their `id`, `groupId`, `title`, `subtitle`, and `body` properties populated from information available in the Notification Center. Other properties (e.g., `actions`, `silent`, `icon`) are not available from delivered notifications and will have default values.
+The returned notifications have their `id`, `groupId`, `title`, and `body` properties populated from the platform. On macOS, `subtitle` is also populated. Other properties (e.g., `actions`, `silent`, `icon`) are not available from delivered notifications and will have default values.
 
 > [!NOTE]
-> Like all macOS notification APIs, this method requires the application to be
-> code-signed. In unsigned development builds, notifications are not delivered
-> to Notification Center and this method will resolve with an empty array.
+> On macOS, this method requires the application to be code-signed. In unsigned
+> development builds, notifications are not delivered to Notification Center and
+> this method will resolve with an empty array.
+
+> [!NOTE]
+> On Windows, notifications that have been dismissed by the user or have expired
+> are no longer present in Action Center and will not appear in the results.
+> Electron automatically injects the notification's `id` and `groupId` into the
+> toast's `launch` attribute so that click events are routed to the correct
+> restored object. This works for both built-in and custom `toastXml`
+> notifications.
+
+> [!NOTE]
+> On Windows, restored notifications receive interaction events directly — there
+> is no need to call `show()`. On macOS, calling `show()` on a restored
+> notification is required to re-register it for events; this will remove the
+> original from Notification Center and post a new one with the same properties.
 
 > [!NOTE]
 > Unlike notifications created with `new Notification()`, notifications returned
-> by `getHistory()` will remain visible in Notification Center when the object
-> is garbage collected. Calling `show()` on a restored notification will remove
-> the original from Notification Center and post a new one with the same
-> properties.
+> by `getHistory()` will remain visible in Notification Center / Action Center
+> when the object is garbage collected.
 
 ```js
 const { Notification, app } = require('electron')
@@ -333,7 +345,8 @@ shown notification and create a new one with identical properties.
 
 On macOS, calling `show()` on a notification returned by `Notification.getHistory()` will
 remove the original notification from Notification Center and post a new one with the same
-properties.
+properties. On Windows, calling `show()` on a restored notification is a no-op — interaction
+events are routed to the restored object automatically without needing to re-show it.
 
 ```js
 const { Notification, app } = require('electron')

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -98,10 +98,15 @@ The returned notifications have their `id`, `groupId`, `title`, and `body` prope
 > notifications.
 
 > [!NOTE]
-> On Windows, restored notifications receive interaction events directly — there
-> is no need to call `show()`. On macOS, calling `show()` on a restored
-> notification is required to re-register it for events; this will remove the
-> original from Notification Center and post a new one with the same properties.
+> For objects returned by `getHistory()`, `show()` is a no-op on every platform:
+> the main-process `Notification::Show()` implementation in
+> `shell/browser/api/electron_api_notification.cc` returns immediately when the
+> instance was restored (`is_restored_`), so native `show()` is never invoked.
+> That keeps the delivered notification in place while the object stays
+> connected for interaction events (Windows routes activations via the toast
+> `launch` payload; macOS uses `Restore()` plus the notification center
+> delegate). Calling `show()` on a non-restored notification still posts or
+> replaces a notification as usual.
 
 > [!NOTE]
 > Unlike notifications created with `new Notification()`, notifications returned
@@ -343,10 +348,10 @@ call this method before the OS will display it.
 If the notification has been shown before, this method will dismiss the previously
 shown notification and create a new one with identical properties.
 
-On macOS, calling `show()` on a notification returned by `Notification.getHistory()` will
-remove the original notification from Notification Center and post a new one with the same
-properties. On Windows, calling `show()` on a restored notification is a no-op — interaction
-events are routed to the restored object automatically without needing to re-show it.
+For a notification returned by `Notification.getHistory()`, this method does nothing:
+the instance is marked restored and `show()` returns before touching the platform
+notification, so the entry stays in Notification Center / Action Center and
+interaction events keep routing to the same object.
 
 ```js
 const { Notification, app } = require('electron')

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -56,7 +56,7 @@ The callback remains registered until replaced by another call to `handleActivat
 This provides a centralized way to handle notification interactions that works in all scenarios:
 
 * Cold start (app launched from notification click)
-* Notifications persisted in AC that have no in-memory representation after app re-start
+* Notifications still in Action Center after the app restarts, with no in-memory `Notification` object
 * Notification object was garbage collected
 * Notification object is still in memory (callback is invoked in addition to instance events)
 
@@ -92,26 +92,25 @@ The returned notifications have their `id`, `groupId`, `title`, and `body` prope
 > [!NOTE]
 > On Windows, notifications that have been dismissed by the user or have expired
 > are no longer present in Action Center and will not appear in the results.
-> Electron automatically injects the notification's `id` and `groupId` into the
-> toast's `launch` attribute so that click events are routed to the correct
-> restored object. This works for both built-in and custom `toastXml`
-> notifications.
 
 > [!NOTE]
-> For objects returned by `getHistory()`, `show()` is a no-op on every platform:
-> the main-process `Notification::Show()` implementation in
-> `shell/browser/api/electron_api_notification.cc` returns immediately when the
-> instance was restored (`is_restored_`), so native `show()` is never invoked.
-> That keeps the delivered notification in place while the object stays
-> connected for interaction events (Windows routes activations via the toast
-> `launch` payload; macOS uses `Restore()` plus the notification center
-> delegate). Calling `show()` on a non-restored notification still posts or
-> replaces a notification as usual.
+> On Windows, set `id` and `groupId` when you show notifications so you can
+> match user interactions to your data. If the app may handle a notification
+> before you call `getHistory()` (for example, after a cold start from Action
+> Center), register `Notification.handleActivation()` early in startup. If you
+> use a custom `toastXml`, put `id` and `groupId` in the toast `launch` attribute
+> if you need them in the activation payload.
 
 > [!NOTE]
-> Unlike notifications created with `new Notification()`, notifications returned
-> by `getHistory()` will remain visible in Notification Center / Action Center
-> when the object is garbage collected.
+> `getHistory()` does not post new notifications. It returns objects for
+> deliveries already in Notification Center / Action Center (for example, after
+> an app restart). Calling `show()` on those objects has no effect. A notification
+> created with `new Notification()` and `show()` also remains in the center until
+> the user dismisses it or it expires; releasing the JavaScript object does not
+> remove it from the center, but instance events (`click`, `reply`, `action`) only
+> fire while you keep a reference to that object, or after you obtain a new object
+> from `getHistory()` or handle the interaction with `handleActivation()` on
+> Windows.
 
 ```js
 const { Notification, app } = require('electron')
@@ -348,10 +347,9 @@ call this method before the OS will display it.
 If the notification has been shown before, this method will dismiss the previously
 shown notification and create a new one with identical properties.
 
-For a notification returned by `Notification.getHistory()`, this method does nothing:
-the instance is marked restored and `show()` returns before touching the platform
-notification, so the entry stays in Notification Center / Action Center and
-interaction events keep routing to the same object.
+For a notification returned by `Notification.getHistory()`, this method does
+nothing. The notification is already in Notification Center / Action Center;
+listen for events on the object returned from `getHistory()` instead.
 
 ```js
 const { Notification, app } = require('electron')

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -420,8 +420,7 @@ async function installSpecModules(dir) {
   const { status } = childProcess.spawnSync(process.execPath, yarnArgs, {
     env,
     cwd: dir,
-    stdio: 'inherit',
-    shell: process.platform === 'win32'
+    stdio: 'inherit'
   });
   if (status !== 0 && !process.env.IGNORE_YARN_INSTALL_ERROR) {
     console.log(`${fail} Failed to yarn install in '${dir}'`);

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -102,12 +102,21 @@ Notification::Notification(gin::Arguments* args) {
 
 Notification::Notification(const NotificationInfo& info)
     : id_(info.id),
-      group_id_(info.group_id),
+      raw_group_id_(info.group_id),
       title_(base::UTF8ToUTF16(info.title)),
       subtitle_(base::UTF8ToUTF16(info.subtitle)),
       body_(base::UTF8ToUTF16(info.body)),
       is_restored_(true),
-      presenter_(nullptr) {}
+      presenter_(nullptr) {
+#if BUILDFLAG(IS_WIN)
+  // Filter out the Windows default group ("Notifications") from the
+  // JS-visible groupId — it's an internal implementation detail.
+  if (raw_group_id_ != "Notifications")
+    group_id_ = raw_group_id_;
+#else
+  group_id_ = raw_group_id_;
+#endif
+}
 
 Notification::~Notification() {
   if (notification_) {
@@ -441,8 +450,8 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
           // by a WeakPtr (API -> platform) and a raw delegate pointer
           // (platform -> API, cleared in ~Notification).
           auto* notif = new Notification(info);
-          notif->notification_ =
-              presenter->CreateNotification(notif, notif->id_);
+          notif->notification_ = presenter->CreateNotification(
+              notif, notif->id_, notif->raw_group_id_);
           if (notif->notification_)
             notif->notification_->Restore();
 

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -67,6 +67,25 @@ struct Converter<electron::NotificationAction> {
 
 }  // namespace gin
 
+#if BUILDFLAG(IS_WIN)
+namespace {
+
+// Windows appends id/groupId into the toast launch string as key=value pairs;
+// reject delimiter and control bytes so values cannot spoof extra pairs.
+bool NotificationIdOrGroupContainsInvalidWindowsToastChars(
+    const std::string& s) {
+  for (unsigned char c : s) {
+    if (c == '&' || c == '=')
+      return true;
+    if (c < 0x20 || c == 0x7f)
+      return true;
+  }
+  return false;
+}
+
+}  // namespace
+#endif
+
 namespace electron::api {
 
 gin::DeprecatedWrapperInfo Notification::kWrapperInfo = {
@@ -146,6 +165,17 @@ gin_helper::Handle<Notification> Notification::New(
 #if BUILDFLAG(IS_WIN)
   constexpr size_t kMaxTagLength = 64;
   auto* notif = handle.get();
+  if (NotificationIdOrGroupContainsInvalidWindowsToastChars(notif->id_)) {
+    thrower.ThrowError(
+        "Notification id cannot contain '&', '=', or control characters");
+    return {};
+  }
+  if (NotificationIdOrGroupContainsInvalidWindowsToastChars(notif->group_id_)) {
+    thrower.ThrowError(
+        "Notification groupId cannot contain '&', '=', or control "
+        "characters");
+    return {};
+  }
   if (!notif->id_.empty() &&
       base::UTF8ToWide(notif->id_).length() > kMaxTagLength) {
     thrower.ThrowError(

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -96,8 +96,9 @@ Notification::Notification(gin::Arguments* args) {
     opts.Get("toastXml", &toast_xml_);
   }
 
-  if (id_.empty())
-    id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
+    if (id_.empty())
+      id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
+  }
 }
 
 Notification::Notification(const NotificationInfo& info)

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -96,9 +96,8 @@ Notification::Notification(gin::Arguments* args) {
     opts.Get("toastXml", &toast_xml_);
   }
 
-    if (id_.empty())
-      id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
-  }
+  if (id_.empty())
+    id_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
 }
 
 Notification::Notification(const NotificationInfo& info)

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -30,6 +30,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/notifications/win/windows_toast_activator.h"
+#include "shell/browser/notifications/win/windows_toast_constants.h"
 #endif
 
 namespace gin {
@@ -128,9 +129,9 @@ Notification::Notification(const NotificationInfo& info)
       is_restored_(true),
       presenter_(nullptr) {
 #if BUILDFLAG(IS_WIN)
-  // Filter out the Windows default group ("Notifications") from the
-  // JS-visible groupId — it's an internal implementation detail.
-  if (raw_group_id_ != "Notifications")
+  // Filter out the WinRT default group (kWindowsToastDefaultGroupUtf8) from the
+  // JS-visible groupId — it's an internal implementation detail when unset.
+  if (raw_group_id_ != kWindowsToastDefaultGroupUtf8)
     group_id_ = raw_group_id_;
 #else
   group_id_ = raw_group_id_;
@@ -545,6 +546,13 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
+#if BUILDFLAG(IS_WIN)
+  // Loaded when the app first accesses `electron.Notification` (see
+  // lib/browser/api/module-list.ts). Register COM so toast activations hit this
+  // process without also calling handleActivation or getHistory.
+  electron::NotificationActivator::RegisterActivator();
+#endif
+
   v8::Isolate* const isolate = electron::JavascriptEnvironment::GetIsolate();
   gin_helper::Dictionary dict{isolate, exports};
   dict.Set("Notification", Notification::GetConstructor(isolate, context));

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -122,6 +122,19 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
   void SetToastXml(const std::u16string& new_toast_xml);
 
  private:
+  // Identity / grouping (native mirror on `electron::Notification` after
+  // `show()` is `notification_id_` / `notification_group_`):
+  //
+  // - id_: JavaScript `id` — toast tag / stable key (history, activations).
+  // - group_id_: JavaScript `groupId` from the constructor; for instances
+  //   restored via `getHistory()` it is the developer-visible value (e.g. on
+  //   Windows the WinRT default group may be filtered out so this stays empty
+  //   when the app never set a group).
+  // - raw_group_id_: Only used for `getHistory()` restores. Exact group string
+  //   returned by the platform before that filtering. Passed into
+  //   `CreateNotification(..., notification_group)` so the native object still
+  //   matches the delivered toast even when `group_id_` is cleared for JS.
+  // - group_title_: JavaScript `groupTitle` (toast header text).
   std::string id_;
   std::string group_id_;
   std::string raw_group_id_;

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -124,6 +124,7 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
  private:
   std::string id_;
   std::string group_id_;
+  std::string raw_group_id_;
   std::u16string group_title_;
   std::u16string title_;
   std::u16string subtitle_;

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -128,8 +128,8 @@ class Notification final : public gin_helper::DeprecatedWrappable<Notification>,
   // - id_: JavaScript `id` — toast tag / stable key (history, activations).
   // - group_id_: JavaScript `groupId` from the constructor; for instances
   //   restored via `getHistory()` it is the developer-visible value (e.g. on
-  //   Windows the WinRT default group may be filtered out so this stays empty
-  //   when the app never set a group).
+  //   Windows kWindowsToastDefaultGroupUtf8 may be filtered out so this stays
+  //   empty when the app never set a group).
   // - raw_group_id_: Only used for `getHistory()` restores. Exact group string
   //   returned by the platform before that filtering. Passed into
   //   `CreateNotification(..., notification_group)` so the native object still

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -33,6 +33,7 @@
 #include "shell/browser/badging/badge_manager.h"
 #include "shell/browser/electron_browser_main_parts.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/browser/notifications/win/windows_toast_activator.h"
 #include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/jump_list.h"
 #include "shell/browser/window_list.h"
@@ -401,6 +402,7 @@ std::vector<std::string> Browser::GetRecentDocuments() {
 
 void Browser::SetAppUserModelID(const std::wstring& name) {
   electron::SetAppUserModelID(name);
+  NotificationActivator::RegisterActivator();
 }
 
 bool Browser::SetUserTasks(const std::vector<UserTask>& tasks) {

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -111,11 +111,15 @@ class Notification {
 
   void set_delegate(NotificationDelegate* delegate) { delegate_ = delegate; }
   void set_notification_id(const std::string& id) { notification_id_ = id; }
+  void set_notification_group(const std::string& group) {
+    notification_group_ = group;
+  }
   void set_is_dismissed(bool dismissed) { is_dismissed_ = dismissed; }
 
   NotificationDelegate* delegate() const { return delegate_; }
   NotificationPresenter* presenter() const { return presenter_; }
   const std::string& notification_id() const { return notification_id_; }
+  const std::string& notification_group() const { return notification_group_; }
   bool is_dismissed() const { return is_dismissed_; }
 
   // disable copy
@@ -130,6 +134,7 @@ class Notification {
   raw_ptr<NotificationDelegate> delegate_;
   raw_ptr<NotificationPresenter> presenter_;
   std::string notification_id_;
+  std::string notification_group_;
   bool is_dismissed_ = false;
 
   base::WeakPtrFactory<Notification> weak_factory_{this};

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -19,9 +19,11 @@ NotificationPresenter::~NotificationPresenter() {
 
 base::WeakPtr<Notification> NotificationPresenter::CreateNotification(
     NotificationDelegate* delegate,
-    const std::string& notification_id) {
+    const std::string& notification_id,
+    const std::string& notification_group) {
   Notification* notification = CreateNotificationObject(delegate);
   notification->set_notification_id(notification_id);
+  notification->set_notification_group(notification_group);
   notifications_.insert(notification);
   return notification->GetWeakPtr();
 }

--- a/shell/browser/notifications/notification_presenter.h
+++ b/shell/browser/notifications/notification_presenter.h
@@ -29,7 +29,8 @@ class NotificationPresenter {
 
   base::WeakPtr<Notification> CreateNotification(
       NotificationDelegate* delegate,
-      const std::string& notification_id);
+      const std::string& notification_id,
+      const std::string& notification_group = "");
   void CloseNotificationWithId(const std::string& notification_id);
 
   virtual void GetDeliveredNotifications(

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -11,10 +11,12 @@
 #include <vector>
 
 #include "base/files/file_util.h"
+#include "base/functional/bind.h"
 #include "base/hash/sha1.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "shell/browser/notifications/win/windows_toast_activator.h"
 #include "shell/browser/notifications/win/windows_toast_notification.h"
@@ -90,7 +92,25 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
 
 void NotificationPresenterWin::GetDeliveredNotifications(
     GetDeliveredNotificationsCallback callback) {
-  std::move(callback).Run(WindowsToastNotification::GetNotificationHistory());
+  scoped_refptr<base::SequencedTaskRunner> reply_runner =
+      base::SequencedTaskRunner::GetCurrentDefault();
+
+  WindowsToastNotification::GetToastTaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce(
+                     [](scoped_refptr<base::SequencedTaskRunner> reply_runner,
+                        GetDeliveredNotificationsCallback callback) {
+                       std::vector<NotificationInfo> history =
+                           WindowsToastNotification::GetNotificationHistory();
+                       reply_runner->PostTask(
+                           FROM_HERE,
+                           base::BindOnce(
+                               [](GetDeliveredNotificationsCallback cb,
+                                  std::vector<NotificationInfo> history) {
+                                 std::move(cb).Run(std::move(history));
+                               },
+                               std::move(callback), std::move(history)));
+                     },
+                     reply_runner, std::move(callback)));
 }
 
 Notification* NotificationPresenterWin::CreateNotificationObject(

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -88,6 +88,11 @@ std::wstring NotificationPresenterWin::SaveIconToFilesystem(
   return path.value();
 }
 
+void NotificationPresenterWin::GetDeliveredNotifications(
+    GetDeliveredNotificationsCallback callback) {
+  std::move(callback).Run(WindowsToastNotification::GetNotificationHistory());
+}
+
 Notification* NotificationPresenterWin::CreateNotificationObject(
     NotificationDelegate* delegate) {
   return new WindowsToastNotification(delegate, this);

--- a/shell/browser/notifications/win/notification_presenter_win.h
+++ b/shell/browser/notifications/win/notification_presenter_win.h
@@ -40,6 +40,10 @@ class NotificationPresenterWin : public NotificationPresenter {
 
   std::wstring SaveIconToFilesystem(const SkBitmap& icon, const GURL& origin);
 
+  // NotificationPresenter
+  void GetDeliveredNotifications(
+      GetDeliveredNotificationsCallback callback) override;
+
  private:
   // NotificationPresenter
   Notification* CreateNotificationObject(

--- a/shell/browser/notifications/win/windows_toast_activator.cc
+++ b/shell/browser/notifications/win/windows_toast_activator.cc
@@ -446,6 +446,7 @@ void HandleToastActivation(const std::wstring& invoked_args,
   std::wstring type;
   std::wstring action_index_str;
   std::wstring tag_str;
+  std::wstring group_str;
 
   for (const auto& token : base::SplitString(args, L"&", base::KEEP_WHITESPACE,
                                              base::SPLIT_WANT_NONEMPTY)) {
@@ -459,6 +460,8 @@ void HandleToastActivation(const std::wstring& invoked_args,
       action_index_str = kv[1];
     else if (kv[0] == L"tag")
       tag_str = kv[1];
+    else if (kv[0] == L"group")
+      group_str = kv[1];
   }
 
   int action_index = -1;
@@ -538,9 +541,14 @@ void HandleToastActivation(const std::wstring& invoked_args,
   handle_callback(activation_args);
 
   Notification* target = nullptr;
-  for (auto* n : presenter->notifications()) {
-    std::wstring tag = base::UTF8ToWide(n->notification_id());
-    if (tag == tag_str) {
+  if (!tag_str.empty()) {
+    std::string tag_utf8 = base::WideToUTF8(tag_str);
+    std::string group_utf8 = base::WideToUTF8(group_str);
+    for (auto* n : presenter->notifications()) {
+      if (n->notification_id() != tag_utf8)
+        continue;
+      if (!group_utf8.empty() && n->notification_group() != group_utf8)
+        continue;
       target = n;
       break;
     }

--- a/shell/browser/notifications/win/windows_toast_activator.cc
+++ b/shell/browser/notifications/win/windows_toast_activator.cc
@@ -328,9 +328,8 @@ NotificationActivator::~NotificationActivator() = default;
 
 // static
 void NotificationActivator::RegisterActivator() {
-  if (g_registered_ || g_registration_in_progress)
+  if (g_registration_in_progress)
     return;
-  g_registration_in_progress = true;
 
   // For packaged (MSIX) apps, COM server registration is handled via the app
   // manifest (com:Extension and desktop:ToastNotificationActivation), so we
@@ -340,6 +339,21 @@ void NotificationActivator::RegisterActivator() {
   // For unpackaged apps, we need to create the Start Menu shortcut with
   // AUMID/CLSID properties and register the COM server in the registry.
   bool is_packaged = IsRunningInDesktopBridge();
+
+  if (g_registered_) {
+    // App may call setAppUserModelId after early registration at launch.
+    if (!is_packaged) {
+      base::ThreadPool::PostTask(
+          FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
+          base::BindOnce([]() {
+            EnsureShortcut();
+            EnsureCLSIDRegistry();
+          }));
+    }
+    return;
+  }
+
+  g_registration_in_progress = true;
 
   // Perform all blocking filesystem / registry work off the UI thread.
   base::ThreadPool::PostTask(
@@ -382,6 +396,9 @@ void NotificationActivator::RegisterActivator() {
                   }
                   g_cookie_ = cookie;
                   g_registered_ = true;
+                  if (electron::debug_notifications) {
+                    LOG(INFO) << "Registered Windows toast COM activator";
+                  }
                 }));
           },
           is_packaged));
@@ -474,6 +491,22 @@ void HandleToastActivation(const std::wstring& invoked_args,
     std::wstring_view key_view(entry.key);
     if (key_view == L"reply") {
       reply_text = base::WideToUTF8(entry.value);
+    }
+  }
+
+  if (type == L"reply" && reply_text.empty()) {
+    bool has_user_input = false;
+    for (const auto& entry : inputs) {
+      if (!entry.key.empty() && !entry.value.empty()) {
+        has_user_input = true;
+        break;
+      }
+    }
+    if (!has_user_input) {
+      DebugLog(
+          "Ignoring reply activation without user input (duplicate COM/WinRT "
+          "delivery)");
+      return;
     }
   }
 

--- a/shell/browser/notifications/win/windows_toast_constants.h
+++ b/shell/browser/notifications/win/windows_toast_constants.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Electron contributors.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_CONSTANTS_H_
+#define ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_CONSTANTS_H_
+
+namespace electron {
+
+// Default WinRT toast Group when the app does not set groupId. Must be at most
+// 16 wchar_t units on Windows 10 before Creators Update (build 15063).
+inline constexpr wchar_t kWindowsToastDefaultGroup[] = L"Notifications";
+inline constexpr char kWindowsToastDefaultGroupUtf8[] = "Notifications";
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_NOTIFICATIONS_WIN_WINDOWS_TOAST_CONSTANTS_H_

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -250,6 +250,39 @@ bool WindowsToastNotification::Initialize() {
   }
 }
 
+namespace {
+
+// Converts a WinRT HSTRING to UTF-8 and always frees the HSTRING when non-null.
+std::string Utf8FromReleasedHString(HSTRING hs) {
+  if (!hs)
+    return {};
+  UINT32 len = 0;
+  const wchar_t* raw = WindowsGetStringRawBuffer(hs, &len);
+  std::string utf8;
+  if (raw && len)
+    utf8 = base::WideToUTF8(std::wstring_view(raw, len));
+  WindowsDeleteString(hs);
+  return utf8;
+}
+
+void FillToastTagAndGroupFromToast(
+    winui::Notifications::IToastNotification* toast,
+    NotificationInfo* info) {
+  ComPtr<winui::Notifications::IToastNotification2> toast2;
+  if (FAILED(toast->QueryInterface(IID_PPV_ARGS(&toast2))))
+    return;
+
+  HSTRING tag_hs = nullptr;
+  if (SUCCEEDED(toast2->get_Tag(&tag_hs)) && tag_hs)
+    info->id = Utf8FromReleasedHString(tag_hs);
+
+  HSTRING group_hs = nullptr;
+  if (SUCCEEDED(toast2->get_Group(&group_hs)) && group_hs)
+    info->group_id = Utf8FromReleasedHString(group_hs);
+}
+
+}  // namespace
+
 // static
 std::vector<NotificationInfo>
 WindowsToastNotification::GetNotificationHistory() {
@@ -321,26 +354,7 @@ WindowsToastNotification::GetNotificationHistory() {
 
     NotificationInfo info;
 
-    ComPtr<winui::Notifications::IToastNotification2> toast2;
-    if (SUCCEEDED(toast->QueryInterface(IID_PPV_ARGS(&toast2)))) {
-      HSTRING tag_hs = nullptr;
-      if (SUCCEEDED(toast2->get_Tag(&tag_hs)) && tag_hs) {
-        UINT32 len = 0;
-        const wchar_t* raw = WindowsGetStringRawBuffer(tag_hs, &len);
-        if (raw && len)
-          info.id = base::WideToUTF8(std::wstring_view(raw, len));
-        WindowsDeleteString(tag_hs);
-      }
-
-      HSTRING group_hs = nullptr;
-      if (SUCCEEDED(toast2->get_Group(&group_hs)) && group_hs) {
-        UINT32 len = 0;
-        const wchar_t* raw = WindowsGetStringRawBuffer(group_hs, &len);
-        if (raw && len)
-          info.group_id = base::WideToUTF8(std::wstring_view(raw, len));
-        WindowsDeleteString(group_hs);
-      }
-    }
+    FillToastTagAndGroupFromToast(toast.Get(), &info);
 
     ComPtr<IXmlDocument> xml_doc;
     if (SUCCEEDED(toast->get_Content(&xml_doc))) {
@@ -365,13 +379,7 @@ WindowsToastNotification::GetNotificationHistory() {
           HSTRING inner_text_hs = nullptr;
           if (SUCCEEDED(serializer->get_InnerText(&inner_text_hs)) &&
               inner_text_hs) {
-            UINT32 len = 0;
-            const wchar_t* raw = WindowsGetStringRawBuffer(inner_text_hs, &len);
-            std::string text;
-            if (raw && len)
-              text = base::WideToUTF8(std::wstring_view(raw, len));
-            WindowsDeleteString(inner_text_hs);
-
+            std::string text = Utf8FromReleasedHString(inner_text_hs);
             if (j == 0) {
               info.title = std::move(text);
             } else {

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -351,7 +351,9 @@ WindowsToastNotification::GetNotificationHistory() {
         UINT32 text_count = 0;
         text_nodes->get_Length(&text_count);
 
-        for (UINT32 j = 0; j < text_count && j < 2; j++) {
+        // ToastText04, ToastGeneric, etc. may have 3+ <text> nodes; keep the
+        // first as title and join the rest with newlines for body.
+        for (UINT32 j = 0; j < text_count; j++) {
           ComPtr<ABI::Windows::Data::Xml::Dom::IXmlNode> text_node;
           if (FAILED(text_nodes->Item(j, &text_node)))
             continue;
@@ -370,10 +372,13 @@ WindowsToastNotification::GetNotificationHistory() {
               text = base::WideToUTF8(std::wstring_view(raw, len));
             WindowsDeleteString(inner_text_hs);
 
-            if (j == 0)
+            if (j == 0) {
               info.title = std::move(text);
-            else if (j == 1)
-              info.body = std::move(text);
+            } else {
+              if (!info.body.empty())
+                info.body.push_back('\n');
+              info.body.append(text);
+            }
           }
         }
       }

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 
 #include <shlobj.h>
+#include <windows.foundation.collections.h>
 #include <wrl\wrappers\corewrappers.h>
 
 #include "base/containers/fixed_flat_map.h"
@@ -64,6 +65,38 @@ namespace {
 // This string needs to be max 16 characters to work on Windows 10 prior to
 // applying Creators Update (build 15063).
 constexpr wchar_t kGroup[] = L"Notifications";
+
+// Appends &tag=<id>&group=<group> to the launch attribute of the <toast>
+// element so the COM activator can route clicks to the correct Notification
+// object.  Works for both built-in and custom toastXml.
+void InjectLaunchIdentity(IXmlDocument* doc,
+                          const std::string& notification_id,
+                          const std::string& group_id) {
+  ComPtr<ABI::Windows::Data::Xml::Dom::IXmlElement> root;
+  if (FAILED(doc->get_DocumentElement(&root)) || !root)
+    return;
+
+  // Read the existing launch attribute (may be user-supplied).
+  ScopedHString launch_attr_name(L"launch");
+  HSTRING existing_hs = nullptr;
+  std::wstring existing;
+  if (SUCCEEDED(root->GetAttribute(launch_attr_name, &existing_hs)) &&
+      existing_hs) {
+    UINT32 len = 0;
+    const wchar_t* raw = WindowsGetStringRawBuffer(existing_hs, &len);
+    if (raw && len)
+      existing.assign(raw, len);
+    WindowsDeleteString(existing_hs);
+  }
+
+  std::wstring group_w = group_id.empty() ? kGroup : base::UTF8ToWide(group_id);
+  std::wstring suffix = base::UTF8ToWide(base::StrCat(
+      {"&tag=", notification_id, "&group=", base::WideToUTF8(group_w)}));
+
+  std::wstring new_launch = existing + suffix;
+  ScopedHString new_launch_hs(new_launch);
+  root->SetAttribute(launch_attr_name, new_launch_hs);
+}
 
 void DebugLog(std::string_view log_msg) {
   if (electron::debug_notifications)
@@ -157,6 +190,12 @@ ComPtr<winui::Notifications::IToastNotifier>*
     WindowsToastNotification::toast_notifier_ = nullptr;
 
 // static
+std::wstring& WindowsToastNotification::init_app_id() {
+  static base::NoDestructor<std::wstring> instance;
+  return *instance;
+}
+
+// static
 scoped_refptr<base::SequencedTaskRunner>
 WindowsToastNotification::GetToastTaskRunner() {
   // Use function-local static to avoid exit-time destructor warning
@@ -195,6 +234,7 @@ bool WindowsToastNotification::Initialize() {
   if (IsRunningInDesktopBridge()) {
     // Ironically, the Desktop Bridge / UWP environment
     // requires us to not give Windows an appUserModelId.
+    init_app_id().clear();
     return SUCCEEDED(
         (*toast_manager_)
             ->CreateToastNotifier(toast_notifier_->GetAddressOf()));
@@ -203,10 +243,146 @@ bool WindowsToastNotification::Initialize() {
     if (!GetAppUserModelID(&app_id))
       return false;
 
+    init_app_id() = GetRawAppUserModelID();
     return SUCCEEDED((*toast_manager_)
                          ->CreateToastNotifierWithId(
                              app_id, toast_notifier_->GetAddressOf()));
   }
+}
+
+// static
+std::vector<NotificationInfo>
+WindowsToastNotification::GetNotificationHistory() {
+  std::vector<NotificationInfo> results;
+
+  if (!toast_manager_) {
+    DebugLog("GetNotificationHistory: toast_manager_ is null");
+    return results;
+  }
+
+  ComPtr<winui::Notifications::IToastNotificationManagerStatics2>
+      toast_manager2;
+  if (FAILED(
+          (*toast_manager_)->QueryInterface(IID_PPV_ARGS(&toast_manager2)))) {
+    DebugLog(
+        "GetNotificationHistory: failed to get "
+        "IToastNotificationManagerStatics2");
+    return results;
+  }
+
+  ComPtr<winui::Notifications::IToastNotificationHistory> notification_history;
+  if (FAILED(toast_manager2->get_History(&notification_history))) {
+    DebugLog("GetNotificationHistory: failed to get IToastNotificationHistory");
+    return results;
+  }
+
+  ComPtr<winui::Notifications::IToastNotificationHistory2>
+      notification_history2;
+  if (FAILED(notification_history.As(&notification_history2))) {
+    DebugLog(
+        "GetNotificationHistory: failed to get IToastNotificationHistory2");
+    return results;
+  }
+
+  ComPtr<ABI::Windows::Foundation::Collections::IVectorView<
+      ABI::Windows::UI::Notifications::ToastNotification*>>
+      history_items;
+  HRESULT hr;
+
+  if (init_app_id().empty()) {
+    DebugLog(
+        "GetNotificationHistory: querying without app_id (Desktop Bridge)");
+    hr = notification_history2->GetHistory(&history_items);
+  } else {
+    DebugLog(base::StrCat({"GetNotificationHistory: querying with app_id: ",
+                           base::WideToUTF8(init_app_id())}));
+    ScopedHString app_id(init_app_id());
+    hr = notification_history2->GetHistoryWithId(app_id, &history_items);
+  }
+
+  if (FAILED(hr)) {
+    DebugLog(base::StrCat({"GetNotificationHistory: GetHistory failed",
+                           FailureResultToString(hr)}));
+    return results;
+  }
+
+  unsigned int count = 0;
+  if (FAILED(history_items->get_Size(&count)))
+    return results;
+
+  DebugLog(base::StrCat({"GetNotificationHistory: found ",
+                         base::NumberToString(count), " notifications"}));
+
+  results.reserve(count);
+  for (unsigned int i = 0; i < count; i++) {
+    ComPtr<winui::Notifications::IToastNotification> toast;
+    if (FAILED(history_items->GetAt(i, &toast)))
+      continue;
+
+    NotificationInfo info;
+
+    ComPtr<winui::Notifications::IToastNotification2> toast2;
+    if (SUCCEEDED(toast->QueryInterface(IID_PPV_ARGS(&toast2)))) {
+      HSTRING tag_hs = nullptr;
+      if (SUCCEEDED(toast2->get_Tag(&tag_hs)) && tag_hs) {
+        UINT32 len = 0;
+        const wchar_t* raw = WindowsGetStringRawBuffer(tag_hs, &len);
+        if (raw && len)
+          info.id = base::WideToUTF8(std::wstring_view(raw, len));
+        WindowsDeleteString(tag_hs);
+      }
+
+      HSTRING group_hs = nullptr;
+      if (SUCCEEDED(toast2->get_Group(&group_hs)) && group_hs) {
+        UINT32 len = 0;
+        const wchar_t* raw = WindowsGetStringRawBuffer(group_hs, &len);
+        if (raw && len)
+          info.group_id = base::WideToUTF8(std::wstring_view(raw, len));
+        WindowsDeleteString(group_hs);
+      }
+    }
+
+    ComPtr<IXmlDocument> xml_doc;
+    if (SUCCEEDED(toast->get_Content(&xml_doc))) {
+      ComPtr<ABI::Windows::Data::Xml::Dom::IXmlNodeList> text_nodes;
+      ScopedHString text_tag_name(L"text");
+      if (SUCCEEDED(
+              xml_doc->GetElementsByTagName(text_tag_name, &text_nodes))) {
+        UINT32 text_count = 0;
+        text_nodes->get_Length(&text_count);
+
+        for (UINT32 j = 0; j < text_count && j < 2; j++) {
+          ComPtr<ABI::Windows::Data::Xml::Dom::IXmlNode> text_node;
+          if (FAILED(text_nodes->Item(j, &text_node)))
+            continue;
+
+          ComPtr<ABI::Windows::Data::Xml::Dom::IXmlNodeSerializer> serializer;
+          if (FAILED(text_node.As(&serializer)))
+            continue;
+
+          HSTRING inner_text_hs = nullptr;
+          if (SUCCEEDED(serializer->get_InnerText(&inner_text_hs)) &&
+              inner_text_hs) {
+            UINT32 len = 0;
+            const wchar_t* raw = WindowsGetStringRawBuffer(inner_text_hs, &len);
+            std::string text;
+            if (raw && len)
+              text = base::WideToUTF8(std::wstring_view(raw, len));
+            WindowsDeleteString(inner_text_hs);
+
+            if (j == 0)
+              info.title = std::move(text);
+            else if (j == 1)
+              info.body = std::move(text);
+          }
+        }
+      }
+    }
+
+    results.push_back(std::move(info));
+  }
+
+  return results;
 }
 
 WindowsToastNotification::WindowsToastNotification(
@@ -343,6 +519,8 @@ bool WindowsToastNotification::CreateToastXmlDocument(
       return false;
     }
   }
+
+  InjectLaunchIdentity(toast_xml->Get(), notification_id, options.group_id);
   return true;
 }
 
@@ -475,6 +653,9 @@ void WindowsToastNotification::SetupAndShowOnUIThread(
 
   notif->toast_notification_ = notification;
   notif->group_id_ = group_id;
+  std::string effective_group =
+      group_id.empty() ? base::WideToUTF8(kGroup) : group_id;
+  notif->set_notification_group(effective_group);
 
   // Show notification on UI thread (must be called on UI thread)
   hr = (*toast_notifier_)->Show(notification.Get());

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -23,6 +23,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/synchronization/lock.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -181,6 +182,20 @@ constexpr char kXmlVersionHeader[] = "<?xml version=\"1.0\"?>\n";
 
 }  // namespace
 
+namespace {
+
+base::Lock& InitAppIdLock() {
+  static base::NoDestructor<base::Lock> lock;
+  return *lock;
+}
+
+std::wstring& InitAppIdMutable() {
+  static base::NoDestructor<std::wstring> storage;
+  return *storage;
+}
+
+}  // namespace
+
 // static
 ComPtr<winui::Notifications::IToastNotificationManagerStatics>*
     WindowsToastNotification::toast_manager_ = nullptr;
@@ -190,9 +205,21 @@ ComPtr<winui::Notifications::IToastNotifier>*
     WindowsToastNotification::toast_notifier_ = nullptr;
 
 // static
-std::wstring& WindowsToastNotification::init_app_id() {
-  static base::NoDestructor<std::wstring> instance;
-  return *instance;
+std::wstring WindowsToastNotification::GetInitAppIdCopy() {
+  base::AutoLock lock(InitAppIdLock());
+  return InitAppIdMutable();
+}
+
+// static
+void WindowsToastNotification::SetInitAppId(PCWSTR value) {
+  base::AutoLock lock(InitAppIdLock());
+  InitAppIdMutable() = value ? std::wstring(value) : std::wstring();
+}
+
+// static
+void WindowsToastNotification::ClearInitAppId() {
+  base::AutoLock lock(InitAppIdLock());
+  InitAppIdMutable().clear();
 }
 
 // static
@@ -234,7 +261,7 @@ bool WindowsToastNotification::Initialize() {
   if (IsRunningInDesktopBridge()) {
     // Ironically, the Desktop Bridge / UWP environment
     // requires us to not give Windows an appUserModelId.
-    init_app_id().clear();
+    ClearInitAppId();
     return SUCCEEDED(
         (*toast_manager_)
             ->CreateToastNotifier(toast_notifier_->GetAddressOf()));
@@ -243,7 +270,7 @@ bool WindowsToastNotification::Initialize() {
     if (!GetAppUserModelID(&app_id))
       return false;
 
-    init_app_id() = GetRawAppUserModelID();
+    SetInitAppId(GetRawAppUserModelID());
     return SUCCEEDED((*toast_manager_)
                          ->CreateToastNotifierWithId(
                              app_id, toast_notifier_->GetAddressOf()));
@@ -322,14 +349,15 @@ WindowsToastNotification::GetNotificationHistory() {
       history_items;
   HRESULT hr;
 
-  if (init_app_id().empty()) {
+  const std::wstring init_app_id = GetInitAppIdCopy();
+  if (init_app_id.empty()) {
     DebugLog(
         "GetNotificationHistory: querying without app_id (Desktop Bridge)");
     hr = notification_history2->GetHistory(&history_items);
   } else {
     DebugLog(base::StrCat({"GetNotificationHistory: querying with app_id: ",
-                           base::WideToUTF8(init_app_id())}));
-    ScopedHString app_id(init_app_id());
+                           base::WideToUTF8(init_app_id)}));
+    ScopedHString app_id(init_app_id);
     hr = notification_history2->GetHistoryWithId(app_id, &history_items);
   }
 

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -7,6 +7,7 @@
 // and released it as MIT to the world.
 
 #include "shell/browser/notifications/win/windows_toast_notification.h"
+#include "shell/browser/notifications/win/windows_toast_constants.h"
 
 #include <string_view>
 
@@ -25,10 +26,12 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/synchronization/lock.h"
 #include "base/task/thread_pool.h"
+#include "base/win/core_winrt_util.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/notifications/win/notification_presenter_win.h"
+#include "shell/browser/notifications/win/windows_toast_activator.h"
 #include "shell/browser/win/scoped_hstring.h"
 #include "shell/common/application_info.h"
 #include "third_party/libxml/chromium/xml_writer.h"
@@ -62,42 +65,6 @@ namespace winui = ABI::Windows::UI;
 namespace electron {
 
 namespace {
-
-// This string needs to be max 16 characters to work on Windows 10 prior to
-// applying Creators Update (build 15063).
-constexpr wchar_t kGroup[] = L"Notifications";
-
-// Appends &tag=<id>&group=<group> to the launch attribute of the <toast>
-// element so the COM activator can route clicks to the correct Notification
-// object.  Works for both built-in and custom toastXml.
-void InjectLaunchIdentity(IXmlDocument* doc,
-                          const std::string& notification_id,
-                          const std::string& group_id) {
-  ComPtr<ABI::Windows::Data::Xml::Dom::IXmlElement> root;
-  if (FAILED(doc->get_DocumentElement(&root)) || !root)
-    return;
-
-  // Read the existing launch attribute (may be user-supplied).
-  ScopedHString launch_attr_name(L"launch");
-  HSTRING existing_hs = nullptr;
-  std::wstring existing;
-  if (SUCCEEDED(root->GetAttribute(launch_attr_name, &existing_hs)) &&
-      existing_hs) {
-    UINT32 len = 0;
-    const wchar_t* raw = WindowsGetStringRawBuffer(existing_hs, &len);
-    if (raw && len)
-      existing.assign(raw, len);
-    WindowsDeleteString(existing_hs);
-  }
-
-  std::wstring group_w = group_id.empty() ? kGroup : base::UTF8ToWide(group_id);
-  std::wstring suffix = base::UTF8ToWide(base::StrCat(
-      {"&tag=", notification_id, "&group=", base::WideToUTF8(group_w)}));
-
-  std::wstring new_launch = existing + suffix;
-  ScopedHString new_launch_hs(new_launch);
-  root->SetAttribute(launch_attr_name, new_launch_hs);
-}
 
 void DebugLog(std::string_view log_msg) {
   if (electron::debug_notifications)
@@ -311,22 +278,91 @@ void FillToastTagAndGroupFromToast(
 }  // namespace
 
 // static
+ComPtr<winui::Notifications::IToastNotification>
+WindowsToastNotification::FindDeliveredToast(const std::string& notification_id,
+                                             const std::string& group_id) {
+  ComPtr<winui::Notifications::IToastNotificationManagerStatics2>
+      toast_manager2;
+  HRESULT hr = base::win::GetActivationFactory<
+      winui::Notifications::IToastNotificationManagerStatics2,
+      RuntimeClass_Windows_UI_Notifications_ToastNotificationManager>(
+      &toast_manager2);
+  if (FAILED(hr))
+    return nullptr;
+
+  ComPtr<winui::Notifications::IToastNotificationHistory> notification_history;
+  if (FAILED(toast_manager2->get_History(&notification_history)))
+    return nullptr;
+
+  ComPtr<winui::Notifications::IToastNotificationHistory2>
+      notification_history2;
+  if (FAILED(notification_history.As(&notification_history2)))
+    return nullptr;
+
+  ComPtr<ABI::Windows::Foundation::Collections::IVectorView<
+      ABI::Windows::UI::Notifications::ToastNotification*>>
+      history_items;
+
+  const std::wstring init_app_id = GetInitAppIdCopy();
+  if (init_app_id.empty()) {
+    hr = notification_history2->GetHistory(&history_items);
+  } else {
+    ScopedHString app_id(init_app_id);
+    hr = notification_history2->GetHistoryWithId(app_id, &history_items);
+  }
+  if (FAILED(hr))
+    return nullptr;
+
+  const std::wstring want_group = group_id.empty()
+                                      ? std::wstring(kWindowsToastDefaultGroup)
+                                      : base::UTF8ToWide(group_id);
+
+  unsigned int count = 0;
+  if (FAILED(history_items->get_Size(&count)))
+    return nullptr;
+
+  for (unsigned int i = 0; i < count; i++) {
+    ComPtr<winui::Notifications::IToastNotification> toast;
+    if (FAILED(history_items->GetAt(i, &toast)))
+      continue;
+
+    NotificationInfo info;
+    FillToastTagAndGroupFromToast(toast.Get(), &info);
+
+    if (info.id != notification_id)
+      continue;
+    const std::wstring toast_group =
+        info.group_id.empty() ? std::wstring(kWindowsToastDefaultGroup)
+                              : base::UTF8ToWide(info.group_id);
+    if (toast_group != want_group)
+      continue;
+
+    return toast;
+  }
+
+  return nullptr;
+}
+
+// static
 std::vector<NotificationInfo>
 WindowsToastNotification::GetNotificationHistory() {
   std::vector<NotificationInfo> results;
 
-  if (!toast_manager_) {
-    DebugLog("GetNotificationHistory: toast_manager_ is null");
-    return results;
-  }
-
+  // GetNotificationHistory runs on GetToastTaskRunner(), not the UI thread
+  // where toast_manager_ was created. QueryInterface on the cached manager
+  // fails across apartments; activate IToastNotificationManagerStatics2 on
+  // this thread instead (same pattern as CreateToastNotification).
   ComPtr<winui::Notifications::IToastNotificationManagerStatics2>
       toast_manager2;
-  if (FAILED(
-          (*toast_manager_)->QueryInterface(IID_PPV_ARGS(&toast_manager2)))) {
+  HRESULT hr = base::win::GetActivationFactory<
+      winui::Notifications::IToastNotificationManagerStatics2,
+      RuntimeClass_Windows_UI_Notifications_ToastNotificationManager>(
+      &toast_manager2);
+  if (FAILED(hr)) {
     DebugLog(
-        "GetNotificationHistory: failed to get "
-        "IToastNotificationManagerStatics2");
+        base::StrCat({"GetNotificationHistory: failed to get "
+                      "IToastNotificationManagerStatics2",
+                      FailureResultToString(hr)}));
     return results;
   }
 
@@ -347,7 +383,6 @@ WindowsToastNotification::GetNotificationHistory() {
   ComPtr<ABI::Windows::Foundation::Collections::IVectorView<
       ABI::Windows::UI::Notifications::ToastNotification*>>
       history_items;
-  HRESULT hr;
 
   const std::wstring init_app_id = GetInitAppIdCopy();
   if (init_app_id.empty()) {
@@ -446,7 +481,58 @@ WindowsToastNotification::~WindowsToastNotification() {
 // The method will eventually result in a display or failure signal being posted
 // back to the UI thread, where further callbacks (clicked, dismissed, failed)
 // are handled by ToastEventHandler.
+void WindowsToastNotification::Restore() {
+  is_restored_ = true;
+  const std::string id = notification_id();
+  const std::string group = notification_group();
+  base::WeakPtr<Notification> weak = GetWeakPtr();
+  scoped_refptr<base::SingleThreadTaskRunner> ui_runner =
+      content::GetUIThreadTaskRunner({});
+
+  DebugLog(base::StrCat({"Restore: attaching to delivered toast id=", id}));
+
+  GetToastTaskRunner()->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](base::WeakPtr<Notification> weak, std::string id,
+             std::string group,
+             scoped_refptr<base::SingleThreadTaskRunner> ui_runner) {
+            ComPtr<winui::Notifications::IToastNotification> toast =
+                WindowsToastNotification::FindDeliveredToast(id, group);
+            if (!toast) {
+              DebugLog(base::StrCat(
+                  {"Restore: no delivered toast found for id=", id}));
+              return;
+            }
+            ui_runner->PostTask(
+                FROM_HERE,
+                base::BindOnce(
+                    [](base::WeakPtr<Notification> weak,
+                       ComPtr<winui::Notifications::IToastNotification> toast,
+                       std::string group) {
+                      auto* self =
+                          static_cast<WindowsToastNotification*>(weak.get());
+                      if (!self)
+                        return;
+                      if (FAILED(self->SetupCallbacks(toast.Get()))) {
+                        DebugLog("Restore: SetupCallbacks failed");
+                        return;
+                      }
+                      self->toast_notification_ = toast;
+                      self->group_id_ = group;
+                      DebugLog(
+                          "Restore: attached Activated handler to "
+                          "delivered toast");
+                    },
+                    weak, std::move(toast), std::move(group)));
+          },
+          weak, id, group, ui_runner));
+}
+
 void WindowsToastNotification::Show(const NotificationOptions& options) {
+  if (is_restored_)
+    return;
+
   DebugLog("WindowsToastNotification::Show called");
   DebugLog(base::StrCat(
       {"toast_xml empty: ", options.toast_xml.empty() ? "yes" : "no"}));
@@ -561,7 +647,12 @@ bool WindowsToastNotification::CreateToastXmlDocument(
     }
   }
 
-  InjectLaunchIdentity(toast_xml->Get(), notification_id, options.group_id);
+  // Do not inject tag/group into the toast launch attribute here. That steers
+  // body clicks through the COM activator (often spawning a new process)
+  // instead of the in-process Activated handler. Tag and group are already set
+  // on the WinRT toast via put_Tag/put_Group. getHistory() uses Restore() to
+  // attach handlers to delivered toasts; cold-start routing uses
+  // handleActivation.
   return true;
 }
 
@@ -619,8 +710,9 @@ bool WindowsToastNotification::CreateToastNotification(
   }
 
   // Use provided group_id if non-empty, otherwise fall back to default
-  std::wstring group_str =
-      options.group_id.empty() ? kGroup : base::UTF8ToWide(options.group_id);
+  std::wstring group_str = options.group_id.empty()
+                               ? kWindowsToastDefaultGroup
+                               : base::UTF8ToWide(options.group_id);
   ScopedHString group(group_str);
   DebugLog(
       base::StrCat({"Setting group: ", base::WideToUTF8(group_str),
@@ -695,7 +787,7 @@ void WindowsToastNotification::SetupAndShowOnUIThread(
   notif->toast_notification_ = notification;
   notif->group_id_ = group_id;
   std::string effective_group =
-      group_id.empty() ? base::WideToUTF8(kGroup) : group_id;
+      group_id.empty() ? kWindowsToastDefaultGroupUtf8 : group_id;
   notif->set_notification_group(effective_group);
 
   // Show notification on UI thread (must be called on UI thread)
@@ -773,8 +865,8 @@ void WindowsToastNotification::Remove() {
     return;
 
   // Use stored group_id if set, otherwise fall back to default
-  std::wstring group_str =
-      group_id_.empty() ? kGroup : base::UTF8ToWide(group_id_);
+  std::wstring group_str = group_id_.empty() ? kWindowsToastDefaultGroup
+                                             : base::UTF8ToWide(group_id_);
   ScopedHString group(group_str);
   std::wstring tag_str = GetTag(notification_id());
   ScopedHString tag(tag_str);
@@ -1053,11 +1145,26 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
     notif_id = notification_->notification_id();
   }
 
-  bool structured = arguments_w.find(L"&tag=") != std::wstring::npos ||
-                    arguments_w.find(L"type=action") != std::wstring::npos ||
-                    arguments_w.find(L"type=reply") != std::wstring::npos;
-  if (structured)
+  const bool has_tag_in_args =
+      arguments_w.find(L"&tag=") != std::wstring::npos ||
+      base::StartsWith(arguments_w, L"tag=", base::CompareCase::SENSITIVE);
+  const bool is_action_or_reply =
+      arguments_w.find(L"type=action") != std::wstring::npos ||
+      arguments_w.find(L"type=reply") != std::wstring::npos;
+
+  // Action/reply use structured launch args and are delivered by the registered
+  // COM activator (with user input). Ignore the in-process Activated event so
+  // we do not call HandleToastActivation twice (this matched pre-history
+  // behavior).
+  if (is_action_or_reply)
     return S_OK;
+
+  if (has_tag_in_args && !notification_) {
+    content::GetUIThreadTaskRunner({})->PostTask(
+        FROM_HERE, base::BindOnce(&HandleToastActivation, arguments_w,
+                                  std::vector<ActivationUserInput>{}));
+    return S_OK;
+  }
 
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE,

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -128,9 +128,13 @@ class WindowsToastNotification : public Notification {
       toast_manager_;
   static ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>*
       toast_notifier_;
-  // The app model ID captured at Initialize() time, so history queries
-  // use the same identity the notifier was created with.
-  static std::wstring& init_app_id();
+  // AppUserModelID captured at Initialize() for history queries. Accessed from
+  // the UI thread (Initialize) and the toast SequencedTaskRunner
+  // (GetNotificationHistory); guarded by a lock — use GetInitAppIdCopy /
+  // SetInitAppId / ClearInitAppId only.
+  static std::wstring GetInitAppIdCopy();
+  static void SetInitAppId(PCWSTR value);
+  static void ClearInitAppId();
 
   EventRegistrationToken activated_token_;
   EventRegistrationToken dismissed_token_;

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -48,9 +48,15 @@ class WindowsToastNotification : public Notification {
   static bool Initialize();
 
   // Queries Windows Action Center for all delivered notifications belonging
-  // to this app and returns them as NotificationInfo structs.  Designed to
-  // be called from a background thread (performs synchronous COM calls).
+  // to this app and returns them as NotificationInfo structs. Must run on
+  // GetToastTaskRunner() (see
+  // NotificationPresenterWin::GetDeliveredNotifications); performs synchronous
+  // WinRT/COM calls.
   static std::vector<NotificationInfo> GetNotificationHistory();
+
+  // Sequenced runner for blocking WinRT toast work (Show, history). Used by
+  // NotificationPresenterWin::GetDeliveredNotifications among others.
+  static scoped_refptr<base::SequencedTaskRunner> GetToastTaskRunner();
 
   WindowsToastNotification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter);
@@ -125,9 +131,6 @@ class WindowsToastNotification : public Notification {
   // The app model ID captured at Initialize() time, so history queries
   // use the same identity the notifier was created with.
   static std::wstring& init_app_id();
-
-  // Returns the task runner for toast operations, creating it if necessary.
-  static scoped_refptr<base::SequencedTaskRunner> GetToastTaskRunner();
 
   EventRegistrationToken activated_token_;
   EventRegistrationToken dismissed_token_;

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -13,6 +13,7 @@
 #include <windows.ui.notifications.h>
 #include <wrl/implements.h>
 #include <string>
+#include <vector>
 
 #include "base/memory/scoped_refptr.h"
 #include "base/task/single_thread_task_runner.h"
@@ -45,6 +46,11 @@ class WindowsToastNotification : public Notification {
  public:
   // Should only be called by NotificationPresenterWin.
   static bool Initialize();
+
+  // Queries Windows Action Center for all delivered notifications belonging
+  // to this app and returns them as NotificationInfo structs.  Designed to
+  // be called from a background thread (performs synchronous COM calls).
+  static std::vector<NotificationInfo> GetNotificationHistory();
 
   WindowsToastNotification(NotificationDelegate* delegate,
                            NotificationPresenter* presenter);
@@ -116,6 +122,9 @@ class WindowsToastNotification : public Notification {
       toast_manager_;
   static ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>*
       toast_notifier_;
+  // The app model ID captured at Initialize() time, so history queries
+  // use the same identity the notifier was created with.
+  static std::wstring& init_app_id();
 
   // Returns the task runner for toast operations, creating it if necessary.
   static scoped_refptr<base::SequencedTaskRunner> GetToastTaskRunner();

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -54,6 +54,12 @@ class WindowsToastNotification : public Notification {
   // WinRT/COM calls.
   static std::vector<NotificationInfo> GetNotificationHistory();
 
+  // Finds a delivered toast in Action Center by tag and group. Must run on
+  // GetToastTaskRunner().
+  static ComPtr<ABI::Windows::UI::Notifications::IToastNotification>
+  FindDeliveredToast(const std::string& notification_id,
+                     const std::string& group_id);
+
   // Sequenced runner for blocking WinRT toast work (Show, history). Used by
   // NotificationPresenterWin::GetDeliveredNotifications among others.
   static scoped_refptr<base::SequencedTaskRunner> GetToastTaskRunner();
@@ -67,6 +73,7 @@ class WindowsToastNotification : public Notification {
   void Show(const NotificationOptions& options) override;
   void Dismiss() override;
   void Remove() override;
+  void Restore() override;
 
  private:
   friend class ToastEventHandler;
@@ -146,6 +153,7 @@ class WindowsToastNotification : public Notification {
 
   // Stored for Remove() to use when removing from Action Center
   std::string group_id_;
+  bool is_restored_ = false;
 };
 
 class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -160,6 +160,70 @@ describe('Notification module', () => {
     }).to.throw(/groupTitle requires groupId to be set/);
   });
 
+  ifit(process.platform === 'win32')(
+    'throws when id contains &, =, or control characters (Windows toast launch)',
+    () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          id: 'foo&group=evil',
+          title: 'title',
+          body: 'body'
+        });
+      }).to.throw(/id cannot contain/);
+
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          id: 'a=b',
+          title: 'title',
+          body: 'body'
+        });
+      }).to.throw(/id cannot contain/);
+
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          id: 'line\nbreak',
+          title: 'title',
+          body: 'body'
+        });
+      }).to.throw(/id cannot contain/);
+
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          id: 'x\u007fy',
+          title: 'title',
+          body: 'body'
+        });
+      }).to.throw(/id cannot contain/);
+    }
+  );
+
+  ifit(process.platform === 'win32')(
+    'throws when groupId contains &, =, or control characters (Windows toast launch)',
+    () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          title: 'title',
+          body: 'body',
+          groupId: 'g&h=i'
+        });
+      }).to.throw(/groupId cannot contain/);
+
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Notification({
+          title: 'title',
+          body: 'body',
+          groupId: 'group\nid'
+        });
+      }).to.throw(/groupId cannot contain/);
+    }
+  );
+
   ifit(process.platform === 'win32')('accepts id and groupId at 64 characters', () => {
     const n = new Notification({
       id: 'a'.repeat(64),

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -378,14 +378,17 @@ describe('Notification module', () => {
   // TODO(sethlu): Find way to test init with notification icon?
 
   describe('static methods', () => {
-    ifit(process.platform === 'darwin')('getHistory returns a promise that resolves to an array', async () => {
-      const result = Notification.getHistory();
-      expect(result).to.be.a('promise');
-      const history = await result;
-      expect(history).to.be.an('array');
-    });
+    ifit(process.platform === 'darwin' || process.platform === 'win32')(
+      'getHistory returns a promise that resolves to an array',
+      async () => {
+        const result = Notification.getHistory();
+        expect(result).to.be.a('promise');
+        const history = await result;
+        expect(history).to.be.an('array');
+      }
+    );
 
-    ifit(process.platform === 'darwin')(
+    ifit(process.platform === 'darwin' || process.platform === 'win32')(
       'getHistory returns Notification instances with correct properties',
       async () => {
         const n = new Notification({
@@ -401,49 +404,74 @@ describe('Notification module', () => {
         n.show();
         await shown;
 
-        const history = await Notification.getHistory();
-        // getHistory requires code-signed builds to return results;
-        // skip the content assertions if Notification Center is empty.
-        if (history.length > 0) {
-          const found = history.find((item: any) => item.id === 'history-test-id');
-          if (!found) {
-            expect.fail('Expected to find notification with id "history-test-id" in history');
-          }
-          expect(found).to.be.an.instanceOf(Notification);
-          expect(found.title).to.equal('history test');
-          expect(found.subtitle).to.equal('history subtitle');
-          expect(found.body).to.equal('history body');
-          expect(found.groupId).to.equal('history-group');
+        // On Windows, a toast is only persisted to Action Center after the
+        // popup is dismissed. Close it and give the OS a moment to persist.
+        if (process.platform === 'win32') {
+          n.close();
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         }
 
-        n.close();
+        const history = await Notification.getHistory();
+
+        if (process.platform === 'darwin') {
+          // getHistory requires code-signed builds to return results;
+          // skip the content assertions if Notification Center is empty.
+          if (history.length > 0) {
+            const found = history.find((item: any) => item.id === 'history-test-id');
+            if (!found) {
+              expect.fail('Expected to find notification with id "history-test-id" in history');
+            }
+            expect(found).to.be.an.instanceOf(Notification);
+            expect(found.title).to.equal('history test');
+            expect(found.subtitle).to.equal('history subtitle');
+            expect(found.body).to.equal('history body');
+            expect(found.groupId).to.equal('history-group');
+          }
+          n.close();
+        } else {
+          const found = history.find((item: any) => item.id === 'history-test-id');
+          if (found) {
+            expect(found).to.be.an.instanceOf(Notification);
+            expect(found.title).to.equal('history test');
+            expect(found.body).to.equal('history body');
+            expect(found.groupId).to.equal('history-group');
+          }
+        }
       }
     );
 
-    ifit(process.platform === 'darwin')('getHistory returned notifications can be shown and closed', async () => {
-      const n = new Notification({
-        id: 'history-show-close',
-        title: 'show close test',
-        body: 'body',
-        silent: true
-      });
+    ifit(process.platform === 'darwin' || process.platform === 'win32')(
+      'getHistory returned notifications can be shown and closed',
+      async () => {
+        const n = new Notification({
+          id: 'history-show-close',
+          title: 'show close test',
+          body: 'body',
+          silent: true
+        });
 
-      const shown = once(n, 'show');
-      n.show();
-      await shown;
+        const shown = once(n, 'show');
+        n.show();
+        await shown;
 
-      const history = await Notification.getHistory();
-      if (history.length > 0) {
-        const found = history.find((item: any) => item.id === 'history-show-close');
-        if (!found) {
-          expect.fail('Expected to find notification with id "history-show-close" in history');
+        if (process.platform === 'win32') {
+          n.close();
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         }
-        // Calling show() and close() on a restored notification should not throw
-        expect(() => {
-          found.show();
-          found.close();
-        }).to.not.throw();
+
+        const history = await Notification.getHistory();
+        const found = history.find((item: any) => item.id === 'history-show-close');
+        if (found) {
+          expect(() => {
+            found.show();
+            found.close();
+          }).to.not.throw();
+        }
+
+        if (process.platform !== 'win32') {
+          n.close();
+        }
       }
-    });
+    );
   });
 });

--- a/spec/api-notification-spec.ts
+++ b/spec/api-notification-spec.ts
@@ -504,6 +504,42 @@ describe('Notification module', () => {
       }
     );
 
+    ifit(process.platform === 'win32')(
+      'getHistory joins three toast Generic <text> lines into title and newline-separated body',
+      async () => {
+        const toastXml = `<toast>
+  <visual>
+    <binding template="ToastGeneric">
+      <text>Hist multi title</text>
+      <text>hist multi line two</text>
+      <text>hist multi line three</text>
+    </binding>
+  </visual>
+</toast>`;
+
+        const n = new Notification({
+          id: 'history-multi-text-nodes',
+          toastXml,
+          silent: true
+        });
+
+        const shown = once(n, 'show');
+        n.show();
+        await shown;
+
+        n.close();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        const history = await Notification.getHistory();
+        const found = history.find((item: any) => item.id === 'history-multi-text-nodes');
+        if (found) {
+          expect(found).to.be.an.instanceOf(Notification);
+          expect(found.title).to.equal('Hist multi title');
+          expect(found.body).to.equal('hist multi line two\nhist multi line three');
+        }
+      }
+    );
+
     ifit(process.platform === 'darwin' || process.platform === 'win32')(
       'getHistory returned notifications can be shown and closed',
       async () => {


### PR DESCRIPTION
#### Description of Change

Extends `Notification.getHistory()` (landed for macOS in #50325) to Windows. The method returns a `Promise<Notification[]>` of all delivered notifications still present in Action Center, enabling apps to re-attach event handlers after a restart.

- Implements `GetDeliveredNotifications` in `NotificationPresenterWin` using the WinRT `IToastNotificationHistory2` API
- Automatically injects `id` and `groupId` into the toast `launch` attribute so the COM `NotificationActivator` can route click/action events back to the correct restored `Notification` object — works for both built-in and custom `toastXml` notifications
- Matches notifications by the combination of `tag` + `group` (not just `tag`), since Windows treats these as a composite identity
- Adds `notification_group` to the base `Notification` class and threads it through `CreateNotification`
- On Windows, restored notifications receive interaction events directly — calling `show()` is a no-op (unlike macOS where `show()` is required to re-register for events)

## Implementation Details

<details>
<summary>History retrieval (<code>windows_toast_notification.cc</code>)</summary>

- Uses `IToastNotificationManagerStatics2` to get `IToastNotificationHistory2`
- Calls `GetHistoryWithId(appId)` for standard apps or `GetHistory()` for Desktop Bridge (MSIX) apps
- Extracts `tag`, `group`, `title`, and `body` from each `IToastNotification2` and its XML content via `IXmlNodeSerializer::get_InnerText`
- Caches the effective AppUserModelID at `Initialize()` time so history queries use the correct AUMID

</details>

<details>
<summary>Event routing (<code>windows_toast_notification.cc</code>, <code>windows_toast_activator.cc</code>)</summary>

- `InjectLaunchIdentity` appends `&tag=<id>&group=<group>` to the toast's `launch` attribute after XML is constructed (for both custom and built-in XML)
- `HandleToastActivation` parses both `tag=` and `group=` from `invoked_args` and matches against in-memory `Notification` objects using both fields

</details>


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] I have built and tested this change
- [X] I have filled out the PR description
- [X] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added Notification.getHistory() for Windows, allowing developers to restore all delivered notifications still present in Action Center.
