### PR TITLE
refactor: expose preferredDisplaySurface and deprecate desktopCapturer.getSources

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -1,30 +1,31 @@
 # desktopCapturer
 
 > Access information about media sources that can be used to capture audio and
-> video from the desktop using the [`navigator.mediaDevices.getUserMedia`][] API.
+> video from the desktop using the [`navigator.mediaDevices.getDisplayMedia`][] API.
 
 Process: [Main](../glossary.md#main-process)
 
-The following example shows how to capture video from a desktop window whose
-title is `Electron`:
+> [!WARNING]
+> The `desktopCapturer` module is deprecated. Use
+> [`session.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts)
+> instead, which aligns with the web-standard
+> [`navigator.mediaDevices.getDisplayMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia)
+> API. See the [migration guide](#migrating-from-getsources-to-setdisplaymediarequesthandler) below.
+
+The following example shows how to respond to a `getDisplayMedia` request by
+letting the requesting tab capture itself:
 
 ```js
 // main.js
-const { app, BrowserWindow, desktopCapturer, session } = require('electron')
+const { app, BrowserWindow, session } = require('electron')
 
 app.whenReady().then(() => {
   const mainWindow = new BrowserWindow()
 
   session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
-    desktopCapturer.getSources({ types: ['screen'] }).then((sources) => {
-      // Grant access to the first screen found.
-      callback({ video: sources[0], audio: 'loopback' })
-    })
-    // If true, use the system picker if available.
-    // Note: this is currently experimental. If the system picker
-    // is available, it will be used and the media request handler
-    // will not be invoked.
-  }, { useSystemPicker: true })
+    // Allow the requesting tab to capture itself.
+    callback({ video: request.frame })
+  })
 
   mainWindow.loadFile('index.html')
 })
@@ -78,7 +79,7 @@ See [`navigator.mediaDevices.getDisplayMedia`](https://developer.mozilla.org/en-
 
 The `desktopCapturer` module has the following methods:
 
-### `desktopCapturer.getSources(options)`
+### `desktopCapturer.getSources(options)` _Deprecated_
 
 <!--
 ```YAML history
@@ -88,6 +89,8 @@ changes:
   - pr-url: https://github.com/electron/electron/pull/16427
     description: "This method now returns a Promise instead of using a callback function."
     breaking-changes-header: api-changed-callback-based-versions-of-promisified-apis
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/51235
 ```
 -->
 
@@ -104,12 +107,27 @@ changes:
 
 Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md) objects, each `DesktopCapturerSource` represents a screen or an individual window that can be captured.
 
+**Deprecated:** Use [`session.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts) instead.
+
 > [!NOTE]
 <!-- markdownlint-disable-next-line MD032 -->
 > * Capturing audio requires `NSAudioCaptureUsageDescription` Info.plist key on macOS 14.2 Sonoma and higher - [read more](#macos-versions-142-or-higher).
 > * Capturing the screen contents requires user consent on macOS 10.15 Catalina or higher, which can detected by [`systemPreferences.getMediaAccessStatus`][].
 
-[`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
+### `desktopCapturer.isDisplayMediaSystemPickerAvailable()` _macOS_ _Experimental_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/43581
+```
+-->
+
+Returns `boolean` - Whether the native macOS [`SCContentSharingPicker`](https://developer.apple.com/documentation/screencapturekit/sccontentsharingpicker) is available. Returns `true` on macOS 15 and later, `false` on earlier macOS versions and all non-macOS platforms.
+
+Use this to decide whether to pass `useSystemPicker: true` to [`session.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts) — see the [migration guide](#migrating-from-getsources-to-setdisplaymediarequesthandler) below for an example.
+
+[`navigator.mediaDevices.getDisplayMedia`]: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
 [`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos
 
 ## Caveats
@@ -158,3 +176,66 @@ It is possible to circumvent this limitation by capturing system audio with anot
 [BlackHole](https://existential.audio/blackhole/) or [Soundflower](https://rogueamoeba.com/freebies/soundflower/)
 and passing it through a virtual audio input device. This virtual device can then be queried
 with `navigator.mediaDevices.getUserMedia`.
+
+## Migrating from `getSources` to `setDisplayMediaRequestHandler`
+
+`desktopCapturer.getSources` is deprecated. Applications should migrate to
+[`session.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts),
+which aligns with the web-standard [`navigator.mediaDevices.getDisplayMedia`][] API.
+
+### Why migrate?
+
+* **Web standards alignment** — `getDisplayMedia()` is the web-standard API for screen
+  capture. Using `setDisplayMediaRequestHandler` lets you integrate with it directly.
+* **Platform integration** — On macOS 15+, setting `useSystemPicker: true` invokes the
+  native OS screen picker (SCContentSharingPicker), providing a familiar UX and
+  correct permissions handling.
+* **Simpler architecture** — The handler receives the request when the renderer calls
+  `getDisplayMedia()` and you respond with the chosen source. No need to pre-enumerate
+  sources.
+
+### Before (deprecated)
+
+```js
+const { app, BrowserWindow, desktopCapturer, session } = require('electron')
+
+app.whenReady().then(() => {
+  const mainWindow = new BrowserWindow()
+
+  session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
+    desktopCapturer.getSources({ types: ['screen'] }).then((sources) => {
+      callback({ video: sources[0] })
+    })
+  })
+
+  mainWindow.loadFile('index.html')
+})
+```
+
+### After (recommended)
+
+On macOS 15+, the native OS picker (SCContentSharingPicker) is available. On
+other platforms you must provide your own picker UI. A cross-platform handler
+typically branches on `desktopCapturer.isDisplayMediaSystemPickerAvailable()`:
+
+```js
+const { app, BrowserWindow, desktopCapturer, session } = require('electron')
+
+app.whenReady().then(() => {
+  const mainWindow = new BrowserWindow()
+
+  session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
+    // On macOS 15+, useSystemPicker: true causes the OS to present its own
+    // picker and the handler is not invoked. This branch runs everywhere else
+    // (Windows, Linux, and macOS < 15) — show your own picker UI here and
+    // call callback with the selected source, e.g. via desktopCapturer.getSources().
+    callback({})
+  }, { useSystemPicker: desktopCapturer.isDisplayMediaSystemPickerAvailable() })
+
+  mainWindow.loadFile('index.html')
+})
+```
+
+`request.preferredDisplaySurface` (`'monitor'`, `'window'`, `'browser'`, or
+`'none'`) indicates what kind of surface the caller asked for, and can be used
+to drive the filtering in your custom picker UI.

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1031,6 +1031,7 @@ session.fromPartition('some-partition').setPermissionCheckHandler((webContents, 
     * `videoRequested` Boolean - true if the web content requested a video stream.
     * `audioRequested` Boolean - true if the web content requested an audio stream.
     * `userGesture` Boolean - Whether a user gesture was active when this request was triggered.
+    * `preferredDisplaySurface` string - The preferred display surface type requested by the web content. Can be 'monitor', 'window', 'browser', or 'none'. This corresponds to the [`displaySurface`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/displaySurface) constraint in `getDisplayMedia()`.
   * `callback` Function
     * `streams` Object
       * `video` Object | [WebFrameMain](web-frame-main.md) (optional)
@@ -1057,23 +1058,19 @@ via the `navigator.mediaDevices.getDisplayMedia` API. Use the
 [desktopCapturer](desktop-capturer.md) API to choose which stream(s) to grant
 access to.
 
-`useSystemPicker` allows an application to use the system picker instead of providing a specific video source from `getSources`.
+`useSystemPicker` allows an application to use the native OS picker instead of providing a specific video source from the handler callback.
 This option is experimental, and currently available for MacOS 15+ only. If the system picker is available and `useSystemPicker`
 is set to `true`, the handler will not be invoked.
 
 ```js
-const { session, desktopCapturer } = require('electron')
+const { desktopCapturer, session } = require('electron')
 
 session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
-  desktopCapturer.getSources({ types: ['screen'] }).then((sources) => {
-    // Grant access to the first screen found.
-    callback({ video: sources[0] })
-  })
-  // Use the system picker if available.
-  // Note: this is currently experimental. If the system picker
-  // is available, it will be used and the media request handler
-  // will not be invoked.
-}, { useSystemPicker: true })
+  // Runs on Windows, Linux, and macOS < 15. On macOS 15+ (where
+  // useSystemPicker is effective) the OS presents its own picker and this
+  // handler is not invoked.
+  callback({ video: request.frame })
+}, { useSystemPicker: desktopCapturer.isDisplayMediaSystemPickerAvailable() })
 ```
 
 Passing a [WebFrameMain](web-frame-main.md) object as a video or audio stream

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -25,6 +25,20 @@ fallback frames as well.
 Apps or extensions that relied on Electron skipping those frames should narrow their
 injection target, frame IDs, or match patterns.
 
+### Deprecated: `desktopCapturer.getSources()`
+
+The `desktopCapturer.getSources()` API has been deprecated. Applications should use
+[`session.setDisplayMediaRequestHandler`](api/session.md#sessetdisplaymediarequesthandlerhandler-opts)
+instead, which aligns with the web-standard `navigator.mediaDevices.getDisplayMedia()` API.
+
+The request object passed to the handler now includes a `preferredDisplaySurface` property
+(`'monitor'`, `'window'`, `'browser'`, or `'none'`) reflecting what the renderer asked for via
+`getDisplayMedia({ video: { displaySurface } })`. Handlers can use this to pre-filter sources
+without falling back to `desktopCapturer.getSources()`.
+
+See the [migration guide](api/desktop-capturer.md#migrating-from-getsources-to-setdisplaymediarequesthandler)
+for detailed instructions and examples.
+
 ### Behavior Changed: Dialog methods default to Downloads directory
 
 The `defaultPath` option for the following methods now defaults to the user's Downloads folder (or their home directory if Downloads doesn't exist) when not explicitly provided:

--- a/lib/browser/api/desktop-capturer.ts
+++ b/lib/browser/api/desktop-capturer.ts
@@ -1,3 +1,5 @@
+import * as deprecate from '@electron/internal/common/deprecate';
+
 import { BrowserWindow } from 'electron/main';
 
 const { createDesktopCapturer, isDisplayMediaSystemPickerAvailable } = process._linkedBinding(
@@ -19,7 +21,10 @@ function isValid(options: Electron.SourcesOptions) {
 
 export { isDisplayMediaSystemPickerAvailable };
 
+const getSourcesDeprecated = deprecate.warnOnce('desktopCapturer.getSources', 'session.setDisplayMediaRequestHandler');
+
 export async function getSources(args: Electron.SourcesOptions) {
+  getSourcesDeprecated();
   if (!isValid(args)) throw new Error('Invalid options');
 
   const resizableValues = new Map();

--- a/lib/browser/api/session.ts
+++ b/lib/browser/api/session.ts
@@ -7,20 +7,21 @@ import { net } from 'electron/main';
 const { fromPartition, fromPath, Session } = process._linkedBinding('electron_browser_session');
 const { isDisplayMediaSystemPickerAvailable } = process._linkedBinding('electron_browser_desktop_capturer');
 
-// Fake video window that activates the native system picker
-// This is used to get around the need for a screen/window
-// id in Chrome's desktopCapturer.
-let fakeVideoWindowId = -1;
-// See content/public/browser/desktop_media_id.h
+// Generates a source that triggers the native macOS SCContentSharingPicker.
+// The magic ID kMacOsNativePickerId (-4) is recognized by the Chromium
+// content layer (see content/public/browser/desktop_media_id.h) and routes
+// to ScreenCaptureKitDeviceMac which presents the native picker.
+// Each request needs a unique window_id so Chromium treats them as distinct
+// streams (it deduplicates by DesktopMediaID).
+let nextNativePickerWindowId = -1;
 const kMacOsNativePickerId = -4;
-const systemPickerVideoSource = Object.create(null);
-Object.defineProperty(systemPickerVideoSource, 'id', {
-  get() {
-    return `window:${kMacOsNativePickerId}:${fakeVideoWindowId--}`;
-  }
-});
-systemPickerVideoSource.name = '';
-Object.freeze(systemPickerVideoSource);
+
+function createNativePickerSource() {
+  return {
+    id: `window:${kMacOsNativePickerId}:${nextNativePickerWindowId--}`,
+    name: ''
+  };
+}
 
 Session.prototype._init = function () {
   addIpcDispatchListeners(this);
@@ -50,7 +51,9 @@ Session.prototype.setDisplayMediaRequestHandler = function (handler, opts) {
 
   this._setDisplayMediaRequestHandler(async (req, callback) => {
     if (opts && opts.useSystemPicker && isDisplayMediaSystemPickerAvailable()) {
-      return callback({ video: systemPickerVideoSource });
+      // On macOS 15+, use the native SCContentSharingPicker. This bypasses
+      // the JS handler and lets the OS present its own picker UI.
+      return callback({ video: createNativePickerSource() });
     }
 
     return handler(req, callback);

--- a/shell/common/gin_converters/media_converter.cc
+++ b/shell/common/gin_converters/media_converter.cc
@@ -4,12 +4,33 @@
 
 #include "shell/common/gin_converters/media_converter.h"
 
+#include <string_view>
+
 #include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/render_frame_host.h"
 #include "gin/data_object_builder.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
+
+namespace {
+
+std::string_view PreferredDisplaySurfaceToString(
+    blink::mojom::PreferredDisplaySurface surface) {
+  switch (surface) {
+    case blink::mojom::PreferredDisplaySurface::MONITOR:
+      return "monitor";
+    case blink::mojom::PreferredDisplaySurface::WINDOW:
+      return "window";
+    case blink::mojom::PreferredDisplaySurface::BROWSER:
+      return "browser";
+    case blink::mojom::PreferredDisplaySurface::NO_PREFERENCE:
+    default:
+      return "none";
+  }
+}
+
+}  // namespace
 
 namespace gin {
 
@@ -26,6 +47,8 @@ v8::Local<v8::Value> Converter<content::MediaStreamRequest>::ToV8(
            request.video_type != blink::mojom::MediaStreamType::NO_SERVICE)
       .Set("audioRequested",
            request.audio_type != blink::mojom::MediaStreamType::NO_SERVICE)
+      .Set("preferredDisplaySurface",
+           PreferredDisplaySurfaceToString(request.preferred_display_surface))
       .Build();
 }
 

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -62,6 +62,54 @@ describe('setDisplayMediaRequestHandler', () => {
     expect(ok).to.be.true(message);
   });
 
+  for (const surface of ['monitor', 'window', 'browser'] as const) {
+    it(`includes preferredDisplaySurface='${surface}' in the request object`, async () => {
+      const ses = session.fromPartition('' + Math.random());
+      let mediaRequest: any = null;
+      let w: BrowserWindow | null = null;
+      ses.setDisplayMediaRequestHandler((request, callback) => {
+        mediaRequest = request;
+        callback({ video: w?.webContents.mainFrame });
+      });
+      w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+      await w.loadURL(serverUrl);
+      const { ok, message } = await w.webContents.executeJavaScript(
+        `
+        navigator.mediaDevices.getDisplayMedia({
+          video: { displaySurface: '${surface}' },
+          audio: false,
+        }).then(x => ({ok: x instanceof MediaStream}), e => ({ok: false, message: e.message}))
+      `,
+        true
+      );
+      expect(ok).to.be.true(message);
+      expect(mediaRequest.preferredDisplaySurface).to.equal(surface);
+    });
+  }
+
+  it('defaults preferredDisplaySurface to none when not specified', async () => {
+    const ses = session.fromPartition('' + Math.random());
+    let mediaRequest: any = null;
+    let w: BrowserWindow | null = null;
+    ses.setDisplayMediaRequestHandler((request, callback) => {
+      mediaRequest = request;
+      callback({ video: w?.webContents.mainFrame });
+    });
+    w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await w.loadURL(serverUrl);
+    const { ok, message } = await w.webContents.executeJavaScript(
+      `
+      navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false,
+      }).then(x => ({ok: x instanceof MediaStream}), e => ({ok: false, message: e.message}))
+    `,
+      true
+    );
+    expect(ok).to.be.true(message);
+    expect(mediaRequest.preferredDisplaySurface).to.equal('none');
+  });
+
   it('does not crash when using a bogus ID', async () => {
     const ses = session.fromPartition('' + Math.random());
     let requestHandlerCalled = false;


### PR DESCRIPTION
#### Description of Change

First of a few PRs to pull our desktopCapturer code closer to upstream Chromium's getDisplayMedia / setDisplayMediaRequestHandler and drop the plethora of chromium patches around it. related PR: #51243.

changes:

- `session.setDisplayMediaRequestHandler`'s request object now carries `preferredDisplaySurface` (`"monitor" | "window" | "browser" | "none"`), so handlers can honor what the renderer asked for in `getDisplayMedia({ video: { displaySurface } })` without going back through `desktopCapturer.getSources()`.
- `desktopCapturer.getSources()` is soft-deprecated, added a `warnOnce`, docs block, and breaking-changes entry. It still works but now we're pointing users to  `setDisplayMediaRequestHandler` (optionally `useSystemPicker: true` for the native macOS 15 picker).
- Small cleanup in `session.ts`: replaced the frozen-object-with-getter with `createNativePickerSource()` so each call mints a unique `DesktopMediaID` and Chromium stops deduping concurrent streams. Added a comment for the `kMacOsNativePickerId = -4` magic.

Follow-ups will chip away at the larger capture patches and `electron_api_desktop_capturer.{h,cc}`.

#### Test plan

- [x] `e sync && e build` clean
- [x] `yarn run lint` passes
- [x] Manual: deprecation warning fires once; handler sees the right `preferredDisplaySurface` for monitor / window / browser / default
- [x] Manual on macOS 15: `useSystemPicker: true` shows the native picker, JS handler is skipped
- [x] `spec/api-media-handler-spec.ts` 
- [x] `spec/api-desktop-capturer-spec.ts`

#### Release Notes

Notes: Deprecated `desktopCapturer.getSources()` in favor of `session.setDisplayMediaRequestHandler()`. Added `preferredDisplaySurface` property to the request object in `session.setDisplayMediaRequestHandler`.