### PR TITLE
ci: run siso build as part of Apply Patches workflow

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -18,6 +18,7 @@ jobs:
       pull-requests: read
     outputs:
       has-patches: ${{ steps.filter.outputs.patches }}
+      has-siso-patches: ${{ steps.filter.outputs.siso-patches }}
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -34,6 +35,9 @@ jobs:
           patches:
             - DEPS
             - 'patches/**'
+          siso-patches:
+            - DEPS
+            - '.github/siso-patches/**'
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -83,3 +87,10 @@ jobs:
         path: patches/update-patches.patch
         if-no-files-found: ignore
         archive: false
+
+  build-siso:
+    needs: setup
+    if: ${{ needs.setup.outputs.has-siso-patches == 'true' }}
+    uses: ./.github/workflows/pipeline-segment-build-siso-windows.yml
+    permissions:
+      contents: read

--- a/.github/workflows/rerun-apply-patches.yml
+++ b/.github/workflows/rerun-apply-patches.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'DEPS'
       - 'patches/**'
+      - '.github/siso-patches/**'
 
 permissions: {}
 


### PR DESCRIPTION
This adds a build-siso job that runs when DEPS or .github/siso-patches change, so siso patch issues are detected before chromium rolls land.

Notes: none