### PR TITLE
fix: add MicrotasksScope for worker exit emit in ContextWillDestroy

### DIFF
--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -252,6 +252,13 @@ void WebWorkerObserver::ContextWillDestroy(v8::Local<v8::Context> context) {
               .ToLocal(&emit_v) &&
           emit_v->IsFunction()) {
         v8::Local<v8::Value> args[] = {gin::StringToV8(isolate, "exit")};
+        // Worker/worklet contexts use kScoped microtask policy (set by
+        // Blink). V8 DCHECKs that a MicrotasksScope exists around every
+        // Call() under that policy. We use kDoNotRunMicrotasks because
+        // the context is mid-teardown.
+        v8::MicrotasksScope microtasks_scope{
+            isolate, ctx->GetMicrotaskQueue(),
+            v8::MicrotasksScope::kDoNotRunMicrotasks};
         v8::TryCatch try_catch(isolate);
         emit_v.As<v8::Function>()
             ->Call(ctx, env->process_object(), 1, args)


### PR DESCRIPTION
#### Description of Change

Followup to #47244 which replaced `gin_helper::EmitEvent()` with a direct `v8::Function::Call()` in `WebWorkerObserver::ContextWillDestroy()` to avoid re-entering the microtask checkpoint during worker teardown.

The crash happens when V8 `DCHECK()`s that a there's an active microtasks scope. Under the old code path, this happened in Node with a `node::CallbackScope`. Under the new code path, it's possible for the `DCHECK()` to fail. This PR copies 47244's `ShareEnvironmentWithContext()` approach: it explicitly adds a `kDoNotRunMicrotasks` scope.

Sample DCHECK failure:

```txt
2026-04-26T15:14:06.1477183Z #
2026-04-26T15:14:06.1477421Z # Fatal error in ../../v8/src/api/api-inl.h, line 188
2026-04-26T15:14:06.1478015Z # Debug check failed: microtask_queue->GetMicrotasksScopeDepth() || !microtask_queue->DebugMicrotasksScopeDepthIsZero().
2026-04-26T15:14:06.1478549Z # 
2026-04-26T15:14:06.1478719Z # 
2026-04-26T15:14:06.1478891Z #
2026-04-26T15:14:06.1515803Z #FailureMessage Object: 0xedef6588[6460:0426/151406.150901:WARNING:services/audio/output_device_mixer_manager.cc:132] Making unmixable output stream
2026-04-26T15:14:06.1639285Z [1157:0426/151406.163039:ERROR:base/threading/platform_thread_linux.cc:282] Failed to set realtime priority for thread 8010: Operation not permitted (1)
2026-04-26T15:14:06.1640306Z [1157:0426/151406.163385:ERROR:base/threading/platform_thread_linux.cc:282] Failed to set realtime priority for thread 8009: Operation not permitted (1)
2026-04-26T15:14:06.2235416Z #0 0x000007d278fe base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
2026-04-26T15:14:06.2316008Z #1 0x000007d17c8c base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
2026-04-26T15:14:06.2422161Z #2 0x0000094f7344 gin::(anonymous namespace)::PrintStackTrace() [../../gin/v8_platform.cc:41:27]
2026-04-26T15:14:06.2523712Z #3 0x000009082026 V8_Fatal() [../../v8/src/base/logging.cc:72:28]
2026-04-26T15:14:06.2626021Z #4 0x000009081c26 v8::base::(anonymous namespace)::DefaultDcheckHandler() [../../v8/src/base/logging.cc:59:3]
2026-04-26T15:14:06.2731743Z #5 0x000004626b30 v8::CallDepthScope<>::~CallDepthScope() [../../v8/src/api/api-inl.h:187:9]
2026-04-26T15:14:06.2959664Z #6 0x0000045fe7a6 v8::Function::Call() [../../v8/src/api/api-inl.h:259:20]
2026-04-26T15:14:06.3183364Z #7 0x0000045fea0c v8::Function::Call() [../../v8/src/api/api.cc:5621:10]
2026-04-26T15:14:06.3190582Z #8 0x00000327f484 electron::WebWorkerObserver::ContextWillDestroy() [../../electron/shell/renderer/web_worker_observer.cc:257:15]
2026-04-26T15:14:06.3198558Z #9 0x000003276904 electron::ElectronRendererClient::WillDestroyWorkerContextOnWorkerThread() [../../electron/shell/renderer/electron_renderer_client.cc:262:16]
2026-04-26T15:14:06.3340048Z #10 0x00000ac182ec blink::WorkerThread::PrepareForShutdownOnWorkerThread() [../../third_party/blink/renderer/core/workers/worker_thread.cc:808:26]
2026-04-26T15:14:06.3346091Z #11 0x0000030c9012 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
2026-04-26T15:14:06.3374808Z #12 0x000007cadfb6 
```

Note:  47244 landed ~2 weeks ago and I haven't seen this CI failure until today in the main Chromium roll. TBD what's different in the roll. Either way, explicitly setting a scope in `ContextWillDestroy()` is a worthwhile correctness fix for the maintenance branches.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.