### PR TITLE
fix: add crash diagnostics for ARM64 power notification crash

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -7,9 +7,14 @@
 #include <windows.h>
 #include <wtsapi32.h>
 
+#include "base/debug/alias.h"
+#include "base/debug/crash_logging.h"
 #include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/win/windows_handle_util.h"
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
+#include "components/crash/core/common/crash_key.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "ui/gfx/win/hwnd_util.h"
@@ -19,6 +24,18 @@ namespace electron {
 namespace {
 
 const wchar_t kPowerMonitorWindowClass[] = L"Electron_PowerMonitorHostWindow";
+
+std::string DescribeMemoryState(void* address) {
+  MEMORY_BASIC_INFORMATION mbi = {};
+  if (!VirtualQuery(address, &mbi, sizeof(mbi))) {
+    return "VirtualQuery failed err=" + base::NumberToString(::GetLastError());
+  }
+  // Refs
+  // https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-memory_basic_information
+  return "state=" + base::NumberToString(mbi.State) +
+         " protect=" + base::NumberToString(mbi.Protect) +
+         " type=" + base::NumberToString(mbi.Type);
+}
 
 }  // namespace
 
@@ -49,12 +66,35 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
       static_cast<HANDLE>(window_), DEVICE_NOTIFY_WINDOW_HANDLE);
   PLOG_IF(ERROR, !power_notify_handle_)
       << "RegisterSuspendResumeNotification failed";
+
+  // On ARM64 Windows, UnregisterSuspendResumeNotification may
+  // crash in powrprof!PowerUnregisterSuspendResumeNotification by dereferencing
+  // the HPOWERNOTIFY handle. VirtualQuery on the handle address reveals
+  // whether it was ever a valid pointer.
+  // Use static crash keys (not SCOPED_) so they persist until the crash.
+  if (power_notify_handle_) {
+    static crash_reporter::CrashKeyString<16> reg_handle_key("pm-reg-handle");
+    static crash_reporter::CrashKeyString<64> reg_memstate_key(
+        "pm-reg-memstate");
+    reg_handle_key.Set(
+        base::NumberToString(base::win::HandleToUint32(power_notify_handle_)));
+    reg_memstate_key.Set(DescribeMemoryState(power_notify_handle_));
+  }
 }
 
 void PowerMonitor::DestroyPlatformSpecificMonitors() {
   if (window_) {
     WTSUnRegisterSessionNotification(window_);
     if (power_notify_handle_) {
+      // Capture handle value and memory state at unregistration time.
+      // debug::Alias forces the raw value onto the stack.
+      auto handle_value = base::win::HandleToUint32(power_notify_handle_);
+      base::debug::Alias(&handle_value);
+
+      static crash_reporter::CrashKeyString<64> unreg_memstate_key(
+          "pm-unreg-memstate");
+      unreg_memstate_key.Set(DescribeMemoryState(power_notify_handle_));
+
       UnregisterSuspendResumeNotification(power_notify_handle_);
       power_notify_handle_ = nullptr;
     }


### PR DESCRIPTION
#### Description of Change

For https://github.com/electron/electron/issues/51190

On ARM64 Windows, `UnregisterSuspendResumeNotification` (user32) forwards to `PowerUnregisterSuspendResumeNotification` (powrprof), which treats the `HPOWERNOTIFY` handle as a pointer and dereferences it.

```
Crash reason:  EXCEPTION_ACCESS_VIOLATION_READ
Crash address: 0x2700b4
Crash parameters:
    value: 0x0000000000000000  description: 
    value: 0x00000000002700b4  description: 
Process uptime: 14 seconds

Thread 0 (crashed)
 0  powrprof.dll + 0x5020
     x0 = 0x00000000002700b4    x1 = 0x00000130e6800260
     x2 = 0x00000130e6813b50    x3 = 0x0000234c020208b0
     x4 = 0x0000234c02020900    x5 = 0x00003154022735d0
     x6 = 0x0000000000000000    x7 = 0x00000130e6800000
     x8 = 0x00000000002700b3    x9 = 0x00007fffdee11690
    x10 = 0x00007fffdffbaae8   x11 = 0x00007fffdffbaae8
    x12 = 0x0000000000000018   x13 = 0x0000000000000000
    x14 = 0x0000000000000000   x15 = 0x0000000000000000
    x16 = 0x00007fffd9925000   x17 = 0x0000000000000001
    x18 = 0x0000000000000000   x19 = 0x00000000002700b4
    x20 = 0x0000000000000000   x21 = 0x0000234c02020848
    x22 = 0x0000234c02040000   x23 = 0x0000234c02020900
    x24 = 0x0000000000000060   x25 = 0x0000000000000010
    x26 = 0x0000000000000001   x27 = 0x0000000000000000
    x28 = 0x0000000000000000    fp = 0x00000022bbdfeef0
     lr = 0x00007fffdee116a4    sp = 0x00000022bbdfeef0
     pc = 0x00007fffd9925020
    Found by: given as instruction pointer in context
 1  USER32.dll + 0x716a0
     fp = 0x00000022bbdfef10    lr = 0x00007fffdee116a4
     sp = 0x00000022bbdfef00    pc = 0x00007fffdee116a4
    Found by: previous frame's frame pointer
 2  USER32.dll + 0x716a0
     fp = 0x00000022bbdfef38    lr = 0x00007ff62fceac80
     sp = 0x00000022bbdfef20    pc = 0x00007fffdee116a4
    Found by: previous frame's frame pointer
 3  Slack.exe!electron::api::PowerMonitor::DestroyPlatformSpecificMonitors() [electron_api_power_monitor_win.cc : 55 + 0xc]
     fp = 0x00000022bbdfef60    lr = 0x00007ff62fb555ec
     sp = 0x00000022bbdfef48    pc = 0x00007ff62fceac80
    Found by: previous frame's frame pointer
 4  Slack.exe!electron::api::PowerMonitor::~PowerMonitor() [electron_api_power_monitor.cc : 84 + 0x0]
     fp = 0x00000022bbdfef80    lr = 0x00007ff62fb57668
     sp = 0x00000022bbdfef70    pc = 0x00007ff62fb555ec
    Found by: previous frame's frame pointer
 5  Slack.exe!void electron::api::PowerMonitor::~PowerMonitor() [electron_api_power_monitor.cc : 82 + 0x0]
     fp = 0x00000022bbdff000    lr = 0x00007ff63321f44c
     sp = 0x00000022bbdfef90    pc = 0x00007ff62fb57668
    Found by: previous frame's frame pointer
 6  Slack.exe!cppgc::internal::HeapVisitor<cppgc::internal::`anonymous namespace'::MutatorThreadSweeper>::Traverse(class cppgc::internal::BasePage & const) [heap-visitor.h : 47 + 0x8c]
     fp = 0x00000022bbdff350    lr = 0x00007ff63321f06c
     sp = 0x00000022bbdff010    pc = 0x00007ff63321f44c
    Found by: previous frame's frame pointer
 7  Slack.exe!cppgc::internal::Sweeper::SweeperImpl::Finish() [sweeper.cc : 1311 + 0x2c]
     fp = 0x00000022bbdff410    lr = 0x00007ff630a95a9c
     sp = 0x00000022bbdff360    pc = 0x00007ff63321f06c
    Found by: previous frame's frame pointer
 8  Slack.exe!cppgc::internal::Sweeper::SweeperImpl::FinishIfRunning() [sweeper.cc : 1236 + 0x4]
     fp = 0x00000022bbdff460    lr = 0x00007ff630a8fc98
     sp = 0x00000022bbdff420    pc = 0x00007ff630a95a9c
    Found by: previous frame's frame pointer
 9  Slack.exe!cppgc::internal::HeapBase::Terminate() [heap-base.cc : 281 + 0x0]
     fp = 0x00000022bbdff480    lr = 0x00007ff630695f84
     sp = 0x00000022bbdff470    pc = 0x00007ff630a8fc98
    Found by: previous frame's frame pointer
10  Slack.exe!v8::internal::CppHeap::~CppHeap() [cpp-heap.cc : 540 + 0x20]
     fp = 0x00000022bbdff4a0    lr = 0x00007ff630697918
     sp = 0x00000022bbdff490    pc = 0x00007ff630695f84
    Found by: previous frame's frame pointer
11  Slack.exe!void v8::internal::CppHeap::~CppHeap() [cpp-heap.cc : 539 + 0x0]
     fp = 0x00000022bbdff4d0    lr = 0x00007ff63066088c
     sp = 0x00000022bbdff4b0    pc = 0x00007ff630697918
    Found by: previous frame's frame pointer
12  Slack.exe!v8::internal::Isolate::RunReleaseCppHeapCallback(std::__Cr::unique_ptr<v8::CppHeap,std::__Cr::default_delete<v8::CppHeap> >) [isolate.cc : 7436 + 0x24]
     fp = 0x00000022bbdff510    lr = 0x00007ff632e4c2d4
     sp = 0x00000022bbdff4e0    pc = 0x00007ff63066088c
    Found by: previous frame's frame pointer
13  Slack.exe!v8::internal::Heap::TearDown() [heap.cc : 6450 + 0x0]
     fp = 0x00000022bbdff590    lr = 0x00007ff632dfa0e4
     sp = 0x00000022bbdff520    pc = 0x00007ff632e4c2d4
    Found by: previous frame's frame pointer
14  Slack.exe!v8::internal::Isolate::Deinit() [isolate.cc : 4984 + 0x0]
     fp = 0x00000022bbdff5d8    lr = 0x00007ff63065d738
     sp = 0x00000022bbdff5a0    pc = 0x00007ff632dfa0e4
    Found by: previous frame's frame pointer
15  Slack.exe!v8::internal::Isolate::Deinitialize(v8::internal::Isolate *) [isolate.cc : 4548 + 0x4]
     fp = 0x00000022bbdff5f8    lr = 0x00007ff63065d674
     sp = 0x00000022bbdff5e8    pc = 0x00007ff63065d738
    Found by: previous frame's frame pointer
16  Slack.exe!v8::internal::Isolate::Delete(v8::internal::Isolate *) [isolate.cc : 4529 + 0x0]
     fp = 0x00000022bbdff648    lr = 0x00007ff631dab448
     sp = 0x00000022bbdff608    pc = 0x00007ff63065d674
    Found by: previous frame's frame pointer
17  Slack.exe!gin::IsolateHolder::~IsolateHolder() [isolate_holder.cc : 157 + 0x0]
     fp = 0x00000022bbdff6b0    lr = 0x00007ff62fc1d170
     sp = 0x00000022bbdff658    pc = 0x00007ff631dab448
    Found by: previous frame's frame pointer
18  Slack.exe!electron::JavascriptEnvironment::~JavascriptEnvironment() [javascript_environment.cc : 91 + 0x10]
     fp = 0x00000022bbdff730    lr = 0x00007ff62fc04e64
     sp = 0x00000022bbdff6c0    pc = 0x00007ff62fc1d170
    Found by: previous frame's frame pointer
19  Slack.exe!electron::ElectronBrowserMainParts::PostMainMessageLoopRun() [electron_browser_main_parts.cc : 631 + 0x10]
     fp = 0x00000022bbdff7b8    lr = 0x00007ff630cb27dc
     sp = 0x00000022bbdff740    pc = 0x00007ff62fc04e64
    Found by: previous frame's frame pointer
20  Slack.exe!content::BrowserMainLoop::ShutdownThreadsAndCleanUp() [browser_main_loop.cc : 1164 + 0x0]
     fp = 0x00000022bbdff808    lr = 0x00007ff630cb3ea8
     sp = 0x00000022bbdff7c8    pc = 0x00007ff630cb27dc
    Found by: previous frame's frame pointer
```
    
 The exception was at x19 which carries the callee register x0 the handle value
 
 ```
 powrprof!PowerUnregisterSuspendResumeNotification+20
00007fff`d9925020 b9400269 ldr         w9,[x19]
```

Add crash keys (pm-reg-handle, pm-reg-memstate, pm-unreg-memstate) to capture
- The handle value
- VirtualQuery memory state at both registration and unregistration

If the handle address is `MEM_FREE`, it confirms the handle is an opaque index and powrprof is incorrectly dereferencing it. If `MEM_COMMIT`, it would indicate a use-after-free of the underlying allocation.

Refs https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/powerbase/nf-powerbase-powerunregistersuspendresumenotification.md

#### Release Notes

Notes: Added crash keys to diagnose power monitor shutdown crash on arm64 windows.