### PR TITLE
test: fix race in reentrant `loadURL()` ready-to-commit test

### DIFF
--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -558,9 +558,10 @@ describe('webContents module', () => {
       w.loadURL('data:text/html,<h1>HELLO</h1>');
     });
 
-    it('fails if loadurl is called after the navigation is ready to commit', () => {
+    it('fails if loadurl is called after the navigation is ready to commit', (done) => {
       w.webContents.once('did-fail-load', (_event, _errorCode, _errorDescription, validatedURL) => {
         expect(validatedURL).to.contain('blank.html');
+        done();
       });
 
       // @ts-expect-error internal-only event.


### PR DESCRIPTION
#### Description of Change

Fix `fails if loadurl is called after the navigation is ready to commit` by using a done() callback to ensure the test waits for `did-fail-load`. Previously, the test would return immediately and call `afterEach(closeAllWindows)`, potentially destroying the window while navigation was in flight.

This use of `done()` here matches how the nearby tests work.

Sample test failure:

```
Unhandled exception in main spec runner: TypeError: Object has been destroyed
not ok 390 webContents module loadURL() promise API "after each" hook: closeAllWindows in "loadURL() promise API"
    at BrowserWindow.n.loadURL (node:electron/js2c/browser_init:2:20276)
  done() called multiple times in hook <webContents module loadURL() promise API "after each" hook: closeAllWindows in "loadURL() promise API"> of file D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts; in addition, done() received error: TypeError: Object has been destroyed
    at WebContents.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts:563:11)
      at BrowserWindow.n.loadURL (node:electron/js2c/browser_init:2:20276)
    at Object.onceWrapper (node:events:631:26)
      at WebContents.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts:563:11)
    at WebContents.emit (node:events:509:28)
      at Object.onceWrapper (node:events:631:26)
      at WebContents.emit (node:events:509:28) {
    uncaught: true
  }
  Error: done() called multiple times in hook <webContents module loadURL() promise API "after each" hook: closeAllWindows in "loadURL() promise API"> of file D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts; in addition, done() received error: TypeError: Object has been destroyed
      at BrowserWindow.n.loadURL (node:electron/js2c/browser_init:2:20276)
      at WebContents.<anonymous> (electron\spec\api-web-contents-spec.ts:563:11)
      at Object.onceWrapper (node:events:631:26)
      at WebContents.emit (node:events:509:28) {
    uncaught: true
  }
      at process.emit (node:events:521:24)
      at process.emit (electron\node_modules\source-map-support\source-map-support.js:495:21)
      at process._fatalException (node:internal/process/execution:159:25)
✗ Electron tests failed with code 0x1.
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.