### PR TITLE
fix: validate header name and value in webRequest.onBeforeSendHeaders

### DIFF
--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -253,10 +253,9 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
   for (const auto it : dict) {
-    if (it.second.is_string()) {
-      if (!net::HttpUtil::IsValidHeaderName(it.first) ||
-          !net::HttpUtil::IsValidHeaderValue(it.second.GetString()))
-        continue;
+    if (it.second.is_string() &&
+        net::HttpUtil::IsValidHeaderName(it.first) &&
+        net::HttpUtil::IsValidHeaderValue(it.second.GetString())) {
       out->SetHeader(it.first, std::move(it.second).TakeString());
     }
   }

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -253,8 +253,12 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
   for (const auto it : dict) {
-    if (it.second.is_string())
+    if (it.second.is_string()) {
+      if (!net::HttpUtil::IsValidHeaderName(it.first) ||
+          !net::HttpUtil::IsValidHeaderValue(it.second.GetString()))
+        continue;
       out->SetHeader(it.first, std::move(it.second).TakeString());
+    }
   }
   return true;
 }

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -253,8 +253,7 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
   for (const auto it : dict) {
-    if (it.second.is_string() &&
-        net::HttpUtil::IsValidHeaderName(it.first) &&
+    if (it.second.is_string() && net::HttpUtil::IsValidHeaderName(it.first) &&
         net::HttpUtil::IsValidHeaderValue(it.second.GetString())) {
       out->SetHeader(it.first, std::move(it.second).TakeString());
     }

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -558,12 +558,16 @@ describe('webRequest module', () => {
         requestHeaders['X-Good'] = 'good-value';
         callback({ requestHeaders });
       });
-      ses.webRequest.onSendHeaders((details) => {
-        expect(details.requestHeaders['Invalid Header']).to.be.undefined();
-        expect(details.requestHeaders['Valid-Header']).to.be.undefined();
-        expect(details.requestHeaders['X-Good']).to.equal('good-value');
+      const sentHeaders = new Promise<Electron.OnSendHeadersListenerDetails>((resolve) => {
+        ses.webRequest.onSendHeaders(resolve);
       });
+
       const { data } = await ajax(defaultURL);
+      const details = await sentHeaders;
+
+      expect(details.requestHeaders['Invalid Header']).to.be.undefined();
+      expect(details.requestHeaders['Valid-Header']).to.be.undefined();
+      expect(details.requestHeaders['X-Good']).to.equal('good-value');
       expect(data).to.equal('/');
     });
 

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -550,6 +550,23 @@ describe('webRequest module', () => {
       expect(called).to.be.true();
     });
 
+    it('does not crash on invalid header name or value', async () => {
+      ses.webRequest.onBeforeSendHeaders((details, callback) => {
+        const requestHeaders = details.requestHeaders;
+        requestHeaders['Invalid Header'] = 'valid-value';
+        requestHeaders['Valid-Header'] = 'invalid\r\nvalue';
+        requestHeaders['X-Good'] = 'good-value';
+        callback({ requestHeaders });
+      });
+      ses.webRequest.onSendHeaders((details) => {
+        expect(details.requestHeaders['Invalid Header']).to.be.undefined();
+        expect(details.requestHeaders['Valid-Header']).to.be.undefined();
+        expect(details.requestHeaders['X-Good']).to.equal('good-value');
+      });
+      const { data } = await ajax(defaultURL);
+      expect(data).to.equal('/');
+    });
+
     it('resets the whole headers', async () => {
       const requestHeaders = {
         Test: 'header'


### PR DESCRIPTION
#### Description of Change

Chromium's net::HttpRequestHeaders::SetHeader() uses CHECK() to enforce valid header names and values, which causes a fatal crash if the caller passes invalid strings. When users modify requestHeaders in the onBeforeSendHeaders callback with invalid header names (e.g. containing spaces) or invalid header values (e.g. containing CRLF), the gin::Converter<net::HttpRequestHeaders>::FromV8() calls SetHeader() directly, triggering the CHECK and crashing the process.

This change adds pre-validation using net::HttpUtil::IsValidHeaderName() and net::HttpUtil::IsValidHeaderValue() before calling SetHeader(), silently skipping invalid headers instead of crashing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a  crash when providing invalid HTTP header names or values in the `webRequest.onBeforeSendHeaders()` callback
