### PR TITLE
build: add chrome-release-verify and chrome-release-cls skills

### DIFF
--- a/.claude/skills/chrome-release-cls/SKILL.md
+++ b/.claude/skills/chrome-release-cls/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: chrome-release-cls
+description: Given a Chrome Releases blog post URL (chromereleases.googleblog.com), extract every CVE/bug and find the underlying Gerrit CL that fixed it by searching the local Chromium checkout and sub-repos. Use when asked to map Chrome security release notes to fixing CLs, or to find which commits correspond to CVEs in a Chrome stable update.
+---
+
+# Chrome Release → Fixing CL Mapper
+
+Maps every security fix in a Chrome Releases blog post to the Gerrit CL(s) that fixed it.
+
+## Input
+
+`$ARGUMENTS` — a `https://chromereleases.googleblog.com/...` URL. If empty, ask the user for one.
+
+## Procedure
+
+### 1. Extract CVE → bug ID pairs from the blog post
+
+The blog HTML buries bug IDs inside `<a>` tags, so strip tags first. Run:
+
+```bash
+curl -sL "$URL" | python3 -c '
+import sys, re, html
+t = re.sub(r"<[^>]+>", " ", sys.stdin.read())
+t = re.sub(r"\s+", " ", html.unescape(t))
+seen = set()
+for m in re.finditer(r"\[\s*(\d{6,})\s*\]\s*(Critical|High|Medium|Low)\s*(CVE-\d{4}-\d+):\s*([^.]+?)\.", t):
+    if m.group(3) in seen: continue
+    seen.add(m.group(3))
+    print(f"{m.group(3)}|{m.group(1)}|{m.group(2)}|{m.group(4).strip()}")
+' > /tmp/cve_bugs.txt
+cat /tmp/cve_bugs.txt
+```
+
+If this yields nothing, the page may have changed format — fall back to `grep -oE 'CVE-[0-9]{4}-[0-9]+'` and `grep -oE 'crbug\.com/[0-9]+'` and pair them by order.
+
+### 2. Find the fixing CL for each bug
+
+Search git history in the Chromium checkout and relevant sub-repos for commits whose `Bug:` or `Fixed:` footer references the bug ID, then extract the `Reviewed-on:` Gerrit URL.
+
+Repo selection by component keyword:
+- ANGLE → `third_party/angle`
+- Skia, Graphite → `third_party/skia`
+- PDFium → `third_party/pdfium`
+- Dawn → `third_party/dawn`
+- V8, Turbofan, Maglev, Turboshaft → `v8`
+- everything else → `.` (chromium/src)
+
+Always also fall back to `.` if the hinted repo has no match.
+
+```bash
+cd /root/src/electron/src   # chromium root (parent of electron/)
+
+lookup() {
+  local bug="$1" repos="$2"
+  for repo in $repos . v8 third_party/skia third_party/angle third_party/pdfium third_party/dawn; do
+    local hits
+    hits=$(git -C "$repo" log --all --since='6 months ago' -E \
+           --grep="(Bug|Fixed):.*\\b${bug}\\b" --format='%H' 2>/dev/null | sort -u)
+    [[ -z "$hits" ]] && continue
+    while read -r h; do
+      git -C "$repo" log -1 --format='%B' "$h" | grep '^Reviewed-on:' | sed 's/^/    /'
+      echo "      ↳ $(git -C "$repo" log -1 --format='%s' "$h")"
+    done <<<"$hits"
+    return 0
+  done
+  echo "    (not found locally)"
+}
+```
+
+Drive it from `/tmp/cve_bugs.txt`. Prefer the **non-`[M1xx]`-prefixed** commit subject as the canonical main CL; the `[M1xx]` ones are branch cherry-picks.
+
+### 3. Handle misses
+
+For any bug with no local hit:
+- `git -C <repo> fetch origin` then re-search `--remotes` (fix may be newer than the checkout).
+- Query Gerrit directly: `curl -s "https://chromium-review.googlesource.com/changes/?q=bug:${BUG}&n=10" | tail -n +2 | python3 -m json.tool` (also try `skia-review`, `pdfium-review`, `dawn-review`, `aomedia-review`).
+- If still nothing and the bug was reported very recently (especially by "Google Threat Intelligence" or marked in-the-wild), the CL is likely still access-restricted — report it as such rather than guessing.
+
+### 4. Special cases
+
+- **libaom / libvpx / ffmpeg** components: the actual fix lands upstream; the chromium-side hit will be a `Roll src/third_party/...` commit. Report the roll CL and note the fix is upstream.
+- Multiple `Reviewed-on:` lines in one commit body: cherry-picks keep the original line plus a new one. The **first** `Reviewed-on:` is the original CL.
+- A bug may have multiple distinct fix CLs (fix + follow-up hardening) — list all of them.
+
+### 5. Output
+
+Produce a markdown table per severity level: `CVE | Bug | Component | Fix CL (main)`. Link bugs as `https://crbug.com/<id>`. Save raw output (including all branch merges) to `/tmp/cve_cls.txt` and mention the path.

--- a/.claude/skills/chrome-release-verify/SKILL.md
+++ b/.claude/skills/chrome-release-verify/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: chrome-release-verify
+description: End-to-end Chrome security backport for an Electron release branch. Given a Chrome Releases blog URL and a branch (e.g. 41-x-y), determines which CVE fixes are missing from the *actual synced source*, writes the cherry-pick patches locally, validates them with `e sync --3` + `lint --patches`, then pushes a single PR. Use when asked to backport a Chrome security release to N-x-y, "is CVE-X already in N-x-y?", or to produce/validate the cherry-pick set for a release branch.
+---
+
+# Chrome Release → Validated Backport PR
+
+Input: `$ARGUMENTS` = `<release-branch> <chrome-releases-blog-url>` (e.g. `41-x-y https://chromereleases.googleblog.com/2026/04/stable-channel-update-for-desktop_15.html`). Ask if either is missing.
+
+The flow is **local-first**: nothing is pushed until every patch applies via `e sync --3` and passes `lint --patches`.
+
+## 1. Map CVE → bug → fix CL
+
+Run `/chrome-release-cls <blog-url>` (or its inline procedure) to produce `/tmp/cve_bugs.txt` (`CVE|bug|severity|desc`) and a per-bug canonical fix CL. For each CL also note `repo` (path under `src/`: `.`, `v8`, `third_party/{skia,angle,pdfium,dawn}`, `third_party/libaom/source/libaom`) and `gerrit-host`.
+
+**Prefer the target-milestone merge CL** if one exists (e.g. on `41-x-y` ≈ M146, prefer the `[M146]` cherry-pick over the main CL) — it's already rebased and far less likely to conflict. Find it via `git log --all --grep` on the Change-Id, or Gerrit `?q=bug:<n>`. If Chrome did *not* merge a fix to the target milestone, that's a strong signal the vulnerable code doesn't exist there — flag it for skip rather than forcing a port.
+
+## 2. Prepare a synced worktree
+
+Reuse `bp-<NN>` from `e show configs` if present, else `e worktree add bp-<NN> ~/src/electron-bp-<NN> --source <current> --no-sync`.
+
+```bash
+cd <root>/src/electron
+git fetch origin <branch>
+git checkout -B security-backport/<branch>/<short-date> origin/<branch>
+e use bp-<NN>
+e sync 2>&1 | tee /tmp/bp_sync.log
+```
+
+If sync fails with `NotADirectoryError: '<root>/src/.git/objects/info/alternates'`, remove `GIT_CACHE_PATH` from the bp config's `env` and retry.
+
+## 3. Verify IN-TREE vs NEEDS-BACKPORT
+
+For each bug, three checks against the **synced** repo:
+
+1. `git -C "$repo" log HEAD --since='1 year ago' -E --grep="\b${bug}\b" --format='%h %s'`
+2. Fetch Change-Id from Gerrit, then `git log HEAD --grep="^Change-Id: ${cid}$"`
+3. `grep -rlE "(\b${bug}\b|${cid})" <root>/src/electron/patches/`
+
+Any hit ⇒ IN-TREE. All empty ⇒ NEEDS-BACKPORT.
+
+For each NEEDS-BACKPORT CL, also fetch its file list (`/changes/<proj>~<cl>/revisions/current/files`) and **skip** if every file is under `chrome/browser/`, `chrome/android/`, `ios/`, or `components/**/android/` — Electron doesn't compile those.
+
+Report the table now (`CVE | Sev | Bug | Component | Verdict | CL`) and the proposed backport set; get user sign-off before continuing.
+
+## 4. Write patches locally (no push yet)
+
+For each backport CL, fetch the raw patch and write it into `patches/<dir>/`:
+
+```bash
+curl -s "https://${host}.googlesource.com/changes/${proj//\//%2F}~${cl}/revisions/current/patch" \
+  | base64 -d > "patches/${dir}/cherry-pick-${short}.patch"
+echo "cherry-pick-${short}.patch" >> "patches/${dir}/.patches"
+```
+
+For repos with no Gerrit host `e cherry-pick` supports (e.g. **libaom** on aomedia), instead `git cherry-pick` the upstream commits onto the synced sub-repo HEAD and `git format-patch` the result.
+
+For any newly-created `patches/<dir>/`, append to `patches/config.json` **preserving the compact one-line-per-entry style**:
+
+```json
+  { "patch_dir": "src/electron/patches/<dir>", "repo": "src/third_party/<dir-or-nested-path>" }
+```
+
+## 5. Validate with `e sync --3`
+
+```bash
+e sync --3 2>&1 | tee /tmp/bp_sync3.log
+```
+
+On `Patch failed at NNNN <subject>`:
+
+- `cd` into the failing repo, inspect `git diff` for conflict markers.
+- **Test-only files** (e.g. `web_tests/VirtualTestSuites`, `*_unittest.cc` context drift): take ours (`git checkout --ours -- <file>`) if the security-relevant hunks merged cleanly.
+- **Substantive code conflicts**: check whether a target-milestone merge CL exists and swap to it. If none exists upstream and the surrounding code is structurally different, **drop the patch** (delete the file, remove from `.patches` and `config.json`) and note it for a separate manual-port PR — do not improvise security-fix semantics.
+- After resolving: `git add <files> && git -c commit.gpgsign=false am --continue`, then `e patches <repo>` to export the resolved patch, then re-run `e sync --3`. Repeat until clean.
+
+## 6. Export → lint → re-apply loop
+
+```bash
+e patches all
+node script/lint.js --patches   # must exit 0
+```
+
+If lint reports findings (typically trailing whitespace on `+` content lines), fixing them **changes the bytes the patch writes**, which invalidates the `index <old>..<new>` blob hashes that `e patches` baked in. Hand-editing a `.patch` and pushing it as-is will pass lint locally but fail CI's Apply Patches re-export check with a one-line `index` hash diff.
+
+So whenever lint (or you) modifies any `.patch` file after export, round-trip once more:
+
+```bash
+# fix the lint findings in patches/**/*.patch, then:
+e sync            # re-apply the edited patches (no --3 needed; they applied cleanly last time)
+e patches all     # re-export so index blob hashes match the edited content
+node script/lint.js --patches      # must now exit 0
+git diff --quiet -- patches/ || { echo "patches changed again — repeat the loop"; }
+```
+
+Repeat until `lint --patches` exits 0 **and** `git diff -- patches/` is empty after the final `e patches all`. Only then is the patch set CI-stable.
+
+## 7. Commit, push, PR
+
+```bash
+git add patches/
+git commit -m "chore: cherry-pick <N> changes from <dirs>"
+git push origin HEAD
+gh pr create --repo electron/electron --base <branch> --head <this-branch> \
+  --title "chore: cherry-pick <N> changes from <dirs>" \
+  --label "<branch>" --label backport-check-skip --label semver/patch --label "security 🔒" \
+  --body-file /tmp/pr_body.md
+```
+
+PR body format:
+
+```markdown
+Backports the following changes:
+
+* [`<shortCommit>`](<gerrit-CL-url>) from <patchDir> — <subject> ([<bug>](https://crbug.com/<bug>), CVE-YYYY-NNNN)
+* ...
+
+Notes: Security: backported fixes for CVE-YYYY-NNNN, CVE-YYYY-NNNN, ....
+```
+
+Short commit links to the **Gerrit CL**; bug links to `crbug.com`; CVE comes from the blog mapping (the patch's own `Bug:` footer may differ); `Notes:` is the last line. Mention any dropped patches (with reason) above the `Notes:` line.
+
+Restore `e use <previous>` when done.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,12 +67,13 @@ jobs:
         filters: |
           docs:
             - 'docs/**'
+            - '.claude/**'
             - README.md
             - SECURITY.md
             - CONTRIBUTING.md
             - CODE_OF_CONDUCT.md
           src:
-            - '!docs/**'
+            - '!{docs,.claude}/**'
     - name: Set Outputs for Build Image SHA & Docs Only
       id: set-output
       run: |


### PR DESCRIPTION
Adds two `.claude/skills/` entries that encode the Chrome security-release backport workflow:

- **chrome-release-cls** — given a `chromereleases.googleblog.com` post, extract every CVE/bug and locate the underlying Gerrit CL by searching the local Chromium checkout and sub-repos (chromium, v8, skia, angle, pdfium, dawn, libaom).
- **chrome-release-verify** — end-to-end backport for a release branch: map CVEs→CLs (preferring the target-milestone merge), verify against the *actual synced* `bp-<NN>` worktree which fixes are already in-tree, write the cherry-pick patches locally, validate with `e sync --3` (with conflict-resolution rules), run the `e patches all` → `lint --patches` → re-apply loop until export-stable, then push a single PR with the linked-CL/crbug/CVE body format.

These were used to produce #51136 (42-x-y) and #51137 (41-x-y).

Notes: none