### PR TITLE
fix: browser window webcontents null after destroy

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -508,6 +508,8 @@ win.loadURL('https://github.com')
 A `WebContents` object this window owns. All web page related events and
 operations will be done via it.
 
+Returns `null` if the window has been destroyed.
+
 See the [`webContents` documentation](web-contents.md) for its methods and
 events.
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -16,6 +16,7 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/constructor.h"
+#include "shell/common/gin_helper/destroyable.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -265,9 +265,25 @@ void BrowserWindow::BlurWebView() {
 }
 
 v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
-  if (web_contents_.IsEmpty())
+  if (web_contents_.IsEmpty() || !api_web_contents_)
     return v8::Null(isolate);
   return v8::Local<v8::Value>::New(isolate, web_contents_);
+}
+
+// static
+void BrowserWindow::GetWebContentsCallback(
+    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Isolate* isolate = info.GetIsolate();
+  if (gin_helper::Destroyable::IsDestroyed(info.This())) {
+    info.GetReturnValue().Set(v8::Null(isolate));
+    return;
+  }
+  BrowserWindow* self = nullptr;
+  if (!gin::ConvertFromV8(isolate, info.This(), &self) || !self) {
+    info.GetReturnValue().Set(v8::Null(isolate));
+    return;
+  }
+  info.GetReturnValue().Set(self->GetWebContents(isolate));
 }
 
 void BrowserWindow::OnWindowShow() {
@@ -326,8 +342,14 @@ void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
   prototype->SetClassName(gin::StringToV8(isolate, "BrowserWindow"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("focusOnWebView", &BrowserWindow::FocusOnWebView)
-      .SetMethod("blurWebView", &BrowserWindow::BlurWebView)
-      .SetProperty("webContents", &BrowserWindow::GetWebContents);
+      .SetMethod("blurWebView", &BrowserWindow::BlurWebView);
+
+  // Bind webContents as a raw V8 accessor so that accessing it on a destroyed
+  // BrowserWindow returns null instead of throwing "Object has been destroyed".
+  prototype->PrototypeTemplate()->SetAccessorProperty(
+      gin::StringToSymbol(isolate, "webContents"),
+      v8::FunctionTemplate::New(isolate,
+                                &BrowserWindow::GetWebContentsCallback));
 }
 
 // static

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -75,6 +75,9 @@ class BrowserWindow : public BaseWindow,
   void BlurWebView();
   v8::Local<v8::Value> GetWebContents(v8::Isolate* isolate);
 
+  static void GetWebContentsCallback(
+  const v8::FunctionCallbackInfo<v8::Value>& info);
+
  private:
   // Helpers.
 

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -76,7 +76,7 @@ class BrowserWindow : public BaseWindow,
   v8::Local<v8::Value> GetWebContents(v8::Isolate* isolate);
 
   static void GetWebContentsCallback(
-  const v8::FunctionCallbackInfo<v8::Value>& info);
+      const v8::FunctionCallbackInfo<v8::Value>& info);
 
  private:
   // Helpers.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -325,6 +325,15 @@ describe('BrowserWindow module', () => {
         contents.getProcessId();
       }).to.throw('Object has been destroyed');
     });
+
+    it('returns null for webContents property after window is destroyed', async () => {
+      expect(w.webContents).to.not.be.null();
+      w.destroy();
+      await new Promise(setImmediate);
+      expect(w.isDestroyed()).to.be.true();
+      expect(w.webContents).to.be.null();
+    });
+
     it('should not crash when destroying windows with pending events', () => {
       const focusListener = () => {};
       app.on('browser-window-focus', focusListener);


### PR DESCRIPTION
#### Description of Change

Fixes #44605

Accessing `win.webContents` inside event handlers (e.g. a `DownloadItem`
`updated` handler) after the associated `BrowserWindow` was closed threw
`Error: Object has been destroyed` instead of returning `null`.

**Root cause:** `webContents` was bound via a C++ member function pointer
using `SetProperty`. The gin_helper `CallbackTraits` specialization for
member function pointers unconditionally sets `holder_is_first_argument =
true`, causing `ArgumentHolder` to run a `Destroyable::IsDestroyed()` check
on the holder *before* invoking the getter — throwing the error when the
window is already destroyed.

**Fix:** Replace the `SetProperty` binding with a raw V8
`FunctionCallbackInfo` callback (`GetWebContentsCallback`), following the
same pattern as `IsDestroyedFunc` in `destroyable.cc`. The callback:

1. Explicitly checks `IsDestroyed()` and returns `null` for destroyed windows
2. Returns `null` if the C++ object cannot be unwrapped
3. Guards `GetWebContents()` with an `!api_web_contents_` null check for the
   case where `WebContentsDestroyed()` fires before the `BrowserWindow` C++
   object is deleted

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `win.webContents` throwing an error instead of returning `null` when accessed after the `BrowserWindow` has been destroyed.
