### PR TITLE
build: restrict npm tarball contents to an explicit allowlist

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -6,6 +6,8 @@
     "install-electron": "install.js"
   },
   "files": [
+    "LICENSE",
+    "README.md",
     "abi_version",
     "checksums.json",
     "cli.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,6 +5,14 @@
     "electron": "cli.js",
     "install-electron": "install.js"
   },
+  "files": [
+    "abi_version",
+    "checksums.json",
+    "cli.js",
+    "electron.d.ts",
+    "index.js",
+    "install.js"
+  ],
   "dependencies": {
     "@electron/get": "^5.0.0",
     "@types/node": "^24.9.0",


### PR DESCRIPTION
#### Description of Change

The npm publish flow (`script/release/bin/publish-to-npm.ts:158`) runs `npm pack` in a staging temp dir, but `npm/package.json` had no `files` field — so `npm pack` included everything it found. In the release environment, two unintended files ended up in that dir before pack ran:

- `.npm-cache/_logs/*-debug-0.log` — npm's own debug log, written self-referentially into the pack directory before pack finishes reading files
- `SHASUMS256.txt` — the raw release shasum file (~7.6 kB), which duplicates the info in `checksums.json`

Both leaked into recent electron tarballs (`41.2.1+`, `40.9.1+`, `39.8.8+`; `41.2.0` and earlier patches are clean). The contamination source appears to live in the release-automation infrastructure rather than this repo, but an explicit `files` allowlist in the template `package.json` keeps the tarball clean regardless of what else lands in the staging dir.

Verified locally by populating a staging dir with `.npm-cache/_logs/fake.log` + `SHASUMS256.txt` and running `npm pack` — with the allowlist in place, the tarball matches the last-clean v41.2.0 layout (9 files, down from 11).

Fixes #51290.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none