### PR TITLE
chore: fix linter error in `spec/fixtures/crash-cases/content-tracing-before-ready/`

### DIFF
--- a/spec/fixtures/crash-cases/content-tracing-before-ready/index.js
+++ b/spec/fixtures/crash-cases/content-tracing-before-ready/index.js
@@ -2,38 +2,26 @@ const { app, contentTracing } = require('electron');
 const assert = require('node:assert/strict');
 
 (async () => {
-    // Before app is ready, all contentTracing methods should reject
-    // instead of crashing.
-    if (!app.isReady()) {
-        await assert.rejects(
-            () => contentTracing.startRecording({ included_categories: ['*'] }),
-            /before app is ready/
-        );
+  // Before app is ready, all contentTracing methods should reject
+  // instead of crashing.
+  if (!app.isReady()) {
+    await assert.rejects(() => contentTracing.startRecording({ included_categories: ['*'] }), /before app is ready/);
 
-        await assert.rejects(
-            () => contentTracing.stopRecording(),
-            /before app is ready/
-        );
+    await assert.rejects(() => contentTracing.stopRecording(), /before app is ready/);
 
-        await assert.rejects(
-            () => contentTracing.getCategories(),
-            /before app is ready/
-        );
+    await assert.rejects(() => contentTracing.getCategories(), /before app is ready/);
 
-        await assert.rejects(
-            () => contentTracing.getTraceBufferUsage(),
-            /before app is ready/
-        );
-    }
+    await assert.rejects(() => contentTracing.getTraceBufferUsage(), /before app is ready/);
+  }
 
-    await app.whenReady();
+  await app.whenReady();
 
-    // After app is ready, startRecording should work normally.
-    await contentTracing.startRecording({ included_categories: ['*'] });
-    await contentTracing.stopRecording();
+  // After app is ready, startRecording should work normally.
+  await contentTracing.startRecording({ included_categories: ['*'] });
+  await contentTracing.stopRecording();
 })()
-    .then(app.quit)
-    .catch((err) => {
-        console.error(err);
-        app.exit(1);
-    });
+  .then(app.quit)
+  .catch((err) => {
+    console.error(err);
+    app.exit(1);
+  });


### PR DESCRIPTION
#### Description of Change

chore: fix linter error in `spec/fixtures/crash-cases/content-tracing-before-ready/`
    
Introduced earlier today in 6f2e5cd4 https://github.com/electron/electron/pull/50920.

This happened because that branch was created from `main` _before_ #50692 landed.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none