### PR TITLE
fix: do not pass a `DesktopMediaList* to DesktopCapturer::OnListReady()`

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -240,7 +240,10 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
   ListObserver(DesktopCapturer* capturer,
                DesktopMediaList* list,
                bool need_thumbnails)
-      : capturer_{capturer}, list_{list}, need_thumbnails_{need_thumbnails} {}
+      : capturer_{capturer},
+        list_{list},
+        list_type_{list->GetMediaListType()},
+        need_thumbnails_{need_thumbnails} {}
   ~ListObserver() override = default;
 
   [[nodiscard]] bool IsReady() const {
@@ -267,7 +270,7 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
         base::BindOnce(&DesktopCapturer::OnListReady,
-                       capturer_->weak_ptr_factory_.GetWeakPtr(), list_.get()));
+                       capturer_->weak_ptr_factory_.GetWeakPtr(), list_type_));
   }
 
   // DesktopMediaListObserver:
@@ -294,6 +297,7 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
 
   raw_ptr<DesktopCapturer> capturer_;
   raw_ptr<DesktopMediaList> list_;
+  DesktopMediaList::Type list_type_;
   bool need_thumbnails_ = false;
   bool has_sources_ = false;
   bool notified_ = false;
@@ -410,16 +414,21 @@ void DesktopCapturer::StartHandling(bool capture_window,
                                  weak_ptr_factory_.GetWeakPtr()));
 }
 
-void DesktopCapturer::OnListReady(DesktopMediaList* list) {
+void DesktopCapturer::OnListReady(const DesktopMediaList::Type type) {
   if (finished_)
     return;
 
-  if (list == window_capturer_.get()) {
-    FinalizeList(window_observer_, window_capturer_);
-  } else if (list == screen_capturer_.get()) {
-    FinalizeList(screen_observer_, screen_capturer_);
-  } else {
-    NOTREACHED();
+  switch (type) {
+    case DesktopMediaList::Type::kWindow:
+      if (window_capturer_)
+        FinalizeList(window_observer_, window_capturer_);
+      break;
+    case DesktopMediaList::Type::kScreen:
+      if (screen_capturer_)
+        FinalizeList(screen_observer_, screen_capturer_);
+      break;
+    default:
+      NOTREACHED();
   }
 }
 

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -63,7 +63,7 @@ class DesktopCapturer final
 
   void FinalizeList(std::unique_ptr<ListObserver>& observer,
                     std::unique_ptr<DesktopMediaList>& list);
-  void OnListReady(DesktopMediaList* list);
+  void OnListReady(DesktopMediaList::Type type);
   void OnReadyTimeout();
   void CollectSourcesFrom(DesktopMediaList* list);
   void HandleFailure();


### PR DESCRIPTION
#### Description of Change

Fix another `main`-only desktopCapturer regression.

In `DesktopCapturer::OnListReady(DesktopMediaList* list)`, the list arg was just used as a proxy for the list type, so so just pass the type instead. This solves a lifecycle issue occurring in CI where the callack can outlive the DesktopMediaList.

Sample error log from https://github.com/electron/electron/actions/runs/25070468959/job/73456070492:

```
[48471:0428/193441.269750:FATAL:base/allocator/partition_alloc_support.cc:798] Detected dangling raw_ptr in unretained with id=0x0000013c02e14378:
 Task trace:
 0   Electron Framework  0x000000012283a0ba electron::api::DesktopCapturer::ListObserver::MaybeNotifyReady() + 170
 1   Electron Framework  0x0000000133246dc5 NativeDesktopMediaList::Worker::OnRecurrentCaptureResult(webrtc::DesktopCapturer::Result, std::__Cr::unique_ptr<webrtc::DesktopFrame, std::__Cr::default_delete<webrtc::DesktopFrame>>, long) + 357
 2   Electron Framework  0x000000013328dbcf (anonymous namespace)::ScreenshotManagerCapturer::OnRecurrentCaptureTimer() + 1343
 Stack trace:
 0   Electron Framework  0x000000012ade42f2 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 18
 1   Electron Framework  0x000000012add00e1 base::debug::StackTrace::StackTrace(unsigned long) + 225
 2   Electron Framework  0x000000012ade978a base::allocator::UnretainedDanglingRawPtrDetectedCrash(unsigned long) + 90
 3   Electron Framework  0x000000012ae437f7 base::internal::RawPtrBackupRefImpl<true>::ReportIfDanglingInternal(unsigned long) + 391
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none