### PR TITLE
feat: add Linux startup notification APIs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1337,6 +1337,69 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 Returns `boolean` - Whether the current desktop environment is Unity launcher.
 
+### `app.setAutoStartupNotification(enabled)` _Linux_
+
+* `enabled` boolean
+
+Controls whether Electron automatically notifies the desktop environment
+that the application has finished starting when the `ready` event fires.
+
+On Linux, desktop environments show a "starting" indicator (e.g., a busy
+cursor) when an application launches. By default, Electron clears this
+indicator at `app.ready()`. Set to `false` if your app has a custom loading
+sequence (e.g., a splash screen or auto-updater) and you want to control
+when the notification is sent using `app.notifyStartupComplete()`.
+
+This method can only be called before the `ready` event.
+
+> [!NOTE]
+> On Wayland, `gdk_notify_startup_complete()` may be a no-op. This API
+> primarily affects X11 desktop environments.
+
+```js
+const { app } = require('electron')
+
+// Disable auto-notification for a splash screen workflow
+app.setAutoStartupNotification(false)
+
+app.whenReady().then(() => {
+  showSplashScreen()
+
+  downloadUpdates().then(() => {
+    showMainWindow()
+    // Notify the desktop environment now that the app is truly ready
+    app.notifyStartupComplete()
+  })
+})
+```
+
+### `app.notifyStartupComplete()` _Linux_
+
+Manually notifies the desktop environment that the application has
+finished starting. This clears the startup notification indicator
+(busy cursor) shown by the window manager.
+
+Use this when you have disabled automatic notification with
+`app.setAutoStartupNotification(false)` and want to signal startup
+completion at a specific point in your app's lifecycle.
+
+It is safe to call this method multiple times.
+
+```js
+const { app } = require('electron')
+
+app.setAutoStartupNotification(false)
+
+app.whenReady().then(async () => {
+  await initializeDatabase()
+  await loadUserPreferences()
+  createTrayIcon()
+
+  // Signal that the app has finished starting
+  app.notifyStartupComplete()
+})
+```
+
 ### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
 * `options` Object (optional)

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -105,6 +105,8 @@
 #endif
 
 #if BUILDFLAG(IS_LINUX)
+#include <gdk/gdk.h>
+#include <gtk/gtk.h>
 #include "base/nix/scoped_xdg_activation_token_injector.h"
 #include "base/nix/xdg_util.h"
 #endif
@@ -557,6 +559,14 @@ App::App() {
       ->set_delegate(this);
   Browser::Get()->AddObserver(this);
 
+#if BUILDFLAG(IS_LINUX)
+  // Disable GTK's built-in auto startup notification so Electron controls
+  // when the desktop environment is notified that the app has finished
+  // starting. Without this, GTK independently calls
+  // gdk_notify_startup_complete() on the first window.show().
+  gtk_window_set_auto_startup_notification(FALSE);
+#endif
+
   auto unsafe_pid = content::ChildProcessId::FromUnsafeValue(
       content::ChildProcessHost::kInvalidUniqueID);
   auto process_metric = std::make_unique<electron::ProcessMetric>(
@@ -621,6 +631,13 @@ void App::OnFinishLaunching(base::DictValue launch_info) {
   // Set the application name for audio streams shown in external
   // applications. Only affects pulseaudio currently.
   media::AudioManager::SetGlobalAppName(Browser::Get()->GetName());
+
+  // If auto startup notification is enabled (default), notify the desktop
+  // environment that the application has finished launching. This clears
+  // the busy cursor shown by the window manager during startup.
+  if (auto_startup_notification_) {
+    gdk_notify_startup_complete();
+  }
 #endif
   Emit("ready", base::Value(std::move(launch_info)));
 }
@@ -1177,6 +1194,23 @@ void App::DisableDomainBlockingFor3DAPIs(gin_helper::ErrorThrower thrower) {
     disable_domain_blocking_for_3DAPIs_ = true;
   }
 }
+
+#if BUILDFLAG(IS_LINUX)
+void App::SetAutoStartupNotification(gin_helper::ErrorThrower thrower,
+                                     bool enabled) {
+  if (Browser::Get()->is_ready()) {
+    thrower.ThrowError(
+        "app.setAutoStartupNotification() can only be called "
+        "before app is ready");
+    return;
+  }
+  auto_startup_notification_ = enabled;
+}
+
+void App::NotifyStartupComplete() {
+  gdk_notify_startup_complete();
+}
+#endif
 
 bool App::IsAccessibilitySupportEnabled() {
   auto* ax_state = content::BrowserAccessibilityState::GetInstance();
@@ -1919,6 +1953,10 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #if BUILDFLAG(IS_LINUX)
       .SetMethod("isUnityRunning",
                  base::BindRepeating(&Browser::IsUnityRunning, browser))
+      .SetMethod("setAutoStartupNotification",
+                 &App::SetAutoStartupNotification)
+      .SetMethod("notifyStartupComplete",
+                 &App::NotifyStartupComplete)
 #endif
       .SetProperty("isPackaged", &App::IsPackaged)
       .SetMethod("setAppPath", &App::SetAppPath)

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -214,6 +214,11 @@ class App final : public gin::Wrappable<App>,
   bool Relaunch(gin::Arguments* args);
   void DisableHardwareAcceleration(gin_helper::ErrorThrower thrower);
   bool IsHardwareAccelerationEnabled();
+#if BUILDFLAG(IS_LINUX)
+  void SetAutoStartupNotification(gin_helper::ErrorThrower thrower,
+                                  bool enabled);
+  void NotifyStartupComplete();
+#endif
   void DisableDomainBlockingFor3DAPIs(gin_helper::ErrorThrower thrower);
   bool IsAccessibilitySupportEnabled();
   v8::Local<v8::Value> GetAccessibilitySupportFeatures();
@@ -292,6 +297,9 @@ class App final : public gin::Wrappable<App>,
   bool disable_hw_acceleration_ = false;
   bool disable_domain_blocking_for_3DAPIs_ = false;
   bool watch_singleton_socket_on_ready_ = false;
+#if BUILDFLAG(IS_LINUX)
+  bool auto_startup_notification_ = true;
+#endif
 
   std::unique_ptr<content::ScopedAccessibilityMode> scoped_accessibility_mode_;
 };

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -687,6 +687,28 @@ describe('app module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'linux')('startup notification', () => {
+    it('app.setAutoStartupNotification is a function', () => {
+      expect(app.setAutoStartupNotification).to.be.a('function');
+    });
+
+    it('app.notifyStartupComplete is a function', () => {
+      expect(app.notifyStartupComplete).to.be.a('function');
+    });
+
+    it('app.setAutoStartupNotification throws after app is ready', () => {
+      expect(() => {
+        app.setAutoStartupNotification(false);
+      }).to.throw(/before app is ready/);
+    });
+
+    it('app.notifyStartupComplete does not throw', () => {
+      expect(() => {
+        app.notifyStartupComplete();
+      }).to.not.throw();
+    });
+  });
+
   ifdescribe(
     process.platform !== 'linux' && !process.mas && (process.platform !== 'darwin' || process.arch === 'arm64')
   )('app.get/setLoginItemSettings API', function () {


### PR DESCRIPTION
#### Description of Change

Adds two new Linux-only APIs to give developers explicit control over desktop startup notification timing:

- **`app.setAutoStartupNotification(enabled)`** - Controls whether Electron automatically notifies the desktop environment that the app has finished starting when `app.ready()` fires. Must be called before `app.ready()`. Defaults to `true`.
- **`app.notifyStartupComplete()`** - Manually sends the startup notification to the desktop environment. Safe to call multiple times.

**Background:**

On Linux, desktop environments show a "starting" indicator (e.g., a busy cursor) when an application launches. GTK automatically clears this on the first `window.show()`, but headless and tray-only apps never trigger it, leaving the indicator stuck for up to ~30 seconds (the desktop's startup notification timeout).

This PR disables GTK's built-in auto startup notification (`gtk_window_set_auto_startup_notification(FALSE)`) and gives Electron full control:

- **Default behavior:** Electron calls `gdk_notify_startup_complete()` at `app.ready()`, clearing the indicator for all apps including headless/tray-only ones.
- **Custom behavior:** Apps with splash screens or auto-updaters can call `app.setAutoStartupNotification(false)` before ready, then manually call `app.notifyStartupComplete()` when truly ready.

> **Note:** On Wayland, `gdk_notify_startup_complete()` may be a no-op. These APIs primarily affect X11 desktop environments.

Split out from #51312 as [suggested by @mitchchn](https://github.com/electron/electron/pull/51312) for separate API review. API design based on feedback from @deepak1556 in the same PR.

**Changes:**

| File | Change |
|---|---|
| `shell/browser/api/electron_api_app.h` | Method declarations + `auto_startup_notification_` member |
| `shell/browser/api/electron_api_app.cc` | Implementation: GTK disable in constructor, auto-notify at ready, method bodies, JS bindings |
| `docs/api/app.md` | API documentation with code examples |
| `spec/api-app-spec.ts` | 4 Linux-specific tests |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `app.setAutoStartupNotification(enabled)` and `app.notifyStartupComplete()` APIs on Linux to give developers control over desktop startup notification timing.
