### PR TITLE
fix: set dialog type hint for parentless message boxes on Linux

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -121,6 +121,14 @@ class GtkMessageBox : private NativeWindowObserver {
       gtk::SetGtkTransientForAura(dialog_, parent_->GetNativeWindow(),
                                   platform_);
       gtk_window_set_modal(GTK_WINDOW(dialog_), TRUE);
+    } else {
+      // When there is no parent window, the dialog is a top-level window.
+      // Set the type hint to DIALOG so the window manager treats it as a
+      // dialog (rather than a normal window subject to focus-stealing
+      // prevention), and set urgency to ensure it receives focus promptly.
+      gtk_window_set_type_hint(GTK_WINDOW(dialog_),
+                               GDK_WINDOW_TYPE_HINT_DIALOG);
+      gtk_window_set_urgency_hint(GTK_WINDOW(dialog_), TRUE);
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Fixes #51049.

When `dialog.showMessageBox` is called without a parent `BrowserWindow` on Linux, the GTK dialog was created as a plain top-level window without a type hint. This caused the window manager (particularly on the primary monitor) to apply focus-stealing prevention, delaying the dialog's focus and consequently the promise resolution by several seconds.

This adds `GDK_WINDOW_TYPE_HINT_DIALOG` and an urgency hint to parentless message box dialogs, so the window manager properly identifies them as dialogs requiring immediate user attention rather than treating them as regular windows subject to focus-stealing prevention.

**Why this only affected the primary monitor:** Most Linux window managers apply stricter focus-stealing prevention on the primary display. On secondary monitors, the policy is often more relaxed, which is why the dialog worked correctly there.

**File changed:** `shell/browser/ui/message_box_gtk.cc` (1 file, +8 lines)

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `dialog.showMessageBox` promise resolution being delayed by several seconds on Linux when called without a parent `BrowserWindow` on the primary monitor.
