### PR TITLE
fix: try clearing InspectableWebContents delegate earlier

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1122,15 +1122,18 @@ void WebContents::InitWithWebContents(
 }
 
 WebContents::~WebContents() {
+  // DevTools frontend messages use base::Unretained delegate callbacks.
+  // Clear the delegate before other teardown work can trigger callbacks
+  // into this partially destroyed WebContents.
+  if (inspectable_web_contents_)
+    inspectable_web_contents_->GetView()->SetDelegate(nullptr);
+
   if (web_contents()) {
     auto* permission_manager = static_cast<ElectronPermissionManager*>(
         web_contents()->GetBrowserContext()->GetPermissionControllerDelegate());
     if (permission_manager)
       permission_manager->CancelPendingRequests(web_contents());
   }
-
-  if (inspectable_web_contents_)
-    inspectable_web_contents_->GetView()->SetDelegate(nullptr);
 
   if (owner_window_) {
     owner_window_->RemoveBackgroundThrottlingSource(this);


### PR DESCRIPTION
#### Description of Change

Fix a crash that appears to be a DevTools callback to `DevToolsOpened()` while the WebContents teardown is underway.

This PR re-applies  5bd2938f6af2ef9060772796f02c3ac9c80d5cdb / #49406: the first thing the WebContents destructor does is to clear the IWCV's delegate. That approach was accidentaly weakened by 9f9a5b8 / #50032 which added new code to the beginning of the destructor before clearing the delgate.

Sample crash trace seen today [here](https://github.com/electron/electron/actions/runs/25183582684/job/73838334771):

```
Received signal 11 SEGV_MAPERR 0000000001b8
 0 0x55b70ad996b2 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1048:7]
 1 0x55b70ad81021 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
 2 0x55b70ad9906f base::debug::(anonymous namespace)::StackDumpSignalHandler() [../../base/debug/stack_trace_posix.cc:483:3]
 3 0x7fe851b19520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
 4 0x55b70ac8c60d base::internal::WeakReference::IsValid() [../../base/memory/weak_ptr.cc:74:0]
 5 0x55b7041101e8 electron::api::WebContents::DevToolsOpened() [../../base/memory/weak_ptr.h:238:32]
 6 0x55b7041f5141 electron::InspectableWebContents::LoadCompleted() [../../electron/shell/browser/ui/inspectable_web_contents.cc:632:27]
 7 0x55b704033be3 base::RepeatingCallback<>::Run() [../../base/functional/callback.h:343:12]
 8 0x55b712272d9a (anonymous namespace)::ParseAndHandle<>() [../../chrome/browser/devtools/devtools_embedder_message_dispatcher.cc:320:13]
 9 0x55b712272ec2 base::internal::Invoker<>::Run() [../../base/functional/bind_internal.h:673:12]
10 0x55b712272cf3 base::RepeatingCallback<>::Run() [../../base/functional/callback.h:343:12] 11 0x55b712272c36 DispatcherImpl::Dispatch() [../../chrome/browser/devtools/devtools_embedder_message_dispatcher.cc:389:48] 12 0x55b7041f89c6 electron::InspectableWebContents::HandleMessageFromDevToolsFrontend() [../../electron/shell/browser/ui/inspectable_web_contents.cc:962:33]
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential race condition crash when closing DevTools.