### PR TITLE
fix: report display_mode to Blink for WCO and frameless windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -158,6 +158,7 @@
 #include "third_party/blink/public/common/tokens/tokens.h"
 #include "third_party/blink/public/mojom/frame/find_in_page.mojom.h"
 #include "third_party/blink/public/mojom/frame/fullscreen.mojom.h"
+#include "third_party/blink/public/mojom/manifest/display_mode.mojom.h"
 #include "third_party/blink/public/mojom/messaging/transferable_message.mojom.h"
 #include "third_party/blink/public/mojom/renderer_preferences.mojom.h"
 #include "ui/base/cursor/cursor.h"
@@ -1841,6 +1842,19 @@ content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
 
   return static_cast<JSDialogManagerHelper*>(
       source->GetUserData(kJavaScriptDialogManagerKey));
+}
+
+blink::mojom::DisplayMode WebContents::GetDisplayMode(
+    const content::WebContents* web_contents) {
+  if (owner_window_) {
+    if (owner_window_->IsFullscreen())
+      return blink::mojom::DisplayMode::kFullscreen;
+    if (owner_window_->IsWindowControlsOverlayEnabled())
+      return blink::mojom::DisplayMode::kWindowControlsOverlay;
+    if (!owner_window_->has_frame())
+      return blink::mojom::DisplayMode::kStandalone;
+  }
+  return blink::mojom::DisplayMode::kBrowser;
 }
 
 void WebContents::OnAudioStateChanged(bool audible) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -597,6 +597,8 @@ class WebContents final : public ExclusiveAccessContext,
       content::MediaResponseCallback callback) override;
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* source) override;
+  blink::mojom::DisplayMode GetDisplayMode(
+      const content::WebContents* web_contents) override;
   void OnAudioStateChanged(bool audible) override;
   void UpdatePreferredSize(content::WebContents* web_contents,
                            const gfx::Size& pref_size) override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3738,6 +3738,71 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('display-mode matchMedia', () => {
+    afterEach(async () => {
+      await closeAllWindows();
+      ipcMain.removeAllListeners('geometrychange');
+    });
+
+    it('matches window-controls-overlay when titleBarOverlay is active', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        titleBarStyle: 'hidden',
+        webPreferences: {
+          nodeIntegration: true,
+          contextIsolation: false
+        },
+        titleBarOverlay: { height: 40 }
+      });
+
+      const overlayHTML = path.join(__dirname, 'fixtures', 'pages', 'overlay.html');
+      if (process.platform === 'darwin') {
+        await w.loadFile(overlayHTML);
+      } else {
+        const overlayReady = once(ipcMain, 'geometrychange');
+        await w.loadFile(overlayHTML);
+        await showWindowForWayland(w);
+        await overlayReady;
+      }
+
+      const matches = await w.webContents.executeJavaScript(
+        "matchMedia('(display-mode: window-controls-overlay)').matches"
+      );
+      expect(matches).to.be.true('matchMedia window-controls-overlay should match when WCO is active');
+    });
+
+    it('matches standalone for a frameless window without titleBarOverlay', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        frame: false
+      });
+      await w.loadURL('about:blank');
+
+      const matches = await w.webContents.executeJavaScript(
+        "matchMedia('(display-mode: standalone)').matches"
+      );
+      expect(matches).to.be.true('matchMedia standalone should match for frameless window');
+    });
+
+    it('matches browser for a default framed window', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      });
+      await w.loadURL('about:blank');
+
+      const matches = await w.webContents.executeJavaScript(
+        "matchMedia('(display-mode: browser)').matches"
+      );
+      expect(matches).to.be.true('matchMedia browser should match for default framed window');
+    });
+  });
+
   ifdescribe(process.platform === 'darwin')('"enableLargerThanScreen" option', () => {
     afterEach(closeAllWindows);
     it('can move the window out of screen', () => {


### PR DESCRIPTION
#### Description of Change

Fixes #51393.

Electron's `WebContents` doesn't override `content::WebContentsDelegate::GetDisplayMode()`. Chromium's default returns `blink::mojom::DisplayMode::kBrowser`, gets baked into `WebPreferences::display_mode`, and shipped to Blink. The `matchMedia` evaluator for `(display-mode: …)` reads from there, so it always evaluates `kBrowser` regardless of how the BrowserWindow was configured. The other three WCO signals (`navigator.windowControlsOverlay.visible`, `getTitlebarAreaRect()`, `env(titlebar-area-*)`) take a separate mojo path and stay correct, so the four signals diverge.

This PR adds the `GetDisplayMode()` override and routes the answer through the same `IsWindowControlsOverlayEnabled()` gate (`native_window.h:390-398`) that already powers the other three signals. Same input, same answer; the four signals agree by construction. Full root-cause analysis is in the linked issue.

No Chromium patches required — the change is contained to Electron's shell (`shell/browser/api/electron_api_web_contents.{h,cc}`).

**What changed.** Two files, ~16 lines:

- `shell/browser/api/electron_api_web_contents.h` — declares the override.
- `shell/browser/api/electron_api_web_contents.cc` — adds the include and the implementation. The branches return `kFullscreen` for fullscreen, `kWindowControlsOverlay` when WCO is enabled, `kStandalone` for frameless windows without titleBarOverlay, and `kBrowser` otherwise. The `kStandalone` branch matches Chromium's PWA semantics so existing `isStandalone()`-style checks (e.g., microsoft/vscode#160696) keep working.

**Test plan.** New `describe('display-mode matchMedia', …)` block in `spec/api-browser-window-spec.ts` (~50 lines):

1. `matchMedia('(display-mode: window-controls-overlay)')` matches when `titleBarOverlay` is active (regression test for the linked issue).
2. `matchMedia('(display-mode: standalone)')` matches for a frameless window without `titleBarOverlay`.
3. `matchMedia('(display-mode: browser)')` matches for a default framed window.

Verified locally on Linux (Nobara 43, KDE Plasma 6) against patched HEAD on both Ozone backends — Wayland (native) and X11 (via `--ozone-platform=x11` / XWayland). The issue's probe table reads `matches: true` on both and all four signals agree. Windows 11 and macOS verification of the fix is deferred to CI.

**Behavior changed.** Strict reading is yes — apps relying on `matchMedia('(display-mode: browser)')` matching while WCO is active would see it return `false` after this lands. That's apps relying on a buggy state, not a real breakage. I don't think this rises to a `docs/breaking-changes.md` entry; happy to add one if you disagree.

**AI disclosure.** Per the Electron governance AI policy: I developed this patch with assistance from Anthropic's Opus 4.7 via Claude Code. I built and ran patched Electron locally on Linux (Wayland and X11/XWayland), verified the four-signal probe table reports `true` across the board on both Ozone backends, reviewed the diff line-by-line, and authored the test cases. I'm responsible for the contents and can answer follow-up questions.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `matchMedia('(display-mode: window-controls-overlay)')` and `matchMedia('(display-mode: standalone)')` to match correctly when WCO or frameless windows are active.
