### PR TITLE
docs: add API documentation for app.setDesktopName

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -705,6 +705,18 @@ Overrides the current application's name.
 > [!NOTE]
 > This function overrides the name used internally by Electron; it does not affect the name that the OS uses.
 
+### `app.setDesktopName(name)` _Linux_
+
+* `name` string - The `.desktop` filename (e.g. `'my-app.desktop'`).
+
+Sets the [`.desktop` filename](https://specifications.freedesktop.org/desktop-entry/latest/file-naming.html) on Linux.
+This should match the name of the installed `.desktop` file for the packaged app. If it does not match, the app may not
+show the correct icon or be able to support desktop integration features such as keyboard shortcuts.
+
+The value is used to determine the default `WM_CLASS` on X11 as well as the XDG application ID on Wayland.
+
+Can also be set using `desktopName` in `package.json`. If no `.desktop` name is provided, Electron will choose a default value which may be inaccurate.
+
 ### `app.getLocale()`
 
 Returns `string` - The current application locale, fetched using Chromium's `l10n_util` library.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -710,12 +710,13 @@ Overrides the current application's name.
 * `name` string - The `.desktop` filename (e.g. `'my-app.desktop'`).
 
 Sets the [`.desktop` filename](https://specifications.freedesktop.org/desktop-entry/latest/file-naming.html) on Linux.
-This should match the name of the installed `.desktop` file for the packaged app. If it does not match, the app may not
-show the correct icon or be able to support desktop integration features such as keyboard shortcuts.
+This should match the base filename of the app's installed `.desktop` file. The `.desktop` suffix is optional.
 
-The value is used to determine the default `WM_CLASS` on X11 as well as the XDG application ID on Wayland.
+This value is used to determine the default XDG application ID on Wayland and `WM_CLASS` on X11. If it is not set,
+Electron will attempt to infer a name, but it may not match the packaged app's actual `.desktop` file. This could result
+in the app showing a generic icon or failing to respond to global keyboard shortcuts.
 
-Can also be set using `desktopName` in `package.json`. If no `.desktop` name is provided, Electron will choose a default value which may be inaccurate.
+This API must be called before the `ready` event. The value can also be set using `desktopName` in `package.json`.
 
 ### `app.getLocale()`
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -124,6 +124,22 @@ describe('app module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'linux')('app.setDesktopName(name)', () => {
+    it('sets the desktop name to the CHROME_DESKTOP environment variable', () => {
+      const original = process.env.CHROME_DESKTOP;
+      defer(() => {
+        if (original === undefined) {
+          delete process.env.CHROME_DESKTOP;
+        } else {
+          process.env.CHROME_DESKTOP = original;
+        }
+      });
+
+      app.setDesktopName('electron-test-set-desktop-name.desktop');
+      expect(process.env.CHROME_DESKTOP).to.equal('electron-test-set-desktop-name.desktop');
+    });
+  });
+
   describe('app.getLocale()', () => {
     it('should not be empty', () => {
       expect(app.getLocale()).to.not.equal('');


### PR DESCRIPTION
#### Description of Change

`app.setDesktopName` is not a new API, but it had no API documentation and therefore no generated types, so it was practically undiscoverable. The same is true for the `desktopName` property in `package.json`, which was only mentioned in passing in documentation about progress bars for Unity.

I've documented the API and property and made the case for why it's important for developers to set this value explicitly, as no matter [how we set the default value](https://github.com/electron/electron/pull/51424), it should not be depended on by apps if they want to provide the best experience on Linux.

Refs https://github.com/electron/electron/issues/51375.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Added documentation for `app.setDesktopName` and the `desktopName` property in `package.json` for Linux.
