### PR TITLE
fix: pre-create thinlto-cache dir on Windows to avoid bindflt race

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -104,7 +104,17 @@ runs:
         # Pre-create the ThinLTO cache directory so lld-link does not need to
         # call CreateDirectoryW through the bindflt filter driver, which can
         # return ERROR_INVALID_PARAMETER under concurrent I/O on ARC runners.
-        New-Item -ItemType Directory -Force -Path out\Default\thinlto-cache | Out-Null
+        # Discover the path from GN instead of hardcoding it so we stay in
+        # sync with `cache_dir` in build/config/compiler/BUILD.gn; skip the
+        # pre-create when ThinLTO is disabled (non-official builds).
+        $env:ELECTRON_DEPOT_TOOLS_DISABLE_LOG = "1"
+        $ltoFlag = e d gn desc out/Default //electron:electron_app ldflags 2>$null |
+          Select-String -Pattern '^/lldltocache:(.+)$' |
+          Select-Object -First 1
+        if ($ltoFlag) {
+          $cachePath = Join-Path 'out\Default' $ltoFlag.Matches[0].Groups[1].Value
+          New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+        }
 
         $env:NINJA_SUMMARIZE_BUILD = 1
         if ("${{ inputs.is-release }}" -eq "true") {          

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -105,33 +105,16 @@ runs:
         # call CreateDirectoryW through the bindflt filter driver, which can
         # return ERROR_INVALID_PARAMETER under concurrent I/O on ARC runners.
         #
-        # Run `gn gen` explicitly first so `gn desc` can report the effective
-        # `/lldltocache:` path, then pre-create whatever directory Chromium's
-        # build/config/compiler/BUILD.gn currently configures rather than
-        # hardcoding it. `e build` below re-uses this generated build dir,
-        # so the gn gen cost is paid once.
-        #
-        # Each `e` invocation is shelled through cmd.exe so its informational
-        # stderr (e.g. "INFO Auto-updates disabled") does not surface as a
-        # PowerShell NativeCommandError under GitHub Actions' default
-        # $ErrorActionPreference = 'Stop'.
-        $env:ELECTRON_DEPOT_TOOLS_DISABLE_LOG = "1"
-        cmd /c 'e d gn gen out/Default 2>&1'
-        if ($LASTEXITCODE -ne 0) {
-          Write-Host "gn gen failed with exit code $LASTEXITCODE"
-          exit $LASTEXITCODE
-        }
-        $ltoOutput = cmd /c 'e d gn desc out/Default //electron:electron_app ldflags 2>nul'
-        if ($LASTEXITCODE -eq 0) {
-          $ltoFlag = $ltoOutput |
-            Select-String -Pattern '^/lldltocache:(.+)$' |
-            Select-Object -First 1
-          if ($ltoFlag) {
-            $cachePath = Join-Path 'out\Default' $ltoFlag.Matches[0].Groups[1].Value
-            New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
-          }
-        }
-        $LASTEXITCODE = 0
+        # The path mirrors `cache_dir` in Chromium's
+        # build/config/compiler/BUILD.gn (the `/lldltocache:` ldflag passed
+        # to lld-link). Dynamic discovery via `gn desc` isn't viable here:
+        # `e init` doesn't populate `out/Default`, and `gn gen` can't run
+        # before `e build` because gn.exe isn't installed on the runner
+        # until a later hook. If upstream ever relocates `cache_dir`, this
+        # pre-create silently stops covering the race and the
+        # `LLVM ERROR: can't create cache directory` symptom returns — at
+        # which point update the path here.
+        New-Item -ItemType Directory -Force -Path out\Default\thinlto-cache | Out-Null
 
         $env:NINJA_SUMMARIZE_BUILD = 1
         if ("${{ inputs.is-release }}" -eq "true") {          

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -104,17 +104,34 @@ runs:
         # Pre-create the ThinLTO cache directory so lld-link does not need to
         # call CreateDirectoryW through the bindflt filter driver, which can
         # return ERROR_INVALID_PARAMETER under concurrent I/O on ARC runners.
-        # Discover the path from GN instead of hardcoding it so we stay in
-        # sync with `cache_dir` in build/config/compiler/BUILD.gn; skip the
-        # pre-create when ThinLTO is disabled (non-official builds).
+        #
+        # Run `gn gen` explicitly first so `gn desc` can report the effective
+        # `/lldltocache:` path, then pre-create whatever directory Chromium's
+        # build/config/compiler/BUILD.gn currently configures rather than
+        # hardcoding it. `e build` below re-uses this generated build dir,
+        # so the gn gen cost is paid once.
+        #
+        # Each `e` invocation is shelled through cmd.exe so its informational
+        # stderr (e.g. "INFO Auto-updates disabled") does not surface as a
+        # PowerShell NativeCommandError under GitHub Actions' default
+        # $ErrorActionPreference = 'Stop'.
         $env:ELECTRON_DEPOT_TOOLS_DISABLE_LOG = "1"
-        $ltoFlag = e d gn desc out/Default //electron:electron_app ldflags 2>$null |
-          Select-String -Pattern '^/lldltocache:(.+)$' |
-          Select-Object -First 1
-        if ($ltoFlag) {
-          $cachePath = Join-Path 'out\Default' $ltoFlag.Matches[0].Groups[1].Value
-          New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+        cmd /c 'e d gn gen out/Default 2>&1'
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "gn gen failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
         }
+        $ltoOutput = cmd /c 'e d gn desc out/Default //electron:electron_app ldflags 2>nul'
+        if ($LASTEXITCODE -eq 0) {
+          $ltoFlag = $ltoOutput |
+            Select-String -Pattern '^/lldltocache:(.+)$' |
+            Select-Object -First 1
+          if ($ltoFlag) {
+            $cachePath = Join-Path 'out\Default' $ltoFlag.Matches[0].Groups[1].Value
+            New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+          }
+        }
+        $LASTEXITCODE = 0
 
         $env:NINJA_SUMMARIZE_BUILD = 1
         if ("${{ inputs.is-release }}" -eq "true") {          

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -101,6 +101,11 @@ runs:
         git pack-refs
         cd ..
 
+        # Pre-create the ThinLTO cache directory so lld-link does not need to
+        # call CreateDirectoryW through the bindflt filter driver, which can
+        # return ERROR_INVALID_PARAMETER under concurrent I/O on ARC runners.
+        New-Item -ItemType Directory -Force -Path out\Default\thinlto-cache | Out-Null
+
         $env:NINJA_SUMMARIZE_BUILD = 1
         if ("${{ inputs.is-release }}" -eq "true") {          
           e build --target electron:release_build


### PR DESCRIPTION
#### Description of Change

Pre-creates the `out/Default/thinlto-cache` directory before invoking `e build`
on Windows, preventing lld-link from hitting a transient `ERROR_INVALID_PARAMETER`
when creating the directory through bindflt on the 32-core ARC runners (#51256).

The 32-core Windows ARC runners use container bind mounts backed by a filesystem
filter driver (bindflt/wcifs). Under the concurrent I/O burst of a Chromium build,
`CreateDirectoryW` can transiently fail with `ERROR_INVALID_PARAMETER` — the same
class of bug that #51256 patched for siso's ninja manifest opens. lld-link has no
retry logic, so it aborts with:

```
LLVM ERROR: can't create cache directory thinlto-cache: invalid argument
```

Pre-creating the directory means lld-link's `CreateDirectoryW` becomes a no-op
(`ERROR_ALREADY_EXISTS`), sidestepping the driver race entirely.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none