### PR TITLE
test: add Linux-specific test for `app.getApplicationNameForProtocol()`

### DIFF
--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1517,14 +1517,20 @@ describe('app module', () => {
       const mockScheme = 'mockproto';
       const mockMimeType = `x-scheme-handler/${mockScheme}`;
 
-      function spawnWithXdgMock(url: string, xdgDir: string): Promise<string> {
+      function spawnWithXdgMock(
+        url: string,
+        xdgDataHome: string,
+        xdgConfigHome: string,
+        xdgBinDir: string
+      ): Promise<string> {
         return new Promise((resolve, reject) => {
           const child = cp.spawn(process.execPath, [fixtureApp, url], {
             env: {
               ...process.env,
-              XDG_DATA_HOME: xdgDir,
-              XDG_DATA_DIRS: xdgDir,
-              XDG_CONFIG_HOME: xdgDir
+              PATH: [xdgBinDir, process.env.PATH].filter(Boolean).join(':'),
+              XDG_DATA_HOME: xdgDataHome,
+              XDG_DATA_DIRS: [xdgDataHome, process.env.XDG_DATA_DIRS].filter(Boolean).join(':'),
+              XDG_CONFIG_HOME: xdgConfigHome
             },
             stdio: ['ignore', 'pipe', 'pipe']
           });
@@ -1554,10 +1560,18 @@ describe('app module', () => {
       }
 
       let xdgDir: string;
+      let xdgDataHome: string;
+      let xdgConfigHome: string;
+      let xdgBinDir: string;
       before(() => {
         xdgDir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'electron-xdg-'));
-        const appsDir = path.join(xdgDir, 'applications');
+        xdgDataHome = path.join(xdgDir, 'data');
+        xdgConfigHome = path.join(xdgDir, 'config');
+        xdgBinDir = path.join(xdgDir, 'bin');
+        const appsDir = path.join(xdgDataHome, 'applications');
         fs.mkdirSync(appsDir, { recursive: true });
+        fs.mkdirSync(xdgConfigHome, { recursive: true });
+        fs.mkdirSync(xdgBinDir, { recursive: true });
 
         fs.writeFileSync(
           path.join(appsDir, desktopFileId),
@@ -1570,10 +1584,42 @@ describe('app module', () => {
           ].join('\n')
         );
 
+        const mimeAppsContents = [
+          '[Default Applications]',
+          `${mockMimeType}=${desktopFileId}`,
+          '',
+          '[Added Associations]',
+          `${mockMimeType}=${desktopFileId};`
+        ].join('\n');
+
+        fs.writeFileSync(path.join(xdgConfigHome, 'mimeapps.list'), mimeAppsContents);
+        fs.writeFileSync(path.join(appsDir, 'mimeapps.list'), mimeAppsContents);
+        fs.writeFileSync(path.join(appsDir, 'defaults.list'), mimeAppsContents);
+
+        // Different xdg-utils versions resolve custom XDG dirs differently, so
+        // prepend a deterministic xdg-mime shim for this test.
+        const xdgMimePath = path.join(xdgBinDir, 'xdg-mime');
         fs.writeFileSync(
-          path.join(xdgDir, 'mimeapps.list'),
-          ['[Default Applications]', `${mockMimeType}=${desktopFileId}`].join('\n')
+          xdgMimePath,
+          [
+            '#!/bin/sh',
+            'if [ "$1" != "query" ] || [ "$2" != "default" ]; then',
+            '  exit 1',
+            'fi',
+            'mime="$3"',
+            'for list in "$XDG_CONFIG_HOME/mimeapps.list" "$XDG_DATA_HOME/applications/mimeapps.list" "$XDG_DATA_HOME/applications/defaults.list"; do',
+            '  if [ -f "$list" ]; then',
+            '    result=$(grep "^$mime=" "$list" | head -n 1 | cut -d= -f2 | cut -d";" -f1)',
+            '    if [ -n "$result" ]; then',
+            '      printf "%s\\n" "$result"',
+            '      exit 0',
+            '    fi',
+            '  fi',
+            'done',
+            'exit 0'
+          ].join('\n')
         );
+        fs.chmodSync(xdgMimePath, 0o755);
       });
 
       after(() => {
@@ -1581,12 +1627,12 @@ describe('app module', () => {
       });
 
       it('returns the desktop file ID for a registered protocol', async () => {
-        const name = await spawnWithXdgMock(`${mockScheme}://`, xdgDir);
+        const name = await spawnWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome, xdgBinDir);
         expect(name).to.equal(desktopFileId);
       });
 
       it('returns an empty string for an unregistered protocol', async () => {
-        const name = await spawnWithXdgMock('unregistered-proto://', xdgDir);
+        const name = await spawnWithXdgMock('unregistered-proto://', xdgDataHome, xdgConfigHome, xdgBinDir);
         expect(name).to.equal('');
       });
     });

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1510,6 +1510,86 @@ describe('app module', () => {
     it('returns an empty string for a bogus protocol', () => {
       expect(app.getApplicationNameForProtocol('bogus-protocol://')).to.equal('');
     });
+
+    ifdescribe(process.platform === 'linux')('on Linux with mocked XDG dirs', () => {
+      const fixtureApp = path.join(fixturesPath, 'api', 'protocol-name');
+      const desktopFileId = 'mock-browser.desktop';
+      const mockScheme = 'mockproto';
+      const mockMimeType = `x-scheme-handler/${mockScheme}`;
+
+      function spawnWithXdgMock(url: string, xdgDir: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+          const child = cp.spawn(process.execPath, [fixtureApp, url], {
+            env: {
+              ...process.env,
+              XDG_DATA_HOME: xdgDir,
+              XDG_DATA_DIRS: xdgDir,
+              XDG_CONFIG_HOME: xdgDir
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+          });
+          let stdout = '';
+          let stderr = '';
+          child.stdout.on('data', (d: Buffer) => {
+            stdout += d;
+          });
+          child.stderr.on('data', (d: Buffer) => {
+            stderr += d;
+          });
+          child.on('close', (code) => {
+            if (code !== 0) {
+              reject(new Error(`Fixture exited with code ${code}: ${stderr}`));
+              return;
+            }
+
+            try {
+              const parsed = JSON.parse(stdout);
+              resolve(parsed.name.trimEnd());
+            } catch {
+              reject(new Error(`Failed to parse output: ${stdout}\nstderr: ${stderr}`));
+            }
+          });
+          child.on('error', reject);
+        });
+      }
+
+      let xdgDir: string;
+      before(() => {
+        xdgDir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'electron-xdg-'));
+        const appsDir = path.join(xdgDir, 'applications');
+        fs.mkdirSync(appsDir, { recursive: true });
+
+        fs.writeFileSync(
+          path.join(appsDir, desktopFileId),
+          [
+            '[Desktop Entry]',
+            'Name=Mock Browser',
+            'Exec=/usr/bin/true %u',
+            'Type=Application',
+            `MimeType=${mockMimeType};`
+          ].join('\n')
+        );
+
+        fs.writeFileSync(
+          path.join(xdgDir, 'mimeapps.list'),
+          ['[Default Applications]', `${mockMimeType}=${desktopFileId}`].join('\n')
+        );
+      });
+
+      after(() => {
+        fs.rmSync(xdgDir, { recursive: true, force: true });
+      });
+
+      it('returns the desktop file ID for a registered protocol', async () => {
+        const name = await spawnWithXdgMock(`${mockScheme}://`, xdgDir);
+        expect(name).to.equal(desktopFileId);
+      });
+
+      it('returns an empty string for an unregistered protocol', async () => {
+        const name = await spawnWithXdgMock('unregistered-proto://', xdgDir);
+        expect(name).to.equal('');
+      });
+    });
   });
 
   ifdescribe(process.platform !== 'linux')('getApplicationInfoForProtocol()', () => {

--- a/spec/fixtures/api/protocol-name/main.js
+++ b/spec/fixtures/api/protocol-name/main.js
@@ -1,0 +1,8 @@
+const { app } = require('electron');
+
+app.whenReady().then(() => {
+  const url = process.argv[2];
+  const name = app.getApplicationNameForProtocol(url);
+  process.stdout.write(JSON.stringify({ name }));
+  app.quit();
+});

--- a/spec/fixtures/api/protocol-name/package.json
+++ b/spec/fixtures/api/protocol-name/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-protocol-name",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

Part 1 of 2 to improve `app.getApplicationNameForProtocol()` on Linux.

This half is test-only: It adds XDG env vars to inject mock deskop values so that we can test  `app.getApplicationNameForProtocol()` on Linux with those values.

The other half will reimplement the C++ code to call `g_app_info_get_default_for_uri_scheme()` + `g_app_info_get_display_name()` instead of spawning a new `xdg-mime` process. That half will only target 42-x-y.

Related: https://github.com/electron/electron/pull/51099

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.