### PR TITLE
build: resolve electron_version from git when building in a worktree

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -105,21 +105,25 @@ electron_mac_bundle_id = branding.mac_bundle_id
 if (override_electron_version != "") {
   electron_version = override_electron_version
 } else {
-  # When building from source code tarball there is no git tag available and
+  # When building from a source code tarball there is no git tag available and
   # builders must explicitly pass override_electron_version in gn args.
+  #
+  # Resolve the real locations of packed-refs and HEAD via git so that this
+  # also works when electron/ is a `git worktree` (where .git is a file, not a
+  # directory, and GN's read_file cannot follow the gitdir indirection).
+  electron_git_ref_paths =
+      exec_script("script/get-git-ref-paths.py", [], "list lines")
+
   # This read_file call will assert if there is no git information, without it
   # gn will generate a malformed build configuration and ninja will get into
   # infinite loop.
-  read_file(".git/packed-refs", "string")
+  read_file(electron_git_ref_paths[0], "string")
 
   # Set electron version from git tag.
   electron_version = exec_script("script/get-git-version.py",
                                  [],
                                  "trim string",
-                                 [
-                                   ".git/packed-refs",
-                                   ".git/HEAD",
-                                 ])
+                                 electron_git_ref_paths)
 }
 
 if (is_mas_build) {

--- a/script/get-git-ref-paths.py
+++ b/script/get-git-ref-paths.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+# Resolve the on-disk locations of HEAD and packed-refs for this checkout so
+# that BUILD.gn can register them as build graph inputs. In a plain clone both
+# live under electron/.git/, but in a `git worktree` checkout .git is a file
+# pointing at <common>/.git/worktrees/<name>; HEAD lives there while
+# packed-refs is shared in the common dir. GN's read_file() does not follow
+# that indirection, so we ask git to do it for us.
+
+ELECTRON_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def rev_parse(flag):
+  out = subprocess.check_output(['git', 'rev-parse', flag],
+                                cwd=ELECTRON_DIR,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True).strip()
+  return out if os.path.isabs(out) else os.path.join(ELECTRON_DIR, out)
+
+
+try:
+  git_dir = rev_parse('--git-dir')
+  common_dir = rev_parse('--git-common-dir')
+except (subprocess.CalledProcessError, OSError) as e:
+  sys.stderr.write(f'get-git-ref-paths.py: not a git checkout '
+                   f'(set override_electron_version): {e}\n')
+  sys.exit(1)
+
+for p in (os.path.join(common_dir, 'packed-refs'),
+          os.path.join(git_dir, 'HEAD')):
+  print(os.path.normpath(p).replace('\\', '/'))


### PR DESCRIPTION
`BUILD.gn` derives `electron_version` by reading `.git/packed-refs` and `.git/HEAD` directly. In a `git worktree` checkout (e.g. one created by `e worktree`), `.git` is a *file* containing a `gitdir:` pointer rather than a directory, so GN's `read_file()` fails and `gn gen` aborts unless `override_electron_version` is set by hand.

This change asks git for the real locations via `git rev-parse --git-dir` / `--git-common-dir` in a small helper script and feeds the resolved absolute paths to `read_file()` and the `exec_script` dependency list:

- **Plain clone:** both resolve to `electron/.git/packed-refs` and `electron/.git/HEAD` — no behaviour change.
- **Worktree:** resolves to `<primary>/.git/packed-refs` and `<primary>/.git/worktrees/<name>/HEAD`; `gn gen` now succeeds and ninja still re-gens when tags or HEAD change.
- **Tarball / no git:** the helper exits non-zero so `gn gen` still fails loudly with a message pointing at `override_electron_version` (same intent as the old `read_file` assertion).

Notes: Fixed `gn gen` failing to resolve `electron_version` when building from a `git worktree` checkout.