### PR TITLE
ci: randomly assign stable prep tasks

### DIFF
--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -157,7 +157,7 @@ jobs:
             }))
       - name: Create Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        uses: dsanders11/project-actions/copy-project@5767984408ccc6742f83acc8b8d8ea5e09f329af # v2.0.0
+        uses: dsanders11/project-actions/copy-project@4b06452b0128cf601dac14399aa668a8eed2d684 # v2.0.1
         id: create-release-board
         with:
           drafts: true
@@ -170,6 +170,60 @@ jobs:
           template-view: ${{ steps.generate-project-metadata.outputs.template-view }}
           title: ${{ steps.generate-project-metadata.outputs.major }}-x-y
           token: ${{ steps.generate-token.outputs.token }}
+      - name: Randomly Assign Draft Issues to Release WG Members
+        if: ${{ steps.check-major-version.outputs.MAJOR }}
+        uses: dsanders11/project-actions/github-script@4b06452b0128cf601dac14399aa668a8eed2d684 # v2.0.1
+        env:
+          PROJECT_ID: ${{ steps.create-release-board.outputs.id }}
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { data: members } = await github.rest.teams.listMembersInOrg({
+              org: 'electron',
+              team_slug: 'wg-releases',
+            });
+
+            const excludedLogins = ['nikwen'];
+            const memberLogins = new Set(members.map(m => m.login));
+            for (const login of excludedLogins) {
+              if (!memberLogins.has(login)) {
+                core.warning(`Excluded member "${login}" is not in @electron/wg-releases`);
+              }
+            }
+
+            const eligible = members.filter(m => !excludedLogins.includes(m.login));
+
+            if (eligible.length === 0) {
+              core.warning('No eligible members found in @electron/wg-releases team');
+              return;
+            }
+
+            const projectId = process.env.PROJECT_ID;
+            const draftIssues = await actions.getDraftIssues(projectId);
+
+            if (draftIssues.length === 0) {
+              core.info('No draft issues found in the project');
+              return;
+            }
+
+            // Fisher-Yates shuffle for uniform random assignment
+            const shuffled = [...eligible];
+            for (let i = shuffled.length - 1; i > 0; i--) {
+              const j = Math.floor(Math.random() * (i + 1));
+              [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+            }
+
+            // Assign draft issues round-robin across team members
+            for (let i = 0; i < draftIssues.length; i++) {
+              const member = shuffled[i % shuffled.length];
+              const draftIssue = draftIssues[i];
+              core.info(`Assigning "${draftIssue.content.title}" to ${member.login}`);
+              await actions.editItem(projectId, draftIssue.content.id, {
+                assignees: [member.login],
+              });
+            }
+
+            core.info(`Assigned ${draftIssues.length} draft issues to ${eligible.length} team members`);
       - name: Dump Release Project Board Contents
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         run: gh project item-list ${{ steps.create-release-board.outputs.number }} --owner electron --format json | jq


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Saves us some manual effort and tells people upfront which tasks they have.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
