### PR TITLE
feat: add Linux support for `app.getApplicationInfoForProtocol()`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -882,7 +882,7 @@ Returns `string` - Name of the application handling the protocol, or an empty
 This method returns the application name of the default handler for the protocol
 (aka URI scheme) of a URL.
 
-### `app.getApplicationInfoForProtocol(url)` _macOS_ _Windows_
+### `app.getApplicationInfoForProtocol(url)`
 
 * `url` string - a URL with the protocol name to check. Unlike the other
   methods in this family, this accepts an entire URL, including `://` at a

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1857,11 +1857,9 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod(
           "removeAsDefaultProtocolClient",
           base::BindRepeating(&Browser::RemoveAsDefaultProtocolClient, browser))
-#if !BUILDFLAG(IS_LINUX)
       .SetMethod(
           "getApplicationInfoForProtocol",
           base::BindRepeating(&Browser::GetApplicationInfoForProtocol, browser))
-#endif
       .SetMethod(
           "getApplicationNameForProtocol",
           base::BindRepeating(&Browser::GetApplicationNameForProtocol, browser))

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -161,11 +161,9 @@ class Browser : private WindowListObserver {
 
   std::u16string GetApplicationNameForProtocol(const GURL& url);
 
-#if !BUILDFLAG(IS_LINUX)
   // get the name, icon and path for an application
   v8::Local<v8::Promise> GetApplicationInfoForProtocol(v8::Isolate* isolate,
                                                        const GURL& url);
-#endif
 
   // Set/Get the badge count.
   bool SetBadgeCount(std::optional<int> count);

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -34,8 +34,8 @@
 #include "ui/base/glib/scoped_gobject.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/image/image_skia.h"
-#include "ui/gtk/gtk_compat.h"
-#include "ui/gtk/gtk_util.h"
+#include "ui/gtk/gtk_compat.h"  // nogncheck
+#include "ui/gtk/gtk_util.h"    // nogncheck
 
 #if BUILDFLAG(IS_LINUX)
 #include "shell/browser/linux/unity_service.h"

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -4,6 +4,11 @@
 
 #include "shell/browser/browser.h"
 
+#include <fcntl.h>
+#include <stdlib.h>
+
+#include <string_view>
+
 #if BUILDFLAG(IS_LINUX)
 #include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
@@ -11,6 +16,7 @@
 #endif
 
 #include "base/environment.h"
+#include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "electron/electron_version.h"
@@ -18,7 +24,18 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
+#include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/promise.h"
+#include "shell/common/thread_restrictions.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/base/glib/glib_cast.h"
+#include "ui/base/glib/scoped_gobject.h"
+#include "ui/gfx/image/image.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gtk/gtk_compat.h"
+#include "ui/gtk/gtk_util.h"
 
 #if BUILDFLAG(IS_LINUX)
 #include "shell/browser/linux/unity_service.h"
@@ -48,6 +65,101 @@ bool SetDefaultWebClient(const std::string& protocol) {
   g_clear_error(&error);
   g_object_unref(app_info);
   return success;
+}
+
+[[nodiscard]] ScopedGObject<GAppInfo> GetAppInfoForProtocol(const GURL& url) {
+  const auto scheme = std::string{url.scheme()};  // gio can't use string_views
+  return TakeGObject(g_app_info_get_default_for_uri_scheme(scheme.c_str()));
+}
+
+[[nodiscard]] std::optional<base::FilePath> ResolveExecutablePath(
+    const char* const executable) {
+  if (executable == nullptr || *executable == '\0')
+    return {};
+
+  if (auto path = base::FilePath::FromUTF8Unsafe(executable); path.IsAbsolute())
+    return path;
+
+  gchar* const found = g_find_program_in_path(executable);
+  if (!found)
+    return {};
+
+  const auto path = base::FilePath::FromUTF8Unsafe(found);
+  g_free(found);
+  return path;
+}
+
+[[nodiscard]] gfx::Image GetApplicationIcon(GAppInfo* const app_info) {
+  constexpr int kIconSize = 32;
+
+  GIcon* const icon = g_app_info_get_icon(app_info);
+  if (!icon)
+    return {};
+
+  // Note: this gtk3/gtk4 + icon theme lookup + snapshot control flow
+  // is copied from GtkUi::GetIconForContentType(). We couldn't use it
+  // here because it gets its GIcon from a different place than us.
+  SkBitmap bitmap;
+  if (gtk::GtkCheckVersion(4)) {
+    const auto icon_paintable = gtk::Gtk4IconThemeLookupByGicon(
+        gtk::GetDefaultIconTheme(), icon, kIconSize, 1, GTK_TEXT_DIR_NONE,
+        static_cast<GtkIconLookupFlags>(0));
+    if (!icon_paintable)
+      return {};
+
+    auto* const paintable =
+        GlibCast<GdkPaintable>(icon_paintable.get(), gdk_paintable_get_type());
+    auto* const snapshot = gtk_snapshot_new();
+    gdk_paintable_snapshot(paintable, snapshot, kIconSize, kIconSize);
+    auto* const node = gtk_snapshot_free_to_node(snapshot);
+    GdkTexture* const texture = gtk::GetTextureFromRenderNode(node);
+    if (!texture) {
+      gsk_render_node_unref(node);
+      return {};
+    }
+
+    bitmap.allocN32Pixels(gdk_texture_get_width(texture),
+                          gdk_texture_get_height(texture));
+    gdk_texture_download(texture, static_cast<guchar*>(bitmap.getAddr(0, 0)),
+                         bitmap.rowBytes());
+    gsk_render_node_unref(node);
+  } else {
+    const auto icon_info = gtk::Gtk3IconThemeLookupByGiconForScale(
+        gtk::GetDefaultIconTheme(), icon, kIconSize, 1,
+        static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_FORCE_SIZE));
+    if (!icon_info)
+      return {};
+
+    auto* const surface =
+        gtk_icon_info_load_surface(icon_info.get(), nullptr, nullptr);
+    if (!surface)
+      return {};
+
+    DCHECK_EQ(cairo_surface_get_type(surface), CAIRO_SURFACE_TYPE_IMAGE);
+    DCHECK_EQ(cairo_image_surface_get_format(surface), CAIRO_FORMAT_ARGB32);
+
+    const SkImageInfo image_info =
+        SkImageInfo::Make(cairo_image_surface_get_width(surface),
+                          cairo_image_surface_get_height(surface),
+                          kBGRA_8888_SkColorType, kUnpremul_SkAlphaType);
+    if (!bitmap.installPixels(
+            image_info, cairo_image_surface_get_data(surface),
+            image_info.minRowBytes(),
+            [](void*, void* surface_ptr) {
+              cairo_surface_destroy(
+                  reinterpret_cast<cairo_surface_t*>(surface_ptr));
+            },
+            surface)) {
+      return {};
+    }
+  }
+
+  gfx::ImageSkia image_skia = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
+  if (image_skia.isNull())
+    return {};
+
+  image_skia.MakeThreadSafe();
+  return gfx::Image(image_skia);
 }
 
 }  // namespace
@@ -95,15 +207,53 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 }
 
 std::u16string Browser::GetApplicationNameForProtocol(const GURL& url) {
-  const auto scheme = std::string{url.scheme()};  // gio can't use string_view
-  auto* app_info = g_app_info_get_default_for_uri_scheme(scheme.c_str());
+  auto app_info = GetAppInfoForProtocol(url);
   if (!app_info)
     return {};
 
   const char* const name = g_app_info_get_display_name(app_info);
-  const std::u16string u16name = base::UTF8ToUTF16(name);
-  g_object_unref(app_info);
-  return u16name;
+  return base::UTF8ToUTF16(name);
+}
+
+v8::Local<v8::Promise> Browser::GetApplicationInfoForProtocol(
+    v8::Isolate* const isolate,
+    const GURL& url) {
+  gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
+  const v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  auto app_info = GetAppInfoForProtocol(url);
+  if (!app_info) {
+    promise.RejectWithErrorMessage(
+        "Unable to retrieve installation path to app");
+    return handle;
+  }
+
+  const char* const executable = g_app_info_get_executable(app_info);
+  const auto app_path = ResolveExecutablePath(executable);
+  if (!app_path) {
+    promise.RejectWithErrorMessage(
+        "Unable to retrieve installation path to app");
+    return handle;
+  }
+
+  const char* const app_display_name = g_app_info_get_display_name(app_info);
+  if (!app_display_name || app_display_name[0] == '\0') {
+    promise.RejectWithErrorMessage("Unable to retrieve display name of app");
+    return handle;
+  }
+
+  const gfx::Image app_icon = GetApplicationIcon(app_info);
+  if (app_icon.IsEmpty()) {
+    promise.RejectWithErrorMessage("Failed to get file icon.");
+    return handle;
+  }
+
+  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
+  dict.Set("name", base::UTF8ToUTF16(app_display_name));
+  dict.Set("path", app_path->value());
+  dict.Set("icon", app_icon);
+  promise.Resolve(dict);
+  return handle;
 }
 
 bool Browser::SetBadgeCount(std::optional<int> count) {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1599,18 +1599,108 @@ describe('app module', () => {
     });
   });
 
-  ifdescribe(process.platform !== 'linux')('getApplicationInfoForProtocol()', () => {
+  describe('getApplicationInfoForProtocol()', () => {
     it('returns promise rejection for a bogus protocol', async function () {
       await expect(app.getApplicationInfoForProtocol('bogus-protocol://')).to.eventually.be.rejectedWith(
         'Unable to retrieve installation path to app'
       );
     });
 
-    it('returns resolved promise with appPath, displayName and icon', async function () {
-      const appInfo = await app.getApplicationInfoForProtocol('https://');
-      expect(appInfo.path).not.to.be.undefined();
-      expect(appInfo.name).not.to.be.undefined();
-      expect(appInfo.icon).not.to.be.undefined();
+    ifdescribe(process.platform !== 'linux')('on macOS and Windows', () => {
+      it('returns resolved promise with appPath, displayName and icon', async function () {
+        const appInfo = await app.getApplicationInfoForProtocol('https://');
+        expect(appInfo.path).not.to.be.undefined();
+        expect(appInfo.name).not.to.be.undefined();
+        expect(appInfo.icon).not.to.be.undefined();
+      });
+    });
+
+    ifdescribe(process.platform === 'linux')('on Linux with mocked XDG dirs', () => {
+      const fixtureApp = path.join(fixturesPath, 'api', 'protocol-name');
+      const fixtureIcon = path.join(fixturesPath, 'assets', '1x1.png');
+      const desktopFileId = 'mock-browser.desktop';
+      const mockDisplayName = 'Mock Browser';
+      const mockScheme = 'mockproto';
+      const mockMimeType = `x-scheme-handler/${mockScheme}`;
+
+      function spawnWithXdgMock(
+        url: string,
+        xdgDataHome: string,
+        xdgConfigHome: string
+      ): Promise<{ name: string; path: string; hasIcon: boolean }> {
+        return new Promise((resolve, reject) => {
+          const child = cp.spawn(process.execPath, [fixtureApp, url], {
+            env: {
+              ...process.env,
+              ELECTRON_PROTOCOL_LOOKUP_MODE: 'info',
+              XDG_DATA_HOME: xdgDataHome,
+              XDG_DATA_DIRS: xdgDataHome,
+              XDG_CONFIG_HOME: xdgConfigHome
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+          });
+          let stdout = '';
+          let stderr = '';
+          child.stdout.on('data', (d: Buffer) => {
+            stdout += d;
+          });
+          child.stderr.on('data', (d: Buffer) => {
+            stderr += d;
+          });
+          child.on('close', (code) => {
+            if (code !== 0) {
+              reject(new Error(`Fixture exited with code ${code}: ${stderr}`));
+              return;
+            }
+
+            try {
+              resolve(JSON.parse(stdout));
+            } catch {
+              reject(new Error(`Failed to parse output: ${stdout}\nstderr: ${stderr}`));
+            }
+          });
+          child.on('error', reject);
+        });
+      }
+
+      let xdgDir: string;
+      let xdgDataHome: string;
+      let xdgConfigHome: string;
+      before(() => {
+        ({ xdgDir, xdgDataHome, xdgConfigHome } = makeXdgMockDirectories('electron-xdg-app-info-'));
+
+        const appsDir = path.join(xdgDataHome, 'applications');
+        fs.mkdirSync(appsDir, { recursive: true });
+        fs.mkdirSync(xdgConfigHome, { recursive: true });
+
+        fs.writeFileSync(
+          path.join(appsDir, desktopFileId),
+          [
+            '[Desktop Entry]',
+            `Name=${mockDisplayName}`,
+            'Exec=/usr/bin/true %u',
+            `Icon=${fixtureIcon}`,
+            'Type=Application',
+            `MimeType=${mockMimeType};`
+          ].join('\n')
+        );
+
+        fs.writeFileSync(
+          path.join(xdgConfigHome, 'mimeapps.list'),
+          ['[Default Applications]', `${mockMimeType}=${desktopFileId}`].join('\n')
+        );
+      });
+
+      after(() => {
+        fs.rmSync(xdgDir, { recursive: true, force: true });
+      });
+
+      it('returns appPath, displayName and icon for a registered protocol', async () => {
+        const appInfo = await spawnWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome);
+        expect(appInfo.name).to.equal(mockDisplayName);
+        expect(appInfo.path).to.equal('/usr/bin/true');
+        expect(appInfo.hasIcon).to.equal(true);
+      });
     });
   });
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { setTimeout } from 'node:timers/promises';

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -9,7 +9,6 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { setTimeout } from 'node:timers/promises';
@@ -18,6 +17,12 @@ import { promisify } from 'node:util';
 import { collectStreamBody, getResponse } from './lib/net-helpers';
 import { defer, ifdescribe, ifit, isWayland, listen, waitUntil } from './lib/spec-helpers';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
+import {
+  makeXdgMockDirectories,
+  spawnProtocolInfoWithXdgMock,
+  spawnProtocolNameWithXdgMock,
+  writeProtocolAssociation
+} from './lib/xdg-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
@@ -1513,73 +1518,23 @@ describe('app module', () => {
     });
 
     ifdescribe(process.platform === 'linux')('on Linux with mocked XDG dirs', () => {
-      const fixtureApp = path.join(fixturesPath, 'api', 'protocol-name');
       const desktopFileId = 'mock-browser.desktop';
       const mockDisplayName = 'Mock Browser';
       const mockScheme = 'mockproto';
       const mockMimeType = `x-scheme-handler/${mockScheme}`;
 
-      function spawnWithXdgMock(url: string, xdgDataHome: string, xdgConfigHome: string): Promise<string> {
-        return new Promise((resolve, reject) => {
-          const child = cp.spawn(process.execPath, [fixtureApp, url], {
-            env: {
-              ...process.env,
-              XDG_DATA_HOME: xdgDataHome,
-              XDG_DATA_DIRS: xdgDataHome,
-              XDG_CONFIG_HOME: xdgConfigHome
-            },
-            stdio: ['ignore', 'pipe', 'pipe']
-          });
-          let stdout = '';
-          let stderr = '';
-          child.stdout.on('data', (d: Buffer) => {
-            stdout += d;
-          });
-          child.stderr.on('data', (d: Buffer) => {
-            stderr += d;
-          });
-          child.on('close', (code) => {
-            if (code !== 0) {
-              reject(new Error(`Fixture exited with code ${code}: ${stderr}`));
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(stdout);
-              resolve(parsed.name);
-            } catch {
-              reject(new Error(`Failed to parse output: ${stdout}\nstderr: ${stderr}`));
-            }
-          });
-          child.on('error', reject);
-        });
-      }
-
       let xdgDir: string;
       let xdgDataHome: string;
       let xdgConfigHome: string;
       before(() => {
-        xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-xdg-'));
-        xdgDataHome = path.join(xdgDir, 'data');
-        xdgConfigHome = path.join(xdgDir, 'config');
-        const appsDir = path.join(xdgDataHome, 'applications');
-        fs.mkdirSync(appsDir, { recursive: true });
-        fs.mkdirSync(xdgConfigHome, { recursive: true });
-
-        fs.writeFileSync(
-          path.join(appsDir, desktopFileId),
-          [
-            '[Desktop Entry]',
-            `Name=${mockDisplayName}`,
-            'Exec=/usr/bin/true %u',
-            'Type=Application',
-            `MimeType=${mockMimeType};`
-          ].join('\n')
-        );
-
-        fs.writeFileSync(
-          path.join(xdgConfigHome, 'mimeapps.list'),
-          ['[Default Applications]', `${mockMimeType}=${desktopFileId}`].join('\n')
+        ({ xdgDir, xdgDataHome, xdgConfigHome } = makeXdgMockDirectories('electron-xdg-name-'));
+        writeProtocolAssociation(
+          xdgDataHome,
+          xdgConfigHome,
+          desktopFileId,
+          mockDisplayName,
+          '/usr/bin/true %u',
+          mockMimeType
         );
       });
 
@@ -1588,119 +1543,98 @@ describe('app module', () => {
       });
 
       it('returns the display name for a registered protocol', async () => {
-        const name = await spawnWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome);
+        const name = await spawnProtocolNameWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome);
         expect(name).to.equal(mockDisplayName);
       });
 
       it('returns an empty string for an unregistered protocol', async () => {
-        const name = await spawnWithXdgMock('unregistered-proto://', xdgDataHome, xdgConfigHome);
+        const name = await spawnProtocolNameWithXdgMock('unregistered-proto://', xdgDataHome, xdgConfigHome);
         expect(name).to.equal('');
       });
     });
   });
 
   describe('getApplicationInfoForProtocol()', () => {
+    const fixtureIcon = path.join(fixturesPath, 'assets', '1x1.png');
+    const desktopFileId = 'mock-browser.desktop';
+    const mockDisplayName = 'Mock Browser';
+    const mockScheme = 'mockproto';
+    const mockMimeType = `x-scheme-handler/${mockScheme}`;
+
+    let xdgDir: string;
+    let xdgDataHome: string;
+    let xdgConfigHome: string;
+    let xdgBinDir: string;
+
+    before(() => {
+      if (process.platform !== 'linux') {
+        return;
+      }
+
+      ({ xdgDir, xdgDataHome, xdgConfigHome, xdgBinDir } = makeXdgMockDirectories('electron-xdg-app-info-'));
+      writeProtocolAssociation(
+        xdgDataHome,
+        xdgConfigHome,
+        desktopFileId,
+        mockDisplayName,
+        '/usr/bin/true %u',
+        mockMimeType,
+        fixtureIcon
+      );
+    });
+
+    after(() => {
+      if (process.platform === 'linux') {
+        fs.rmSync(xdgDir, { recursive: true, force: true });
+      }
+    });
+
     it('returns promise rejection for a bogus protocol', async function () {
       await expect(app.getApplicationInfoForProtocol('bogus-protocol://')).to.eventually.be.rejectedWith(
         'Unable to retrieve installation path to app'
       );
     });
 
-    ifdescribe(process.platform !== 'linux')('on macOS and Windows', () => {
-      it('returns resolved promise with appPath, displayName and icon', async function () {
-        const appInfo = await app.getApplicationInfoForProtocol('https://');
-        expect(appInfo.path).not.to.be.undefined();
-        expect(appInfo.name).not.to.be.undefined();
-        expect(appInfo.icon).not.to.be.undefined();
-      });
-    });
-
-    ifdescribe(process.platform === 'linux')('on Linux with mocked XDG dirs', () => {
-      const fixtureApp = path.join(fixturesPath, 'api', 'protocol-name');
-      const fixtureIcon = path.join(fixturesPath, 'assets', '1x1.png');
-      const desktopFileId = 'mock-browser.desktop';
-      const mockDisplayName = 'Mock Browser';
-      const mockScheme = 'mockproto';
-      const mockMimeType = `x-scheme-handler/${mockScheme}`;
-
-      function spawnWithXdgMock(
-        url: string,
-        xdgDataHome: string,
-        xdgConfigHome: string
-      ): Promise<{ name: string; path: string; hasIcon: boolean }> {
-        return new Promise((resolve, reject) => {
-          const child = cp.spawn(process.execPath, [fixtureApp, url], {
-            env: {
-              ...process.env,
-              ELECTRON_PROTOCOL_LOOKUP_MODE: 'info',
-              XDG_DATA_HOME: xdgDataHome,
-              XDG_DATA_DIRS: xdgDataHome,
-              XDG_CONFIG_HOME: xdgConfigHome
-            },
-            stdio: ['ignore', 'pipe', 'pipe']
-          });
-          let stdout = '';
-          let stderr = '';
-          child.stdout.on('data', (d: Buffer) => {
-            stdout += d;
-          });
-          child.stderr.on('data', (d: Buffer) => {
-            stderr += d;
-          });
-          child.on('close', (code) => {
-            if (code !== 0) {
-              reject(new Error(`Fixture exited with code ${code}: ${stderr}`));
-              return;
-            }
-
-            try {
-              resolve(JSON.parse(stdout));
-            } catch {
-              reject(new Error(`Failed to parse output: ${stdout}\nstderr: ${stderr}`));
-            }
-          });
-          child.on('error', reject);
-        });
-      }
-
-      let xdgDir: string;
-      let xdgDataHome: string;
-      let xdgConfigHome: string;
-      before(() => {
-        ({ xdgDir, xdgDataHome, xdgConfigHome } = makeXdgMockDirectories('electron-xdg-app-info-'));
-
-        const appsDir = path.join(xdgDataHome, 'applications');
-        fs.mkdirSync(appsDir, { recursive: true });
-        fs.mkdirSync(xdgConfigHome, { recursive: true });
-
-        fs.writeFileSync(
-          path.join(appsDir, desktopFileId),
-          [
-            '[Desktop Entry]',
-            `Name=${mockDisplayName}`,
-            'Exec=/usr/bin/true %u',
-            `Icon=${fixtureIcon}`,
-            'Type=Application',
-            `MimeType=${mockMimeType};`
-          ].join('\n')
-        );
-
-        fs.writeFileSync(
-          path.join(xdgConfigHome, 'mimeapps.list'),
-          ['[Default Applications]', `${mockMimeType}=${desktopFileId}`].join('\n')
-        );
-      });
-
-      after(() => {
-        fs.rmSync(xdgDir, { recursive: true, force: true });
-      });
-
-      it('returns appPath, displayName and icon for a registered protocol', async () => {
-        const appInfo = await spawnWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome);
+    it('returns resolved promise with appPath, displayName and icon', async function () {
+      if (process.platform === 'linux') {
+        const appInfo = await spawnProtocolInfoWithXdgMock(`${mockScheme}://`, xdgDataHome, xdgConfigHome);
         expect(appInfo.name).to.equal(mockDisplayName);
         expect(appInfo.path).to.equal('/usr/bin/true');
         expect(appInfo.hasIcon).to.equal(true);
+        return;
+      }
+
+      const appInfo = await app.getApplicationInfoForProtocol('https://');
+      expect(appInfo.path).not.to.be.undefined();
+      expect(appInfo.name).not.to.be.undefined();
+      expect(appInfo.icon).not.to.be.undefined();
+    });
+
+    ifit(process.platform === 'linux')('resolves an executable name via PATH', async () => {
+      const pathLookupExecutable = 'mock-browser';
+      const pathLookupExecutablePath = path.join(xdgBinDir, pathLookupExecutable);
+      const pathLookupDisplayName = 'Mock Browser PATH';
+      const pathLookupScheme = 'mockproto-path';
+      const pathLookupMimeType = `x-scheme-handler/${pathLookupScheme}`;
+
+      fs.writeFileSync(pathLookupExecutablePath, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(pathLookupExecutablePath, 0o755);
+      writeProtocolAssociation(
+        xdgDataHome,
+        xdgConfigHome,
+        'mock-browser-path.desktop',
+        pathLookupDisplayName,
+        `${pathLookupExecutable} %u`,
+        pathLookupMimeType,
+        fixtureIcon
+      );
+
+      const appInfo = await spawnProtocolInfoWithXdgMock(`${pathLookupScheme}://`, xdgDataHome, xdgConfigHome, {
+        PATH: [xdgBinDir, process.env.PATH].filter(Boolean).join(':')
       });
+      expect(appInfo.name).to.equal(pathLookupDisplayName);
+      expect(appInfo.path).to.equal(pathLookupExecutablePath);
+      expect(appInfo.hasIcon).to.equal(true);
     });
   });
 

--- a/spec/fixtures/api/protocol-name/main.js
+++ b/spec/fixtures/api/protocol-name/main.js
@@ -1,7 +1,26 @@
 const { app } = require('electron');
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   const url = process.argv[2];
+
+  if (process.env.ELECTRON_PROTOCOL_LOOKUP_MODE === 'info') {
+    try {
+      const info = await app.getApplicationInfoForProtocol(url);
+      process.stdout.write(
+        JSON.stringify({
+          name: info.name,
+          path: info.path,
+          hasIcon: !info.icon.isEmpty()
+        })
+      );
+    } catch (error) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    }
+    app.quit();
+    return;
+  }
+
   const name = app.getApplicationNameForProtocol(url);
   process.stdout.write(JSON.stringify({ name }));
   app.quit();

--- a/spec/fixtures/api/protocol-name/main.js
+++ b/spec/fixtures/api/protocol-name/main.js
@@ -15,7 +15,8 @@ app.whenReady().then(async () => {
       );
     } catch (error) {
       process.stderr.write(`${error.message}\n`);
-      process.exitCode = 1;
+      app.exit(1);
+      return;
     }
     app.quit();
     return;

--- a/spec/lib/xdg-helpers.ts
+++ b/spec/lib/xdg-helpers.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 const fixturesPath = path.resolve(__dirname, '..', 'fixtures');
 const xdgMockFixturePath = path.join(fixturesPath, 'api', 'xdg-mock');
 const protocolLookupFixturePath = path.join(fixturesPath, 'api', 'protocol-name');
+const kDefaultXdgDataDirs = '/usr/local/share:/usr/share';
 
 type ProtocolNameLookupResult = {
   name: string;
@@ -15,6 +16,11 @@ export type ProtocolInfoLookupResult = ProtocolNameLookupResult & {
   path: string;
   hasIcon: boolean;
 };
+
+export function getXdgDataDirsWithFallback(xdgDataHome: string, xdgDataDirs = process.env.XDG_DATA_DIRS) {
+  // Match Chromium's XDG fallback when XDG_DATA_DIRS is unset.
+  return [xdgDataHome, xdgDataDirs || kDefaultXdgDataDirs].join(':');
+}
 
 export function makeXdgMockDirectories(prefix: string) {
   const xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -72,7 +78,7 @@ function spawnProtocolLookupWithXdgMock(
       ...process.env,
       ...extraEnv,
       XDG_DATA_HOME: xdgDataHome,
-      XDG_DATA_DIRS: [xdgDataHome, process.env.XDG_DATA_DIRS].filter(Boolean).join(':'),
+      XDG_DATA_DIRS: getXdgDataDirsWithFallback(xdgDataHome),
       XDG_CONFIG_HOME: xdgConfigHome
     };
     if (lookupMode === 'info') {

--- a/spec/lib/xdg-helpers.ts
+++ b/spec/lib/xdg-helpers.ts
@@ -1,0 +1,132 @@
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const fixturesPath = path.resolve(__dirname, '..', 'fixtures');
+const xdgMockFixturePath = path.join(fixturesPath, 'api', 'xdg-mock');
+const protocolLookupFixturePath = path.join(fixturesPath, 'api', 'protocol-name');
+
+type ProtocolNameLookupResult = {
+  name: string;
+};
+
+export type ProtocolInfoLookupResult = ProtocolNameLookupResult & {
+  path: string;
+  hasIcon: boolean;
+};
+
+export function makeXdgMockDirectories(prefix: string) {
+  const xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.cpSync(xdgMockFixturePath, xdgDir, { recursive: true });
+
+  const xdgDataHome = path.join(xdgDir, 'data');
+  const xdgConfigHome = path.join(xdgDir, 'config');
+  const xdgBinDir = path.join(xdgDir, 'bin');
+
+  fs.chmodSync(path.join(xdgBinDir, 'xdg-mime'), 0o755);
+  fs.chmodSync(path.join(xdgBinDir, 'xdg-settings'), 0o755);
+
+  return { xdgDir, xdgDataHome, xdgConfigHome, xdgBinDir };
+}
+
+export function writeProtocolAssociation(
+  xdgDataHome: string,
+  xdgConfigHome: string,
+  desktopFileId: string,
+  displayName: string,
+  execCommand: string,
+  mimeType: string,
+  iconPath?: string
+) {
+  const appsDir = path.join(xdgDataHome, 'applications');
+  fs.mkdirSync(appsDir, { recursive: true });
+  fs.mkdirSync(xdgConfigHome, { recursive: true });
+
+  const desktopEntry = ['[Desktop Entry]', `Name=${displayName}`, `Exec=${execCommand}`];
+  if (iconPath) {
+    desktopEntry.push(`Icon=${iconPath}`);
+  }
+  desktopEntry.push('Type=Application', `MimeType=${mimeType};`);
+
+  fs.writeFileSync(path.join(appsDir, desktopFileId), desktopEntry.join('\n'));
+  fs.writeFileSync(
+    path.join(xdgConfigHome, 'mimeapps.list'),
+    ['[Default Applications]', `${mimeType}=${desktopFileId}`].join('\n')
+  );
+}
+
+function spawnProtocolLookupWithXdgMock(
+  url: string,
+  xdgDataHome: string,
+  xdgConfigHome: string,
+  options: {
+    lookupMode?: 'info';
+    extraEnv?: Record<string, string | undefined>;
+  } = {}
+): Promise<ProtocolNameLookupResult | ProtocolInfoLookupResult> {
+  const { lookupMode, extraEnv = {} } = options;
+
+  return new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...extraEnv,
+      XDG_DATA_HOME: xdgDataHome,
+      XDG_DATA_DIRS: [xdgDataHome, process.env.XDG_DATA_DIRS].filter(Boolean).join(':'),
+      XDG_CONFIG_HOME: xdgConfigHome
+    };
+    if (lookupMode === 'info') {
+      env.ELECTRON_PROTOCOL_LOOKUP_MODE = 'info';
+    }
+
+    const child = cp.spawn(process.execPath, [protocolLookupFixturePath, url], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data;
+    });
+    child.stderr.on('data', (data: Buffer) => {
+      stderr += data;
+    });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Fixture exited with code ${code}: ${stderr}`));
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(stdout));
+      } catch {
+        reject(new Error(`Failed to parse output: ${stdout}\nstderr: ${stderr}`));
+      }
+    });
+    child.on('error', reject);
+  });
+}
+
+export async function spawnProtocolNameWithXdgMock(
+  url: string,
+  xdgDataHome: string,
+  xdgConfigHome: string,
+  extraEnv: Record<string, string | undefined> = {}
+) {
+  const parsed = (await spawnProtocolLookupWithXdgMock(url, xdgDataHome, xdgConfigHome, {
+    extraEnv
+  })) as ProtocolNameLookupResult;
+  return parsed.name;
+}
+
+export function spawnProtocolInfoWithXdgMock(
+  url: string,
+  xdgDataHome: string,
+  xdgConfigHome: string,
+  extraEnv: Record<string, string | undefined> = {}
+) {
+  return spawnProtocolLookupWithXdgMock(url, xdgDataHome, xdgConfigHome, {
+    lookupMode: 'info',
+    extraEnv
+  }) as Promise<ProtocolInfoLookupResult>;
+}


### PR DESCRIPTION
#### Description of Change

- Implement `app.getApplicationInfoForProtocol()` on Linux.
- Mark it as supported in the docs
- Add tests
- Move XDG test helpers into `spec/lib/xdg-helpers.ts`

Related: #51253, #51197

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added Linux support for `app.getApplicationInfoForProtocol()`.