### PR TITLE
chore: temporarily disable new flaky test

### DIFF
--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -256,12 +256,16 @@ describe('WebContentsView', () => {
       await p;
       expect(await v.webContents.executeJavaScript('document.visibilityState')).to.equal('visible');
 
-      const viewportSize = await v.webContents.executeJavaScript(
-        '({ width: window.innerWidth, height: window.innerHeight })'
-      );
-      const contentBounds = w.getContentBounds();
-      expect(viewportSize.width).to.equal(contentBounds.width);
-      expect(viewportSize.height).to.equal(contentBounds.height);
+      // These two new `expect` calls added in 2026-04-20 @ 2e17a57 are causing
+      // CI flakes. https://github.com/electron/electron/issues/51228
+      // TODO(ckerr) fix the flakes and re-enable
+      //
+      // const viewportSize = await v.webContents.executeJavaScript(
+      //   '({ width: window.innerWidth, height: window.innerHeight })'
+      // );
+      // const contentBounds = w.getContentBounds();
+      // expect(viewportSize.width).to.equal(contentBounds.width);
+      // expect(viewportSize.height).to.equal(contentBounds.height);
     });
 
     it('is initially visible if load happens after attach', async () => {


### PR DESCRIPTION
#### Description of Change

Temporarily disable a `main`-only flaky test that was added in 2026-04-20 @ 2e17a57 / #51071

Flakes reported at #51228.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.