### PR TITLE
fix: report display_mode to Blink for WCO, frameless, and fullscreen windows

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -194,11 +194,24 @@ void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
 #endif
 }
 
+void BrowserWindow::OnWindowEnterFullScreen() {
+  // display_mode reaches Blink via VisualProperties (not WebPreferences),
+  // so the (display-mode: fullscreen) media query only re-evaluates when
+  // visual properties are synced.
+  if (auto* host = web_contents()->GetPrimaryMainFrame())
+    if (auto* rwh = host->GetRenderWidgetHost())
+      rwh->SynchronizeVisualProperties();
+  BaseWindow::OnWindowEnterFullScreen();
+}
+
 void BrowserWindow::OnWindowLeaveFullScreen() {
 #if BUILDFLAG(IS_MAC)
   if (web_contents()->IsFullscreen())
     web_contents()->ExitFullscreen(true);
 #endif
+  if (auto* host = web_contents()->GetPrimaryMainFrame())
+    if (auto* rwh = host->GetRenderWidgetHost())
+      rwh->SynchronizeVisualProperties();
   BaseWindow::OnWindowLeaveFullScreen();
 }
 

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -59,6 +59,7 @@ class BrowserWindow : public BaseWindow,
   // BaseWindow:
   void OnWindowBlur() override;
   void OnWindowFocus() override;
+  void OnWindowEnterFullScreen() override;
   void OnWindowLeaveFullScreen() override;
   void CloseImmediately() override;
   void Focus() override;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -167,6 +167,7 @@
 #include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
 #include "third_party/blink/public/mojom/frame/find_in_page.mojom.h"
 #include "third_party/blink/public/mojom/frame/fullscreen.mojom.h"
+#include "third_party/blink/public/mojom/manifest/display_mode.mojom.h"
 #include "third_party/blink/public/mojom/messaging/transferable_message.mojom.h"
 #include "third_party/blink/public/mojom/renderer_preferences.mojom.h"
 #include "ui/base/cursor/cursor.h"
@@ -1910,6 +1911,19 @@ content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
 
   return static_cast<JSDialogManagerHelper*>(
       source->GetUserData(kJavaScriptDialogManagerKey));
+}
+
+blink::mojom::DisplayMode WebContents::GetDisplayMode(
+    const content::WebContents* web_contents) {
+  if (owner_window_) {
+    if (owner_window_->IsFullscreen())
+      return blink::mojom::DisplayMode::kFullscreen;
+    if (owner_window_->IsWindowControlsOverlayEnabled())
+      return blink::mojom::DisplayMode::kWindowControlsOverlay;
+    if (!owner_window_->has_frame())
+      return blink::mojom::DisplayMode::kStandalone;
+  }
+  return blink::mojom::DisplayMode::kBrowser;
 }
 
 void WebContents::OnAudioStateChanged(bool audible) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -599,6 +599,8 @@ class WebContents final : public ExclusiveAccessContext,
       content::MediaResponseCallback callback) override;
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* source) override;
+  blink::mojom::DisplayMode GetDisplayMode(
+      const content::WebContents* web_contents) override;
   void OnAudioStateChanged(bool audible) override;
   void UpdatePreferredSize(content::WebContents* web_contents,
                            const gfx::Size& pref_size) override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3828,13 +3828,53 @@ describe('BrowserWindow module', () => {
       });
       await w.loadURL('about:blank');
 
+      // Resolve when the renderer's media query flips to true. Returning a
+      // Promise from executeJavaScript awaits it on the main side, so this
+      // races setFullScreen against the IPC delivering display_mode.
+      const fullscreenMatches = w.webContents.executeJavaScript(`
+        new Promise((resolve) => {
+          const mql = matchMedia('(display-mode: fullscreen)');
+          if (mql.matches) { resolve(true); return; }
+          mql.addEventListener('change', () => resolve(mql.matches), { once: true });
+        })
+      `);
+
       const enterFullScreen = once(w, 'enter-full-screen');
       w.show();
       w.setFullScreen(true);
       await enterFullScreen;
 
-      const matches = await w.webContents.executeJavaScript("matchMedia('(display-mode: fullscreen)').matches");
+      const matches = await fullscreenMatches;
       expect(matches).to.be.true('matchMedia fullscreen should match for fullscreen window');
+    });
+
+    ifit(process.platform !== 'darwin')('reverts display-mode after leaving fullscreen', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      });
+      await w.loadURL('about:blank');
+
+      const enterFullScreen = once(w, 'enter-full-screen');
+      w.show();
+      w.setFullScreen(true);
+      await enterFullScreen;
+
+      const browserMatches = w.webContents.executeJavaScript(`
+        new Promise((resolve) => {
+          const mql = matchMedia('(display-mode: browser)');
+          if (mql.matches) { resolve(true); return; }
+          mql.addEventListener('change', () => resolve(mql.matches), { once: true });
+        })
+      `);
+
+      const leaveFullScreen = once(w, 'leave-full-screen');
+      w.setFullScreen(false);
+      await leaveFullScreen;
+
+      const matches = await browserMatches;
+      expect(matches).to.be.true('matchMedia browser should match after leaving fullscreen');
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3760,6 +3760,84 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('display-mode matchMedia', () => {
+    afterEach(async () => {
+      await closeAllWindows();
+      ipcMain.removeAllListeners('geometrychange');
+    });
+
+    it('matches window-controls-overlay when titleBarOverlay is active', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        titleBarStyle: 'hidden',
+        webPreferences: {
+          nodeIntegration: true,
+          contextIsolation: false
+        },
+        titleBarOverlay: { height: 40 }
+      });
+
+      const overlayHTML = path.join(__dirname, 'fixtures', 'pages', 'overlay.html');
+      if (process.platform === 'darwin') {
+        await w.loadFile(overlayHTML);
+      } else {
+        const overlayReady = once(ipcMain, 'geometrychange');
+        await w.loadFile(overlayHTML);
+        await showWindowForWayland(w);
+        await overlayReady;
+      }
+
+      const matches = await w.webContents.executeJavaScript(
+        "matchMedia('(display-mode: window-controls-overlay)').matches"
+      );
+      expect(matches).to.be.true('matchMedia window-controls-overlay should match when WCO is active');
+    });
+
+    it('matches standalone for a frameless window without titleBarOverlay', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        frame: false
+      });
+      await w.loadURL('about:blank');
+
+      const matches = await w.webContents.executeJavaScript("matchMedia('(display-mode: standalone)').matches");
+      expect(matches).to.be.true('matchMedia standalone should match for frameless window');
+    });
+
+    it('matches browser for a default framed window', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      });
+      await w.loadURL('about:blank');
+
+      const matches = await w.webContents.executeJavaScript("matchMedia('(display-mode: browser)').matches");
+      expect(matches).to.be.true('matchMedia browser should match for default framed window');
+    });
+
+    ifit(process.platform !== 'darwin')('matches fullscreen when the window is fullscreen', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        width: 400,
+        height: 400
+      });
+      await w.loadURL('about:blank');
+
+      const enterFullScreen = once(w, 'enter-full-screen');
+      w.show();
+      w.setFullScreen(true);
+      await enterFullScreen;
+
+      const matches = await w.webContents.executeJavaScript("matchMedia('(display-mode: fullscreen)').matches");
+      expect(matches).to.be.true('matchMedia fullscreen should match for fullscreen window');
+    });
+  });
+
   ifdescribe(process.platform === 'darwin')('"enableLargerThanScreen" option', () => {
     afterEach(closeAllWindows);
     it('can move the window out of screen', () => {


### PR DESCRIPTION
#### Description of Change

Fixes #51393.

Electron's `WebContents` doesn't override `content::WebContentsDelegate::GetDisplayMode()`. Chromium's default returns `blink::mojom::DisplayMode::kBrowser`, gets baked into `WebPreferences::display_mode`, and shipped to Blink. The `matchMedia` evaluator for `(display-mode: …)` reads from there, so it always evaluates `kBrowser` regardless of how the BrowserWindow was configured. The other three WCO signals (`navigator.windowControlsOverlay.visible`, `getTitlebarAreaRect()`, `env(titlebar-area-*)`) take a separate mojo path and stay correct, so the four signals diverge.

This PR adds the `GetDisplayMode()` override and routes the answer through the same `IsWindowControlsOverlayEnabled()` gate (`native_window.h:390-398`) that already powers the other three signals. Same input, same answer; the four signals agree by construction. Full root-cause analysis is in the linked issue.

There's a second-order issue I had to chase down empirically. `display_mode` doesn't reach Blink through `WebPreferences` — it rides the `VisualProperties` channel (`content/browser/renderer_host/render_widget_host_impl.cc:1052`, delivered to Blink at `third_party/blink/renderer/core/frame/web_frame_widget_impl.cc:1813`). So `NotifyPreferencesChanged()` on its own isn't enough to flip `matchMedia` on a fullscreen transition. The natural resize cascade picks it up on X11, but on Wayland the cascade doesn't fire and `matchMedia` stays stale. Calling `SynchronizeVisualProperties()` directly from `BrowserWindow`'s fullscreen handlers makes the answer consistent across both backends.

No Chromium patches required — the change is contained to Electron's shell.

**What changed.** Four files, ~55 lines:

- `shell/browser/api/electron_api_web_contents.{h,cc}` — `GetDisplayMode()` override returning `kFullscreen` / `kWindowControlsOverlay` / `kStandalone` / `kBrowser` based on owner-window state.
- `shell/browser/api/electron_api_browser_window.{h,cc}` — `OnWindowEnterFullScreen` / `OnWindowLeaveFullScreen` overrides that call `SynchronizeVisualProperties()` so the new display mode reaches Blink immediately on native fullscreen transitions.

**Test plan.** New `describe('display-mode matchMedia', …)` block in `spec/api-browser-window-spec.ts` with 5 tests:

1. `(display-mode: window-controls-overlay)` matches when `titleBarOverlay` is active.
2. `(display-mode: standalone)` matches for a frameless window without `titleBarOverlay`.
3. `(display-mode: browser)` matches for a default framed window.
4. `(display-mode: fullscreen)` matches after `setFullScreen(true)`.
5. `(display-mode: browser)` matches again after `setFullScreen(false)`.

Tests 4 and 5 use a Promise-based `matchMedia` change-event waiter to wait on the actual visual-properties round-trip instead of polling. Verified locally on Linux (Nobara 43, KDE Plasma 6 + Hyprland) against patched HEAD on both Ozone backends — 5/5 passing across 3 consecutive runs on Wayland with no flake. Windows and macOS coverage deferred to CI.

**Behavior changed.** Strict reading is yes — apps relying on `matchMedia('(display-mode: browser)')` matching while WCO/frameless/fullscreen is active would see it flip to `false` after this lands. That's apps relying on a buggy state, not a real breakage. I don't think this rises to a `docs/breaking-changes.md` entry; happy to add one if you disagree.

**AI disclosure.** Per the Electron governance AI policy: I developed this patch with assistance from Anthropic's Opus 4.7 via Claude Code. The model helped trace the four-signal divergence and draft the `GetDisplayMode()` override; the empirical step — building a local reproducer, watching `matchMedia` go stale on Wayland but not X11, and tracing it back to the `VisualProperties` channel and `SynchronizeVisualProperties()` cascade — surfaced the second-order bug that the C++ override alone didn't fix. I reviewed every line, authored the test cases, and ran 3× consecutive 5/5 passing runs locally.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `matchMedia('(display-mode: ...)')` returning `browser` for window-controls-overlay, frameless, and fullscreen BrowserWindows.