### PR TITLE
test: improve browser window layout coverage

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -92,7 +92,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   // Note that |GetContentsView|, confusingly, does not refer to the same thing
   // as |BaseWindow::GetContentView|.
   window()->GetContentsView()->AddChildViewAt(web_contents_view->view(), 0);
-  window()->GetContentsView()->DeprecatedLayoutImmediately();
+  window()->GetContentsView()->InvalidateLayout();
 
   // Init window after everything has been setup.
   window()->InitFromOptions(options);

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -92,7 +92,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   // Note that |GetContentsView|, confusingly, does not refer to the same thing
   // as |BaseWindow::GetContentView|.
   window()->GetContentsView()->AddChildViewAt(web_contents_view->view(), 0);
-  window()->GetContentsView()->InvalidateLayout();
+  window()->GetContentsView()->DeprecatedLayoutImmediately();
 
   // Init window after everything has been setup.
   window()->InitFromOptions(options);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3455,7 +3455,7 @@ describe('BrowserWindow module', () => {
 
   describe('post-construction web content viewport', () => {
     afterEach(closeAllWindows);
-    it('matches content bounds', async () => {
+    it('matches content size', async () => {
       const w = new BrowserWindow({ show: true, width: 800, height: 600 });
 
       await w.loadURL('about:blank');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3439,6 +3439,21 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('post-construction web content viewport', () => {
+    afterEach(closeAllWindows);
+    it('matches content bounds', async () => {
+      const w = new BrowserWindow({ show: true, width: 800, height: 600 });
+      await w.loadURL('about:blank');
+
+      const viewport = await w.webContents.executeJavaScript(
+        '({ width: window.innerWidth, height: window.innerHeight })'
+      );
+      const contentBounds = w.getContentBounds();
+      expect(contentBounds.width).to.equal(viewport.width);
+      expect(contentBounds.height).to.equal(viewport.height);
+    });
+  });
+
   // On Wayland, hidden windows may not have mapped surfaces or finalized geometry
   // until shown. Tests that depend on real geometry or frame events may need
   // to show the window first.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3144,18 +3144,14 @@ describe('BrowserWindow module', () => {
 
     it('preserves the web content viewport after setting vibrancy', async () => {
       const w = new BrowserWindow({ show: true, width: 800, height: 600 });
-      await w.loadURL('about:blank');
-
-      const contentSize = w.getContentSize();
       const getViewportSize = () => w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
 
-      const before = await getViewportSize();
-      expect(before).to.deep.equal(contentSize);
+      await w.loadURL('about:blank');
+      const contentSize = w.getContentSize();
+      expect(await getViewportSize()).to.deep.equal(contentSize);
 
       w.setVibrancy('titlebar');
-
-      const after = await getViewportSize();
-      expect(after).to.deep.equal(contentSize);
+      expect(await getViewportSize()).to.deep.equal(contentSize);
     });
   });
 
@@ -3459,14 +3455,11 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
     it('matches content bounds', async () => {
       const w = new BrowserWindow({ show: true, width: 800, height: 600 });
+      const getViewportSize = () => w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
+
       await w.loadURL('about:blank');
 
-      const viewport = await w.webContents.executeJavaScript(
-        '({ width: window.innerWidth, height: window.innerHeight })'
-      );
-      const contentBounds = w.getContentBounds();
-      expect(contentBounds.width).to.equal(viewport.width);
-      expect(contentBounds.height).to.equal(viewport.height);
+      expect(await getViewportSize()).to.deep.equal(w.getContentSize());
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -67,6 +67,9 @@ const isBeforeUnload = (event: Event, level: number, message: string) => {
   return message === 'beforeunload';
 };
 
+const getViewportSize = (w: BrowserWindow) =>
+  w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
+
 describe('BrowserWindow module', () => {
   it('sets the correct class name on the prototype', () => {
     expect(BrowserWindow.prototype.constructor.name).to.equal('BrowserWindow');
@@ -3144,14 +3147,13 @@ describe('BrowserWindow module', () => {
 
     it('preserves the web content viewport after setting vibrancy', async () => {
       const w = new BrowserWindow({ show: true, width: 800, height: 600 });
-      const getViewportSize = () => w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
 
       await w.loadURL('about:blank');
       const contentSize = w.getContentSize();
-      expect(await getViewportSize()).to.deep.equal(contentSize);
+      expect(await getViewportSize(w)).to.deep.equal(contentSize);
 
       w.setVibrancy('titlebar');
-      expect(await getViewportSize()).to.deep.equal(contentSize);
+      expect(await getViewportSize(w)).to.deep.equal(contentSize);
     });
   });
 
@@ -3455,11 +3457,9 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
     it('matches content bounds', async () => {
       const w = new BrowserWindow({ show: true, width: 800, height: 600 });
-      const getViewportSize = () => w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
 
       await w.loadURL('about:blank');
-
-      expect(await getViewportSize()).to.deep.equal(w.getContentSize());
+      expect(await getViewportSize(w)).to.deep.equal(w.getContentSize());
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3141,6 +3141,22 @@ describe('BrowserWindow module', () => {
         w.setVibrancy('i-am-not-a-valid-vibrancy-type' as any);
       }).to.not.throw();
     });
+
+    it('preserves the web content viewport after setting vibrancy', async () => {
+      const w = new BrowserWindow({ show: true, width: 800, height: 600 });
+      await w.loadURL('about:blank');
+
+      const contentSize = w.getContentSize();
+      const getViewportSize = () => w.webContents.executeJavaScript('[window.innerWidth, window.innerHeight]');
+
+      const before = await getViewportSize();
+      expect(before).to.deep.equal(contentSize);
+
+      w.setVibrancy('titlebar');
+
+      const after = await getViewportSize();
+      expect(after).to.deep.equal(contentSize);
+    });
   });
 
   ifdescribe(process.platform === 'darwin')('trafficLightPosition', () => {


### PR DESCRIPTION
#### Description of Change

Add more test coverage for WebContents layout invalidation. This is to prepare for removing calls to `views::View::DeprecatedLayoutImmediately()`.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.