### PR TITLE
build: update @electron/get to v5 (42-x-y)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -6,11 +6,11 @@
     "install-electron": "install.js"
   },
   "dependencies": {
-    "@electron/get": "^2.0.0",
+    "@electron/get": "^5.0.0",
     "@types/node": "^24.9.0",
     "extract-zip": "^2.0.1"
   },
   "engines": {
-    "node": ">= 12.20.55"
+    "node": ">= 22.12.0"
   }
 }


### PR DESCRIPTION
Manual backport of #51234 to `42-x-y`.

See that PR for details.

Notes: none
