### PR TITLE
fix: remove atspi active state for background apps

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -644,6 +644,11 @@ void NativeWindowViews::Hide() {
   if (is_modal() && NativeWindow::parent())
     static_cast<NativeWindowViews*>(parent())->DecrementChildModals();
 
+#if BUILDFLAG(IS_LINUX)
+  if (widget()->IsActive())
+    widget()->Deactivate();
+#endif
+
   widget()->Hide();
 
   NotifyWindowHide();


### PR DESCRIPTION
#### Description of Change

When an electron app's window is closed and if the app continues to run in the background on Linux the app continues to hold the [atspi active state](https://docs.gtk.org/atspi2/enum.StateType.html#active). Only the window who holds focus can have active state, only one window can have focus. 

As showed in the following image, Firefox which has focus has the active state but 3 electron app running in the background also the active state. 

<img width="1036" height="215" alt="Screenshot_20260329_181902" src="https://github.com/user-attachments/assets/214965c6-77ba-44a7-957a-6e778719477d" />

```c
#include <at-spi-2.0/atspi/atspi.h>
#include <glib-2.0/glib.h>
#include <glib-2.0/gobject/gobject.h>
#include <stdio.h>

int main() {
  atspi_init();
  AtspiAccessible *desktop = atspi_get_desktop(0);
  for (int i = 0; i < atspi_accessible_get_child_count(desktop, NULL); i++) {
    AtspiAccessible *app =
        atspi_accessible_get_child_at_index(desktop, i, NULL);
    for (int j = 0; j < atspi_accessible_get_child_count(app, NULL); j++) {
      AtspiAccessible *win = atspi_accessible_get_child_at_index(app, j, NULL);
      const char *name = atspi_accessible_get_name(win, NULL);
      if (strlen(name) == 0) {
        g_object_unref(win);
        continue;
      }
      printf("%s: ", name);
      AtspiStateSet *state_set = atspi_accessible_get_state_set(win);
      GArray *states = atspi_state_set_get_states(state_set);
      printf("\x1b[32m");
      for (int k = 0; k < states->len; k++) {
        printf("%d, ", states->data[k]);
      }
      printf("\x1b[0m\n");
      g_object_unref(state_set);
      g_object_unref(win);
    }
    g_object_unref(app);
  }
  g_object_unref(desktop);
  return 0;
}
``` 

With the fix electron apps will no longer have the active state when hidden.
<img width="1066" height="235" alt="Screenshot_20260329_182257" src="https://github.com/user-attachments/assets/7847b191-22f4-4eb1-8c72-acc98e885514" />

This bug makes it difficult to figure out which window is active when using atspi alone. On XOrg it's really easy to find the active window but on Wayland it's a pain for different Desktop Environments and Window Managers.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Electron apps will no longer hold an atspi active state when running the background for Linux systems<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->