### PR TITLE
fix: reset `printToPDF` queue after a rejection

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -229,7 +229,7 @@ function parsePageSize(pageSize: string | ElectronInternal.PageSize) {
 
 // Translate the options of printToPDF.
 
-let pendingPromise: Promise<any> | undefined;
+const printToPDFQueues = new WeakMap<Electron.WebContents, Promise<unknown>>();
 WebContents.prototype.printToPDF = async function (options) {
   const margins = checkType(options.margins ?? {}, 'object', 'margins');
   const pageSize = parsePageSize(options.pageSize ?? 'letter');
@@ -261,16 +261,19 @@ WebContents.prototype.printToPDF = async function (options) {
     ...pageSize
   };
 
-  if (this._printToPDF) {
-    if (pendingPromise) {
-      pendingPromise = pendingPromise.then(() => this._printToPDF(printSettings));
-    } else {
-      pendingPromise = this._printToPDF(printSettings);
-    }
-    return pendingPromise;
-  } else {
+  if (!this._printToPDF) {
     throw new Error('Printing feature is disabled');
   }
+
+  const prev = printToPDFQueues.get(this) ?? Promise.resolve();
+  const next = prev.catch(() => {}).then(() => this._printToPDF(printSettings));
+  printToPDFQueues.set(this, next);
+  next
+    .finally(() => {
+      if (printToPDFQueues.get(this) === next) printToPDFQueues.delete(this);
+    })
+    .catch(() => {});
+  return next;
 };
 
 // TODO(codebytere): deduplicate argument sanitization by moving rest of

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -3187,6 +3187,16 @@ describe('webContents module', () => {
       expect(pdfInfo.numPages).to.equal(3);
     });
 
+    it('recovers after a prior call fails with an invalid page range', async () => {
+      await w.loadURL('data:text/html,<h1>Hello, World!</h1>');
+
+      await expect(w.webContents.printToPDF({ pageRanges: '999' })).to.eventually.be.rejected();
+
+      const data = await w.webContents.printToPDF({});
+      const pdfInfo = await readPDF(data);
+      expect(pdfInfo.numPages).to.equal(1);
+    });
+
     it('does not tag PDFs by default', async () => {
       await w.loadFile(path.join(__dirname, 'fixtures', 'api', 'print-to-pdf-small.html'));
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/51145

The module-scoped `pendingPromise` in `webContents.printToPDF` was chained with `.then(onFulfilled)` and never cleared. Once a call rejected (e.g. an out-of-range `pageRanges` like `"999"`), subsequent calls chained onto the rejected promise and short-circuited without ever invoking `_printToPDF` — so every following call re-surfaced the original error.

Replace the shared variable with a per-`WebContents` `WeakMap` queue that swallows prior rejections before chaining and clears its entry once the tail drains.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `webContents.printToPDF` rejecting on all subsequent calls after a prior call was rejected with an invalid `pageRanges` value.