### PR TITLE
fix: heap profiling test flakes

### DIFF
--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -9,6 +9,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import { ifdescribe, ifit, startRemoteControlApp } from './lib/spec-helpers';
 
+const isCI = !!process.env.CI;
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 // FIXME: The tests are skipped on linux arm/arm64
@@ -169,12 +170,21 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
     });
   });
 
-  describe.skip('enableHeapProfiling', () => {
+  describe('enableHeapProfiling', function () {
+    const enableHeapProfilingTestTimeout = 120000;
+
+    this.timeout(enableHeapProfilingTestTimeout);
+
     const checkForHeapDumps = async (options?: EnableHeapProfilingOptions | false) => {
-      const rc = await startRemoteControlApp();
+      const rc = await startRemoteControlApp([`--remote-app-timeout=${enableHeapProfilingTestTimeout}`]);
 
       const { hasBrowserProcessHeapDump, hasRendererProcessHeapDump, hasUtilityProcessHeapDump } = await rc.remotely(
-        async (utilityProcessPath: string, options: EnableHeapProfilingOptions | false | undefined) => {
+        async (
+          htmlPath: string,
+          utilityProcessPath: string,
+          options: EnableHeapProfilingOptions | false | undefined,
+          isCI: boolean
+        ) => {
           const { contentTracing, BrowserWindow, utilityProcess } = require('electron');
           const { once } = require('node:events');
           const fs = require('node:fs');
@@ -200,25 +210,26 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
 
           if (options !== false) await contentTracing.enableHeapProfiling(options);
 
-          const interval = 1000;
           await contentTracing.startRecording({
             included_categories: ['disabled-by-default-memory-infra'],
             excluded_categories: ['*'],
             memory_dump_config: {
-              triggers: [{ mode: 'detailed', periodic_interval_ms: interval }]
+              triggers: [{ mode: 'detailed', periodic_interval_ms: 1000 }]
             }
           });
 
           // Launch a renderer process
           const window = new BrowserWindow({ show: false });
-          await window.webContents.loadURL('about:blank');
+          await window.webContents.loadFile(htmlPath);
 
           // Launch a utility process
           const utility = utilityProcess.fork(utilityProcessPath);
           await once(utility, 'spawn');
 
           // Collect heap dumps
-          await setTimeout(2 * interval);
+          // - We wait for a long time because sometimes processes take a few seconds to start sending heap dumps.
+          // - CI machines are slower, so we wait longer there than when running locally.
+          await setTimeout(isCI ? 10000 : 4000);
 
           const path = await contentTracing.stopRecording();
           const data = fs.readFileSync(path, 'utf8');
@@ -236,8 +247,10 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
             hasUtilityProcessHeapDump
           };
         },
+        path.join(fixturesPath, 'api', 'content-tracing', 'index.html'),
         path.join(fixturesPath, 'api', 'content-tracing', 'utility.js'),
-        options
+        options,
+        isCI
       );
 
       const [code] = await once(rc.process, 'exit');

--- a/spec/fixtures/api/content-tracing/index.html
+++ b/spec/fixtures/api/content-tracing/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+</html>

--- a/spec/fixtures/apps/remote-control/main.js
+++ b/spec/fixtures/apps/remote-control/main.js
@@ -8,6 +8,21 @@ const http = require('node:http');
 const promises_1 = require('node:timers/promises');
 const v8 = require('node:v8');
 
+function getAutoQuitTimeout() {
+  const argPrefix = '--remote-app-timeout=';
+  const arg = process.argv.find((arg) => arg.startsWith(argPrefix));
+
+  if (arg) {
+    const timeout = parseInt(arg.slice(argPrefix.length), 10);
+
+    if (Number.isSafeInteger(timeout) && timeout > 0) {
+      return timeout;
+    }
+  }
+
+  return 30000;
+}
+
 if (app.commandLine.hasSwitch('boot-eval')) {
   // eslint-disable-next-line no-eval
   eval(app.commandLine.getSwitchValue('boot-eval'));
@@ -39,4 +54,4 @@ app.whenReady().then(() => {
 
 setTimeout(() => {
   process.exit(0);
-}, 30000);
+}, getAutoQuitTimeout());


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/51207.

I was able to reproduce a situation similar to the test failure locally when stopping the trace recording shortly after it was started. Apparently, sometimes it can take a few seconds for processes to start sending heap dumps. (Sometimes, one process takes longer than all the other processes.) If we stop the recording before we receive heap dumps from all processes, our assertions will fail.

For some reason, renderers take longer to start sending heap dumps when they load a page from a URL instead of a file (e.g., `https://www.google.com/` or `about:blank`).

Thus, this PR makes two changes to address the failures:

- Give processes more time to start sending heap dumps
- Load from a file instead of a URL (so that the renderer starts sending heap dumps sooner)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none