### PR TITLE
chore: cherry-pick 3 changes from skia, angle, webrtc

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,2 +1,3 @@
 optionally_validate_gl_max_uniform_blocks_at_compile_time.patch
 cherry-pick-cl-7708753.patch
+cherry-pick-6d8b704e2a.patch

--- a/patches/angle/cherry-pick-6d8b704e2a.patch
+++ b/patches/angle/cherry-pick-6d8b704e2a.patch
@@ -56,7 +56,7 @@ diff --git a/src/libANGLE/renderer/metal/TextureMtl.mm b/src/libANGLE/renderer/m
 index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b176899917 100644
 --- a/src/libANGLE/renderer/metal/TextureMtl.mm
 +++ b/src/libANGLE/renderer/metal/TextureMtl.mm
-@@ -777,8 +777,8 @@ mtl::TextureRef &GetLayerLevelTextureView(
+@@ -777,8 +777,8 @@ GLenum OverrideSwizzleValue(const gl::Context *context,
  class TextureMtl::NativeTextureWrapper : angle::NonCopyable
  {
    public:
@@ -67,7 +67,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      {
          ASSERT(mNativeTexture && mNativeTexture->valid());
      }
-@@ -810,6 +810,7 @@ class TextureMtl::NativeTextureWrapper : angle::NonCopyable
+@@ -810,6 +810,7 @@ void getBytes(ContextMtl *context,
                                   getNativeLevel(glLevel), slice, dataOut);
      }
  
@@ -75,7 +75,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      GLuint getBaseGLLevel() const { return mBaseGLLevel; }
      // Get max addressable GL level that this texture supports.
      GLuint getMaxSupportedGLLevel() const { return mBaseGLLevel + mipmapLevels() - 1; }
-@@ -855,14 +856,17 @@ class TextureMtl::NativeTextureWrapper : angle::NonCopyable
+@@ -855,14 +856,17 @@ uint32_t height(GLuint glLevel) const
    protected:
      mtl::TextureRef mNativeTexture;
      const GLuint mBaseGLLevel;
@@ -95,7 +95,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      {}
  
      // Create a view of one slice at a level.
-@@ -952,7 +956,6 @@ void TextureMtl::deallocateNativeStorage(bool keepImages, bool keepSamplerStateA
+@@ -952,7 +956,6 @@ uint32_t height(GLuint glLevel) const
      if (!keepSamplerStateAndFormat)
      {
          mMetalSamplerState = nil;
@@ -103,7 +103,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      }
  }
  
-@@ -976,9 +979,9 @@ angle::Result TextureMtl::ensureNativeStorageCreated(const gl::Context *context)
+@@ -976,9 +979,9 @@ uint32_t height(GLuint glLevel) const
      ANGLE_CHECK(contextMtl, desc.format.valid(), gl::err::kInternalError, GL_INVALID_OPERATION);
      angle::FormatID angleFormatId =
          angle::Format::InternalFormatToID(desc.format.info->sizedInternalFormat);
@@ -115,7 +115,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  
      // Transfer data from defined images to actual texture object
      int numCubeFaces = static_cast<int>(mNativeTextureStorage->cubeFaces());
-@@ -1019,44 +1022,46 @@ angle::Result TextureMtl::createNativeStorage(const gl::Context *context,
+@@ -1019,44 +1022,46 @@ uint32_t height(GLuint glLevel) const
                                                gl::TextureType type,
                                                GLuint mips,
                                                GLuint samples,
@@ -173,7 +173,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
                  /** renderTargetOnly */ false, allowFormatView, &nativeTextureStorage));
              break;
          default:
-@@ -1066,15 +1071,16 @@ angle::Result TextureMtl::createNativeStorage(const gl::Context *context,
+@@ -1066,15 +1071,16 @@ uint32_t height(GLuint glLevel) const
      if (mState.getImmutableFormat())
      {
          mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
@@ -193,7 +193,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  
      ANGLE_TRY(createViewFromBaseToMaxLevel());
  
-@@ -1091,11 +1097,14 @@ angle::Result TextureMtl::ensureSamplerStateCreated(const gl::Context *context)
+@@ -1091,11 +1097,14 @@ uint32_t height(GLuint glLevel) const
          return angle::Result::Continue;
      }
  
@@ -209,7 +209,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      {
          // On devices not supporting filtering for depth textures, we need to convert to nearest
          // here.
-@@ -1151,7 +1160,8 @@ angle::Result TextureMtl::createViewFromBaseToMaxLevel()
+@@ -1151,7 +1160,8 @@ uint32_t height(GLuint glLevel) const
      }
  
      mViewFromBaseToMaxLevel = std::make_unique<NativeTextureWrapper>(
@@ -219,7 +219,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  
      // Recreate in bindToShader()
      mSwizzleStencilSamplingView = nullptr;
-@@ -1228,9 +1238,15 @@ angle::Result TextureMtl::ensureImageCreated(const gl::Context *context,
+@@ -1228,9 +1238,15 @@ uint32_t height(GLuint glLevel) const
      mtl::TextureRef &image = getImage(index);
      if (!image)
      {
@@ -236,7 +236,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      }
      return angle::Result::Continue;
  }
-@@ -1321,7 +1337,7 @@ void TextureMtl::retainImageDefinitions()
+@@ -1321,7 +1337,7 @@ uint32_t height(GLuint glLevel) const
                  continue;
              }
              imageDef.image    = createImageViewFromTextureStorage(face, imageMipLevel);
@@ -245,7 +245,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          }
      }
  }
-@@ -1349,7 +1365,7 @@ ImageDefinitionMtl &TextureMtl::getImageDefinition(const gl::ImageIndex &imageIn
+@@ -1349,7 +1365,7 @@ uint32_t height(GLuint glLevel) const
  
          imageDef.image =
              createImageViewFromTextureStorage(cubeFaceOrZero, imageIndex.getLevelIndex());
@@ -254,7 +254,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      }
  
      return imageDef;
-@@ -1368,22 +1384,24 @@ angle::Result TextureMtl::getRenderTarget(ContextMtl *context,
+@@ -1368,22 +1384,24 @@ uint32_t height(GLuint glLevel) const
              ? gl::RenderToTextureImageIndex::Default
              : static_cast<gl::RenderToTextureImageIndex>(PackSampleCount(implicitSamples));
  
@@ -283,7 +283,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
              }
          }
      }
-@@ -1391,13 +1409,13 @@ angle::Result TextureMtl::getRenderTarget(ContextMtl *context,
+@@ -1391,13 +1409,13 @@ uint32_t height(GLuint glLevel) const
      if (implicitSamples > 1 && !rtt.getImplicitMSTexture())
      {
          // This format must supports implicit resolve
@@ -299,7 +299,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          }
          rtt.setImplicitMSTexture(msTexture);
      }
-@@ -1639,12 +1657,12 @@ angle::Result TextureMtl::setEGLImageTarget(const gl::Context *context,
+@@ -1639,12 +1657,12 @@ uint32_t height(GLuint glLevel) const
          return angle::Result::Stop;
      }
  
@@ -316,7 +316,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  
      mSlices = mNativeTextureStorage->cubeFacesOrArrayLength();
  
-@@ -1676,9 +1694,9 @@ angle::Result TextureMtl::generateMipmap(const gl::Context *context)
+@@ -1676,9 +1694,9 @@ uint32_t height(GLuint glLevel) const
          return angle::Result::Continue;
      }
  
@@ -329,7 +329,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  
      bool avoidGPUPath =
          contextMtl->getDisplay()->getFeatures().forceNonCSBaseMipmapGeneration.enabled &&
-@@ -1711,7 +1729,7 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
+@@ -1711,7 +1729,7 @@ uint32_t height(GLuint glLevel) const
      ASSERT(mViewFromBaseToMaxLevel);
  
      ContextMtl *contextMtl           = mtl::GetImpl(context);
@@ -338,7 +338,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      // This format must have mip generation function.
      ANGLE_CHECK(contextMtl, angleFormat.mipGenerationFunction, gl::err::kInternalError,
                  GL_INVALID_OPERATION);
-@@ -1780,8 +1798,8 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
+@@ -1780,8 +1798,8 @@ uint32_t height(GLuint glLevel) const
      return angle::Result::Continue;
  }
  
@@ -349,7 +349,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  {
      // On iOS devices with GPU family 5 and later, Metal doesn't apply lossless compression to
      // the texture if we set MTLTextureUsagePixelFormatView. This shouldn't be a problem though
-@@ -1789,7 +1807,7 @@ bool TextureMtl::needsFormatViewForPixelLocalStorage(
+@@ -1789,7 +1807,7 @@ uint32_t height(GLuint glLevel) const
      // images.
      if (plsOptions.type == ShPixelLocalStorageType::ImageLoadStore)
      {
@@ -358,7 +358,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          {
              case MTLPixelFormatRGBA8Unorm:
              case MTLPixelFormatRGBA8Uint:
-@@ -1818,9 +1836,9 @@ angle::Result TextureMtl::bindTexImage(const gl::Context *context, egl::Surface
+@@ -1818,9 +1836,9 @@ uint32_t height(GLuint glLevel) const
  
      mBoundSurface         = surface;
      auto pBuffer          = GetImplAs<OffscreenSurfaceMtl>(surface);
@@ -371,7 +371,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      mSlices = mNativeTextureStorage->cubeFacesOrArrayLength();
  
      ANGLE_TRY(ensureSamplerStateCreated(context));
-@@ -1931,47 +1949,48 @@ angle::Result TextureMtl::bindToShader(const gl::Context *context,
+@@ -1931,47 +1949,48 @@ uint32_t height(GLuint glLevel) const
      {
          ContextMtl *contextMtl             = mtl::GetImpl(context);
          const angle::FeaturesMtl &features = contextMtl->getDisplay()->getFeatures();
@@ -432,7 +432,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          }
          else
          {
-@@ -2049,7 +2068,8 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+@@ -2049,7 +2068,8 @@ uint32_t height(GLuint glLevel) const
          // from the given size, or the format is different, we are redefining the image so we
          // must release it.
          ASSERT(mNativeTextureStorage->textureType() == mtl::GetTextureType(index.getType()));
@@ -442,7 +442,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          {
              // Keep other images
              deallocateNativeStorage(/*keepImages=*/true);
-@@ -2063,8 +2083,6 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+@@ -2063,8 +2083,6 @@ uint32_t height(GLuint glLevel) const
      }
  
      ContextMtl *contextMtl = mtl::GetImpl(context);
@@ -451,7 +451,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      ImageDefinitionMtl &imageDef = getImageDefinition(index);
  
      // If native texture still exists, it means the size hasn't been changed, no need to create new
-@@ -2073,14 +2091,16 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+@@ -2073,14 +2091,16 @@ uint32_t height(GLuint glLevel) const
      {
          ASSERT(imageDef.image->textureType() ==
                     mtl::GetTextureType(GetTextureImageType(index.getType())) &&
@@ -472,7 +472,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
          // Create image to hold texture's data at this level & slice:
          switch (index.getType())
          {
-@@ -2129,9 +2149,7 @@ angle::Result TextureMtl::setStorageImpl(const gl::Context *context,
+@@ -2129,9 +2149,7 @@ uint32_t height(GLuint glLevel) const
      // Tell context to rebind textures
      contextMtl->invalidateCurrentTextures();
  
@@ -483,7 +483,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      ANGLE_TRY(createViewFromBaseToMaxLevel());
  
      return angle::Result::Continue;
-@@ -2544,7 +2562,7 @@ angle::Result TextureMtl::convertAndSetPerSliceSubImage(const gl::Context *conte
+@@ -2544,7 +2562,7 @@ uint32_t height(GLuint glLevel) const
                                                      kAvoidStagingBuffers, imageDef.image));
                  }
              }
@@ -492,7 +492,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      }  // if (unpackBuffer)
  
      return angle::Result::Continue;
-@@ -2662,7 +2680,11 @@ angle::Result TextureMtl::copySubImageImpl(const gl::Context *context,
+@@ -2662,7 +2680,11 @@ uint32_t height(GLuint glLevel) const
  
      ANGLE_TRY(ensureImageCreated(context, index));
  
@@ -505,7 +505,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      {
          return copySubImageCPU(context, index, modifiedDestOffset, clippedSourceArea,
                                 internalFormat, source, colorReadRT);
-@@ -2723,7 +2745,9 @@ angle::Result TextureMtl::copySubImageCPU(const gl::Context *context,
+@@ -2723,7 +2745,9 @@ uint32_t height(GLuint glLevel) const
  
      ContextMtl *contextMtl = mtl::GetImpl(context);
  
@@ -516,7 +516,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      const int dstRowPitch          = dstFormat.pixelBytes * clippedSourceArea.width;
      angle::MemoryBuffer conversionRow;
      ANGLE_CHECK_GL_ALLOC(contextMtl, conversionRow.resize(dstRowPitch));
-@@ -2804,7 +2828,9 @@ angle::Result TextureMtl::copySubTextureImpl(const gl::Context *context,
+@@ -2804,7 +2828,9 @@ uint32_t height(GLuint glLevel) const
      const mtl::Format &sourceFormat        = contextMtl->getPixelFormat(srcImageDef.formatID);
      const angle::Format &sourceAngleFormat = sourceFormat.actualAngleFormat();
  
@@ -527,7 +527,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
      {
          return copySubTextureCPU(context, index, destOffset, internalFormat,
                                   mtl::kZeroNativeMipLevel, sourceBox, sourceAngleFormat,
-@@ -2862,8 +2888,10 @@ angle::Result TextureMtl::copySubTextureWithDraw(const gl::Context *context,
+@@ -2862,8 +2888,10 @@ uint32_t height(GLuint glLevel) const
      blitParams.unpackUnmultiplyAlpha  = unpackUnmultiplyAlpha;
      blitParams.transformLinearToSrgb  = sourceAngleFormat.isSRGB;
  
@@ -539,7 +539,7 @@ index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b1
  }
  
  angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
-@@ -2883,7 +2911,9 @@ angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
+@@ -2883,7 +2911,9 @@ uint32_t height(GLuint glLevel) const
  
      ContextMtl *contextMtl = mtl::GetImpl(context);
  

--- a/patches/angle/cherry-pick-6d8b704e2a.patch
+++ b/patches/angle/cherry-pick-6d8b704e2a.patch
@@ -1,0 +1,596 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Thu, 19 Mar 2026 15:17:08 -0400
+Subject: Metal: Remove TextureMtl::mFormat
+
+TextureMtl::mFormat is supposed to represent the format of the native
+storage but it was updated to the last format set on any mip level, even
+if it is not in the native storage. This is extremely error prone, a lot
+of the Metal texturing code relied on it being properly set.
+
+Remove mFormat and query it from the native storage or the specific
+image desc.
+
+Bug: chromium:493256564
+Change-Id: I629c009b34c7ef7ca5fa7a97f5845accf22b13b8
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7684363
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+
+diff --git a/src/libANGLE/renderer/metal/TextureMtl.h b/src/libANGLE/renderer/metal/TextureMtl.h
+index 65283cdb644bb5b2bb2ded12addafaf7d4b78c3d..2dfd58b0cd9b26258624285b58715378e99a904e 100644
+--- a/src/libANGLE/renderer/metal/TextureMtl.h
++++ b/src/libANGLE/renderer/metal/TextureMtl.h
+@@ -182,15 +182,14 @@ class TextureMtl : public TextureImpl
+                                     int layer,
+                                     GLenum format);
+ 
+-    const mtl::Format &getFormat() const { return mFormat; }
+-
+   private:
+     void deallocateNativeStorage(bool keepImages, bool keepSamplerStateAndFormat = false);
+     angle::Result createNativeStorage(const gl::Context *context,
+                                       gl::TextureType type,
+                                       GLuint mips,
+                                       GLuint samples,
+-                                      const gl::Extents &size);
++                                      const gl::Extents &size,
++                                      const mtl::Format &format);
+     angle::Result onBaseMaxLevelsChanged(const gl::Context *context);
+     angle::Result ensureSamplerStateCreated(const gl::Context *context);
+     // Ensure image at given index is created:
+@@ -328,10 +327,10 @@ class TextureMtl : public TextureImpl
+ 
+     angle::Result generateMipmapCPU(const gl::Context *context);
+ 
+-    bool needsFormatViewForPixelLocalStorage(const ShPixelLocalStorageOptions &) const;
++    bool needsFormatViewForPixelLocalStorage(const ShPixelLocalStorageOptions &,
++                                             const mtl::Format &format) const;
+     bool isImmutableOrPBuffer() const;
+ 
+-    mtl::Format mFormat;
+     egl::Surface *mBoundSurface = nullptr;
+     class NativeTextureWrapper;
+     class NativeTextureWrapperWithViewSupport;
+diff --git a/src/libANGLE/renderer/metal/TextureMtl.mm b/src/libANGLE/renderer/metal/TextureMtl.mm
+index 9301862a49a4cd42db567aa427cfb631d668fe88..0dcbddd41f22928d1eafab3f6274b2b176899917 100644
+--- a/src/libANGLE/renderer/metal/TextureMtl.mm
++++ b/src/libANGLE/renderer/metal/TextureMtl.mm
+@@ -777,8 +777,8 @@ mtl::TextureRef &GetLayerLevelTextureView(
+ class TextureMtl::NativeTextureWrapper : angle::NonCopyable
+ {
+   public:
+-    NativeTextureWrapper(mtl::TextureRef texture, GLuint baseGLLevel)
+-        : mNativeTexture(std::move(texture)), mBaseGLLevel(baseGLLevel)
++    NativeTextureWrapper(mtl::TextureRef texture, GLuint baseGLLevel, const mtl::Format &format)
++        : mNativeTexture(std::move(texture)), mBaseGLLevel(baseGLLevel), mFormat(format)
+     {
+         ASSERT(mNativeTexture && mNativeTexture->valid());
+     }
+@@ -810,6 +810,7 @@ class TextureMtl::NativeTextureWrapper : angle::NonCopyable
+                                  getNativeLevel(glLevel), slice, dataOut);
+     }
+ 
++    const mtl::Format &getFormat() const { return mFormat; }
+     GLuint getBaseGLLevel() const { return mBaseGLLevel; }
+     // Get max addressable GL level that this texture supports.
+     GLuint getMaxSupportedGLLevel() const { return mBaseGLLevel + mipmapLevels() - 1; }
+@@ -855,14 +856,17 @@ class TextureMtl::NativeTextureWrapper : angle::NonCopyable
+   protected:
+     mtl::TextureRef mNativeTexture;
+     const GLuint mBaseGLLevel;
++    const mtl::Format mFormat;
+ };
+ 
+ // This class extends NativeTextureWrapper with support for view creation
+ class TextureMtl::NativeTextureWrapperWithViewSupport : public NativeTextureWrapper
+ {
+   public:
+-    NativeTextureWrapperWithViewSupport(mtl::TextureRef texture, GLuint baseGLLevel)
+-        : NativeTextureWrapper(std::move(texture), baseGLLevel)
++    NativeTextureWrapperWithViewSupport(mtl::TextureRef texture,
++                                        GLuint baseGLLevel,
++                                        const mtl::Format &format)
++        : NativeTextureWrapper(std::move(texture), baseGLLevel, format)
+     {}
+ 
+     // Create a view of one slice at a level.
+@@ -952,7 +956,6 @@ void TextureMtl::deallocateNativeStorage(bool keepImages, bool keepSamplerStateA
+     if (!keepSamplerStateAndFormat)
+     {
+         mMetalSamplerState = nil;
+-        mFormat            = mtl::Format();
+     }
+ }
+ 
+@@ -976,9 +979,9 @@ angle::Result TextureMtl::ensureNativeStorageCreated(const gl::Context *context)
+     ANGLE_CHECK(contextMtl, desc.format.valid(), gl::err::kInternalError, GL_INVALID_OPERATION);
+     angle::FormatID angleFormatId =
+         angle::Format::InternalFormatToID(desc.format.info->sizedInternalFormat);
+-    mFormat = contextMtl->getPixelFormat(angleFormatId);
++    mtl::Format format = contextMtl->getPixelFormat(angleFormatId);
+ 
+-    ANGLE_TRY(createNativeStorage(context, mState.getType(), mips, 0, desc.size));
++    ANGLE_TRY(createNativeStorage(context, mState.getType(), mips, 0, desc.size, format));
+ 
+     // Transfer data from defined images to actual texture object
+     int numCubeFaces = static_cast<int>(mNativeTextureStorage->cubeFaces());
+@@ -1019,44 +1022,46 @@ angle::Result TextureMtl::createNativeStorage(const gl::Context *context,
+                                               gl::TextureType type,
+                                               GLuint mips,
+                                               GLuint samples,
+-                                              const gl::Extents &size)
++                                              const gl::Extents &size,
++                                              const mtl::Format &format)
+ {
+     ASSERT(samples == 0 || mips == 0);
+     ContextMtl *contextMtl = mtl::GetImpl(context);
+ 
+     // Create actual texture object:
+     mSlices              = 1;
+-    bool allowFormatView = mFormat.hasDepthAndStencilBits() ||
+-                           needsFormatViewForPixelLocalStorage(
+-                               contextMtl->getDisplay()->getNativePixelLocalStorageOptions());
++    bool allowFormatView =
++        format.hasDepthAndStencilBits() ||
++        needsFormatViewForPixelLocalStorage(
++            contextMtl->getDisplay()->getNativePixelLocalStorageOptions(), format);
+     mtl::TextureRef nativeTextureStorage;
+     switch (type)
+     {
+         case gl::TextureType::_2D:
+-            ANGLE_TRY(mtl::Texture::Make2DTexture(
+-                contextMtl, mFormat, size.width, size.height, mips,
+-                /** renderTargetOnly */ false, allowFormatView, &nativeTextureStorage));
++            ANGLE_TRY(mtl::Texture::Make2DTexture(contextMtl, format, size.width, size.height, mips,
++                                                  /** renderTargetOnly */ false, allowFormatView,
++                                                  &nativeTextureStorage));
+             break;
+         case gl::TextureType::CubeMap:
+             mSlices = 6;
+-            ANGLE_TRY(mtl::Texture::MakeCubeTexture(contextMtl, mFormat, size.width, mips,
++            ANGLE_TRY(mtl::Texture::MakeCubeTexture(contextMtl, format, size.width, mips,
+                                                     /** renderTargetOnly */ false, allowFormatView,
+                                                     &nativeTextureStorage));
+             break;
+         case gl::TextureType::_3D:
+             ANGLE_TRY(mtl::Texture::Make3DTexture(
+-                contextMtl, mFormat, size.width, size.height, size.depth, mips,
++                contextMtl, format, size.width, size.height, size.depth, mips,
+                 /** renderTargetOnly */ false, allowFormatView, &nativeTextureStorage));
+             break;
+         case gl::TextureType::_2DArray:
+             mSlices = size.depth;
+             ANGLE_TRY(mtl::Texture::Make2DArrayTexture(
+-                contextMtl, mFormat, size.width, size.height, mips, mSlices,
++                contextMtl, format, size.width, size.height, mips, mSlices,
+                 /** renderTargetOnly */ false, allowFormatView, &nativeTextureStorage));
+             break;
+         case gl::TextureType::_2DMultisample:
+             ANGLE_TRY(mtl::Texture::Make2DMSTexture(
+-                contextMtl, mFormat, size.width, size.height, samples,
++                contextMtl, format, size.width, size.height, samples,
+                 /** renderTargetOnly */ false, allowFormatView, &nativeTextureStorage));
+             break;
+         default:
+@@ -1066,15 +1071,16 @@ angle::Result TextureMtl::createNativeStorage(const gl::Context *context,
+     if (mState.getImmutableFormat())
+     {
+         mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
+-            std::move(nativeTextureStorage), /*baseGLLevel=*/0);
++            std::move(nativeTextureStorage), /*baseGLLevel=*/0, format);
+     }
+     else
+     {
+         mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
+-            std::move(nativeTextureStorage), /*baseGLLevel=*/mState.getEffectiveBaseLevel());
++            std::move(nativeTextureStorage), /*baseGLLevel=*/mState.getEffectiveBaseLevel(),
++            format);
+     }
+ 
+-    ANGLE_TRY(checkForEmulatedChannels(context, mFormat, *mNativeTextureStorage));
++    ANGLE_TRY(checkForEmulatedChannels(context, format, *mNativeTextureStorage));
+ 
+     ANGLE_TRY(createViewFromBaseToMaxLevel());
+ 
+@@ -1091,11 +1097,14 @@ angle::Result TextureMtl::ensureSamplerStateCreated(const gl::Context *context)
+         return angle::Result::Continue;
+     }
+ 
++    ASSERT(mNativeTextureStorage);
++
+     ContextMtl *contextMtl = mtl::GetImpl(context);
+ 
+     mtl::SamplerDesc samplerDesc(mState.getSamplerState());
+ 
+-    if (mFormat.actualAngleFormat().depthBits && !mFormat.getCaps().filterable)
++    const mtl::Format &storageFormat = mNativeTextureStorage->getFormat();
++    if (storageFormat.actualAngleFormat().depthBits && !storageFormat.getCaps().filterable)
+     {
+         // On devices not supporting filtering for depth textures, we need to convert to nearest
+         // here.
+@@ -1151,7 +1160,8 @@ angle::Result TextureMtl::createViewFromBaseToMaxLevel()
+     }
+ 
+     mViewFromBaseToMaxLevel = std::make_unique<NativeTextureWrapper>(
+-        nativeViewFromBaseToMaxLevelRef, mState.getEffectiveBaseLevel());
++        nativeViewFromBaseToMaxLevelRef, mState.getEffectiveBaseLevel(),
++        mNativeTextureStorage->getFormat());
+ 
+     // Recreate in bindToShader()
+     mSwizzleStencilSamplingView = nullptr;
+@@ -1228,9 +1238,15 @@ angle::Result TextureMtl::ensureImageCreated(const gl::Context *context,
+     mtl::TextureRef &image = getImage(index);
+     if (!image)
+     {
++        ContextMtl *contextMtl = mtl::GetImpl(context);
++
+         // Image at this level hasn't been defined yet. We need to define it:
+         const gl::ImageDesc &desc = mState.getImageDesc(index);
+-        ANGLE_TRY(redefineImage(context, index, mFormat, desc.size));
++        angle::FormatID angleFormatId =
++            angle::Format::InternalFormatToID(desc.format.info->sizedInternalFormat);
++        mtl::Format format = contextMtl->getPixelFormat(angleFormatId);
++
++        ANGLE_TRY(redefineImage(context, index, format, desc.size));
+     }
+     return angle::Result::Continue;
+ }
+@@ -1321,7 +1337,7 @@ void TextureMtl::retainImageDefinitions()
+                 continue;
+             }
+             imageDef.image    = createImageViewFromTextureStorage(face, imageMipLevel);
+-            imageDef.formatID = mFormat.intendedFormatId;
++            imageDef.formatID = mNativeTextureStorage->getFormat().intendedFormatId;
+         }
+     }
+ }
+@@ -1349,7 +1365,7 @@ ImageDefinitionMtl &TextureMtl::getImageDefinition(const gl::ImageIndex &imageIn
+ 
+         imageDef.image =
+             createImageViewFromTextureStorage(cubeFaceOrZero, imageIndex.getLevelIndex());
+-        imageDef.formatID = mFormat.intendedFormatId;
++        imageDef.formatID = mNativeTextureStorage->getFormat().intendedFormatId;
+     }
+ 
+     return imageDef;
+@@ -1368,22 +1384,24 @@ angle::Result TextureMtl::getRenderTarget(ContextMtl *context,
+             ? gl::RenderToTextureImageIndex::Default
+             : static_cast<gl::RenderToTextureImageIndex>(PackSampleCount(implicitSamples));
+ 
++    ImageDefinitionMtl &imageDef = getImageDefinition(imageIndex);
++    mtl::Format format           = context->getPixelFormat(imageDef.formatID);
++
+     GLuint layer         = GetImageLayerIndexFrom(imageIndex);
+     RenderTargetMtl &rtt = mRenderTargets[imageIndex][renderToTextureIndex];
+     if (!rtt.getTexture())
+     {
+         // Lazy initialization of render target:
+-        mtl::TextureRef &image = getImage(imageIndex);
+-        if (image)
++        if (imageDef.image)
+         {
+             if (imageIndex.getType() == gl::TextureType::CubeMap)
+             {
+                 // Cube map is special, the image is already the view of its layer
+-                rtt.set(image, mtl::kZeroNativeMipLevel, 0, mFormat);
++                rtt.set(imageDef.image, mtl::kZeroNativeMipLevel, 0, format);
+             }
+             else
+             {
+-                rtt.set(image, mtl::kZeroNativeMipLevel, layer, mFormat);
++                rtt.set(imageDef.image, mtl::kZeroNativeMipLevel, layer, format);
+             }
+         }
+     }
+@@ -1391,13 +1409,13 @@ angle::Result TextureMtl::getRenderTarget(ContextMtl *context,
+     if (implicitSamples > 1 && !rtt.getImplicitMSTexture())
+     {
+         // This format must supports implicit resolve
+-        ANGLE_CHECK(context, mFormat.getCaps().resolve, gl::err::kInternalError, GL_INVALID_VALUE);
++        ANGLE_CHECK(context, format.getCaps().resolve, gl::err::kInternalError, GL_INVALID_VALUE);
+         mtl::TextureRef &msTexture = mImplicitMSTextures[imageIndex][renderToTextureIndex];
+         if (!msTexture)
+         {
+             const gl::ImageDesc &desc = mState.getImageDesc(imageIndex);
+             ANGLE_TRY(mtl::Texture::MakeMemoryLess2DMSTexture(
+-                context, mFormat, desc.size.width, desc.size.height, implicitSamples, &msTexture));
++                context, format, desc.size.width, desc.size.height, implicitSamples, &msTexture));
+         }
+         rtt.setImplicitMSTexture(msTexture);
+     }
+@@ -1639,12 +1657,12 @@ angle::Result TextureMtl::setEGLImageTarget(const gl::Context *context,
+         return angle::Result::Stop;
+     }
+ 
+-    mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
+-        imageMtl->getTexture(), /*baseGLLevel=*/0);
+-
+     const angle::FormatID angleFormatId =
+         angle::Format::InternalFormatToID(image->getFormat().info->sizedInternalFormat);
+-    mFormat = contextMtl->getPixelFormat(angleFormatId);
++    mtl::Format imageFormat = contextMtl->getPixelFormat(angleFormatId);
++
++    mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
++        imageMtl->getTexture(), /*baseGLLevel=*/0, imageFormat);
+ 
+     mSlices = mNativeTextureStorage->cubeFacesOrArrayLength();
+ 
+@@ -1676,9 +1694,9 @@ angle::Result TextureMtl::generateMipmap(const gl::Context *context)
+         return angle::Result::Continue;
+     }
+ 
+-    const mtl::FormatCaps &caps = mFormat.getCaps();
+-    //
+-    bool sRGB = mFormat.actualInternalFormat().colorEncoding == GL_SRGB;
++    const mtl::Format &format   = mNativeTextureStorage->getFormat();
++    const mtl::FormatCaps &caps = format.getCaps();
++    bool sRGB                   = format.actualInternalFormat().colorEncoding == GL_SRGB;
+ 
+     bool avoidGPUPath =
+         contextMtl->getDisplay()->getFeatures().forceNonCSBaseMipmapGeneration.enabled &&
+@@ -1711,7 +1729,7 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
+     ASSERT(mViewFromBaseToMaxLevel);
+ 
+     ContextMtl *contextMtl           = mtl::GetImpl(context);
+-    const angle::Format &angleFormat = mFormat.actualAngleFormat();
++    const angle::Format &angleFormat = mViewFromBaseToMaxLevel->getFormat().actualAngleFormat();
+     // This format must have mip generation function.
+     ANGLE_CHECK(contextMtl, angleFormat.mipGenerationFunction, gl::err::kInternalError,
+                 GL_INVALID_OPERATION);
+@@ -1780,8 +1798,8 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
+     return angle::Result::Continue;
+ }
+ 
+-bool TextureMtl::needsFormatViewForPixelLocalStorage(
+-    const ShPixelLocalStorageOptions &plsOptions) const
++bool TextureMtl::needsFormatViewForPixelLocalStorage(const ShPixelLocalStorageOptions &plsOptions,
++                                                     const mtl::Format &format) const
+ {
+     // On iOS devices with GPU family 5 and later, Metal doesn't apply lossless compression to
+     // the texture if we set MTLTextureUsagePixelFormatView. This shouldn't be a problem though
+@@ -1789,7 +1807,7 @@ bool TextureMtl::needsFormatViewForPixelLocalStorage(
+     // images.
+     if (plsOptions.type == ShPixelLocalStorageType::ImageLoadStore)
+     {
+-        switch (mFormat.metalFormat)
++        switch (format.metalFormat)
+         {
+             case MTLPixelFormatRGBA8Unorm:
+             case MTLPixelFormatRGBA8Uint:
+@@ -1818,9 +1836,9 @@ angle::Result TextureMtl::bindTexImage(const gl::Context *context, egl::Surface
+ 
+     mBoundSurface         = surface;
+     auto pBuffer          = GetImplAs<OffscreenSurfaceMtl>(surface);
+-    mNativeTextureStorage = std::make_unique<NativeTextureWrapperWithViewSupport>(
+-        pBuffer->getColorTexture(), /*baseGLLevel=*/0);
+-    mFormat = pBuffer->getColorFormat();
++    mtl::Format pbufferFormat = pBuffer->getColorFormat();
++    mNativeTextureStorage     = std::make_unique<NativeTextureWrapperWithViewSupport>(
++        pBuffer->getColorTexture(), /*baseGLLevel=*/0, pbufferFormat);
+     mSlices = mNativeTextureStorage->cubeFacesOrArrayLength();
+ 
+     ANGLE_TRY(ensureSamplerStateCreated(context));
+@@ -1931,47 +1949,48 @@ angle::Result TextureMtl::bindToShader(const gl::Context *context,
+     {
+         ContextMtl *contextMtl             = mtl::GetImpl(context);
+         const angle::FeaturesMtl &features = contextMtl->getDisplay()->getFeatures();
++        const mtl::Format &format          = mNativeTextureStorage->getFormat();
+ 
+         // Sampling from unused channels of depth and stencil textures is undefined in Metal.
+         // ANGLE relies on swizzled views to enforce values required by OpenGL ES specs. Some
+         // drivers fail to sample from a swizzled view of a stencil texture so skip this step.
+-        const bool skipStencilSwizzle = mFormat.actualFormatId == angle::FormatID::S8_UINT &&
++        const bool skipStencilSwizzle = format.actualFormatId == angle::FormatID::S8_UINT &&
+                                         features.avoidStencilTextureSwizzle.enabled;
+         if (!skipStencilSwizzle &&
+             (mState.getSwizzleState().swizzleRequired() ||
+-             mFormat.actualAngleFormat().hasDepthOrStencilBits() || mFormat.swizzled) &&
++             format.actualAngleFormat().hasDepthOrStencilBits() || format.swizzled) &&
+             features.hasTextureSwizzle.enabled)
+         {
+             const gl::InternalFormat &glInternalFormat = *mState.getBaseLevelDesc().format.info;
+ 
+             MTLTextureSwizzleChannels swizzle = MTLTextureSwizzleChannelsMake(
+                 mtl::GetTextureSwizzle(OverrideSwizzleValue(
+-                    context, mState.getSwizzleState().swizzleRed, mFormat, glInternalFormat)),
++                    context, mState.getSwizzleState().swizzleRed, format, glInternalFormat)),
+                 mtl::GetTextureSwizzle(OverrideSwizzleValue(
+-                    context, mState.getSwizzleState().swizzleGreen, mFormat, glInternalFormat)),
++                    context, mState.getSwizzleState().swizzleGreen, format, glInternalFormat)),
+                 mtl::GetTextureSwizzle(OverrideSwizzleValue(
+-                    context, mState.getSwizzleState().swizzleBlue, mFormat, glInternalFormat)),
++                    context, mState.getSwizzleState().swizzleBlue, format, glInternalFormat)),
+                 mtl::GetTextureSwizzle(OverrideSwizzleValue(
+-                    context, mState.getSwizzleState().swizzleAlpha, mFormat, glInternalFormat)));
++                    context, mState.getSwizzleState().swizzleAlpha, format, glInternalFormat)));
+ 
+-            MTLPixelFormat format = mViewFromBaseToMaxLevel->pixelFormat();
++            MTLPixelFormat pixelFormat = mViewFromBaseToMaxLevel->pixelFormat();
+             if (mState.isStencilMode())
+             {
+-                if (format == MTLPixelFormatDepth32Float_Stencil8)
++                if (pixelFormat == MTLPixelFormatDepth32Float_Stencil8)
+                 {
+-                    format = MTLPixelFormatX32_Stencil8;
++                    pixelFormat = MTLPixelFormatX32_Stencil8;
+                 }
+ #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+-                else if (format == MTLPixelFormatDepth24Unorm_Stencil8)
++                else if (pixelFormat == MTLPixelFormatDepth24Unorm_Stencil8)
+                 {
+-                    format = MTLPixelFormatX24_Stencil8;
++                    pixelFormat = MTLPixelFormatX24_Stencil8;
+                 }
+ #endif
+             }
+ 
+             mSwizzleStencilSamplingView = mNativeTextureStorage->createMipsSwizzleView(
+                 mViewFromBaseToMaxLevel->getBaseGLLevel(), mViewFromBaseToMaxLevel->mipmapLevels(),
+-                format, swizzle);
++                pixelFormat, swizzle);
+         }
+         else
+         {
+@@ -2049,7 +2068,8 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+         // from the given size, or the format is different, we are redefining the image so we
+         // must release it.
+         ASSERT(mNativeTextureStorage->textureType() == mtl::GetTextureType(index.getType()));
+-        if (mFormat != mtlFormat || size != mNativeTextureStorage->size(glLevel))
++        if (mNativeTextureStorage->getFormat() != mtlFormat ||
++            size != mNativeTextureStorage->size(glLevel))
+         {
+             // Keep other images
+             deallocateNativeStorage(/*keepImages=*/true);
+@@ -2063,8 +2083,6 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+     }
+ 
+     ContextMtl *contextMtl = mtl::GetImpl(context);
+-    // Cache last defined image format:
+-    mFormat                      = mtlFormat;
+     ImageDefinitionMtl &imageDef = getImageDefinition(index);
+ 
+     // If native texture still exists, it means the size hasn't been changed, no need to create new
+@@ -2073,14 +2091,16 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
+     {
+         ASSERT(imageDef.image->textureType() ==
+                    mtl::GetTextureType(GetTextureImageType(index.getType())) &&
+-               imageDef.formatID == mFormat.intendedFormatId && imageDef.image->sizeAt0() == size);
++               imageDef.formatID == mNativeTextureStorage->getFormat().intendedFormatId &&
++               imageDef.image->sizeAt0() == size);
+     }
+     else
+     {
+         imageDef.formatID    = mtlFormat.intendedFormatId;
+-        bool allowFormatView = mFormat.hasDepthAndStencilBits() ||
+-                               needsFormatViewForPixelLocalStorage(
+-                                   contextMtl->getDisplay()->getNativePixelLocalStorageOptions());
++        bool allowFormatView =
++            mtlFormat.hasDepthAndStencilBits() ||
++            needsFormatViewForPixelLocalStorage(
++                contextMtl->getDisplay()->getNativePixelLocalStorageOptions(), mtlFormat);
+         // Create image to hold texture's data at this level & slice:
+         switch (index.getType())
+         {
+@@ -2129,9 +2149,7 @@ angle::Result TextureMtl::setStorageImpl(const gl::Context *context,
+     // Tell context to rebind textures
+     contextMtl->invalidateCurrentTextures();
+ 
+-    mFormat = mtlFormat;
+-
+-    ANGLE_TRY(createNativeStorage(context, type, mips, samples, size));
++    ANGLE_TRY(createNativeStorage(context, type, mips, samples, size, mtlFormat));
+     ANGLE_TRY(createViewFromBaseToMaxLevel());
+ 
+     return angle::Result::Continue;
+@@ -2544,7 +2562,7 @@ angle::Result TextureMtl::convertAndSetPerSliceSubImage(const gl::Context *conte
+                                                     kAvoidStagingBuffers, imageDef.image));
+                 }
+             }
+-        }  // if (mFormat.intendedAngleFormat().isBlock)
++        }  // if (imageFormat.intendedAngleFormat().isBlock)
+     }  // if (unpackBuffer)
+ 
+     return angle::Result::Continue;
+@@ -2662,7 +2680,11 @@ angle::Result TextureMtl::copySubImageImpl(const gl::Context *context,
+ 
+     ANGLE_TRY(ensureImageCreated(context, index));
+ 
+-    if (!mFormat.getCaps().isRenderable())
++    ContextMtl *contextMtl = mtl::GetImpl(context);
++    mtl::Format format     = contextMtl->getPixelFormat(
++        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
++
++    if (!format.getCaps().isRenderable())
+     {
+         return copySubImageCPU(context, index, modifiedDestOffset, clippedSourceArea,
+                                internalFormat, source, colorReadRT);
+@@ -2723,7 +2745,9 @@ angle::Result TextureMtl::copySubImageCPU(const gl::Context *context,
+ 
+     ContextMtl *contextMtl = mtl::GetImpl(context);
+ 
+-    const angle::Format &dstFormat = angle::Format::Get(mFormat.actualFormatId);
++    mtl::Format format = contextMtl->getPixelFormat(
++        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
++    const angle::Format &dstFormat = angle::Format::Get(format.actualFormatId);
+     const int dstRowPitch          = dstFormat.pixelBytes * clippedSourceArea.width;
+     angle::MemoryBuffer conversionRow;
+     ANGLE_CHECK_GL_ALLOC(contextMtl, conversionRow.resize(dstRowPitch));
+@@ -2804,7 +2828,9 @@ angle::Result TextureMtl::copySubTextureImpl(const gl::Context *context,
+     const mtl::Format &sourceFormat        = contextMtl->getPixelFormat(srcImageDef.formatID);
+     const angle::Format &sourceAngleFormat = sourceFormat.actualAngleFormat();
+ 
+-    if (!mFormat.getCaps().isRenderable())
++    mtl::Format format = contextMtl->getPixelFormat(
++        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
++    if (!format.getCaps().isRenderable())
+     {
+         return copySubTextureCPU(context, index, destOffset, internalFormat,
+                                  mtl::kZeroNativeMipLevel, sourceBox, sourceAngleFormat,
+@@ -2862,8 +2888,10 @@ angle::Result TextureMtl::copySubTextureWithDraw(const gl::Context *context,
+     blitParams.unpackUnmultiplyAlpha  = unpackUnmultiplyAlpha;
+     blitParams.transformLinearToSrgb  = sourceAngleFormat.isSRGB;
+ 
++    mtl::Format format = contextMtl->getPixelFormat(
++        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
+     return displayMtl->getUtils().copyTextureWithDraw(context, cmdEncoder, sourceAngleFormat,
+-                                                      mFormat.actualAngleFormat(), blitParams);
++                                                      format.actualAngleFormat(), blitParams);
+ }
+ 
+ angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
+@@ -2883,7 +2911,9 @@ angle::Result TextureMtl::copySubTextureCPU(const gl::Context *context,
+ 
+     ContextMtl *contextMtl = mtl::GetImpl(context);
+ 
+-    const angle::Format &dstAngleFormat = mFormat.actualAngleFormat();
++    mtl::Format format = contextMtl->getPixelFormat(
++        angle::Format::InternalFormatToID(internalFormat.sizedInternalFormat));
++    const angle::Format &dstAngleFormat = format.actualAngleFormat();
+     const int srcRowPitch               = sourceAngleFormat.pixelBytes * sourceBox.width;
+     const int srcImageSize              = srcRowPitch * sourceBox.height;
+     const int convRowPitch              = dstAngleFormat.pixelBytes * sourceBox.width;
+diff --git a/src/tests/gl_tests/TextureTest.cpp b/src/tests/gl_tests/TextureTest.cpp
+index 9fa5f82d02d07928e0ba52fccc9b6450288eee6d..890d4defd1838d8eff612e4e81f10850fb278292 100644
+--- a/src/tests/gl_tests/TextureTest.cpp
++++ b/src/tests/gl_tests/TextureTest.cpp
+@@ -2864,6 +2864,39 @@ TEST_P(Texture2DTest, PBOWithMultipleDraws)
+     EXPECT_EQ(expected, actual);
+ }
+ 
++// Regression test for TextureMtl::mFormat becoming mismatched with the native storage format when
++// updating mips outside of the storage.
++TEST_P(Texture2DTestES3, StaleFormatCacheOutOrRangeMip)
++{
++
++    GLTexture tex;
++    glBindTexture(GL_TEXTURE_2D, tex);
++    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 4);
++    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
++    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
++
++    // Create RGBA8 texture with one mip.
++    constexpr GLuint kWidth = 24;
++    std::vector<GLColor> pixels(kWidth, GLColor::red);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kWidth, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                 pixels.data());
++
++    // Force native storage allocation with a draw
++    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), essl3_shaders::fs::Red());
++    drawQuad(program, essl3_shaders::PositionAttrib(), 0.5f);
++
++    // Set data on a high mip with a different format causing mFormat to change in TextureMtl
++    glTexImage2D(GL_TEXTURE_2D, 10, GL_R8, 1, 1, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
++
++    GLFramebuffer fbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    // Check that ReadPixels reads RGBA data from mip 0 correctly.
++    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
++}
++
+ // Almost mirrors UnitTest_DMSAA_dst_read test from Android skqp test suite
+ TEST_P(Texture2DTestES3, UnitTest_DMSAA_dst_read)
+ {

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -3,3 +3,4 @@ cherry-pick-7911bee5d90e.patch
 cherry-pick-cl-1206356.patch
 cherry-pick-cl-1196676.patch
 cherry-pick-cl-1209736.patch
+cherry-pick-8c705ac86366.patch

--- a/patches/skia/cherry-pick-8c705ac86366.patch
+++ b/patches/skia/cherry-pick-8c705ac86366.patch
@@ -1,0 +1,103 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen Nusko <nuskos@google.com>
+Date: Mon, 07 Apr 2026 14:00:00 -0700
+Subject: Use SkSafeMath to prevent overflow in pixel offset
+ calculations.
+
+The trim methods in SkReadPixelsRec and SkWritePixelsRec now use
+SkSafeMath to calculate the offset for fPixels. This addresses potential
+integer overflows when computing the y and x offsets and their sum.
+Additionally, a check for fInfo.minRowBytes() == 0 is added, as
+minRowBytes() returns 0 on overflow. If any overflow occurs during
+offset calculation, trim will now return false.
+
+See linked bug for potential security issue that motivated this.
+
+And see (sorry internal only) go/code-terracotta-review-explainer for
+evaluting this phase (1) patch.
+
+Bug:b/495534710
+Change-Id: I0b2a684b5ad1105c7d25418556e40b4d9f511daf
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1194336
+Auto-Submit: Stephen Nusko <nuskos@google.com>
+Commit-Queue: Stephen Nusko <nuskos@google.com>
+Reviewed-by: Kaylee Lubick <kjlubick@google.com>
+Reviewed-by: Florin Malita <fmalita@google.com>
+
+diff --git a/src/core/SkReadPixelsRec.cpp b/src/core/SkReadPixelsRec.cpp
+index 505bfb51b3..f7e9661629 100644
+--- a/src/core/SkReadPixelsRec.cpp
++++ b/src/core/SkReadPixelsRec.cpp
+@@ -7,9 +7,12 @@
+ #include "src/core/SkReadPixelsRec.h"
+ 
+ #include "include/core/SkRect.h"
++#include "src/base/SkSafeMath.h"
+ 
+ bool SkReadPixelsRec::trim(int srcWidth, int srcHeight) {
+-    if (nullptr == fPixels || fRowBytes < fInfo.minRowBytes()) {
++    // fInfo.minRowBytes() returns 0 if the size doesn't fit in `size_t`.
++    const size_t minRowBytes = fInfo.minRowBytes();
++    if (nullptr == fPixels || fRowBytes < minRowBytes || minRowBytes == 0) {
+         return false;
+     }
+     if (0 >= fInfo.width() || 0 >= fInfo.height()) {
+@@ -30,9 +33,17 @@ bool SkReadPixelsRec::trim(int srcWidth, int srcHeight) {
+     if (y > 0) {
+         y = 0;
+     }
+-    // here x,y are either 0 or negative
++    // here x,y are either 0 or negative (safe to cast to size_t)
+     // we negate and add them so UBSAN (pointer-overflow) doesn't get confused.
+-    fPixels = ((char*)fPixels + -y*fRowBytes + -x*fInfo.bytesPerPixel());
++    SkSafeMath safeMath;
++    const size_t y_offset = safeMath.mul(-y, fRowBytes);
++    const size_t x_offset = safeMath.mul(-x, fInfo.bytesPerPixel());
++    const size_t total = safeMath.add(y_offset, x_offset);
++    if (!safeMath.ok()) {
++        return false;
++    }
++
++    fPixels = ((char*)fPixels + total);
+     // the intersect may have shrunk info's logical size
+     fInfo = fInfo.makeDimensions(srcR.size());
+     fX = srcR.x();
+diff --git a/src/core/SkWritePixelsRec.cpp b/src/core/SkWritePixelsRec.cpp
+index 20b2003f59..d1bad0f51e 100644
+--- a/src/core/SkWritePixelsRec.cpp
++++ b/src/core/SkWritePixelsRec.cpp
+@@ -8,9 +8,12 @@
+ #include "src/core/SkWritePixelsRec.h"
+ 
+ #include "include/core/SkRect.h"
++#include "src/base/SkSafeMath.h"
+ 
+ bool SkWritePixelsRec::trim(int dstWidth, int dstHeight) {
+-    if (nullptr == fPixels || fRowBytes < fInfo.minRowBytes()) {
++    // fInfo.minRowBytes() returns 0 if the size doesn't fit in `size_t`.
++    const size_t minRowBytes = fInfo.minRowBytes();
++    if (nullptr == fPixels || fRowBytes < minRowBytes || minRowBytes == 0) {
+         return false;
+     }
+     if (0 >= fInfo.width() || 0 >= fInfo.height()) {
+@@ -31,9 +34,17 @@ bool SkWritePixelsRec::trim(int dstWidth, int dstHeight) {
+     if (y > 0) {
+         y = 0;
+     }
+-    // here x,y are either 0 or negative
++    // here x,y are either 0 or negative (safe to cast to size_t)
+     // we negate and add them so UBSAN (pointer-overflow) doesn't get confused.
+-    fPixels = ((const char*)fPixels + -y*fRowBytes + -x*fInfo.bytesPerPixel());
++    SkSafeMath safeMath;
++    const size_t y_offset = safeMath.mul(-y, fRowBytes);
++    const size_t x_offset = safeMath.mul(-x, fInfo.bytesPerPixel());
++    const size_t total = safeMath.add(y_offset, x_offset);
++    if (!safeMath.ok()) {
++        return false;
++    }
++
++    fPixels = ((const char*)fPixels + total);
+     // the intersect may have shrunk info's logical size
+     fInfo = fInfo.makeDimensions(dstR.size());
+     fX = dstR.x();
+

--- a/patches/skia/cherry-pick-8c705ac86366.patch
+++ b/patches/skia/cherry-pick-8c705ac86366.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stephen Nusko <nuskos@google.com>
-Date: Mon, 07 Apr 2026 14:00:00 -0700
-Subject: Use SkSafeMath to prevent overflow in pixel offset
- calculations.
+Date: Tue, 7 Apr 2026 14:00:00 -0700
+Subject: Use SkSafeMath to prevent overflow in pixel offset calculations.
 
 The trim methods in SkReadPixelsRec and SkWritePixelsRec now use
 SkSafeMath to calculate the offset for fPixels. This addresses potential
@@ -25,7 +24,7 @@ Reviewed-by: Kaylee Lubick <kjlubick@google.com>
 Reviewed-by: Florin Malita <fmalita@google.com>
 
 diff --git a/src/core/SkReadPixelsRec.cpp b/src/core/SkReadPixelsRec.cpp
-index 505bfb51b3..f7e9661629 100644
+index 505bfb51b34a6946b878f4c2d0c1ee0bb86b2cdb..f7e9661629e28a80c6d6d32100c80913806f6917 100644
 --- a/src/core/SkReadPixelsRec.cpp
 +++ b/src/core/SkReadPixelsRec.cpp
 @@ -7,9 +7,12 @@
@@ -63,7 +62,7 @@ index 505bfb51b3..f7e9661629 100644
      fInfo = fInfo.makeDimensions(srcR.size());
      fX = srcR.x();
 diff --git a/src/core/SkWritePixelsRec.cpp b/src/core/SkWritePixelsRec.cpp
-index 20b2003f59..d1bad0f51e 100644
+index 20b2003f59d265a84b6a24413374789663b5481e..d1bad0f51e6ad208edb39f0c0c473e0fa177d119 100644
 --- a/src/core/SkWritePixelsRec.cpp
 +++ b/src/core/SkWritePixelsRec.cpp
 @@ -8,9 +8,12 @@
@@ -100,4 +99,3 @@ index 20b2003f59..d1bad0f51e 100644
      // the intersect may have shrunk info's logical size
      fInfo = fInfo.makeDimensions(dstR.size());
      fX = dstR.x();
-

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,2 @@
 fix_handle_pipewire_capturer_initialization_and_management.patch
+cherry-pick-731795bab2d8.patch

--- a/patches/webrtc/cherry-pick-731795bab2d8.patch
+++ b/patches/webrtc/cherry-pick-731795bab2d8.patch
@@ -2,6 +2,9 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tommi <tommi@webrtc.org>
 Date: Mon, 23 Mar 2026 17:29:21 +0100
 Subject: Refactor AddCertificateReports to prevent crash
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 When processing certificate stats with duplicate fingerprints,
 ReplaceOrAddNew would delete the existing stats report that was
@@ -37,13 +40,13 @@ index f43f33e48e5af014584727d4a7ac273a88949f0c..de6a2a7da36669d343ccfc3e6c940756
 @@ -21,6 +21,7 @@
  #include <utility>
  #include <vector>
-
+ 
 +#include "absl/container/flat_hash_set.h"
  #include "absl/strings/str_cat.h"
  #include "absl/strings/string_view.h"
  #include "api/audio/audio_processing_statistics.h"
 @@ -750,8 +751,13 @@ StatsReport* LegacyStatsCollector::AddCertificateReports(
-
+ 
    StatsReport* first_report = nullptr;
    StatsReport* prev_report = nullptr;
 +  absl::flat_hash_set<std::string> visited_fingerprints;
@@ -55,15 +58,15 @@ index f43f33e48e5af014584727d4a7ac273a88949f0c..de6a2a7da36669d343ccfc3e6c940756
 +
      StatsReport::Id id(StatsReport::NewTypedId(
          StatsReport::kStatsReportTypeCertificate, stats->fingerprint));
-
+ 
 diff --git a/pc/legacy_stats_collector.h b/pc/legacy_stats_collector.h
 index 791fb2c416be59763169fde7d65fcf423d13fc1e..ac29da054e9f846ad95588eefb38d828bdec4fb8 100644
 --- a/pc/legacy_stats_collector.h
 +++ b/pc/legacy_stats_collector.h
 @@ -110,6 +110,11 @@ class LegacyStatsCollector : public LegacyStatsCollectorInterface {
-
+ 
    bool UseStandardBytesStats() const { return use_standard_bytes_stats_; }
-
+ 
 +  StatsReport* AddCertificateReportsForTest(
 +      std::unique_ptr<SSLCertificateStats> cert_stats) {
 +    return AddCertificateReports(std::move(cert_stats));
@@ -71,7 +74,7 @@ index 791fb2c416be59763169fde7d65fcf423d13fc1e..ac29da054e9f846ad95588eefb38d828
 +
   private:
    friend class LegacyStatsCollectorTest;
-
+ 
 diff --git a/pc/legacy_stats_collector_unittest.cc b/pc/legacy_stats_collector_unittest.cc
 index 0f62cb07e5474f467d131ba0b7761364091de4e2..fe964a3f30d8c68ce3f17f23aa294dccb06df187 100644
 --- a/pc/legacy_stats_collector_unittest.cc
@@ -87,7 +90,7 @@ index 0f62cb07e5474f467d131ba0b7761364091de4e2..fe964a3f30d8c68ce3f17f23aa294dcc
 @@ -1447,6 +1448,21 @@ TEST_F(LegacyStatsCollectorTest, ChainedCertificateReportsCreated) {
                           remote_ders);
  }
-
+ 
 +TEST_F(LegacyStatsCollectorTest,
 +       AddCertificateReports_DuplicateFingerprintDoesNotCrash) {
 +  auto pc = CreatePeerConnection();

--- a/patches/webrtc/cherry-pick-731795bab2d8.patch
+++ b/patches/webrtc/cherry-pick-731795bab2d8.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Mon, 23 Mar 2026 17:29:21 +0100
+Subject: Refactor AddCertificateReports to prevent crash
+
+When processing certificate stats with duplicate fingerprints,
+ReplaceOrAddNew would delete the existing stats report that was
+previously added and pointed to by first_report or prev_report.
+
+By adding tracking for duplicate fingerprints we can find the existing
+report and avoid replacing it.
+
+Bug: chromium:486495143
+Change-Id: Iabc41ae064476c1e5853cdff1dbbcab449f8df27
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/459320
+Reviewed-by: Evan Shrubsole <eshr@webrtc.org>
+Reviewed-by: Henrik Boström <hbos@webrtc.org>
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#47242}
+
+diff --git a/pc/BUILD.gn b/pc/BUILD.gn
+index f6a1f3767a3f3c31f72ed94311c5a40a6b950cba..a75291ea25e70a66322a19ba56069b7f58be81ce 100644
+--- a/pc/BUILD.gn
++++ b/pc/BUILD.gn
+@@ -1475,6 +1475,7 @@ rtc_library("legacy_stats_collector") {
+     "../rtc_base:threading",
+     "../rtc_base:timeutils",
+     "../system_wrappers",
++    "//third_party/abseil-cpp/absl/container:flat_hash_set",
+     "//third_party/abseil-cpp/absl/strings",
+     "//third_party/abseil-cpp/absl/strings:string_view",
+   ]
+diff --git a/pc/legacy_stats_collector.cc b/pc/legacy_stats_collector.cc
+index f43f33e48e5af014584727d4a7ac273a88949f0c..de6a2a7da36669d343ccfc3e6c94075695adac5d 100644
+--- a/pc/legacy_stats_collector.cc
++++ b/pc/legacy_stats_collector.cc
+@@ -21,6 +21,7 @@
+ #include <utility>
+ #include <vector>
+
++#include "absl/container/flat_hash_set.h"
+ #include "absl/strings/str_cat.h"
+ #include "absl/strings/string_view.h"
+ #include "api/audio/audio_processing_statistics.h"
+@@ -750,8 +751,13 @@ StatsReport* LegacyStatsCollector::AddCertificateReports(
+
+   StatsReport* first_report = nullptr;
+   StatsReport* prev_report = nullptr;
++  absl::flat_hash_set<std::string> visited_fingerprints;
+   for (SSLCertificateStats* stats = cert_stats.get(); stats;
+        stats = stats->issuer.get()) {
++    if (!visited_fingerprints.insert(stats->fingerprint).second) {
++      break;
++    }
++
+     StatsReport::Id id(StatsReport::NewTypedId(
+         StatsReport::kStatsReportTypeCertificate, stats->fingerprint));
+
+diff --git a/pc/legacy_stats_collector.h b/pc/legacy_stats_collector.h
+index 791fb2c416be59763169fde7d65fcf423d13fc1e..ac29da054e9f846ad95588eefb38d828bdec4fb8 100644
+--- a/pc/legacy_stats_collector.h
++++ b/pc/legacy_stats_collector.h
+@@ -110,6 +110,11 @@ class LegacyStatsCollector : public LegacyStatsCollectorInterface {
+
+   bool UseStandardBytesStats() const { return use_standard_bytes_stats_; }
+
++  StatsReport* AddCertificateReportsForTest(
++      std::unique_ptr<SSLCertificateStats> cert_stats) {
++    return AddCertificateReports(std::move(cert_stats));
++  }
++
+  private:
+   friend class LegacyStatsCollectorTest;
+
+diff --git a/pc/legacy_stats_collector_unittest.cc b/pc/legacy_stats_collector_unittest.cc
+index 0f62cb07e5474f467d131ba0b7761364091de4e2..fe964a3f30d8c68ce3f17f23aa294dccb06df187 100644
+--- a/pc/legacy_stats_collector_unittest.cc
++++ b/pc/legacy_stats_collector_unittest.cc
+@@ -55,6 +55,7 @@
+ #include "rtc_base/null_socket_server.h"
+ #include "rtc_base/rtc_certificate.h"
+ #include "rtc_base/socket_address.h"
++#include "rtc_base/ssl_certificate.h"
+ #include "rtc_base/ssl_identity.h"
+ #include "rtc_base/ssl_stream_adapter.h"
+ #include "rtc_base/thread.h"
+@@ -1447,6 +1448,21 @@ TEST_F(LegacyStatsCollectorTest, ChainedCertificateReportsCreated) {
+                          remote_ders);
+ }
+
++TEST_F(LegacyStatsCollectorTest,
++       AddCertificateReports_DuplicateFingerprintDoesNotCrash) {
++  auto pc = CreatePeerConnection();
++  auto stats = CreateStatsCollector(pc.get());
++
++  // Create duplicate fingerprints chain
++  auto issuer_stats = std::make_unique<SSLCertificateStats>(
++      "same_fingerprint", "sha-1", "cert_issuer", nullptr);
++  auto cert_stats = std::make_unique<SSLCertificateStats>(
++      "same_fingerprint", "sha-1", "cert_leaf", std::move(issuer_stats));
++
++  // This should not crash (Use-After-Free)
++  stats->AddCertificateReportsForTest(std::move(cert_stats));
++}
++
+ // This test verifies that all certificates without chains are correctly
+ // reported.
+ TEST_F(LegacyStatsCollectorTest, ChainlessCertificateReportsCreated) {


### PR DESCRIPTION
<details>
<summary>cherry-pick 8c705ac86366 from skia</summary>

Use SkSafeMath to prevent overflow in pixel offset calculations.

The trim methods in SkReadPixelsRec and SkWritePixelsRec now use
SkSafeMath to calculate the offset for fPixels. This addresses potential
integer overflows when computing the y and x offsets and their sum.

Bug:b/495534710
Change-Id: I0b2a684b5ad1105c7d25418556e40b4d9f511daf
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1481416
Commit-Queue: Stephen Nusko <nuskos@google.com>
Reviewed-by: Herb Derby <herb@google.com>
</details>

<details>
<summary>cherry-pick 6d8b704e2a from angle</summary>

Metal: Remove TextureMtl::mFormat

TextureMtl::mFormat is supposed to represent the format of the native
storage but it was updated to the last format set on any mip level, even
if it is not in the native storage. This is extremely error prone, a lot
of the Metal texturing code relied on it being properly set.

Remove mFormat and query it from the native storage or the specific
image desc.

Bug: chromium:493256564
Change-Id: I629c009b34c7ef7ca5fa7a97f5845accf22b13b8
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7684363
Commit-Queue: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
</details>

<details>
<summary>cherry-pick 731795bab2d8 from webrtc</summary>

Refactor AddCertificateReports to prevent crash

When processing certificate stats with duplicate fingerprints,
ReplaceOrAddNew would delete the existing stats report that was
previously added and pointed to by first_report or prev_report.

By adding tracking for duplicate fingerprints we can find the existing
report and avoid replacing it.

Bug: chromium:486495143
Change-Id: Iabc41ae064476c1e5853cdff1dbbcab449f8df27
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/459320
Reviewed-by: Evan Shrubsole <eshr@webrtc.org>
Reviewed-by: Henrik Boström <hbos@webrtc.org>
Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
Cr-Commit-Position: refs/heads/main@{#47242}
</details>

Notes: Backported several fixes in Skia, ANGLE, and WebRTC from upstream