### PR TITLE
fix: align process.exit() behavior in main process with Node.js

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -72,8 +72,17 @@ if (process.platform === 'win32') {
   }
 }
 
-// Map process.exit to app.exit, which quits gracefully.
-process.exit = app.exit as () => never;
+// Map process.exit to app.exit, which quits gracefully. When called without
+// an explicit code, fall back to process.exitCode like Node.js does.
+process.exit = ((code: number | string | undefined | null) => {
+  // Refs https://github.com/nodejs/node/blob/fc192ee030ee076b948ce7d9d72cba6c101989b8/lib/internal/process/per_thread.js#L229-L252
+  if (code !== undefined) {
+    // Node.js handles any string to number conversion here for us
+    process.exitCode = code;
+  }
+
+  app.exit(process.exitCode || 0);
+}) as typeof process.exit;
 
 // Load the RPC server.
 require('@electron/internal/browser/rpc-server');

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -17,7 +17,14 @@ import {
   spawn
 } from './lib/codesign-helpers';
 import { withTempDirectory } from './lib/fs-helpers';
-import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
+import {
+  getRemoteContext,
+  ifdescribe,
+  ifit,
+  itremote,
+  startRemoteControlApp,
+  useRemoteContext
+} from './lib/spec-helpers';
 
 const mainFixturesPath = path.resolve(__dirname, 'fixtures');
 
@@ -586,8 +593,114 @@ describe('node feature', () => {
     });
   });
 
+  describe('process.exit', () => {
+    it('exits with exit code zero when called without an argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        setImmediate(() => process.exit());
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(0);
+    });
+
+    it('uses process.exitCode when called without an argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        process.exitCode = 42;
+        setImmediate(() => process.exit());
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(42);
+    });
+
+    it('overrides process.exitCode when called with an argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        process.exitCode = 42;
+        setImmediate(() => process.exit(11));
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(11);
+    });
+
+    it('can be called with a null argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        setImmediate(() => process.exit(null));
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(0);
+    });
+
+    it('can be called with a number argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        setImmediate(() => process.exit(7));
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(7);
+    });
+
+    it('throws with an invalid number argument', async () => {
+      const rc = await startRemoteControlApp();
+      let stdout = '';
+      rc.process.stdout!.on('data', (d) => {
+        stdout += d.toString();
+      });
+      rc.remotely(() => {
+        setImmediate(() => {
+          try {
+            process.exit(4.2);
+          } catch (err) {
+            console.log(err);
+            process.exit(99);
+          }
+        });
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(99);
+      expect(stdout).to.match(
+        /RangeError \[ERR_OUT_OF_RANGE\]: The value of "code" is out of range. It must be an integer./
+      );
+    });
+
+    it('can be called with a string argument', async () => {
+      const rc = await startRemoteControlApp();
+      rc.remotely(() => {
+        setImmediate(() => process.exit('12'));
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(12);
+    });
+
+    it('throws with an invalid string argument', async () => {
+      const rc = await startRemoteControlApp();
+      let stdout = '';
+      rc.process.stdout!.on('data', (d) => {
+        stdout += d.toString();
+      });
+      rc.remotely(() => {
+        setImmediate(() => {
+          try {
+            process.exit('invalid');
+          } catch (err) {
+            console.log(err);
+            process.exit(99);
+          }
+        });
+      }).catch(() => {});
+      const [code] = await once(rc.process, 'exit');
+      expect(code).to.equal(99);
+      expect(stdout).to.match(/TypeError \[ERR_INVALID_ARG_TYPE\]/);
+    });
+  });
+
   describe('process.stdout', () => {
     useRemoteContext();
+
+    it('is a real Node stream', () => {
+      expect((process.stdout as any)._type).to.not.be.undefined();
+    });
 
     itremote('does not throw an exception when accessed', () => {
       expect(() => process.stdout).to.not.throw();
@@ -920,12 +1033,6 @@ describe('node feature', () => {
 
       child.stderr.on('data', listener);
       child.stdout.on('data', listener);
-    });
-  });
-
-  describe('process.stdout', () => {
-    it('is a real Node stream', () => {
-      expect((process.stdout as any)._type).to.not.be.undefined();
     });
   });
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Fixes #27893

The `process.exit` implementation in the main process is not aligned with upstream behavior from Node.js, most notably around `process.exit()` not using `process.exitCode`, and also around taking values as strings.

Adds test coverage for these and a few other test cases. Ideally we'd run Node.js' upstream tests for `process.exit` to ensure alignment, but ran into a few issues with those tests, so I'll pursue that later.

There's a minor unrelated change where I noticed there were two different `describe` blocks in the tests for `process.stdout` so I consolidated them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:
* Fixed an issue with the main process where `process.exit()` with no argument did not exit with `process.exitCode`
* Fixed handling of string value arguments to `process.exit()` in the main process
