### PR TITLE
build: update ANGLE repository URL to GitHub mirror

### DIFF
--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -133,7 +133,7 @@ runs:
       run : |
         cd src/third_party/angle
         rm -f .git/objects/info/alternates
-        git remote set-url origin https://chromium.googlesource.com/angle/angle.git
+        git remote set-url origin https://github.com/google/angle.git
         cp .git/config .git/config.backup
         git remote remove origin
         mv .git/config.backup .git/config


### PR DESCRIPTION
Avoids a potential source of 429, we hit this repo clone on _every job_ unlike checkout with only runs on a src cache miss

Notes: none