### PR TITLE
fix: prevent borders and smearing in transparent frameless/client fra…

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -239,7 +239,9 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     if (ui::OzonePlatform::GetInstance()->IsWindowCompositingSupported()) {
       // Set the opaque region.
       std::vector<gfx::Rect> opaque_region;
-      if (IsShowingFrame(window_state)) {
+      if (native_window_view_->IsTranslucent()) {
+        // Leave opaque_region empty.
+      } else if (IsShowingFrame(window_state)) {
         // The opaque region is a list of rectangles that contain only fully
         // opaque pixels of the window.  We need to convert the clipping
         // rounded-rect into this format.

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -203,6 +203,12 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   if (frame()->IsFullscreen())
     return;
 
+  if (window()->IsWindowControlsOverlayEnabled())
+    UpdateFrameCaptionButtons();
+
+  if (window()->IsTranslucent())
+    return;
+
   const bool active = ShouldPaintAsActive();
   const gfx::Insets border = FrameBorderInsets(false);
   const bool showing_shadow = linux_frame_layout_->IsShowingShadow();
@@ -228,11 +234,6 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   ::PaintRestoredFrameBorderLinux(*canvas, *this, frame_background_.get(), clip,
                                   showing_shadow, active, border, shadow_values,
                                   linux_frame_layout_->tiled());
-
-  if (!window()->IsWindowControlsOverlayEnabled())
-    return;
-
-  UpdateFrameCaptionButtons();
 }
 
 void OpaqueFrameView::PaintAsActiveChanged() {


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/50541 to 42-x-y.

See that PR for details.

Notes: Fixed a regression on Linux where transparent frameless windows would have visible borders. Also fixed a longstanding issue where transparent windows on Linux could show smeared and glitched content as windows moved around.