### PR TITLE
chore: remove calls to DeprecatedLayoutImmediately

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -240,6 +240,13 @@ void NativeWindow::SetShape(const std::vector<gfx::Rect>& rects) {
   widget()->SetShape(std::make_unique<std::vector<gfx::Rect>>(rects));
 }
 
+void NativeWindow::FlushPendingRootLayout(views::View* view) {
+  view->InvalidateLayout();
+
+  if (views::Widget* widget = view->GetWidget())
+    widget->LayoutRootViewIfNecessary();
+}
+
 bool NativeWindow::IsClosed() const {
   return is_closed_;
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -462,6 +462,7 @@ class NativeWindow : public views::WidgetDelegate {
   const views::Widget* GetWidget() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
+  void FlushPendingRootLayout(views::View* view);
 
   static inline constexpr base::cstring_view kNativeWindowKey =
       "__ELECTRON_NATIVE_WINDOW__";

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -381,7 +381,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
 
   root_view->AddChildViewRaw(content_view());
 
-  root_view->InvalidateLayout();
+  FlushPendingRootLayout(root_view);
 }
 
 void NativeWindowMac::Close() {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -381,7 +381,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
 
   root_view->AddChildViewRaw(content_view());
 
-  root_view->DeprecatedLayoutImmediately();
+  root_view->InvalidateLayout();
 }
 
 void NativeWindowMac::Close() {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -533,7 +533,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
   set_content_view(view);
   focused_view_ = view;
   root_view_.GetMainView()->AddChildViewRaw(content_view());
-  root_view_.GetMainView()->DeprecatedLayoutImmediately();
+  root_view_.GetMainView()->InvalidateLayout();
 }
 
 void NativeWindowViews::Close() {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -533,7 +533,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
   set_content_view(view);
   focused_view_ = view;
   root_view_.GetMainView()->AddChildViewRaw(content_view());
-  root_view_.GetMainView()->InvalidateLayout();
+  FlushPendingRootLayout(root_view_.GetMainView());
 }
 
 void NativeWindowViews::Close() {

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -23,6 +23,16 @@
 #include "ui/views/window/client_view.h"
 
 namespace electron {
+namespace {
+
+void FlushPendingRootLayout(views::View* view) {
+  view->InvalidateLayout();
+
+  if (views::Widget* widget = view->GetWidget())
+    widget->LayoutRootViewIfNecessary();
+}
+
+}  // namespace
 
 class DevToolsWindowDelegate : public views::ClientView,
                                public views::WidgetDelegate {
@@ -135,7 +145,7 @@ void InspectableWebContentsView::ShowDevTools(bool activate) {
     devtools_web_view_->SetWebContents(
         inspectable_web_contents_->GetDevToolsWebContents());
     devtools_web_view_->RequestFocus();
-    InvalidateLayout();
+    FlushPendingRootLayout(this);
   }
 }
 
@@ -173,7 +183,7 @@ void InspectableWebContentsView::CloseDevTools() {
   } else {
     devtools_web_view_->SetVisible(false);
     devtools_web_view_->SetWebContents(nullptr);
-    InvalidateLayout();
+    FlushPendingRootLayout(this);
   }
 }
 
@@ -223,7 +233,7 @@ void InspectableWebContentsView::SetIsDocked(bool docked, bool activate) {
 void InspectableWebContentsView::SetContentsResizingStrategy(
     const DevToolsContentsResizingStrategy& strategy) {
   strategy_.CopyFrom(strategy);
-  InvalidateLayout();
+  FlushPendingRootLayout(this);
 }
 
 void InspectableWebContentsView::SetTitle(const std::u16string& title) {

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -135,7 +135,7 @@ void InspectableWebContentsView::ShowDevTools(bool activate) {
     devtools_web_view_->SetWebContents(
         inspectable_web_contents_->GetDevToolsWebContents());
     devtools_web_view_->RequestFocus();
-    DeprecatedLayoutImmediately();
+    InvalidateLayout();
   }
 }
 
@@ -173,7 +173,7 @@ void InspectableWebContentsView::CloseDevTools() {
   } else {
     devtools_web_view_->SetVisible(false);
     devtools_web_view_->SetWebContents(nullptr);
-    DeprecatedLayoutImmediately();
+    InvalidateLayout();
   }
 }
 
@@ -223,7 +223,7 @@ void InspectableWebContentsView::SetIsDocked(bool docked, bool activate) {
 void InspectableWebContentsView::SetContentsResizingStrategy(
     const DevToolsContentsResizingStrategy& strategy) {
   strategy_.CopyFrom(strategy);
-  DeprecatedLayoutImmediately();
+  InvalidateLayout();
 }
 
 void InspectableWebContentsView::SetTitle(const std::u16string& title) {

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -256,12 +256,17 @@ describe('WebContentsView', () => {
       await p;
       expect(await v.webContents.executeJavaScript('document.visibilityState')).to.equal('visible');
 
-      const viewportSize = await v.webContents.executeJavaScript(
-        '({ width: window.innerWidth, height: window.innerHeight })'
-      );
-      const contentBounds = w.getContentBounds();
-      expect(viewportSize.width).to.equal(contentBounds.width);
-      expect(viewportSize.height).to.equal(contentBounds.height);
+      // The attach path may lay out synchronously or via deferred invalidation,
+      // but the viewport should settle to the content bounds in either case.
+      await expect(
+        waitUntil(async () => {
+          const viewportSize = await v.webContents.executeJavaScript(
+            '({ width: window.innerWidth, height: window.innerHeight })'
+          );
+          const contentBounds = w.getContentBounds();
+          return viewportSize.width === contentBounds.width && viewportSize.height === contentBounds.height;
+        })
+      ).to.eventually.be.fulfilled();
     });
 
     it('is initially visible if load happens after attach', async () => {

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -256,17 +256,12 @@ describe('WebContentsView', () => {
       await p;
       expect(await v.webContents.executeJavaScript('document.visibilityState')).to.equal('visible');
 
-      // The attach path may lay out synchronously or via deferred invalidation,
-      // but the viewport should settle to the content bounds in either case.
-      await expect(
-        waitUntil(async () => {
-          const viewportSize = await v.webContents.executeJavaScript(
-            '({ width: window.innerWidth, height: window.innerHeight })'
-          );
-          const contentBounds = w.getContentBounds();
-          return viewportSize.width === contentBounds.width && viewportSize.height === contentBounds.height;
-        })
-      ).to.eventually.be.fulfilled();
+      const viewportSize = await v.webContents.executeJavaScript(
+        '({ width: window.innerWidth, height: window.innerHeight })'
+      );
+      const contentBounds = w.getContentBounds();
+      expect(viewportSize.width).to.equal(contentBounds.width);
+      expect(viewportSize.height).to.equal(contentBounds.height);
     });
 
     it('is initially visible if load happens after attach', async () => {


### PR DESCRIPTION
#### Description of Change

Replace the calls to `DeprecatedLayoutImmediately` that have test coverage.

- The docked DevTools test added last week (#51071) covers the three calls in IWCV.
- api-web-contents-view-spec covers the calls from NativeWindow{Views,Mac}.

There are a couple of remaining calls that don't have test coverage yet. I'll get to them in a followup.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.