### PR TITLE
chore: cherry-pick 1 change from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -175,3 +175,4 @@ cherry-pick-d141d62357df.patch
 cherry-pick-c75f63de7188.patch
 cherry-pick-7687618.patch
 patch_osr_control_screen_info.patch
+cherry-pick-cve-2026-6920.patch

--- a/patches/chromium/cherry-pick-cve-2026-6920.patch
+++ b/patches/chromium/cherry-pick-cve-2026-6920.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Date: Wed, 15 Apr 2026 09:02:46 -0700
+Subject: Validate route_id for command buffers
+
+Some route ids are reserved, we shouldn't allow command buffer
+operations on them.
+
+(cherry picked from commit 1880a4c3156b118953e2658f772afd666c0b3ed8)
+
+Bug: 499891888
+Fixed: 502436611
+Change-Id: Id4c32103d8db70d9819112d4eb8d5c840d033300
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7747910
+Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1613096}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7760833
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7680@{#3951}
+Cr-Branched-From: 76b7d80e5cda23fe6537eed26d68c92e995c7f39-refs/heads/main@{#1582197}
+
+diff --git a/gpu/ipc/service/gpu_channel.cc b/gpu/ipc/service/gpu_channel.cc
+index e56cd25e65b0ba5db4ab39ba9ab0314ee13696d8..6918504a510d5a2a0aba3539156f72d53331d622 100644
+--- a/gpu/ipc/service/gpu_channel.cc
++++ b/gpu/ipc/service/gpu_channel.cc
+@@ -971,6 +971,11 @@ void GpuChannel::CreateCommandBuffer(
+     return;
+   }
+ 
++  if (route_id <= static_cast<int32_t>(GpuChannelReservedRoutes::kMaxValue)) {
++    LOG(ERROR) << "ContextResult::kFatalFailure: using reserved route";
++    return;
++  }
++
+   int32_t stream_id = init_params->stream_id;
+   CommandBufferId command_buffer_id =
+       CommandBufferIdFromChannelAndRoute(client_id_, route_id);
+@@ -1032,6 +1037,10 @@ void GpuChannel::DestroyCommandBuffer(int32_t route_id) {
+   TRACE_EVENT1("gpu", "GpuChannel::OnDestroyCommandBuffer", "route_id",
+                route_id);
+ 
++  if (route_id <= static_cast<int32_t>(GpuChannelReservedRoutes::kMaxValue)) {
++    return;
++  }
++
+   std::unique_ptr<CommandBufferStub> stub;
+   auto it = stubs_.find(route_id);
+   if (it != stubs_.end()) {


### PR DESCRIPTION
#### Description of Change

Backports an upstream change that tightens route_id validation in the GPU command buffer.

<details>
<summary>cherry-pick dacff5aaddce from chromium</summary>

Validate route_id for command buffers

Some route ids are reserved, we shouldn't allow command buffer
operations on them.

(cherry picked from commit 1880a4c3156b118953e2658f772afd666c0b3ed8)

Bug: 499891888
Fixed: 502436611
Change-Id: Id4c32103d8db70d9819112d4eb8d5c840d033300
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7747910
Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
</details>

#### Checklist

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Backported a fix for route_id validation in the GPU command buffer.
