### PR TITLE
fix: skip heap profiling tests in CI

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -169,7 +169,7 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
     });
   });
 
-  describe('enableHeapProfiling', () => {
+  describe.skip('enableHeapProfiling', () => {
     const checkForHeapDumps = async (options?: EnableHeapProfilingOptions | false) => {
       const rc = await startRemoteControlApp();
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Refs https://github.com/electron/electron/issues/51207.

Some tests from https://github.com/electron/electron/pull/50826 seem to be flaky in CI.

What's happening is that if there aren’t enough memory allocations, `contentTracing` won’t record anything that would show up in traces. The actual code is fine.

This wasn’t an issue locally or in CI on the original PR, but it seems to be an issue now.

For now, this PR skips the tests. Then I’ll fix them properly later this week.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
