### PR TITLE
fix: ensure stable bounds on Windows when toggling setResizable for frameless windows

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -295,8 +295,7 @@ gfx::Size WinFrameView::GetMaximumSize() const {
 }
 
 gfx::Insets WinFrameView::RestoredFrameBorderInsets() const {
-  if (window_->has_frame() || !window_->has_thick_frame() ||
-      !window_->IsResizable())
+  if (window_->has_frame() || !window_->has_thick_frame())
     return {};
 
   const int thickness =

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -124,10 +124,11 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       // monitors with different DPIs before changing this code.
       *insets = gfx::Insets::TLBR(thickness, thickness, thickness, thickness);
       return true;
-    } else if (native_window_view_->has_thick_frame() &&
-               native_window_view_->IsResizable()) {
+    } else if (native_window_view_->has_thick_frame()) {
       // Grow the insets to support resize targets past the frame edge like in
-      // windows with standard frames.
+      // windows with standard frames. Non-resizable windows still get input
+      // insets for stable bounds and so they can be dragged from outer edges,
+      // also like in windows with standard frames.
       *insets = gfx::Insets::TLBR(0, thickness, thickness, thickness);
       return true;
     }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -5564,6 +5564,20 @@ describe('BrowserWindow module', () => {
         expectBoundsEqual(w.getContentSize(), [10, 10]);
       });
 
+      it('does not change window size when disabled and enabled for frameless window', () => {
+        const w = new BrowserWindow({
+          show: false,
+          width: 400,
+          height: 300,
+          frame: false
+        });
+
+        w.setResizable(false);
+        expectBoundsEqual(w.getSize(), [400, 300]);
+        w.setResizable(true);
+        expectBoundsEqual(w.getSize(), [400, 300]);
+      });
+
       ifit(process.platform === 'win32')('do not change window with frame bounds when maximized', () => {
         const w = new BrowserWindow({
           show: true,


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/51252 to 41-x-y.

See that PR for details.

Notes: Fixed a regression on Windows where frameless windows changed their size after calling `setResizable`.