### PR TITLE
fix: ignore draggable regions in hidden `WebContentsView`

### DIFF
--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -82,6 +82,8 @@ void WebContentsView::ApplyBorderRadius() {
 }
 
 int WebContentsView::NonClientHitTest(const gfx::Point& point) {
+  if (!view() || !view()->GetVisible())
+    return HTNOWHERE;
   if (api_web_contents_) {
     auto* iwc = api_web_contents_->inspectable_web_contents();
     if (!iwc)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/51176

Hidden child WebContentsViews were still contributing their draggable regions to the parent window's non-client hit test, so clicks in the area where a hidden view's draggable element would render still dragged the window. Early-return HTNOWHERE when the view is not visible.

Tested with https://gist.github.com/b5e30f6d143986ccdd32cd77fb26b839

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `app-region: drag` inside a hidden `WebContentsView` would still drag the parent window on Windows.
