### PR TITLE
chore: cherry-pick 7 changes from chromium (40-x-y)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -183,3 +183,8 @@ cherry-pick-cl-7732030.patch
 cherry-pick-cl-7757063.patch
 cherry-pick-7673406.patch
 cherry-pick-7687618.patch
+cherry-pick-4e9562ca7b42.patch
+cherry-pick-fccaeb9e0967.patch
+cherry-pick-c75f63de7188.patch
+cherry-pick-d141d62357df.patch
+cherry-pick-848cf5567223.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -181,3 +181,5 @@ cherry-pick-cl-7743444.patch
 cherry-pick-cl-7745786.patch
 cherry-pick-cl-7732030.patch
 cherry-pick-cl-7757063.patch
+cherry-pick-7673406.patch
+cherry-pick-7687618.patch

--- a/patches/chromium/cherry-pick-4e9562ca7b42.patch
+++ b/patches/chromium/cherry-pick-4e9562ca7b42.patch
@@ -16,6 +16,7 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7649387
 Reviewed-by: Hongchan Choi <hongchan@chromium.org>
 Commit-Queue: Michael Wilson <mjwilson@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1597152}
+
 diff --git a/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc b/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc
 index b3b95dd1cc67c9448f050029c02329a0b2e5deee..88a8f39cd61c9b1fc349747c48210859abb4bac2 100644
 --- a/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc

--- a/patches/chromium/cherry-pick-4e9562ca7b42.patch
+++ b/patches/chromium/cherry-pick-4e9562ca7b42.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Wilson <mjwilson@chromium.org>
+Date: Tue, 10 Mar 2026 10:08:27 -0700
+Subject: Replace UNSAFE_BUFFERS in AudioParamHandler with safe operations
+
+This should cause no functional change.
+
+Also do a small optimization in HandleNaNValues for inputs that are
+larger than 4 by skipping the first if check, since we expect longer
+inputs in general.
+
+Bug: 401184803
+Bug: 490642831
+Change-Id: I1044267b7e6370af4793fe973fe36224630ced95
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7649387
+Reviewed-by: Hongchan Choi <hongchan@chromium.org>
+Commit-Queue: Michael Wilson <mjwilson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1597152}
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc b/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc
+index b3b95dd1cc67c9448f050029c02329a0b2e5deee..88a8f39cd61c9b1fc349747c48210859abb4bac2 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_param_handler.cc
+@@ -51,40 +51,35 @@ constexpr float kSetTargetThreshold = 4.539992976248485e-05f;
+ void HandleNaNValues(base::span<float> values, float default_value) {
+   unsigned k = 0;
+ #if defined(ARCH_CPU_X86_FAMILY)
+-  if (values.size() >= 4) {
+-    __m128 defaults = _mm_set1_ps(default_value);
+-    for (k = 0; k < values.size(); k += 4) {
+-      // SAFETY: The for loop condition has been checked k < values.size().
+-      __m128 v = _mm_loadu_ps(UNSAFE_BUFFERS(values.data() + k));
+-      // cmpuord returns all 1's if v is NaN for each elmeent of v.
+-      __m128 isnan = _mm_cmpunord_ps(v, v);
+-      // Replace NaN parts with default.
+-      __m128 result = _mm_and_ps(isnan, defaults);
+-      // Merge in the parts that aren't NaN
+-      result = _mm_or_ps(_mm_andnot_ps(isnan, v), result);
+-      // SAFETY: The for loop condition has been checked k < values.size().
+-      _mm_storeu_ps(UNSAFE_BUFFERS(values.data() + k), result);
+-    }
++  // Truncate to the next-lowest multiple of 4.
++  const size_t truncated_size = values.size() & ~3;
++  __m128 defaults = _mm_set1_ps(default_value);
++  for (k = 0; k < truncated_size; k += 4) {
++    __m128 v = _mm_loadu_ps(values.subspan(k, 4u).data());
++    // cmpuord returns all 1's if v is NaN for each elmeent of v.
++    __m128 isnan = _mm_cmpunord_ps(v, v);
++    // Replace NaN parts with default.
++    __m128 result = _mm_and_ps(isnan, defaults);
++    // Merge in the parts that aren't NaN
++    result = _mm_or_ps(_mm_andnot_ps(isnan, v), result);
++    _mm_storeu_ps(values.subspan(k, 4u).data(), result);
+   }
+ #elif defined(CPU_ARM_NEON)
+-  if (values.size() >= 4) {
+-    uint32x4_t defaults =
+-        reinterpret_cast<uint32x4_t>(vdupq_n_f32(default_value));
+-    for (k = 0; k < values.size(); k += 4) {
+-      // SAFETY: The for loop condition has been checked k < values.size().
+-      float32x4_t v = vld1q_f32(UNSAFE_BUFFERS(values.data() + k));
+-      // Returns true (all ones) if v is not NaN
+-      uint32x4_t is_not_nan = vceqq_f32(v, v);
+-      // Get the parts that are not NaN
+-      uint32x4_t result =
+-          vandq_u32(is_not_nan, reinterpret_cast<uint32x4_t>(v));
+-      // Replace the parts that are NaN with the default and merge with previous
+-      // result.  (Note: vbic_u32(x, y) = x and not y)
+-      result = vorrq_u32(result, vbicq_u32(defaults, is_not_nan));
+-      // SAFETY: The for loop condition has been checked k < values.size().
+-      vst1q_f32(UNSAFE_BUFFERS(values.data() + k),
+-                reinterpret_cast<float32x4_t>(result));
+-    }
++  // Truncate to the next-lowest multiple of 4.
++  const size_t truncated_size = values.size() & ~3;
++  uint32x4_t defaults =
++      reinterpret_cast<uint32x4_t>(vdupq_n_f32(default_value));
++  for (k = 0; k < truncated_size; k += 4) {
++    float32x4_t v = vld1q_f32(values.subspan(k, 4u).data());
++    // Returns true (all ones) if v is not NaN
++    uint32x4_t is_not_nan = vceqq_f32(v, v);
++    // Get the parts that are not NaN
++    uint32x4_t result = vandq_u32(is_not_nan, reinterpret_cast<uint32x4_t>(v));
++    // Replace the parts that are NaN with the default and merge with previous
++    // result.  (Note: vbic_u32(x, y) = x and not y)
++    result = vorrq_u32(result, vbicq_u32(defaults, is_not_nan));
++    vst1q_f32(values.subspan(k, 4u).data(),
++              reinterpret_cast<float32x4_t>(result));
+   }
+ #endif
+ 
+@@ -1831,10 +1826,7 @@ std::tuple<size_t, float, unsigned> AudioParamHandler::ProcessLinearRamp(
+ 
+     // Process 4 loop steps.
+     for (; write_index < fill_to_frame_trunc; write_index += 4) {
+-      // SAFETY: DCHECK previously checked that `fill_to_frame_trunc <
+-      // values.size()`. In the for loop, `write_index < fill_to_frame_trunc` so
+-      // this is safe.
+-      _mm_storeu_ps(UNSAFE_BUFFERS(values.data() + write_index), v_value);
++      _mm_storeu_ps(values.subspan(write_index, 4u).data(), v_value);
+       v_value = _mm_add_ps(v_value, v_inc);
+     }
+   }
+@@ -2020,10 +2012,7 @@ std::tuple<size_t, float, unsigned> AudioParamHandler::ProcessSetTarget(
+         v_value = _mm_set_ps1(value);
+ 
+         v_result = _mm_add_ps(v_value, _mm_mul_ps(v_delta, v_c));
+-        // SAFETY: DCHECK previously checked that `fill_to_frame_trunc <
+-        // values.size()`. In the for loop, `write_index < fill_to_frame_trunc`
+-        // so this is safe.
+-        _mm_storeu_ps(UNSAFE_BUFFERS(values.data() + write_index), v_result);
++        _mm_storeu_ps(values.subspan(write_index, 4u).data(), v_result);
+ 
+         // Update value for next iteration.
+         value += delta * c3;
+@@ -2184,10 +2173,7 @@ std::tuple<size_t, float, unsigned> AudioParamHandler::ProcessSetValueCurve(
+       __m128 v_value =
+           _mm_add_ps(v_c0, _mm_mul_ps(_mm_sub_ps(v_c1, v_c0), v_delta));
+ 
+-      // SAFETY: DCHECK previously checked that `fill_to_frame_trunc <
+-      // values.size()`. In the for loop, `write_index < fill_to_frame_trunc` so
+-      // this is safe.
+-      _mm_storeu_ps(UNSAFE_BUFFERS(values.data() + write_index), v_value);
++      _mm_storeu_ps(values.subspan(write_index, 4u).data(), v_value);
+     }
+     // Pass along k to the serial loop.
+     k = truncated_steps;

--- a/patches/chromium/cherry-pick-7673406.patch
+++ b/patches/chromium/cherry-pick-7673406.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wei Wang <wei4.wang@intel.com>
+Date: Wed, 18 Mar 2026 20:00:51 -0700
+Subject: [WebNN] Reject fusing per-channel quantized gemm if the quantized
+ dimension of filter is not 0
+
+The FULLY_CONNECTED's underlying kernels expect the per-channel
+quantization axis to be the output channel(axis 0). So reject
+fusing per-channel quantized gemm and fall back to the unfused
+operators path if the quantized dimension of filter is not 0.
+
+Bug: 493319454
+Change-Id: Ib7e1236a535dc6a34d3ff9b9f0124a101bd89dbf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673406
+Reviewed-by: Phillis Tang <phillis@chromium.org>
+Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
+Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
+Cr-Commit-Position: refs/heads/main@{#1601718}
+
+diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
+index 56411065d59c299840d557104719fd70ff456bc2..a65f758d782536017c8a11f5397412e4c1d9a58b 100644
+--- a/services/webnn/tflite/graph_builder_tflite.cc
++++ b/services/webnn/tflite/graph_builder_tflite.cc
+@@ -1958,6 +1958,19 @@
+     return std::nullopt;
+   }
+ 
++  // The FULLY_CONNECTED's underlying kernels expect the per-channel
++  // quantization axis to be the output channel dimension (axis 0). This means
++  // the first dimension of the scale can not be equal to 1.
++  // https://source.chromium.org/chromium/chromium/src/+/main:third_party/litert/src/tflite/kernels/internal/reference/integer_ops/fully_connected.h;l=68;drc=9213607704a73d1e877921d0454abb11f761bdcc
++  if (per_channel_quantization) {
++    const auto& scale_shape =
++        GetOperand(b_dequantize.scale_operand_id).descriptor.shape();
++
++    if (scale_shape[0] == 1) {
++      return std::nullopt;
++    }
++  }
++
+   // The a_scale * b_scale should be about the same as c_scale for per-tensor
+   // quantization.
+   // https://source.chromium.org/chromium/chromium/src/+/main:third_party/tflite/src/tensorflow/lite/kernels/kernel_util.cc;l=303;drc=492dc9719f6e1845f4f5c0553cd5c7651115f671

--- a/patches/chromium/cherry-pick-7673406.patch
+++ b/patches/chromium/cherry-pick-7673406.patch
@@ -18,10 +18,10 @@ Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
 Cr-Commit-Position: refs/heads/main@{#1601718}
 
 diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
-index 56411065d59c299840d557104719fd70ff456bc2..a65f758d782536017c8a11f5397412e4c1d9a58b 100644
+index 56411065d59c299840d557104719fd70ff456bc2..28aea1bf23601330e4dd60d4d124905800a0846c 100644
 --- a/services/webnn/tflite/graph_builder_tflite.cc
 +++ b/services/webnn/tflite/graph_builder_tflite.cc
-@@ -1958,6 +1958,19 @@
+@@ -1958,6 +1958,19 @@ GraphBuilderTflite::CanFuseQuantizeAndGetOutput(const mojom::Gemm& gemm) {
      return std::nullopt;
    }
  

--- a/patches/chromium/cherry-pick-7687618.patch
+++ b/patches/chromium/cherry-pick-7687618.patch
@@ -16,10 +16,10 @@ Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
 Cr-Commit-Position: refs/heads/main@{#1602966}
 
 diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
-index 56411065d59c299840d557104719fd70ff456bc2..32e7a227f38b4919582f65db7166a5ac29273710 100644
+index 28aea1bf23601330e4dd60d4d124905800a0846c..d9cdbf3c71fad5c5da6e688c57d7ef4ef46da668 100644
 --- a/services/webnn/tflite/graph_builder_tflite.cc
 +++ b/services/webnn/tflite/graph_builder_tflite.cc
-@@ -6535,6 +6535,68 @@
+@@ -6548,6 +6548,68 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
      return base::unexpected("Pool2d in tflite doesn't support dilations.");
    }
  
@@ -88,7 +88,7 @@ index 56411065d59c299840d557104719fd70ff456bc2..32e7a227f38b4919582f65db7166a5ac
    ::tflite::BuiltinOperator operator_code;
    std::optional<TensorInfo> quantized_output;
    const mojom::Operand& input_operand = GetOperand(pool2d.input_operand_id);
-@@ -6560,9 +6622,6 @@
+@@ -6573,9 +6635,6 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
    CHECK_EQ(input_shape.size(), 4u);
    const webnn::Size2d<uint32_t> input_size2d = {.height = input_shape[1],
                                                  .width = input_shape[2]};

--- a/patches/chromium/cherry-pick-7687618.patch
+++ b/patches/chromium/cherry-pick-7687618.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wei Wang <wei4.wang@intel.com>
+Date: Fri, 20 Mar 2026 19:57:55 -0700
+Subject: [WebNN] Prevent Pool2d indirection buffer overflow in TFLite
+
+Add a check to ensure the size of the internal indirection buffer used
+by TFLite's Pool2d implementation does not exceed the maximum value
+of a size_t integer.
+
+Bug: 494158331
+Change-Id: I984556f0f608badf8f73fcbb096da5f41170a958
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7687618
+Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
+Cr-Commit-Position: refs/heads/main@{#1602966}
+
+diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
+index 56411065d59c299840d557104719fd70ff456bc2..32e7a227f38b4919582f65db7166a5ac29273710 100644
+--- a/services/webnn/tflite/graph_builder_tflite.cc
++++ b/services/webnn/tflite/graph_builder_tflite.cc
+@@ -6535,6 +6535,68 @@
+     return base::unexpected("Pool2d in tflite doesn't support dilations.");
+   }
+ 
++  // Check the indirection buffer size to ensure it does not exceed the maximum
++  // value of a size_t integer.
++  const mojom::Operand& output_operand = GetOperand(pool2d.output_operand_id);
++  const auto& output_shape = output_operand.descriptor.shape();
++  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
++                                                 .width = output_shape[2]};
++  const webnn::Size2d<uint32_t> filter_size2d = {
++      .height = pool2d.window_dimensions->height,
++      .width = pool2d.window_dimensions->width};
++  base::CheckedNumeric<int32_t> checked_output_height = 0;
++
++  if (pool2d.kind == mojom::Pool2d::Kind::kMaxPool2d) {
++    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/xnnpack/src/src/operators/max-pooling-nhwc.c;l=488;drc=b269899e63e0110d1ccf964a741be2833a9ecd9b
++    checked_output_height = output_size2d.height;
++  } else {
++    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/xnnpack/src/src/operators/average-pooling-nhwc.c;l=442;drc=b269899e63e0110d1ccf964a741be2833a9ecd9b
++    auto checked_top_height =
++        base::CheckedNumeric<int32_t>(pool2d.padding->beginning->height);
++    auto checked_stride_height =
++        base::CheckedNumeric<int32_t>(pool2d.strides->height);
++    checked_top_height += checked_stride_height;
++    checked_top_height -= 1;
++    checked_top_height /= checked_stride_height;
++
++    auto checked_bottom_height =
++        base::CheckedNumeric<int32_t>(pool2d.padding->ending->height);
++    checked_bottom_height += checked_stride_height;
++    checked_bottom_height -= 1;
++    checked_bottom_height /= checked_stride_height;
++
++    checked_output_height = checked_top_height;
++    checked_output_height += checked_bottom_height;
++    checked_output_height += 1;
++  }
++
++  auto checked_filter_height =
++      base::CheckedNumeric<int32_t>(filter_size2d.height);
++  auto checked_filter_width =
++      base::CheckedNumeric<int32_t>(filter_size2d.width);
++  auto checked_pooling_size = checked_filter_height;
++  checked_pooling_size *= checked_filter_width;
++
++  auto checked_output_width =
++      base::CheckedNumeric<int32_t>(output_size2d.width);
++  checked_output_width -= 1;
++  checked_output_width *= base::CheckedNumeric<int32_t>(
++      std::min(pool2d.strides->width, filter_size2d.width));
++  checked_output_width *= checked_filter_height;
++  auto checked_step_height = checked_pooling_size + checked_output_width;
++
++  auto checked_indirection_buffer_size = checked_pooling_size;
++  checked_indirection_buffer_size -= 1;
++  checked_output_height *= checked_step_height;
++  checked_indirection_buffer_size += checked_output_height;
++  checked_indirection_buffer_size *=
++      base::CheckedNumeric<int32_t>(sizeof(void*));
++  if (!checked_indirection_buffer_size.IsValid()) {
++    return base::unexpected(
++        "Pool2d doesn't support configurations requiring an internal "
++        "computation buffer that exceeds the maximum size.");
++  }
++
+   ::tflite::BuiltinOperator operator_code;
+   std::optional<TensorInfo> quantized_output;
+   const mojom::Operand& input_operand = GetOperand(pool2d.input_operand_id);
+@@ -6560,9 +6622,6 @@
+   CHECK_EQ(input_shape.size(), 4u);
+   const webnn::Size2d<uint32_t> input_size2d = {.height = input_shape[1],
+                                                 .width = input_shape[2]};
+-  webnn::Size2d<uint32_t> filter_size2d = {
+-      .height = pool2d.window_dimensions->height,
+-      .width = pool2d.window_dimensions->width};
+   ASSIGN_OR_RETURN(
+       TfLitePadding padding_mode,
+       GetTfLitePaddingMode(*pool2d.padding, input_size2d, filter_size2d,

--- a/patches/chromium/cherry-pick-848cf5567223.patch
+++ b/patches/chromium/cherry-pick-848cf5567223.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Baron <dbaron@chromium.org>
+Date: Mon, 24 Mar 2026 11:30:00 -0700
+Subject: Check parent nodes when handling vector node insertions.
+
+In the optimized vector node insertion case, check the parent node just
+as in the regular case.
+
+Fixed: 496281816
+Change-Id: I0fc6956d1c09fcb7ea54d94819fdf1cb06fbd9e5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7705373
+Commit-Queue: David Baron <dbaron@chromium.org>
+Reviewed-by: Mason Freed <masonf@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1605818}
+
+diff --git a/third_party/blink/renderer/core/dom/container_node.cc b/third_party/blink/renderer/core/dom/container_node.cc
+index e9c32e0b266d9964b9aa620ad16880bd13aeec19..ff3ed40d7c9438d49d0ca5dbccad41c7fe9a9e4c 100644
+--- a/third_party/blink/renderer/core/dom/container_node.cc
++++ b/third_party/blink/renderer/core/dom/container_node.cc
+@@ -326,6 +326,21 @@ bool ContainerNode::EnsurePreInsertionValidity(
+         return false;
+       }
+     }
++
++    // Node::ConvertNodeUnionsIntoNodes behaves differently depending on
++    // whether there is one node or more than one, since it simulates
++    // insertion into a DocumentFragment for the latter case.  If it handled
++    // more than one node, then it already removed the children from their old
++    // parent.  Check here that those removals didn't do anything bad.  (We
++    // could potentially make this faster by using a DOMMutationDetector in
++    // ConvertNodeUnionsIntoNodes and storing whether we need to do this.)
++    if (new_children->size() != 1u &&
++        RuntimeEnabledFeatures::
++            RecheckParentDuringNodeVectorInsertionEnabled() &&
++        !RecheckNodeInsertionStructuralPrereq(*new_children, next,
++                                              exception_state)) {
++      return false;
++    }
+   } else if (auto* child_fragment = DynamicTo<DocumentFragment>(new_child)) {
+     for (Node* node = child_fragment->firstChild(); node;
+          node = node->nextSibling()) {
+@@ -348,7 +363,7 @@ bool ContainerNode::EnsurePreInsertionValidity(
+ bool ContainerNode::RecheckNodeInsertionStructuralPrereq(
+     const NodeVector& new_children,
+     const Node* next,
+-    ExceptionState& exception_state) {
++    ExceptionState& exception_state) const {
+   for (const auto& child : new_children) {
+     if (child->parentNode()) {
+       // A new child was added to another parent before adding to this
+diff --git a/third_party/blink/renderer/core/dom/container_node.h b/third_party/blink/renderer/core/dom/container_node.h
+index 4667ca8c8e09480b2ee5bd3210ac5db16c92eee6..8c7264198d3cbda22677d254323b29b0d59b5995 100644
+--- a/third_party/blink/renderer/core/dom/container_node.h
++++ b/third_party/blink/renderer/core/dom/container_node.h
+@@ -581,7 +581,7 @@ class CORE_EXPORT ContainerNode : public Node {
+ 
+   bool RecheckNodeInsertionStructuralPrereq(const NodeVector&,
+                                             const Node* next,
+-                                            ExceptionState&);
++                                            ExceptionState&) const;
+   inline bool CheckParserAcceptChild(const Node& new_child) const;
+   inline bool IsHostIncludingInclusiveAncestorOfThis(const Node&,
+                                                      ExceptionState&) const;
+diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+index f87e3e39cf90abafc05cb6b279716b937c0d904f..2eb5cc1183652fa6b307b074694a99d2430943da 100644
+--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
++++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -4135,6 +4135,11 @@
+       name: "ReadableStreamBYOBReaderReadMinOption",
+       status: "stable",
+     },
++    {
++      // Shipping in M148, so should be removed around M150.
++      name: "RecheckParentDuringNodeVectorInsertion",
++      status: "stable",
++    },
+     {
+       name: "RecordSameDocumentPresentationTimeOnce",
+       status: "stable",
+diff --git a/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..e754cd6e6a6484f8f85fbdcf3fae2d8accc492cb
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html
+@@ -0,0 +1,26 @@
++<!DOCTYPE HTML>
++<div id="target"></div>
++<div id="evilParent"></div>
++<div id="node1">node1</div>
++<script>
++  window.node1 = document.getElementById("node1");
++  function runTest() {
++    document.getElementById("target").append(node1, document.getElementById("node2"));
++  }
++</script>
++<div id="node2">
++  <iframe allow="unload" srcdoc="
++      <!DOCTYPE HTML>
++      <script>
++        window.addEventListener('load', function() {
++          window.parent.runTest();
++        });
++        window.addEventListener('unload', function() {
++          let p = window.parent;
++          let doc = p.document;
++          doc.getElementById('evilParent').appendChild(p.node1);
++        });
++      </script>
++    ">
++  </iframe>
++</div>
+diff --git a/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html.headers b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html.headers
+new file mode 100644
+index 0000000000000000000000000000000000000000..f1e8ace831407eccae03f62ff5e77ee7d1586005
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html.headers
+@@ -0,0 +1 @@
++Permissions-Policy: unload=*
+

--- a/patches/chromium/cherry-pick-848cf5567223.patch
+++ b/patches/chromium/cherry-pick-848cf5567223.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Baron <dbaron@chromium.org>
-Date: Mon, 24 Mar 2026 11:30:00 -0700
+Date: Tue, 24 Mar 2026 11:30:00 -0700
 Subject: Check parent nodes when handling vector node insertions.
 
 In the optimized vector node insertion case, check the parent node just
@@ -62,10 +62,10 @@ index 4667ca8c8e09480b2ee5bd3210ac5db16c92eee6..8c7264198d3cbda22677d254323b29b0
    inline bool IsHostIncludingInclusiveAncestorOfThis(const Node&,
                                                       ExceptionState&) const;
 diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-index f87e3e39cf90abafc05cb6b279716b937c0d904f..2eb5cc1183652fa6b307b074694a99d2430943da 100644
+index 47af3989c1681de3004ec85d4ac5dd9718b0a825..5858f58a3ac36cb4f491c33d167845155bb582b1 100644
 --- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
 +++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-@@ -4135,6 +4135,11 @@
+@@ -4139,6 +4139,11 @@
        name: "ReadableStreamBYOBReaderReadMinOption",
        status: "stable",
      },
@@ -116,4 +116,3 @@ index 0000000000000000000000000000000000000000..f1e8ace831407eccae03f62ff5e77ee7
 +++ b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload.https.html.headers
 @@ -0,0 +1 @@
 +Permissions-Policy: unload=*
-

--- a/patches/chromium/cherry-pick-c75f63de7188.patch
+++ b/patches/chromium/cherry-pick-c75f63de7188.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lynne Jiang <lyjiang@google.com>
+Date: Fri, 20 Mar 2026 14:20:32 -0700
+Subject: [webnn] Validate output channels are a multiple of groups in Conv2d.
+
+Add a check in `ValidateConv2d` to ensure `output_channels % attributes.groups == 0`. This is a requirement for grouped convolutions. Add a unit test to cover this invalid case.
+
+Bug: 493708165
+Change-Id: Id83552a5fb2b95f84981f28ca7162331e17559cd
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7687895
+Commit-Queue: Lynne Jiang <lyjiang@google.com>
+Reviewed-by: Phillis Tang <phillis@chromium.org>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1602846}
+diff --git a/services/webnn/public/cpp/graph_validation_utils.cc b/services/webnn/public/cpp/graph_validation_utils.cc
+index df746354236b2856e499cc8d925363744da044cd..0b685a93dc7a2959b63dc585b59afca761034ed3 100644
+--- a/services/webnn/public/cpp/graph_validation_utils.cc
++++ b/services/webnn/public/cpp/graph_validation_utils.cc
+@@ -733,6 +733,10 @@ base::expected<OperandDescriptor, std::string> ValidateConv2dAndInferOutput(
+         "The groups must evenly divide the input channels to filter input "
+         "channels."));
+   }
++  if (output_channels % attributes.groups != 0) {
++    return base::unexpected(ErrorWithLabel(
++        label, "The groups must evenly divide the output channels."));
++  }
+ 
+   // Validate and calculate output sizes.
+   ASSIGN_OR_RETURN(
+diff --git a/services/webnn/webnn_graph_impl_unittest.cc b/services/webnn/webnn_graph_impl_unittest.cc
+index faa0a3671864e9f8ed8c7a8354c7650abc93baa9..3f8e930def83c5fa8e8c13a1e729f9ddffc89e54 100644
+--- a/services/webnn/webnn_graph_impl_unittest.cc
++++ b/services/webnn/webnn_graph_impl_unittest.cc
+@@ -1285,6 +1285,20 @@ TEST_F(WebNNGraphImplTest, Conv2dTest) {
+         .expected = false}
+         .Test(*this);
+   }
++  {
++    // Test invalid conv2d: output_channels is not a multiple of groups.
++    // output_channels (7) % groups (2) != 0.
++    Conv2dTester{.type = mojom::Conv2d::Kind::kDirect,
++                 .input = {.type = OperandDataType::kFloat32,
++                           .dimensions = {1, 4, 5, 5}},
++                 .filter = {.type = OperandDataType::kFloat32,
++                            .dimensions = {7, 2, 3, 3}},
++                 .attributes = {.groups = 2},
++                 .output = {.type = OperandDataType::kFloat32,
++                            .dimensions = {1, 7, 3, 3}},
++                 .expected = false}
++        .Test(*this);
++  }
+   {
+     // Test the invalid graph when the number of filter input channels
+     // doesn't match the result of input channels divided by groups

--- a/patches/chromium/cherry-pick-c75f63de7188.patch
+++ b/patches/chromium/cherry-pick-c75f63de7188.patch
@@ -12,11 +12,12 @@ Commit-Queue: Lynne Jiang <lyjiang@google.com>
 Reviewed-by: Phillis Tang <phillis@chromium.org>
 Reviewed-by: Reilly Grant <reillyg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1602846}
+
 diff --git a/services/webnn/public/cpp/graph_validation_utils.cc b/services/webnn/public/cpp/graph_validation_utils.cc
-index df746354236b2856e499cc8d925363744da044cd..0b685a93dc7a2959b63dc585b59afca761034ed3 100644
+index 88666458d4c9c53ad93030d8cc4e3e4198429cf0..54b8df4d6752077c1c750507769724d184c5dd00 100644
 --- a/services/webnn/public/cpp/graph_validation_utils.cc
 +++ b/services/webnn/public/cpp/graph_validation_utils.cc
-@@ -733,6 +733,10 @@ base::expected<OperandDescriptor, std::string> ValidateConv2dAndInferOutput(
+@@ -738,6 +738,10 @@ base::expected<OperandDescriptor, std::string> ValidateConv2dAndInferOutput(
          "The groups must evenly divide the input channels to filter input "
          "channels."));
    }
@@ -28,10 +29,10 @@ index df746354236b2856e499cc8d925363744da044cd..0b685a93dc7a2959b63dc585b59afca7
    // Validate and calculate output sizes.
    ASSIGN_OR_RETURN(
 diff --git a/services/webnn/webnn_graph_impl_unittest.cc b/services/webnn/webnn_graph_impl_unittest.cc
-index faa0a3671864e9f8ed8c7a8354c7650abc93baa9..3f8e930def83c5fa8e8c13a1e729f9ddffc89e54 100644
+index 76625d0672d5e296d87a6c5ff7cb76f37947a225..966d0f712c3d9f49b85f05c07ac6aaae36836ca6 100644
 --- a/services/webnn/webnn_graph_impl_unittest.cc
 +++ b/services/webnn/webnn_graph_impl_unittest.cc
-@@ -1285,6 +1285,20 @@ TEST_F(WebNNGraphImplTest, Conv2dTest) {
+@@ -1284,6 +1284,20 @@ TEST_F(WebNNGraphImplTest, Conv2dTest) {
          .expected = false}
          .Test(*this);
    }

--- a/patches/chromium/cherry-pick-d141d62357df.patch
+++ b/patches/chromium/cherry-pick-d141d62357df.patch
@@ -1,0 +1,407 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fu, Junwei <junwei.fu@intel.com>
+Date: Tue, 18 Mar 2026 03:25:47 -0700
+Subject: WebNN: Use output size for TransposeConv SAME padding in
+ TFLite
+
+This CL aligns the TFLite backend's padding calculation for
+convTranspose2d with the TFLite kernel implementation.
+
+Bug: 492668885, 491869941
+Change-Id: Ibfbcd2bf9b80b6ab2b2f0fccf9596975537f9cc8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7677538
+Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
+Commit-Queue: Fu, Junwei <junwei.fu@intel.com>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1601883}
+
+diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
+index 56411065d59c299840d557104719fd70ff456bc2..72610d822fe2a67beecbd5000cff3a4740922288 100644
+--- a/services/webnn/tflite/graph_builder_tflite.cc
++++ b/services/webnn/tflite/graph_builder_tflite.cc
+@@ -206,40 +206,50 @@ struct PaddingSizes {
+ 
+ // Helper to calculate the explicit padding for tflite::Padding_SAME mode with
+ // https://www.tensorflow.org/versions/r2.14/api_docs/python/tf/nn#notes_on_padding_2.
++// For transpose conv, caller should pass output size as input_size.
+ std::optional<PaddingSizes> CalculateExplicitPaddingForSamePaddingMode(
+     uint32_t input_size,
+     uint32_t filter_size,
+     uint32_t stride,
+-    uint32_t dilation,
+-    bool is_transposed_conv2d) {
+-  auto checked_dilated_filter_size =
+-      (base::MakeCheckedNum<uint32_t>(filter_size) - 1) * dilation + 1;
+-  auto checked_input_size = base::MakeCheckedNum<uint32_t>(input_size);
+-  base::CheckedNumeric<uint32_t> checked_total_padding;
+-  if (is_transposed_conv2d) {
+-    // The checked_total_padding (beginningPadding + endingPadding) can be
+-    // calculated from the expression `outputSize = (inputSize - 1) * stride +
+-    // (filterSize - 1) * dilation + 1 - beginningPadding - endingPadding` that
+-    // is documented in the section of computing convtranspose output size:
+-    // https://www.w3.org/TR/webnn/#api-mlgraphbuilder-convtranspose2d
+-    checked_total_padding = (checked_input_size - 1) * stride +
+-                            checked_dilated_filter_size -
+-                            checked_input_size * stride;
+-  } else {
+-    auto checked_output_size = (checked_input_size + stride - 1) / stride;
+-    auto checked_needed_input_size =
+-        (checked_output_size - 1) * stride + checked_dilated_filter_size;
+-    if (!checked_needed_input_size.IsValid()) {
+-      return std::nullopt;
+-    }
+-    checked_total_padding = checked_needed_input_size.ValueOrDie() > input_size
+-                                ? checked_needed_input_size - input_size
+-                                : base::MakeCheckedNum<uint32_t>(0);
++    uint32_t dilation) {
++  // The SAME padding mode in TFLite follows the formula:
++  // output_size = ceil(input_size / stride)
++  // total_padding = (output_size - 1) * stride + dilated_filter_size -
++  // input_size See:
++  // https://www.tensorflow.org/versions/r2.14/api_docs/python/tf/nn#notes_on_padding_2
++  auto checked_dilated_filter_size = base::CheckedNumeric<int32_t>(filter_size);
++  checked_dilated_filter_size -= 1;
++  checked_dilated_filter_size *= base::CheckedNumeric<int32_t>(dilation);
++  checked_dilated_filter_size += 1;
++
++  auto checked_input_size = base::CheckedNumeric<int32_t>(input_size);
++  auto checked_stride = base::CheckedNumeric<int32_t>(stride);
++  base::CheckedNumeric<int32_t> checked_output_size = checked_input_size;
++  checked_output_size += checked_stride;
++  checked_output_size -= 1;
++  checked_output_size /= checked_stride;
++
++  base::CheckedNumeric<int32_t> checked_needed_input_size = checked_output_size;
++  checked_needed_input_size -= 1;
++  checked_needed_input_size *= checked_stride;
++  checked_needed_input_size += checked_dilated_filter_size;
++  if (!checked_needed_input_size.IsValid()) {
++    return std::nullopt;
++  }
++  uint32_t needed_input_size;
++  if (!checked_needed_input_size.AssignIfValid(&needed_input_size)) {
++    return std::nullopt;
+   }
++  base::CheckedNumeric<uint32_t> checked_total_padding =
++      needed_input_size > input_size
++          ? base::CheckedNumeric<uint32_t>(needed_input_size) - input_size
++          : base::CheckedNumeric<uint32_t>(0);
+ 
+   // Same upper padding.
+-  auto checked_padding_begin = checked_total_padding / 2;
+-  auto checked_padding_end = (checked_total_padding + 1) / 2;
++  base::CheckedNumeric<uint32_t> checked_padding_begin =
++      checked_total_padding / 2;
++  base::CheckedNumeric<uint32_t> checked_padding_end =
++      (checked_total_padding + 1) / 2;
+   uint32_t padding_begin, padding_end;
+   if (!checked_padding_begin.AssignIfValid(&padding_begin) ||
+       !checked_padding_end.AssignIfValid(&padding_end)) {
+@@ -254,13 +264,48 @@ struct TfLitePadding {
+   std::optional<std::array<uint32_t, 4>> paddings;
+ };
+ 
+-// Helper to get tflite padding mode for convolution 2d or pooling 2d.
++// Calculate explicit padding end to ensure TFLite's VALID padding produces the
++// expected WebNN output shape for ceil rounding type.
++base::expected<uint32_t, std::string> CalculatePaddingEndForCeilRoundingType(
++    uint32_t input_size,
++    uint32_t filter_size,
++    uint32_t stride,
++    uint32_t dilation,
++    uint32_t output_size,
++    uint32_t padding_begin) {
++  // Calculate the dilated filter sizes that are validated in graph validation.
++  auto checked_effective_filter_size =
++      base::CheckedNumeric<int32_t>(filter_size);
++  checked_effective_filter_size -= 1;
++  checked_effective_filter_size *= base::CheckedNumeric<int32_t>(dilation);
++  checked_effective_filter_size += 1;
++  CHECK(checked_effective_filter_size.IsValid());
++
++  // Adjust ending padding to match the specified output.
++  auto checked_padding_end_int32 = base::CheckedNumeric<int32_t>(output_size);
++  checked_padding_end_int32 -= 1;
++  checked_padding_end_int32 *= base::CheckedNumeric<int32_t>(stride);
++  checked_padding_end_int32 += checked_effective_filter_size;
++  checked_padding_end_int32 -= base::CheckedNumeric<int32_t>(input_size);
++  checked_padding_end_int32 -= base::CheckedNumeric<int32_t>(padding_begin);
++
++  auto checked_padding_end = checked_padding_end_int32.Cast<uint32_t>();
++  // Check if the value is valid for rounding to uint32_t type.
++  if (!checked_padding_end.IsValid()) {
++    return base::unexpected("The padding end is too large.");
++  }
++  return checked_padding_end.ValueOrDie();
++}
++
++// Helper to get tflite padding mode for convolution 2d or pooling 2d floor
++// rounding type, not ceil.
+ base::expected<TfLitePadding, std::string> GetTfLitePaddingMode(
+     const mojom::Padding2d& padding2d,
+     const webnn::Size2d<uint32_t>& input,
+     const webnn::Size2d<uint32_t>& filter,
+     const mojom::Size2d& stride,
+     const mojom::Size2d& dilation,
++    const webnn::Size2d<uint32_t>& output,
+     bool is_transposed_conv2d) {
+   // WebNN explicit padding is in [beginning_height, ending_height,
+   // beginning_width, ending_width] sequence.
+@@ -274,13 +319,18 @@ base::expected<TfLitePadding, std::string> GetTfLitePaddingMode(
+ 
+   // Convert the explicit padding to tflite same padding mode, The TFLite PAD
+   // operator need to be inserted if the calculated padding are not the same as
+-  // explicit padding.
++  // explicit padding for direct conv.
++  //
++  // In TFLite, TransposeConv's SAME padding is calculated based on the
++  // output size. See:
++  // https://source.chromium.org/chromium/chromium/src/+/main:third_party/litert/src/tflite/kernels/transpose_conv.cc;drc=7d88950ea445f5b671d18e64f9614aff397fde50;l=841
++  const uint32_t height_size =
++      is_transposed_conv2d ? output.height : input.height;
++  const uint32_t width_size = is_transposed_conv2d ? output.width : input.width;
+   const auto padding_height = CalculateExplicitPaddingForSamePaddingMode(
+-      input.height, filter.height, stride.height, dilation.height,
+-      is_transposed_conv2d);
++      height_size, filter.height, stride.height, dilation.height);
+   const auto padding_width = CalculateExplicitPaddingForSamePaddingMode(
+-      input.width, filter.width, stride.width, dilation.width,
+-      is_transposed_conv2d);
++      width_size, filter.width, stride.width, dilation.width);
+   if (!padding_height || !padding_width) {
+     return base::unexpected("Failed to calculate explicit padding.");
+   }
+@@ -291,11 +341,89 @@ base::expected<TfLitePadding, std::string> GetTfLitePaddingMode(
+     return TfLitePadding{.mode = ::tflite::Padding_SAME};
+   }
+ 
++  // TFLite's TransposeConv SAME padding mode doesn't support output padding.
++  // Passing output size with non-zero output padding won't match and select
++  // TFLite SAME padding mode.
++  // TODO(crbug.com/493652470): Support explicit padding for transpose conv2d.
++  if (is_transposed_conv2d) {
++    return base::unexpected(
++        "Explicit padding is not supported for transpose conv2d.");
++  }
++
+   // The explicit padding are used to insert a TfLite PAD operator.
+   return TfLitePadding{.mode = ::tflite::Padding_VALID,
+                        .paddings = explicit_padding};
+ }
+ 
++// Helper to get tflite padding mode for pooling 2d.
++base::expected<TfLitePadding, std::string> GetPool2dTfLitePaddingMode(
++    const mojom::Padding2d& padding2d,
++    const webnn::Size2d<uint32_t>& input,
++    const webnn::Size2d<uint32_t>& filter,
++    const mojom::Size2d& stride,
++    const mojom::Size2d& dilation,
++    const webnn::Size2d<uint32_t>& output) {
++  // TFLite always performs a floor operation in VALID mode. If WebNN's
++  // RoundingType is ceil, the `actual_output_height` might be 1 greater than
++  // what TFLite's VALID padding formula (floor based) would produce. In this
++  // case, the ending_padding must be increased to ensure the TFLite internal
++  // division result is large enough that its floor matches WebNN's ceil.
++  //
++  // Calculate double output sizes to get the type of rounding.
++  webnn::Padding2d webnn_padding2d = {
++      .beginning =
++          webnn::Size2d<uint32_t>{.height = padding2d.beginning->height,
++                                  .width = padding2d.beginning->width},
++      .ending = webnn::Size2d<uint32_t>{.height = padding2d.ending->height,
++                                        .width = padding2d.ending->width}};
++  webnn::Size2d<uint32_t> webnn_strides = {.height = stride.height,
++                                           .width = stride.width};
++  webnn::Size2d<uint32_t> webnn_dilations = {.height = dilation.height,
++                                             .width = dilation.width};
++  ASSIGN_OR_RETURN(
++      const webnn::Size2d<double> calculated_output_sizes,
++      ValidateAndCalculateConv2dOutputSizes(
++          input.height, input.width, filter.height, filter.width,
++          webnn_padding2d, webnn_strides, webnn_dilations, "Pool2d"));
++
++  // Get the actual integer output size from the output operand and compare to
++  // determine rounding type.
++  const uint32_t actual_output_height = output.height;
++  const uint32_t actual_output_width = output.width;
++  if (actual_output_height ==
++          base::ClampFloor<uint32_t>(calculated_output_sizes.height) &&
++      actual_output_width ==
++          base::ClampFloor<uint32_t>(calculated_output_sizes.width)) {
++    // Use TFLite's SAME padding mode if it matches WebNN explicit padding.
++    // Otherwise, a TFLite PAD operator will be inserted later using VALID
++    // padding.
++    return GetTfLitePaddingMode(padding2d, input, filter, stride, dilation,
++                                output, /*is_transposed_conv2d=*/false);
++  } else if (actual_output_height ==
++                 base::ClampCeil<uint32_t>(calculated_output_sizes.height) &&
++             actual_output_width ==
++                 base::ClampCeil<uint32_t>(calculated_output_sizes.width)) {
++    ASSIGN_OR_RETURN(
++        const uint32_t padding_height_end,
++        CalculatePaddingEndForCeilRoundingType(
++            input.height, filter.height, stride.height, dilation.height,
++            output.height, padding2d.beginning->height));
++    ASSIGN_OR_RETURN(
++        const uint32_t padding_width_end,
++        CalculatePaddingEndForCeilRoundingType(
++            input.width, filter.width, stride.width, dilation.width,
++            output.width, padding2d.beginning->width));
++    std::array<uint32_t, 4> explicit_padding = {
++        padding2d.beginning->height, padding_height_end,
++        padding2d.beginning->width, padding_width_end};
++    // The explicit padding are used to insert a TfLite PAD operator.
++    return TfLitePadding{.mode = ::tflite::Padding_VALID,
++                         .paddings = explicit_padding};
++  }
++
++  return base::unexpected("Output size does not match floor or ceil rounding.");
++}
++
+ // Sort the indexes of the elements in the axes array based on their values and
+ // return the sorted index array for adding a transpose operation if needed. For
+ // example input shape is [2, 1, 4, 3], the shape of the scale and bias is [3,
+@@ -3870,10 +3998,47 @@ auto GraphBuilderTflite::SerializeConv2d(const mojom::Conv2d& conv2d)
+   const auto& filter_shape = filter_operand.descriptor.shape();
+   const webnn::Size2d<uint32_t> filter_size2d = {.height = filter_shape[1],
+                                                  .width = filter_shape[2]};
++
++  if (conv2d.kind == mojom::Conv2d::Kind::kDirect) {
++    // Calculate the im2col temp tensor size [batch_size * output_height *
++    // output_width * input_channels * filter_height, filter_width].
++    const base::CheckedNumeric<int32_t> im2col_elements =
++        base::CheckedNumeric<int32_t>(input_shape[0]) * output_shape[1] *
++        output_shape[2] * input_channels * filter_size2d.height *
++        filter_size2d.width;
++
++    // Check against the 32-bit signed integer limit to avoid overflow in
++    // TFLite.
++    if (!im2col_elements.IsValid()) {
++      return base::unexpected(
++          "Conv2d doesn't support configurations that require an internal "
++          "computation buffer exceeding INT32_MAX elements.");
++    }
++  }
++
++  if (conv2d.kind == mojom::Conv2d::Kind::kTransposed) {
++    // Calculate the col2im temp tensor size [input_height * input_width,
++    // filter_height * filter_width * output_depth].
++    const base::CheckedNumeric<int32_t> col2im_elements =
++        base::CheckedNumeric<int32_t>(input_size2d.height) *
++        input_size2d.width * filter_size2d.height * filter_size2d.width *
++        output_channels;
++
++    // Check against the 32-bit signed integer limit to avoid overflow in
++    // TFLite.
++    if (!col2im_elements.IsValid()) {
++      return base::unexpected(
++          "convTranspose2d doesn't support configurations that require an "
++          "internal computation buffer exceeding INT32_MAX elements.");
++    }
++  }
++
++  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
++                                                 .width = output_shape[2]};
+   ASSIGN_OR_RETURN(
+       TfLitePadding padding_mode,
+       GetTfLitePaddingMode(*conv2d.padding, input_size2d, filter_size2d,
+-                           *conv2d.strides, *conv2d.dilations,
++                           *conv2d.strides, *conv2d.dilations, output_size2d,
+                            conv2d.kind == mojom::Conv2d::Kind::kTransposed));
+ 
+   std::optional<FusedActivationOutputInfo> fused_activation =
+@@ -6558,16 +6723,19 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
+ 
+   const auto& input_shape = input_operand.descriptor.shape();
+   CHECK_EQ(input_shape.size(), 4u);
++  const mojom::Operand& output_operand = GetOperand(pool2d.output_operand_id);
++  const auto& output_shape = output_operand.descriptor.shape();
+   const webnn::Size2d<uint32_t> input_size2d = {.height = input_shape[1],
+                                                 .width = input_shape[2]};
++  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
++                                                 .width = output_shape[2]};
+   webnn::Size2d<uint32_t> filter_size2d = {
+       .height = pool2d.window_dimensions->height,
+       .width = pool2d.window_dimensions->width};
+-  ASSIGN_OR_RETURN(
+-      TfLitePadding padding_mode,
+-      GetTfLitePaddingMode(*pool2d.padding, input_size2d, filter_size2d,
+-                           *pool2d.strides, *pool2d.dilations,
+-                           /*is_transposed_conv2d=*/false));
++  ASSIGN_OR_RETURN(TfLitePadding padding_mode,
++                   GetPool2dTfLitePaddingMode(
++                       *pool2d.padding, input_size2d, filter_size2d,
++                       *pool2d.strides, *pool2d.dilations, output_size2d));
+   ASSIGN_OR_RETURN(
+       const TensorInfo& input_tensor_info,
+       SerializeInputTensorInfo(
+diff --git a/third_party/blink/web_tests/platform/mac/virtual/webnn-service-with-gpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_gpu-expected.txt b/third_party/blink/web_tests/platform/mac/virtual/webnn-service-with-gpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_gpu-expected.txt
+index 035d7f3a1387c642e65205daef788ccc2db0b12f..7d6b36e0e78a0b41a0c4b1b280286e9574822e00 100644
+--- a/third_party/blink/web_tests/platform/mac/virtual/webnn-service-with-gpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_gpu-expected.txt
++++ b/third_party/blink/web_tests/platform/mac/virtual/webnn-service-with-gpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_gpu-expected.txt
+@@ -4,15 +4,13 @@ This is a testharness.js-based test.
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.groups=2 options.strides=[2, 2]
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 0.2787136137485504 by ULP distance: expected a number less than or equal to 8n but got 1049539469n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+-[FAIL] [required] convTranspose2d same output size different padding (padding=1, outputPadding=0))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
+ [FAIL] [required] convTranspose2d same output size different padding (padding=2, outputPadding=2))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float16 actual 0 should be close enough to expected 0.27880859375 by ULP distance: expected a number less than or equal to 8 but got 13430
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ Harness: the test ran to completion.
+diff --git a/third_party/blink/web_tests/virtual/webnn-service-on-cpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_cpu-expected.txt b/third_party/blink/web_tests/virtual/webnn-service-on-cpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_cpu-expected.txt
+index 035d7f3a1387c642e65205daef788ccc2db0b12f..7d6b36e0e78a0b41a0c4b1b280286e9574822e00 100644
+--- a/third_party/blink/web_tests/virtual/webnn-service-on-cpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_cpu-expected.txt
++++ b/third_party/blink/web_tests/virtual/webnn-service-on-cpu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_cpu-expected.txt
+@@ -4,15 +4,13 @@ This is a testharness.js-based test.
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.groups=2 options.strides=[2, 2]
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 0.2787136137485504 by ULP distance: expected a number less than or equal to 8n but got 1049539469n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+-[FAIL] [required] convTranspose2d same output size different padding (padding=1, outputPadding=0))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
+ [FAIL] [required] convTranspose2d same output size different padding (padding=2, outputPadding=2))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float16 actual 0 should be close enough to expected 0.27880859375 by ULP distance: expected a number less than or equal to 8 but got 13430
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ Harness: the test ran to completion.
+diff --git a/third_party/blink/web_tests/virtual/webnn-service-on-npu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_npu-expected.txt b/third_party/blink/web_tests/virtual/webnn-service-on-npu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_npu-expected.txt
+index 035d7f3a1387c642e65205daef788ccc2db0b12f..7d6b36e0e78a0b41a0c4b1b280286e9574822e00 100644
+--- a/third_party/blink/web_tests/virtual/webnn-service-on-npu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_npu-expected.txt
++++ b/third_party/blink/web_tests/virtual/webnn-service-on-npu/external/wpt/webnn/conformance_tests/conv_transpose2d.https.any_npu-expected.txt
+@@ -4,15 +4,13 @@ This is a testharness.js-based test.
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.groups=2 options.strides=[2, 2]
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 0.2787136137485504 by ULP distance: expected a number less than or equal to 8n but got 1049539469n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float32 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+-[FAIL] [required] convTranspose2d same output size different padding (padding=1, outputPadding=0))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
+ [FAIL] [required] convTranspose2d same output size different padding (padding=2, outputPadding=2))
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float32 actual 0 should be close enough to expected 1 by ULP distance: expected a number less than or equal to 18n but got 1065353216n
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.padding
+-  assert_less_than_equal: assert_array_approx_equals_ulp: test convTranspose2d float16 actual 0 should be close enough to expected 0.27880859375 by ULP distance: expected a number less than or equal to 8 but got 13430
++  promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': Explicit padding is not supported for transpose conv2d."
+ [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.dilations
+   promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
+ Harness: the test ran to completion.
+

--- a/patches/chromium/cherry-pick-d141d62357df.patch
+++ b/patches/chromium/cherry-pick-d141d62357df.patch
@@ -14,6 +14,53 @@ Commit-Queue: Fu, Junwei <junwei.fu@intel.com>
 Reviewed-by: Reilly Grant <reillyg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1601883}
 
+diff --git a/services/webnn/public/cpp/graph_validation_utils.cc b/services/webnn/public/cpp/graph_validation_utils.cc
+index 54b8df4d6752077c1c750507769724d184c5dd00..9f96304e1f280e56edc33d76f6729ea0e3b72f20 100644
+--- a/services/webnn/public/cpp/graph_validation_utils.cc
++++ b/services/webnn/public/cpp/graph_validation_utils.cc
+@@ -58,6 +58,8 @@ static constexpr char kVarianceParam[] = "variance";
+ static constexpr char kWeightParam[] = "weight";
+ static constexpr char kZeroPointParam[] = "zeroPoint";
+ 
++}  // namespace
++
+ // Validate and calculate the output spatial dimensions of conv2d given
+ // input sizes, filter sizes, padding, strides and dilations.
+ // Return the calculated output sizes in double precision floating point number
+@@ -102,6 +104,8 @@ ValidateAndCalculateConv2dOutputSizes(const uint32_t input_height,
+                         .width = float_output_width.value()};
+ }
+ 
++namespace {
++
+ // Validate and calculate the output spatial dimensions of convTranspose2d given
+ // input sizes, filter sizes, padding, strides, dilations and output padding.
+ base::expected<Size2d<uint32_t>, std::string>
+diff --git a/services/webnn/public/cpp/graph_validation_utils.h b/services/webnn/public/cpp/graph_validation_utils.h
+index bfc247629d9071138e0e7f2a46316a588e9b5872..8331b0c6b6fc92c48a5e0bb7be18a2e043fb1d7d 100644
+--- a/services/webnn/public/cpp/graph_validation_utils.h
++++ b/services/webnn/public/cpp/graph_validation_utils.h
+@@ -450,6 +450,20 @@ base::expected<OperandDescriptor, std::string> COMPONENT_EXPORT(
+                                  const uint32_t axis,
+                                  std::string_view label);
+ 
++// Validate and calculate the output spatial dimensions of conv2d given
++// input sizes, filter sizes, padding, strides and dilations.
++// Return the calculated output sizes in double precision floating point number
++// if no errors.
++base::expected<Size2d<double>, std::string> COMPONENT_EXPORT(WEBNN_PUBLIC_CPP)
++    ValidateAndCalculateConv2dOutputSizes(uint32_t input_height,
++                                          uint32_t input_width,
++                                          uint32_t filter_height,
++                                          uint32_t filter_width,
++                                          const Padding2d& padding,
++                                          const Size2d<uint32_t>& strides,
++                                          const Size2d<uint32_t>& dilations,
++                                          std::string_view label);
++
+ // Validate and infer output information of 2-D convolution operator defined in
+ // WebIDL here https://www.w3.org/TR/webnn/#api-mlgraphbuilder-conv2d
+ base::expected<OperandDescriptor, std::string> COMPONENT_EXPORT(
 diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
 index d9cdbf3c71fad5c5da6e688c57d7ef4ef46da668..b2fcd0a39695ce98f7d70368ebb32ab7669bcf45 100644
 --- a/services/webnn/tflite/graph_builder_tflite.cc

--- a/patches/chromium/cherry-pick-d141d62357df.patch
+++ b/patches/chromium/cherry-pick-d141d62357df.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Fu, Junwei <junwei.fu@intel.com>
-Date: Tue, 18 Mar 2026 03:25:47 -0700
-Subject: WebNN: Use output size for TransposeConv SAME padding in
- TFLite
+From: "Fu, Junwei" <junwei.fu@intel.com>
+Date: Wed, 18 Mar 2026 03:25:47 -0700
+Subject: WebNN: Use output size for TransposeConv SAME padding in TFLite
 
 This CL aligns the TFLite backend's padding calculation for
 convTranspose2d with the TFLite kernel implementation.
@@ -16,7 +15,7 @@ Reviewed-by: Reilly Grant <reillyg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1601883}
 
 diff --git a/services/webnn/tflite/graph_builder_tflite.cc b/services/webnn/tflite/graph_builder_tflite.cc
-index 56411065d59c299840d557104719fd70ff456bc2..72610d822fe2a67beecbd5000cff3a4740922288 100644
+index d9cdbf3c71fad5c5da6e688c57d7ef4ef46da668..b2fcd0a39695ce98f7d70368ebb32ab7669bcf45 100644
 --- a/services/webnn/tflite/graph_builder_tflite.cc
 +++ b/services/webnn/tflite/graph_builder_tflite.cc
 @@ -206,40 +206,50 @@ struct PaddingSizes {
@@ -261,7 +260,7 @@ index 56411065d59c299840d557104719fd70ff456bc2..72610d822fe2a67beecbd5000cff3a47
  // Sort the indexes of the elements in the axes array based on their values and
  // return the sorted index array for adding a transpose operation if needed. For
  // example input shape is [2, 1, 4, 3], the shape of the scale and bias is [3,
-@@ -3870,10 +3998,47 @@ auto GraphBuilderTflite::SerializeConv2d(const mojom::Conv2d& conv2d)
+@@ -3883,10 +4011,47 @@ auto GraphBuilderTflite::SerializeConv2d(const mojom::Conv2d& conv2d)
    const auto& filter_shape = filter_operand.descriptor.shape();
    const webnn::Size2d<uint32_t> filter_size2d = {.height = filter_shape[1],
                                                   .width = filter_shape[2]};
@@ -310,19 +309,10 @@ index 56411065d59c299840d557104719fd70ff456bc2..72610d822fe2a67beecbd5000cff3a47
                             conv2d.kind == mojom::Conv2d::Kind::kTransposed));
  
    std::optional<FusedActivationOutputInfo> fused_activation =
-@@ -6558,16 +6723,19 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
- 
-   const auto& input_shape = input_operand.descriptor.shape();
+@@ -6635,11 +6800,10 @@ auto GraphBuilderTflite::SerializePool2d(const mojom::Pool2d& pool2d)
    CHECK_EQ(input_shape.size(), 4u);
-+  const mojom::Operand& output_operand = GetOperand(pool2d.output_operand_id);
-+  const auto& output_shape = output_operand.descriptor.shape();
    const webnn::Size2d<uint32_t> input_size2d = {.height = input_shape[1],
                                                  .width = input_shape[2]};
-+  const webnn::Size2d<uint32_t> output_size2d = {.height = output_shape[1],
-+                                                 .width = output_shape[2]};
-   webnn::Size2d<uint32_t> filter_size2d = {
-       .height = pool2d.window_dimensions->height,
-       .width = pool2d.window_dimensions->width};
 -  ASSIGN_OR_RETURN(
 -      TfLitePadding padding_mode,
 -      GetTfLitePaddingMode(*pool2d.padding, input_size2d, filter_size2d,
@@ -404,4 +394,3 @@ index 035d7f3a1387c642e65205daef788ccc2db0b12f..7d6b36e0e78a0b41a0c4b1b280286e95
  [FAIL] [required] convTranspose2d float16 4D input and filter tensors options.dilations
    promise_test: Unhandled rejection with value: object "NotSupportedError: Failed to execute 'build' on 'MLGraphBuilder': convTranspose2d doesn't support dilations and groups."
  Harness: the test ran to completion.
-

--- a/patches/chromium/cherry-pick-fccaeb9e0967.patch
+++ b/patches/chromium/cherry-pick-fccaeb9e0967.patch
@@ -17,6 +17,7 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673253
 Reviewed-by: Thomas Guilbert <tguilbert@chromium.org>
 Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1600910}
+
 diff --git a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc b/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc
 index a3160d119f3e1218f1b5cac26c4cebeeb096017f..ce6b35edb32b619f88e5d4d003ce136da0458373 100644
 --- a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc

--- a/patches/chromium/cherry-pick-fccaeb9e0967.patch
+++ b/patches/chromium/cherry-pick-fccaeb9e0967.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dale Curtis <dalecurtis@chromium.org>
+Date: Tue, 17 Mar 2026 17:33:03 -0700
+Subject: Ensure AudioRendererMixer holds lock during sink switch
+
+This guards `switch_output_device_in_progress_` with a lock that
+can be held during the final phase of a setSinkId() operation
+within the AudioRendererMixerInput. It ensures that if Stop()
+is called, we don't incorrectly reconnect the new sink, and if
+a device changes is in flight, that we stall the Stop() call.
+
+R=tguilbert
+
+Fixed: 492218537
+Change-Id: I9ec6efb9678762a22b1b1c8a2f8918771c264678
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673253
+Reviewed-by: Thomas Guilbert <tguilbert@chromium.org>
+Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1600910}
+diff --git a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc b/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc
+index a3160d119f3e1218f1b5cac26c4cebeeb096017f..ce6b35edb32b619f88e5d4d003ce136da0458373 100644
+--- a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc
++++ b/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.cc
+@@ -96,6 +96,17 @@ void AudioRendererMixerInput::Start() {
+ }
+ 
+ void AudioRendererMixerInput::Stop() {
++  {
++    // Prevents race conditions when Stop() is called during a device change.
++    base::AutoLock auto_lock(device_change_lock_);
++    if (switch_output_device_in_progress_) {
++      switch_output_device_in_progress_ = false;
++    }
++  }
++  StopInternal();
++}
++
++void AudioRendererMixerInput::StopInternal() {
+   // Stop() may be called at any time, if Pause() hasn't been called we need to
+   // remove our mixer input before shutdown.
+   Pause();
+@@ -154,10 +165,13 @@ void AudioRendererMixerInput::GetOutputDeviceInfoAsync(
+     return;
+   }
+ 
+-  if (switch_output_device_in_progress_) {
+-    DCHECK(!godia_in_progress_);
+-    pending_device_info_cb_ = std::move(info_cb);
+-    return;
++  {
++    base::AutoLock auto_lock(device_change_lock_);
++    if (switch_output_device_in_progress_) {
++      DCHECK(!godia_in_progress_);
++      pending_device_info_cb_ = std::move(info_cb);
++      return;
++    }
+   }
+ 
+   godia_in_progress_ = true;
+@@ -192,7 +206,10 @@ void AudioRendererMixerInput::SwitchOutputDevice(
+     media::OutputDeviceStatusCB callback) {
+   // If a GODIA() call is in progress, defer until it's complete.
+   if (godia_in_progress_) {
+-    DCHECK(!switch_output_device_in_progress_);
++    {
++      base::AutoLock auto_lock(device_change_lock_);
++      DCHECK(!switch_output_device_in_progress_);
++    }
+ 
+     // Abort any previous device switch which may be pending.
+     if (pending_switch_cb_) {
+@@ -214,7 +231,10 @@ void AudioRendererMixerInput::SwitchOutputDevice(
+     return;
+   }
+ 
+-  switch_output_device_in_progress_ = true;
++  {
++    base::AutoLock auto_lock(device_change_lock_);
++    switch_output_device_in_progress_ = true;
++  }
+ 
+   // Request a new sink using the new device id. This process may fail, so to
+   // avoid interrupting working audio, don't set any class variables until we
+@@ -307,45 +327,48 @@ void AudioRendererMixerInput::OnDeviceSwitchReady(
+     media::OutputDeviceStatusCB switch_cb,
+     scoped_refptr<media::AudioRendererSink> sink,
+     media::OutputDeviceInfo device_info) {
+-  DCHECK(switch_output_device_in_progress_);
+-  switch_output_device_in_progress_ = false;
+-
+-  if (device_info.device_status() != media::OUTPUT_DEVICE_STATUS_OK) {
+-    sink->Stop();
+-    std::move(switch_cb).Run(device_info.device_status());
+-
+-    // Start any pending device info request.
+-    if (pending_device_info_cb_) {
+-      GetOutputDeviceInfoAsync(std::move(pending_device_info_cb_));
+-    }
++  auto return_status = device_info.device_status();
+ 
+-    return;
+-  }
+-
+-  const bool has_mixer = !!mixer_;
+-  const bool is_playing = playing_;
+-
+-  // This may occur if Start() hasn't yet been called.
+-  if (sink_) {
+-    sink_->Stop();
+-  }
++  {
++    base::AutoLock auto_lock(device_change_lock_);
++
++    if (device_info.device_status() != media::OUTPUT_DEVICE_STATUS_OK) {
++      // Case: Device change failed.
++      sink->Stop();
++    } else if (!switch_output_device_in_progress_) {
++      // Case: Stop() called during device change.
++      sink->Stop();
++      return_status = media::OUTPUT_DEVICE_STATUS_ERROR_INTERNAL;
++    } else {
++      // Case: Device change succeeded, connect to new sink.
++      const bool has_mixer = !!mixer_;
++      const bool is_playing = playing_;
++
++      // This may occur if Start() hasn't yet been called.
++      if (sink_) {
++        sink_->Stop();
++      }
+ 
+-  sink_ = std::move(sink);
+-  device_info_ = device_info;
+-  device_id_ = device_info.device_id();
++      sink_ = std::move(sink);
++      device_info_ = device_info;
++      device_id_ = device_info.device_id();
+ 
+-  auto callback = callback_;
+-  Stop();
+-  callback_ = callback;
++      auto callback = callback_;
++      StopInternal();
++      callback_ = callback;
+ 
+-  if (has_mixer) {
+-    Start();
+-    if (is_playing) {
+-      Play();
++      if (has_mixer) {
++        Start();
++        if (is_playing) {
++          Play();
++        }
++      }
+     }
++
++    switch_output_device_in_progress_ = false;
+   }
+ 
+-  std::move(switch_cb).Run(device_info.device_status());
++  std::move(switch_cb).Run(return_status);
+ 
+   // Start any pending device info request.
+   if (pending_device_info_cb_) {
+diff --git a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.h b/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.h
+index e13df618d5cc86221a12d060d892474e2cbc8c49..f511187bfd7f164c0c5d7c10a894a3e81c0a7fbc 100644
+--- a/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.h
++++ b/third_party/blink/renderer/modules/media/audio/audio_renderer_mixer_input.h
+@@ -80,6 +80,7 @@ class BLINK_MODULES_EXPORT AudioRendererMixerInput
+   void OnRenderError();
+ 
+  private:
++  void StopInternal();
+   ~AudioRendererMixerInput() override;
+ 
+   friend class AudioRendererMixerInputTest;
+@@ -118,6 +119,9 @@ class BLINK_MODULES_EXPORT AudioRendererMixerInput
+                            scoped_refptr<media::AudioRendererSink> sink,
+                            media::OutputDeviceInfo device_info);
+ 
++  // Prevents race conditions when Stop() is called during a device change.
++  base::Lock device_change_lock_;
++
+   // AudioParameters received during Initialize().
+   media::AudioParameters params_;
+ 
+@@ -143,7 +147,8 @@ class BLINK_MODULES_EXPORT AudioRendererMixerInput
+   // exclusive when executing; these flags indicate whether one or the other is
+   // in progress. Each method will use the other method's to defer its action.
+   bool godia_in_progress_ = false;
+-  bool switch_output_device_in_progress_ = false;
++  bool switch_output_device_in_progress_ GUARDED_BY(device_change_lock_) =
++      false;
+ 
+   // Set by GetOutputDeviceInfoAsync() if a SwitchOutputDevice() call is in
+   // progress. GetOutputDeviceInfoAsync() will be invoked again with this value


### PR DESCRIPTION
<details>
<summary>cherry-pick 7673406 from chromium</summary>

[WebNN] Reject fusing per-channel quantized gemm if the quantized dimension of filter is not 0

The FULLY_CONNECTED's underlying kernels expect the per-channel
quantization axis to be the output channel(axis 0). So reject
fusing per-channel quantized gemm and fall back to the unfused
operators path if the quantized dimension of filter is not 0.

Bug: 493319454
Change-Id: Ib7e1236a535dc6a34d3ff9b9f0124a101bd89dbf
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7673406
Reviewed-by: Phillis Tang <phillis@chromium.org>
Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Cr-Commit-Position: refs/heads/main@{#1601718}
</details>

<details>
<summary>cherry-pick 7687618 from chromium</summary>

[WebNN] Prevent Pool2d indirection buffer overflow in TFLite

Add a check to ensure the size of the internal indirection buffer used
by TFLite's Pool2d implementation does not exceed the maximum value
of a size_t integer.

Bug: 494158331
Change-Id: I984556f0f608badf8f73fcbb096da5f41170a958
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7687618
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Commit-Queue: Wang, Wei4 <wei4.wang@intel.com>
Cr-Commit-Position: refs/heads/main@{#1602966}
</details>

<details>
<summary>cherry-pick 4e9562ca7b42 from chromium</summary>

Upgrade DCHECK_EQ to CHECK_EQ in audio_processor.cc.

Bug: 493234757
Change-Id: Iaf1abb6e84b36d36eac100ef20b88e6f2d3e8fbd
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7708432
Reviewed-by: Thomas Guilbert <music@chromium.org>
Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1604200}
</details>

<details>
<summary>cherry-pick fccaeb9e0967 from chromium</summary>

Fix dangling pointer bug in VaapiVideoEncodeAccelerator

Bug: 492736100
Change-Id: I998bc71a1f2c58a009f9e8d9e9f27fe1aed89e69
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7685816
Reviewed-by: Hirokazu Honda <hiroh@chromium.org>
Commit-Queue: Miguel Casas <mcasas@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1602416}
</details>

<details>
<summary>cherry-pick c75f63de7188 from chromium</summary>

[WebNN] Use int32_t for checking im2col/col2im size limits

Bug: 493413432
Change-Id: If316b1b19ead6618e67e2ff7d5f4f2c4e57b3bba
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7694571
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Commit-Queue: Fu, Junwei <junwei.fu@intel.com>
Cr-Commit-Position: refs/heads/main@{#1603271}
</details>

<details>
<summary>cherry-pick d141d62357df from chromium</summary>

WebNN: Use output size for TransposeConv SAME padding in TFLite

This CL aligns the TFLite backend's padding calculation for
convTranspose2d with the TFLite kernel implementation.

Bug: 492668885, 491869941
Change-Id: Ibfbcd2bf9b80b6ab2b2f0fccf9596975537f9cc8
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7677538
Reviewed-by: Hu, Ningxin <ningxin.hu@intel.com>
Commit-Queue: Fu, Junwei <junwei.fu@intel.com>
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1601883}
</details>

<details>
<summary>cherry-pick 848cf5567223 from chromium</summary>

Check parent nodes when handling vector node insertions.

In the optimized vector node insertion case, check the parent node just
as in the regular case.

Fixed: 496281816
Change-Id: I0fc6956d1c09fcb7ea54d94819fdf1cb06fbd9e5
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7705373
Commit-Queue: David Baron <dbaron@chromium.org>
Reviewed-by: Mason Freed <masonf@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1605818}
</details>

Notes: Backported security fixes for 493319454, 494158331, 493234757, 492736100, 493413432, 492668885, 496281816.