### PR TITLE
fix: restore generated headers before clang-tidy runs

### DIFF
--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -125,15 +125,7 @@ jobs:
       run: |
         cd src/electron
         git pack-refs
-    - name: Download Out Gen Artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-      with:
-        name: out_gen_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./src/out/${{ env.ELECTRON_OUT_DIR }}/gen
-    - name: Add Clang problem matcher
-      shell: bash
-      run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
-    - name: Run Clang-Tidy
+    - name: Prepare Clang-Tidy Output Directory
       run: |
         e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH} --remote-build none
 
@@ -144,10 +136,18 @@ jobs:
         fi
 
         e build --only-gen
-
-        # Copy macOS framework headers so clang-tidy can find them via -F.
-        # This must happen after e build --only-gen since e init -f may
-        # recreate the output directory.
+    - name: Download Out Gen Artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        name: out_gen_artifacts_${{ env.ARTIFACT_KEY }}
+        path: ./src/out/${{ env.ELECTRON_OUT_DIR }}/gen
+    - name: Add Clang problem matcher
+      shell: bash
+      run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
+    - name: Run Clang-Tidy
+      run: |
+        # e init -f may recreate the output directory, so restore downloaded
+        # generated headers only after the output tree has been prepared.
         if [ "${{ inputs.target-platform }}" = "macos" ]; then
           OUT=src/out/${ELECTRON_OUT_DIR}
           SQRL=src/third_party/squirrel.mac


### PR DESCRIPTION
#### Description of Change

Fix a 61e815c2 bug that breaks CI for new PRs built on top of it.

That commits runs clang-tidy by prepping the output directory in a way that can wipe the downloaded generated headers. This fix adds a "restore generated files" step between the prep and run steps.

Sample CI failure [here](https://productionresultssa1.blob.core.windows.net/actions-results/14e161ca-8ca8-41b1-badb-986f06de7343/workflow-job-run-6b4dac15-5d99-51f0-b2a9-0f7fc71c787b/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-04-21T00%3A25%3A32Z&sig=2dgQYa3y5l%2F%2Blldcl9xI6SWWQUYxYRAZXAhLST5ZYiM%3D&ske=2026-04-21T01%3A46%3A34Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-04-20T21%3A46%3A34Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-04-21T00%3A15%3A27Z&sv=2025-11-05):

```txt
2026-04-20T23:17:22.7380280Z Found compiler error(s). 2026-04-20T23:17:22.7380740Z
2026-04-20T23:17:22.7381430Z     8 | #include "base/debug/debugging_buildflags.h"
2026-04-20T23:17:22.7382500Z       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-04-20T23:17:22.7383020Z
2026-04-20T23:19:44.3320970Z
2026-04-20T23:20:08.6192580Z ##[error]../../base/dcheck_is_on.h:8:10: error: 'base/debug/debugging_buildflags.h' file not found [clang-diagnostic-error]
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.