### PR TITLE
chore: cherry-pick 1 change from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -184,3 +184,4 @@ cherry-pick-fccaeb9e0967.patch
 cherry-pick-c75f63de7188.patch
 cherry-pick-d141d62357df.patch
 cherry-pick-848cf5567223.patch
+cherry-pick-cve-2026-6920.patch

--- a/patches/chromium/cherry-pick-cve-2026-6920.patch
+++ b/patches/chromium/cherry-pick-cve-2026-6920.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Date: Fri, 10 Apr 2026 14:17:34 -0700
+Subject: Validate route_id for command buffers
+
+Some route ids are reserved, we shouldn't allow command buffer
+operations on them.
+
+Bug: 499891888
+Change-Id: Id4c32103d8db70d9819112d4eb8d5c840d033300
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7747910
+Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1613096}
+
+diff --git a/gpu/ipc/service/gpu_channel.cc b/gpu/ipc/service/gpu_channel.cc
+index c51bf92540c12aec81cd6bd4c67c3e5b85917b2e..71a9a35c10a2337863ef40475b2d07b982b1d7d6 100644
+--- a/gpu/ipc/service/gpu_channel.cc
++++ b/gpu/ipc/service/gpu_channel.cc
+@@ -995,6 +995,11 @@ void GpuChannel::CreateCommandBuffer(
+     return;
+   }
+ 
++  if (route_id <= static_cast<int32_t>(GpuChannelReservedRoutes::kMaxValue)) {
++    LOG(ERROR) << "ContextResult::kFatalFailure: using reserved route";
++    return;
++  }
++
+   int32_t stream_id = init_params->stream_id;
+   int32_t share_group_id = init_params->share_group_id;
+   CommandBufferStub* share_group = LookupCommandBuffer(share_group_id);
+@@ -1086,6 +1091,10 @@ void GpuChannel::DestroyCommandBuffer(int32_t route_id) {
+   TRACE_EVENT1("gpu", "GpuChannel::OnDestroyCommandBuffer", "route_id",
+                route_id);
+ 
++  if (route_id <= static_cast<int32_t>(GpuChannelReservedRoutes::kMaxValue)) {
++    return;
++  }
++
+   std::unique_ptr<CommandBufferStub> stub;
+   auto it = stubs_.find(route_id);
+   if (it != stubs_.end()) {


### PR DESCRIPTION
#### Description of Change

Backports an upstream change that tightens route_id validation in the GPU command buffer.

<details>
<summary>cherry-pick dacff5aaddce from chromium</summary>

Validate route_id for command buffers

Some route ids are reserved, we shouldn't allow command buffer
operations on them.

(cherry picked from commit 1880a4c3156b118953e2658f772afd666c0b3ed8)

Bug: 499891888
Fixed: 502436611
Change-Id: Id4c32103d8db70d9819112d4eb8d5c840d033300
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7747910
Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
</details>

#### Checklist

- [x] PR description included
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Backported a fix for route_id validation in the GPU command buffer.
