### PR TITLE
fix: don't let tests hang for an hour

### DIFF
--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -2,35 +2,22 @@ import { BrowserWindow } from 'electron';
 
 import { expect } from 'chai';
 
-import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { stripVTControlCharacters } from 'node:util';
+
+import { spawnAndWait } from './lib/spec-helpers';
+
+const fixtureTimeout = 20000;
+const fixtureKillTimeout = 5000;
 
 const runFixture = async (appPath: string, args: string[] = []) => {
-  const result = cp.spawn(process.execPath, [appPath, ...args], {
-    stdio: 'pipe'
+  return await spawnAndWait(process.execPath, [appPath, ...args], {
+    timeout: fixtureTimeout,
+    killTimeout: fixtureKillTimeout,
+    stripOutput: true
   });
-
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  result.stdout.on('data', (chunk) => stdout.push(chunk));
-  result.stderr.on('data', (chunk) => stderr.push(chunk));
-
-  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
-    result.on('close', (code, signal) => {
-      resolve([code, signal]);
-    });
-  });
-
-  return {
-    code,
-    signal,
-    stdout: stripVTControlCharacters(Buffer.concat(stdout).toString().trim()),
-    stderr: stripVTControlCharacters(Buffer.concat(stderr).toString().trim())
-  };
 };
 
 const fixturePath = path.resolve(__dirname, 'fixtures', 'esm');

--- a/spec/lib/spec-helpers.ts
+++ b/spec/lib/spec-helpers.ts
@@ -11,6 +11,7 @@ import * as net from 'node:net';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
 import * as v8 from 'node:v8';
 
 const addOnly = <T>(fn: Function): T => {
@@ -107,6 +108,77 @@ export async function startRemoteControlApp(extraArgs: string[] = [], options?: 
     appProcess.kill('SIGINT');
   });
   return new RemoteControlApp(appProcess, port);
+}
+
+export interface SpawnAndWaitResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SpawnAndWaitOptions extends childProcess.SpawnOptionsWithoutStdio {
+  timeout: number;
+  killTimeout?: number;
+  stripOutput?: boolean;
+}
+
+function formatSpawnOutput(stdout: Buffer[], stderr: Buffer[], stripOutput = false) {
+  const normalize = (chunks: Buffer[]) => {
+    const output = Buffer.concat(chunks).toString().trim();
+    return stripOutput ? stripVTControlCharacters(output) : output;
+  };
+
+  return {
+    stdout: normalize(stdout),
+    stderr: normalize(stderr)
+  };
+}
+
+export async function spawnAndWait(
+  command: string,
+  args: string[],
+  options: SpawnAndWaitOptions
+): Promise<SpawnAndWaitResult> {
+  const { timeout, killTimeout = 5000, stripOutput, ...spawnOptions } = options;
+  const child = childProcess.spawn(command, args, spawnOptions);
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on('data', (chunk) => stdout.push(chunk));
+  child.stderr.on('data', (chunk) => stderr.push(chunk));
+
+  let timedOut = false;
+  let killTimeoutId: NodeJS.Timeout | undefined;
+  const timeoutId = globalThis.setTimeout(() => {
+    timedOut = true;
+    child.kill();
+    killTimeoutId = globalThis.setTimeout(() => {
+      child.kill('SIGKILL');
+    }, killTimeout);
+  }, timeout);
+
+  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      resolve([code, signal]);
+    });
+  }).finally(() => {
+    globalThis.clearTimeout(timeoutId);
+    if (killTimeoutId) globalThis.clearTimeout(killTimeoutId);
+  });
+
+  const output = formatSpawnOutput(stdout, stderr, stripOutput);
+  if (timedOut) {
+    throw new Error(
+      `Timed out after ${timeout}ms waiting for ${command} ${args.join(' ')} to exit. Process closed with code ${code} and signal ${signal}.\n\nstdout:\n${output.stdout}\n\nstderr:\n${output.stderr}`
+    );
+  }
+
+  return {
+    code,
+    signal,
+    ...output
+  };
 }
 
 export function waitUntil(callback: () => boolean | Promise<boolean>, opts: { rate?: number; timeout?: number } = {}) {


### PR DESCRIPTION
#### Description of Change

Fix two spec runner bugs that could cause tests to hang forever.

1. Add a `spawnAndWait()` spec helper that ensures that spawned processes are cleaned up. When a caller-provided timeout is reached, the helper terminates the child process and escalates to `SIGKILL` if the process doesn't exit cleanly.
 
2. In the "rerun failed tests" phase of `script/spec-runner.js`, enforce a timeout based on MOCHA_TIMEOUT.

Sample error CI log from [here](https://github.com/electron/electron/actions/runs/25190449135/job/73936505057?pr=51420):

```
Rerunning failed test: esm renderer process nodeIntegration without context isolation should use import.meta callback handling from Node.js for Node.js modules (esm-spec.ts)
========================================
Running: /Users/runner/work/electron/electron/src/out/Default/Electron.app/Contents/MacOS/Electron electron/spec --enableRerun=3 --trace-uncaught true --enable-logging true --files /Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts -g esm renderer process nodeIntegration without context isolation should use import\.meta callback handling from Node\.js for Node\.js modules
2071

Error: The action 'Run Electron Tests' has timed out after 60 minutes.
```

Complements https://github.com/electron/electron/pull/51441. This PR is "try to fix the runner to not hang on a failed test", 514441 is "try to fix the test."

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.