### PR TITLE
fix: set XDG app ID and WM_CLASS based on normalized app name

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -74,6 +74,19 @@ if (option.modules.length > 0) {
   (Module as any)._preloadModules(option.modules);
 }
 
+// See lib/browser/desktop-name.ts
+function defaultDesktopName(name: string | undefined): string {
+  const slug =
+    name &&
+    name
+      .normalize('NFKD')
+      .replace(/\p{M}/gu, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  return slug ? `${slug}.desktop` : `${path.basename(process.execPath)}.desktop`;
+}
+
 async function loadApplicationPackage(packagePath: string) {
   // Add a flag indicating app is started from default app.
   Object.defineProperty(process, 'defaultApp', {
@@ -113,10 +126,7 @@ async function loadApplicationPackage(packagePath: string) {
         app.name = packageJson.name;
       }
 
-      // Set application's desktop name (Linux). These usually match the executable name,
-      // so use it as the default to ensure the app gets the correct icon in the taskbar and application switcher.
-      const desktopName = packageJson.desktopName || `${path.basename(process.execPath)}.desktop`;
-      app.setDesktopName(desktopName);
+      app.setDesktopName(packageJson.desktopName || defaultDesktopName(app.name));
 
       // Set v8 flags, deliberately lazy load so that apps that do not use this
       // feature do not pay the price

--- a/lib/browser/desktop-name.ts
+++ b/lib/browser/desktop-name.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+
+// Derive a default Linux .desktop filename from an app's human-readable name if one is not set
+// by the developer. The name must be compatible with the XDG Desktop Entry specification:
+// https://specifications.freedesktop.org/desktop-entry/latest/file-naming.html. Fall back to
+// the executable name if it is not possible to generate a suitable name.
+//
+// The name is lowercased and hyphenated so it is more likely to match the .desktop file created
+// when the app is packaged, which is important for desktop integration and matching icons on Wayland.
+export function defaultDesktopName(name: string | undefined): string {
+  // NFKD decomposes accented chars into base characters + combining marks.
+  // \p{M} drops the combining marks.
+  const slug =
+    name &&
+    name
+      .normalize('NFKD')
+      .replace(/\p{M}/gu, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  return slug ? `${slug}.desktop` : `${path.basename(process.execPath)}.desktop`;
+}

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -1,4 +1,5 @@
 import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
+import { defaultDesktopName } from '@electron/internal/browser/desktop-name';
 
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
@@ -127,10 +128,7 @@ if (packageJson.productName != null) {
   app.name = `${packageJson.name}`.trim();
 }
 
-// Set application's desktop name (Linux). These usually match the executable name,
-// so use it as the default to ensure the app gets the correct icon in the taskbar and application switcher.
-const desktopName = packageJson.desktopName || `${path.basename(process.execPath)}.desktop`;
-app.setDesktopName(desktopName);
+app.setDesktopName(packageJson.desktopName || defaultDesktopName(app.name));
 
 // Set v8 flags, deliberately lazy load so that apps that do not use this
 // feature do not pay the price

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -296,14 +296,17 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
 
   params.native_widget = new ElectronDesktopNativeWidgetAura{this, widget()};
 #elif BUILDFLAG(IS_LINUX)
-  std::string name = Browser::Get()->GetName();
+  // Set the WM_CLASS and XDG App ID to the same value
+  // for best compatibility with both X11 and Wayland.
+  const auto app_id = platform_util::GetXdgAppId();
+  const std::string name = app_id.value_or(Browser::Get()->GetName());
   // Set WM_WINDOW_ROLE.
   params.wm_role_name = "browser-window";
   // Set WM_CLASS.
   params.wm_class_name = base::ToLowerASCII(name);
   params.wm_class_class = name;
   // Set Wayland application ID.
-  if (auto const app_id = platform_util::GetXdgAppId()) {
+  if (app_id) {
     params.wayland_app_id = *app_id;
   }
 

--- a/spec/desktop-name-spec.ts
+++ b/spec/desktop-name-spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import * as path from 'node:path';
+
+import { defaultDesktopName } from '../lib/browser/desktop-name';
+import { ifdescribe } from './lib/spec-helpers';
+
+ifdescribe(process.platform === 'linux')('defaultDesktopName', () => {
+  it("derives an appropriate .desktop name from the app's human readable name", () => {
+    const fallback = `${path.basename(process.execPath)}.desktop`;
+    const cases: Array<[string | undefined, string]> = [
+      ['Word', 'word.desktop'],
+      ['Two Words', 'two-words.desktop'],
+      ['Three Word Phrase', 'three-word-phrase.desktop'],
+      ['Version 7', 'version-7.desktop'],
+      ['already-hyphenated', 'already-hyphenated.desktop'],
+      ['@org/pkg-name', 'org-pkg-name.desktop'],
+      ['Décor Naïveté', 'decor-naivete.desktop'],
+      ['Mixed  Punct / And!', 'mixed-punct-and.desktop'],
+      ['  -Trim-  ', 'trim.desktop'],
+      ['日本語japanese', 'japanese.desktop'],
+      [undefined, fallback],
+      ['', fallback],
+      ['   ', fallback],
+      ['日本語', fallback],
+      ['!!!', fallback]
+    ];
+    for (const [input, expected] of cases) {
+      expect(defaultDesktopName(input)).to.equal(expected, `input: ${JSON.stringify(input)}`);
+    }
+  });
+});


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Fixes https://github.com/electron/electron/issues/51375.

This PR is an improvement to the logic in https://github.com/electron/electron/pull/49988, which set a default XDG App ID based on the app's executable path if a `desktopName` is not provided by the developer.

The exec name is usually good for compatibility but it has an important edge case: it cannot distinguish apps which do not rename their `electron` binary. This is a common practice for packages on Arch Linux which use "shared" copies of a single version of Electron as dependencies.

My solution is to restore the original logic to base the ID on productName/app.name, but to normalize the value so that it conforms to the FreeDesktop spec and so that it is likely to match the name of the .desktop file which would be created by packaging tools such as Forge/Fiddle. (Unfortunately there is no way to be 100% sure, since this is a packaging concern -- for best results, developers should set `desktopName` in package.json and not rely on a generated default value.) If it is not possible for Electron to derive a suitable name, it falls back to the executable name as in #49988.

In practice, most apps will have the same XDG app ID as in #49988, either because the normalized slug has the same value as the binary name, or because the developer is already setting `desktopName` properly.

String normalization can be messy, so I've added a table test for the kinds of values I've seen in Electron app names, as well as some names that cannot be normalized. The test did to not fit into any of the existing spec files because it is unit testing a non-public API, similar to the `parse-features-string` spec.

Finally, I made a change to set the same value for XDG app ID and WM_CLASS, which is a best practice to support both Wayland and X11. This fully solves https://github.com/electron/electron/issues/48391 and is a pre-req for https://github.com/electron/electron/issues/45866.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Improved the way Electron determines the default XDG App ID and WM_CLASS on Linux for better platform compatibility if `desktopName` is not provided in `package.json`.
