### PR TITLE
fix: always emit `executableWillLaunchAtLogin` from `getLoginItemSettings`

### DIFF
--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -84,9 +84,12 @@ struct LoginItemSettings {
   std::wstring name;
 
   // used in browser::getLoginItemSettings
-  bool executable_will_launch_at_login = false;
   std::vector<LaunchItem> launch_items;
 #endif
+
+  // used in browser::getLoginItemSettings; only meaningful on Windows but
+  // always emitted so consumers don't observe `undefined`.
+  bool executable_will_launch_at_login = false;
 
   LoginItemSettings();
   ~LoginItemSettings();

--- a/shell/common/gin_converters/login_item_settings_converter.cc
+++ b/shell/common/gin_converters/login_item_settings_converter.cc
@@ -70,11 +70,13 @@ v8::Local<v8::Value> Converter<electron::LoginItemSettings>::ToV8(
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
 #if BUILDFLAG(IS_WIN)
   dict.Set("launchItems", val.launch_items);
-  dict.Set("executableWillLaunchAtLogin", val.executable_will_launch_at_login);
 #elif BUILDFLAG(IS_MAC)
   if (base::mac::MacOSMajorVersion() >= 13)
     dict.Set("status", val.status);
 #endif
+  // Always emit `executableWillLaunchAtLogin` so callers don't see undefined
+  // on non-Windows platforms; the value is only meaningful on Windows.
+  dict.Set("executableWillLaunchAtLogin", val.executable_will_launch_at_login);
   dict.Set("openAtLogin", val.open_at_login);
   dict.Set("openAsHidden", val.open_as_hidden);
   dict.Set("restoreState", val.restore_state);

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -834,7 +834,8 @@ describe('app module', () => {
           openAsHidden: false,
           restoreState: false,
           wasOpenedAtLogin: false,
-          wasOpenedAsHidden: false
+          wasOpenedAsHidden: false,
+          executableWillLaunchAtLogin: false
         });
       });
 
@@ -872,7 +873,8 @@ describe('app module', () => {
           openAsHidden: false,
           restoreState: false,
           wasOpenedAtLogin: false,
-          wasOpenedAsHidden: false
+          wasOpenedAsHidden: false,
+          executableWillLaunchAtLogin: false
         });
       });
     });


### PR DESCRIPTION
## Description

`Converter<LoginItemSettings>::ToV8` in `shell/common/gin_converters/login_item_settings_converter.cc` only set `executableWillLaunchAtLogin` inside the `#if BUILDFLAG(IS_WIN)` branch. As a result, `app.getLoginItemSettings()` on macOS returned an object where `executableWillLaunchAtLogin` was `undefined` rather than the boolean its documented type implies.

## Fix

- Move the `executable_will_launch_at_login` field out of the Windows-only section of `LoginItemSettings` in `shell/browser/browser.h` so it is defined (default `false`) on every platform.
- Unconditionally emit `executableWillLaunchAtLogin` in the V8 converter.

The value is still only meaningful on Windows (computed by `Browser::GetLoginItemSettings` in `browser_win.cc`); on other platforms it now reliably reads as `false` instead of `undefined`.

## Checklist

- [x] PR description describes what the change does (no need to specify why)
- [x] PR title follows semantic [commit messages](https://conventionalcommits.org/)
- [x] No `semver/major` change

Notes: Fixed `app.getLoginItemSettings()` returning `undefined` for `executableWillLaunchAtLogin` on macOS; the property is now always a boolean.