### PR TITLE
fix: ensure stable bounds on Windows when toggling setResizable for frameless windows

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -281,8 +281,7 @@ gfx::Size WinFrameView::GetMaximumSize() const {
 }
 
 gfx::Insets WinFrameView::RestoredFrameBorderInsets() const {
-  if (window_->has_frame() || !window_->has_thick_frame() ||
-      !window_->IsResizable())
+  if (window_->has_frame() || !window_->has_thick_frame())
     return {};
 
   const int thickness =

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -121,10 +121,11 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       // monitors with different DPIs before changing this code.
       *insets = gfx::Insets::TLBR(thickness, thickness, thickness, thickness);
       return true;
-    } else if (native_window_view_->has_thick_frame() &&
-               native_window_view_->IsResizable()) {
+    } else if (native_window_view_->has_thick_frame()) {
       // Grow the insets to support resize targets past the frame edge like in
-      // windows with standard frames.
+      // windows with standard frames. Non-resizable windows still get input
+      // insets for stable bounds and so they can be dragged from outer edges,
+      // also like in windows with standard frames.
       *insets = gfx::Insets::TLBR(0, thickness, thickness, thickness);
       return true;
     }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5790,6 +5790,20 @@ describe('BrowserWindow module', () => {
         expectBoundsEqual(w.getSize(), [400, 300]);
       });
 
+      it('does not change window size when disabled and enabled for frameless window', () => {
+        const w = new BrowserWindow({
+          show: false,
+          width: 400,
+          height: 300,
+          frame: false
+        });
+
+        w.setResizable(false);
+        expectBoundsEqual(w.getSize(), [400, 300]);
+        w.setResizable(true);
+        expectBoundsEqual(w.getSize(), [400, 300]);
+      });
+
       ifit(process.platform === 'win32')('do not change window with frame bounds when maximized', () => {
         const w = new BrowserWindow({
           show: true,


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Fixes https://github.com/electron/electron/issues/51244.

Refs https://github.com/electron/electron/pull/50706.

Thick frame frameless windows now get input insets even if they aren't resizable, preventing their size from changing after calls to `setResizability()`.

This additionally is more consistent with how native apps behave: e.g. run `charmap.exe` and drag it over a text document. The text cursor changes to the pointer before you reach the edge of the frame, and the window will be focused if you click in that area, even though it can't be resized by dragging.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed a regression on Windows where frameless windows changed their size after calling `setResizable`.
