### PR TITLE
ci: don't upload build stats on Windows if build fails

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -107,6 +107,10 @@ runs:
         } else {
           e build --target electron:testing_build
         }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "e build failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
         Copy-Item out\Default\.ninja_log out\electron_ninja_log
         node electron\script\check-symlinks.js
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

On non-Windows builds the steps after `e build` are not taken if the build fails, but on Windows they are, so build stats for partial failed builds are being uploaded. This change aligns the behavior with the non-Windows build steps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
