### PR TITLE
fix: macOS menu roles missing Tahoe icons

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -527,7 +527,6 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   if (icon.IsImage()) {
     item.image = icon.GetImage().ToNSImage();
   } else {
-    std::u16string role = model->GetRoleAt(index);
     item.image = nil;
     // Since macOS Tahoe introduced default menu icons, some role-based
     // menu items receive a system-provided icon. When we clear `item.image`
@@ -535,9 +534,11 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
     // default icon. To ensure the correct icon is shown, we force AppKit to
     // refresh the item by reassigning its action selector (clear then set),
     // which causes the menu item to update its displayed icon.
+    std::u16string role = model->GetRoleAt(index);
     if (!role.empty()) {
       for (const Role& pair : kRolesMap) {
         if (role == base::ASCIIToUTF16(pair.role)) {
+          item.action = nil;
           item.action = pair.selector;
           break;
         }

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -527,7 +527,22 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   if (icon.IsImage()) {
     item.image = icon.GetImage().ToNSImage();
   } else {
+    std::u16string role = model->GetRoleAt(index);
     item.image = nil;
+    // Since macOS Tahoe introduced default menu icons, some role-based
+    // menu items receive a system-provided icon. When we clear `item.image`
+    // (set it to nil) AppKit may remove or fail to restore the role's
+    // default icon. To ensure the correct icon is shown, we force AppKit to
+    // refresh the item by reassigning its action selector (clear then set),
+    // which causes the menu item to update its displayed icon.
+    if (!role.empty()) {
+      for (const Role& pair : kRolesMap) {
+        if (role == base::ASCIIToUTF16(pair.role)) {
+          item.action = pair.selector;
+          break;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes: #50609

This PR fixes an issue where menu icons would disappear after the first time they were opened.

Since macOS Tahoe introduced default menu icons, some role-based menu items receive a system-provided icon. When we clear `item.image` (set it to nil) AppKit may remove or fail to restore the role's default icon. To ensure the correct icon is shown, we force AppKit to refresh the item by reassigning its action selector (clear then set), which causes the menu item to update its displayed icon.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: None