### PR TITLE
fix: Add crash test case during the destructor of the Promise class

### DIFF
--- a/spec/fixtures/crash-cases/promise-destroy-crash/index.js
+++ b/spec/fixtures/crash-cases/promise-destroy-crash/index.js
@@ -1,0 +1,40 @@
+const { app, BrowserWindow, shell } = require('electron');
+
+let win = null;
+
+function createWindow() {
+  win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    show: true,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadURL('data:text/html,<h1>repro</h1>');
+}
+
+async function createPromiseAndQuit() {
+  const url = `unknownscheme-${Date.now()}://test`;
+  const p = shell.openExternal(url, { activate: false });
+
+  setTimeout(() => {
+    app.quit();
+  }, 0);
+
+  p.then(() => {
+    console.log('promise resolved.');
+  }).catch(() => {
+    console.log('promise rejected.');
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  setTimeout(() => {
+    createPromiseAndQuit();
+  }, 500);
+});


### PR DESCRIPTION
During program shutdown, there may be a situation where the isolate is destroyed, but the promise still exists in the task queue. When the task queue is cleared and the promise is destructed, specifically when v8::Global is destroyed, it may cause a pointer exception.

The crash stack trace is as follows:
```
>	electron.exe!v8::internal::GlobalHandles::Destroy(unsigned __int64 * location) 行 664	C++	已加载符号。
 	[内联框架] electron.exe!v8::PersistentBase<v8::Promise::Resolver>::Reset() 行 451	C++	已加载符号。
 	[内联框架] electron.exe!v8::Global<v8::Promise::Resolver>::~Global() 行 383	C++	已加载符号。
 	electron.exe!gin_helper::PromiseBase::~PromiseBase() 行 43	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::__tuple_leaf<0,gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>,0>::~__tuple_leaf() 行 366	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::tuple<gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>::~tuple() 行 578	C++	已加载符号。
 	[内联框架] electron.exe!base::internal::BindState<0,1,0,void (*)(gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>, std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>),gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>::~BindState() 行 1175	C++	已加载符号。
 	electron.exe!base::internal::BindState<0,1,0,void (*)(gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>, std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>),gin_helper::Promise<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>::Destroy(const base::internal::BindStateBase * self=0x0000671400b9cfa0) 行 1188	C++	已加载符号。
 	[内联框架] electron.exe!base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>::~OnceCallback() 行 97	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::__tuple_leaf<0,base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>,0>::~__tuple_leaf() 行 366	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::__tuple_impl<std::__Cr::__integer_sequence<unsigned long long,0,1>,base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>,base::internal::OwnedWrapper<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>,std::__Cr::default_delete<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>>>>::~__tuple_impl() 行 514	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::tuple<base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>,base::internal::OwnedWrapper<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>,std::__Cr::default_delete<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>>>>::~tuple() 行 578	C++	已加载符号。
 	[内联框架] electron.exe!base::internal::BindState<0,1,0,void (*)(base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>, std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>> *),base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>,base::internal::OwnedWrapper<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>,std::__Cr::default_delete<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>>>>::~BindState() 行 1175	C++	已加载符号。
 	electron.exe!base::internal::BindState<0,1,0,void (*)(base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>, std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>> *),base::OnceCallback<void (const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> &)>,base::internal::OwnedWrapper<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>,std::__Cr::default_delete<std::__Cr::unique_ptr<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>,std::__Cr::default_delete<std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>>>>>>>::Destroy(const base::internal::BindStateBase * self=0x00006714008b6b80) 行 1188	C++	已加载符号。
 	[内联框架] electron.exe!base::OnceCallback<void ()>::~OnceCallback() 行 97	C++	已加载符号。
 	electron.exe!base::internal::PostTaskAndReplyRelay::~PostTaskAndReplyRelay() 行 90	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::__tuple_leaf<0,base::internal::PostTaskAndReplyRelay,0>::~__tuple_leaf() 行 366	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::tuple<base::internal::PostTaskAndReplyRelay>::~tuple() 行 578	C++	已加载符号。
 	[内联框架] electron.exe!base::internal::BindState<0,1,0,void (*)(base::internal::PostTaskAndReplyRelay),base::internal::PostTaskAndReplyRelay>::~BindState() 行 1175	C++	已加载符号。
 	electron.exe!base::internal::BindState<0,1,0,void (*)(base::internal::PostTaskAndReplyRelay),base::internal::PostTaskAndReplyRelay>::Destroy(const base::internal::BindStateBase * self=0x0000671400097d20) 行 1188	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::__destroy_at(base::sequence_manager::Task * __loc=0x0000671400649930) 行 67	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::allocator_traits<std::__Cr::allocator<base::sequence_manager::Task>>::destroy(std::__Cr::allocator<base::sequence_manager::Task> &, base::sequence_manager::Task * __p=0x0000671400649930) 行 313	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::deque<base::sequence_manager::Task,std::__Cr::allocator<base::sequence_manager::Task>>::clear() 行 2422	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::deque<base::sequence_manager::Task,std::__Cr::allocator<base::sequence_manager::Task>>::~deque() 行 614	C++	已加载符号。
 	electron.exe!base::sequence_manager::internal::TaskQueueImpl::UnregisterTaskQueue() 行 360	C++	已加载符号。
 	electron.exe!base::sequence_manager::internal::SequenceManagerImpl::UnregisterTaskQueueImpl(std::__Cr::unique_ptr<base::sequence_manager::internal::TaskQueueImpl,std::__Cr::default_delete<base::sequence_manager::internal::TaskQueueImpl>> task_queue={...}) 行 400	C++	已加载符号。
 	electron.exe!base::sequence_manager::TaskQueue::Handle::reset() 行 126	C++	已加载符号。
 	electron.exe!content::BrowserTaskQueues::~BrowserTaskQueues() 行 208	C++	已加载符号。
 	electron.exe!content::BrowserUIThreadScheduler::~BrowserUIThreadScheduler() 行 36	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::default_delete<content::BrowserUIThreadScheduler>::operator()(content::BrowserUIThreadScheduler * __ptr=0x000067100011c380) 行 74	C++	已加载符号。
 	[内联框架] electron.exe!std::__Cr::unique_ptr<content::BrowserUIThreadScheduler,std::__Cr::default_delete<content::BrowserUIThreadScheduler>>::reset(content::BrowserUIThreadScheduler * __p) 行 288	C++	已加载符号。
 	electron.exe!content::BrowserTaskExecutor::Shutdown() 行 231	C++	已加载符号。
 	electron.exe!content::ContentMainRunnerImpl::Shutdown() 行 1354	C++	已加载符号。
 	electron.exe!content::RunContentProcess(content::ContentMainParams params, content::ContentMainRunner * content_main_runner=0x000067100007c340) 行 363	C++	已加载符号。
 	electron.exe!content::ContentMain(content::ContentMainParams params) 行 369	C++	已加载符号。
 	electron.exe!wWinMain(HINSTANCE__ * instance, HINSTANCE__ *, wchar_t * cmd, int) 行 235	C++	已加载符号。
 	[内联框架] electron.exe!invoke_main() 行 118	C++	非用户代码。已加载符号。
 	electron.exe!__scrt_common_main_seh() 行 288	C++	非用户代码。已加载符号。
 	kernel32.dll!00007ffbccdde8d7()	未知	非用户代码。无法查找或打开 PDB 文件。
 	ntdll.dll!00007ffbce6ac48c()	未知	非用户代码。无法查找或打开 PDB 文件。

```

#### Description of Change
Add an isolate destructor watcher; if islate is destroyed, destroy v8::Global early.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
