### PR TITLE
fix: include permission element string resources in locale paks

### DIFF
--- a/build/electron_paks.gni
+++ b/build/electron_paks.gni
@@ -65,6 +65,7 @@ template("electron_extra_paks") {
       "$root_gen_dir/net/net_resources.pak",
       "$root_gen_dir/third_party/blink/public/resources/blink_resources.pak",
       "$root_gen_dir/third_party/blink/public/resources/inspector_overlay_resources.pak",
+      "$root_gen_dir/third_party/blink/public/strings/permission_element_generated_strings.pak",
       "$target_gen_dir/electron_resources.pak",
     ]
     deps = [
@@ -83,6 +84,7 @@ template("electron_extra_paks") {
       "//net:net_resources",
       "//third_party/blink/public:devtools_inspector_resources",
       "//third_party/blink/public:resources",
+      "//third_party/blink/public/strings:permission_element_generated_strings",
       "//ui/webui/resources",
     ]
     if (defined(invoker.deps)) {
@@ -187,6 +189,7 @@ template("electron_paks") {
       "${root_gen_dir}/extensions/strings/extensions_strings_",
       "${root_gen_dir}/services/strings/services_strings_",
       "${root_gen_dir}/third_party/blink/public/strings/blink_strings_",
+      "${root_gen_dir}/third_party/blink/public/strings/permission_element_strings_",
       "${root_gen_dir}/ui/strings/app_locale_settings_",
       "${root_gen_dir}/ui/strings/auto_image_annotation_strings_",
       "${root_gen_dir}/ui/strings/ax_strings_",
@@ -204,6 +207,7 @@ template("electron_paks") {
       "//extensions/strings",
       "//services/strings",
       "//third_party/blink/public/strings",
+      "//third_party/blink/public/strings:permission_element_strings",
       "//ui/strings:app_locale_settings",
       "//ui/strings:auto_image_annotation_strings",
       "//ui/strings:ax_strings",

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1118,6 +1118,17 @@ describe('chromium features', () => {
     });
   });
 
+  describe('<geolocation> element', () => {
+    afterEach(closeAllWindows);
+
+    it('does not crash the renderer', (done) => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.once('did-finish-load', () => done());
+      w.webContents.once('render-process-gone', () => done(new Error('renderer crashed / was killed')));
+      w.loadURL('data:text/html,<geolocation></geolocation>');
+    });
+  });
+
   describe('File System API,', () => {
     let w: BrowserWindow | null = null;
 


### PR DESCRIPTION
#### Description of Change

Fixes #51204.

The `<geolocation>` HTML element looks up `IDS_PERMISSION_REQUEST_GEOLOCATION` via `ResourceBundle::GetLocalizedString()`. These string IDs are defined in `third_party/blink/public/strings/permission_element_strings.grd`. Electron didn't include those resources in its pak files, causing a `CHECK(!data->empty())` during string lookup.

The crash started happening in the Chrome 145 roll because upstream enabled `GeolocationElement` by default in  https://chromium-review.googlesource.com/c/chromium/src/+/7198303.

This PR adds the per-locale `permission_element_strings` paks and the aggregated `permission_element_generated_strings` pak to `electron_paks.gni`. This matches how Chrome includes them in `chrome/chrome_repack_locales.gni` and `chrome/chrome_paks.gni`.

I also added a regression test.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a renderer crash when a page uses the `<geolocation>` HTML element.