### PR TITLE
ci: route rustc linker invocations through abs_link_wrapper

### DIFF
--- a/build/win/abs_link_wrapper.py
+++ b/build/win/abs_link_wrapper.py
@@ -66,7 +66,7 @@ def _resolve_arg(arg):
     """Resolve a single command-line argument if it's a relative file path."""
     stripped = arg.strip('"')
     if _is_file_path(arg) and not os.path.isabs(stripped):
-        return '"' + os.path.abspath(stripped) + '"'
+        return os.path.abspath(stripped)
     return arg
 
 

--- a/build/win/abs_link_wrapper.py
+++ b/build/win/abs_link_wrapper.py
@@ -4,13 +4,13 @@
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
-"""Wrapper for lld-link that resolves .obj paths in .rsp files to absolute.
+"""Wrapper for lld-link that resolves relative paths to absolute.
 
-Usage: abs_link_wrapper.py <lld-link args...>
+Usage: abs_link_wrapper.py <lld-link> <args...>
 
-The script finds the @rspfile argument, rewrites relative .obj/.res/.lib
-paths inside it to absolute paths, then invokes lld-link with the
-rewritten rsp file.
+The first argument is the real linker executable. The script resolves
+relative .obj/.rlib/.res/.lib paths in both @rspfile contents and direct
+command-line arguments to absolute paths, then invokes the real linker.
 """
 
 import os
@@ -31,7 +31,7 @@ def _is_file_path(token):
     if '/' not in t and '\\' not in t:
         return False
     # File extensions we care about
-    return t.endswith(('.obj', '.res', '.lib', '.a', '.o'))
+    return t.endswith(('.obj', '.res', '.lib', '.a', '.o', '.rlib'))
 
 
 def _resolve_rsp(rsp_path):
@@ -62,6 +62,14 @@ def _resolve_rsp(rsp_path):
     return abs_rsp
 
 
+def _resolve_arg(arg):
+    """Resolve a single command-line argument if it's a relative file path."""
+    stripped = arg.strip('"')
+    if _is_file_path(arg) and not os.path.isabs(stripped):
+        return '"' + os.path.abspath(stripped) + '"'
+    return arg
+
+
 def main():
     args = []
     for arg in sys.argv[1:]:
@@ -70,7 +78,7 @@ def main():
             resolved = _resolve_rsp(rsp_path)
             args.append('@' + resolved)
         else:
-            args.append(arg)
+            args.append(_resolve_arg(arg))
 
     return subprocess.call(args)
 

--- a/patches/chromium/build_gn_arg_to_support_linker_wrapper_script_on_windows.patch
+++ b/patches/chromium/build_gn_arg_to_support_linker_wrapper_script_on_windows.patch
@@ -11,7 +11,7 @@ wrapper to convert rsp file arguments to absolute paths.
 Should be removed when associated container bug is addressed.
 
 diff --git a/build/toolchain/win/toolchain.gni b/build/toolchain/win/toolchain.gni
-index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..6a1be11308e435ecc39d937f4e59598c9eab60c5 100644
+index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..b814d6cb7c71a86784993e5fc530f3af32346792 100644
 --- a/build/toolchain/win/toolchain.gni
 +++ b/build/toolchain/win/toolchain.gni
 @@ -14,6 +14,12 @@ import("//build/toolchain/win/win_toolchain_data.gni")
@@ -62,7 +62,7 @@ index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..6a1be11308e435ecc39d937f4e59598c
 +                     "exit /b %ERRORLEVEL%",
 +                   ])
 +        _rust_link_wrapper_rel =
-+            rebase_path(_rust_link_wrapper_cmd, root_build_dir)
++            rebase_path(_rust_link_wrapper_cmd)
 +        rustc_windows_args =
 +            " -Clinker=$_rust_link_wrapper_rel$rust_linkflags $rustc_common_args"
 +      }

--- a/patches/chromium/build_gn_arg_to_support_linker_wrapper_script_on_windows.patch
+++ b/patches/chromium/build_gn_arg_to_support_linker_wrapper_script_on_windows.patch
@@ -11,7 +11,7 @@ wrapper to convert rsp file arguments to absolute paths.
 Should be removed when associated container bug is addressed.
 
 diff --git a/build/toolchain/win/toolchain.gni b/build/toolchain/win/toolchain.gni
-index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..8fbdb201f08e9ce77579b087ae82ec7b7046c1e3 100644
+index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..6a1be11308e435ecc39d937f4e59598c9eab60c5 100644
 --- a/build/toolchain/win/toolchain.gni
 +++ b/build/toolchain/win/toolchain.gni
 @@ -14,6 +14,12 @@ import("//build/toolchain/win/win_toolchain_data.gni")
@@ -43,7 +43,34 @@ index a62df6bfc70ddfb4aa3ad6975e4fb50b42c3bc79..8fbdb201f08e9ce77579b087ae82ec7b
        sys_lib_flags = "${invoker.sys_lib_flags}"
  
        # TODO(thakis): Remove once crbug.com/1300005 is fixed
-@@ -526,7 +539,16 @@ template("msvc_toolchain") {
+@@ -356,6 +369,26 @@ template("msvc_toolchain") {
+ 
+       rustc_windows_args = " -Clinker=$link$rust_linkflags $rustc_common_args"
+ 
++      # When win_abs_link_wrapper is set, generate a .cmd wrapper that rustc
++      # will invoke as the "linker". The wrapper resolves relative file paths
++      # to absolute before calling the real lld-link
++      if (win_abs_link_wrapper != "") {
++        _abs_link_wrapper_py =
++            rebase_path(win_abs_link_wrapper, root_build_dir)
++        _rust_link_wrapper_cmd =
++            "$root_build_dir/abs_link_wrapper_" + target_name + ".cmd"
++        write_file(_rust_link_wrapper_cmd,
++                   [
++                     "@echo off",
++                     "\"$python_path\" \"$_abs_link_wrapper_py\" \"$link\" %*",
++                     "exit /b %ERRORLEVEL%",
++                   ])
++        _rust_link_wrapper_rel =
++            rebase_path(_rust_link_wrapper_cmd, root_build_dir)
++        rustc_windows_args =
++            " -Clinker=$_rust_link_wrapper_rel$rust_linkflags $rustc_common_args"
++      }
++
+       tool("rust_staticlib") {
+         libname = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
+         rspfile = rustc_rsp_path
+@@ -526,7 +559,16 @@ template("msvc_toolchain") {
  
      tool("alink") {
        rspfile = "{{output}}.rsp"


### PR DESCRIPTION
#### Description of Change

Followup to https://github.com/electron/electron/pull/51311

Refs https://github.com/electron/electron/actions/runs/24917746222/job/72973188622

Rust link targets invoke lld-link internally via rustc's `-Clinker= flag`, bypassing the abs_link_wrapper from BindFlt issue. This causes the same undefined symbol flakes on Rust targets.

The change routes through `abs_link_wrapper.py` to resolve relative `.obj/.rlib` paths to absolute before calling `lld-link`.

**Before:**

```
  rustc ... -Clinker=..\..\third_party\llvm-build\...\lld-link.exe

  lld-link.exe -flavor link \
    win_clang_x86_.../obj/.../libhashbrown_lib.rlib \
    win_clang_x86_.../obj/.../libquote_lib.rlib \
    ...
 ```

**After:**

```
  rustc ... -Clinker=abs_link_wrapper_win_clang_x86.cmd

  python.exe abs_link_wrapper.py lld-link.exe -flavor link \
    "C:\src\out\Default\win_clang_x86_.../obj/.../libhashbrown_lib.rlib" \
    "C:\src\out\Default\win_clang_x86_.../obj/.../libquote_lib.rlib" \
    ...
 ```

Hopefully this is the last in the series 😄 

#### Release Notes

Notes: none