### PR TITLE
build: rebase siso patches onto siso 7bcc56206d23

### DIFF
--- a/.github/siso-patches/0001-siso-reuse-the-outer-os.File-for-chunked-ReadAt-in-f.patch
+++ b/.github/siso-patches/0001-siso-reuse-the-outer-os.File-for-chunked-ReadAt-in-f.patch
@@ -1,4 +1,4 @@
-From 85b561ea4dbc76ba98af020b970f3aa6b20fdb9e Mon Sep 17 00:00:00 2001
+From aab86e682d6f40e110700f36c9c37f6655fb14f1 Mon Sep 17 00:00:00 2001
 From: Samuel Attard <sam@electronjs.org>
 Date: Wed, 8 Apr 2026 23:24:15 -0700
 Subject: [PATCH] siso: reuse the outer *os.File for chunked ReadAt in
@@ -25,10 +25,10 @@ it; see microsoft/Windows-Containers#<tbd>.
  1 file changed, 7 deletions(-)
 
 diff --git a/siso/toolsupport/ninjautil/file_parser.go b/siso/toolsupport/ninjautil/file_parser.go
-index 8c18d084..63116662 100644
+index f8c7eff..75b1d6e 100644
 --- a/siso/toolsupport/ninjautil/file_parser.go
 +++ b/siso/toolsupport/ninjautil/file_parser.go
-@@ -111,13 +111,6 @@ func (p *fileParser) readFile(ctx context.Context, fname string) ([]byte, error)
+@@ -128,13 +128,6 @@ func (p *fileParser) readFile(ctx context.Context, fname string) ([]byte, error)
  		eg.Go(func() error {
  			p.sema <- struct{}{}
  			defer func() { <-p.sema }()
@@ -43,5 +43,5 @@ index 8c18d084..63116662 100644
  				n, err := f.ReadAt(chunkBuf, pos)
  				if err != nil {
 -- 
-2.53.0
+2.52.0
 

--- a/.github/siso-patches/0002-siso-retry-transient-ERROR_INVALID_PARAMETER-when-op.patch
+++ b/.github/siso-patches/0002-siso-retry-transient-ERROR_INVALID_PARAMETER-when-op.patch
@@ -1,4 +1,4 @@
-From a8afee1089ec2ae9ab5837b438d07338aefb3bc4 Mon Sep 17 00:00:00 2001
+From 1786f2266cba6a66343e5af2b724214930c8292f Mon Sep 17 00:00:00 2001
 From: Samuel Attard <sam@electronjs.org>
 Date: Wed, 22 Apr 2026 16:27:51 -0700
 Subject: [PATCH] siso: retry transient ERROR_INVALID_PARAMETER when opening
@@ -27,7 +27,7 @@ Other platforms keep the direct os.Open path.
  create mode 100644 siso/toolsupport/ninjautil/openfile_windows.go
 
 diff --git a/siso/toolsupport/ninjautil/file_parser.go b/siso/toolsupport/ninjautil/file_parser.go
-index 6311666..324528d 100644
+index 75b1d6e..4a3e639 100644
 --- a/siso/toolsupport/ninjautil/file_parser.go
 +++ b/siso/toolsupport/ninjautil/file_parser.go
 @@ -7,7 +7,6 @@ package ninjautil
@@ -35,10 +35,10 @@ index 6311666..324528d 100644
  	"context"
  	"fmt"
 -	"os"
+ 	"path/filepath"
  	"runtime/trace"
  	"sync"
- 	"time"
-@@ -91,7 +90,7 @@ func (p *fileParser) parseFile(ctx context.Context, fname string) error {
+@@ -108,7 +107,7 @@ func (p *fileParser) parseFile(ctx context.Context, fname string) error {
  // readFile reads a file of fname in parallel.
  func (p *fileParser) readFile(ctx context.Context, fname string) ([]byte, error) {
  	defer trace.StartRegion(ctx, "ninja.read").End()
@@ -128,5 +128,5 @@ index 0000000..f9d8e9d
 +	}
 +}
 -- 
-2.53.0
+2.52.0
 


### PR DESCRIPTION
The Chromium 149.0.7798.0 roll (#50814) bumped the pinned siso revision to `7bcc56206d234b3024df08ffd4ee6d40eea32623`, and upstream added a `path/filepath` import to `siso/toolsupport/ninjautil/file_parser.go`. That broke the import-block context for the 0002 `ERROR_INVALID_PARAMETER` retry patch, so `git am --3way` could no longer build a fake ancestor and the `build-siso-windows` job has been failing at the **Apply in-tree siso patches** step on `main`.

This re-exports both `.github/siso-patches/` patches against the new siso SHA. No functional change to the patched code — only line offsets, index hashes and the import-hunk context move.

Verified locally by replicating the CI step end-to-end: fresh `--depth=1` clone of `chromium.googlesource.com/build` at the pinned SHA, `git am --3way .github/siso-patches/*.patch`, `go vet ./toolsupport/ninjautil/...`, and `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build` all succeed.

Notes: none