### PR TITLE
build: create a symlink to src/buildtools during sync

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -54,7 +54,6 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"out\": \"Testing\"
             },
             \"env\": {
-                \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1b7bd25dae4a780bb3170fff56c9327b53aaf7eb
+      export BUILD_TOOLS_SHA=8143a3d225e9f24048bd916b3b334bb757d29194
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -57,9 +57,6 @@ jobs:
         @Subdir src/buildtools/linux64
         gn/gn/linux-amd64 $gn_version
         CIPD
-
-        buildtools_path="$(pwd)/src/buildtools"
-        echo "CHROMIUM_BUILDTOOLS_PATH=$buildtools_path" >> $GITHUB_ENV
     - name: Download clang-format Binary
       shell: bash
       run: |
@@ -80,11 +77,10 @@ jobs:
     - name: Run Lint
       shell: bash
       run: |
-        # gn.py tries to find a gclient root folder starting from the current dir.
-        # When it fails and returns "None" path, the whole script fails. Let's "fix" it.
-        touch .gclient
-        # Another option would be to checkout "buildtools" inside the Electron checkout,
-        # but then we would lint its contents (at least gn format), and it doesn't pass it.
+        # Clean things up so `depot_tools/gclient_paths.py` finds src/buildtools properly
+        echo '' > .gclient
+        rm -f .gclient_entries
+        ln -s src/buildtools buildtools
 
         cd src/electron
         node script/yarn.js install --immutable

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -189,8 +189,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Free up space (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -141,10 +141,10 @@ jobs:
           export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
         fi
 
-        e build --only-gen
+        e build --gen=only
 
         # Copy macOS framework headers so clang-tidy can find them via -F.
-        # This must happen after e build --only-gen since e init -f may
+        # This must happen after e build since e init -f may
         # recreate the output directory.
         if [ "${{ inputs.target-platform }}" = "macos" ]; then
           OUT=src/out/${ELECTRON_OUT_DIR}

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -111,8 +111,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Checkout Electron
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -112,8 +112,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Checkout Electron
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
@@ -128,6 +126,11 @@ jobs:
         git pack-refs
     - name: Run GN Check for ${{ inputs.target-archs }}
       run: |
+        # `depot_tools/gclient_paths.py` tries to find a gclient root folder starting from the current dir.
+        # We also need to set up a symlink to src/buildtools so that `build-tools` can find it properly.
+        touch .gclient
+        ln -s src/buildtools buildtools
+
         for target_cpu in ${{ inputs.target-archs }}
         do
           e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu $target_cpu --remote-build none

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -147,7 +147,7 @@ jobs:
             export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
           fi
 
-          e build --only-gen
+          e build --gen=only
 
           e d gn check out/Default //electron:electron_lib
           e d gn check out/Default //electron:electron_app

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -202,8 +202,6 @@ jobs:
           src/electron/script/generate-deps-hash.js
 
           echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-      - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-        run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos

--- a/DEPS
+++ b/DEPS
@@ -156,6 +156,15 @@ hooks = [
     ],
   },
   {
+    'name': 'buildtools_symlink',
+    'condition': 'checkout_chromium and process_deps',
+    'pattern': 'src/electron',
+    'action': [
+      'python3',
+      'src/electron/script/create-buildtools-symlink.py',
+    ],
+  },
+  {
     'name': 'sysroot_arm',
     'pattern': '.',
     'condition': 'install_sysroot and checkout_linux and checkout_arm',

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -173,27 +173,6 @@ $ gclient sync -f
 
 ### Building
 
-**Set the environment variable for chromium build tools**
-
-On Linux & MacOS
-
-```sh
-$ cd src
-$ export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
-```
-
-On Windows:
-
-```sh
-# cmd
-$ cd src
-$ set CHROMIUM_BUILDTOOLS_PATH=%cd%\buildtools
-
-# PowerShell
-$ cd src
-$ $env:CHROMIUM_BUILDTOOLS_PATH = "$(Get-Location)\buildtools"
-```
-
 **To generate Testing build config of Electron:**
 
 On Linux & MacOS

--- a/script/create-buildtools-symlink.py
+++ b/script/create-buildtools-symlink.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Create a buildtools symlink in the gclient root directory.
+
+This enables gclient_paths.py to locate buildtools without needing the
+CHROMIUM_BUILDTOOLS_PATH environment variable.
+"""
+
+import os
+import sys
+
+
+def main():
+  electron_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+  src_dir = os.path.dirname(electron_dir)
+  gclient_root = os.path.dirname(src_dir)
+
+  source = os.path.join(src_dir, 'buildtools')
+  link_name = os.path.join(gclient_root, 'buildtools')
+
+  if not os.path.isdir(source):
+    print(f'buildtools not found at {source}', file=sys.stderr)
+    return 1
+
+  # Already a symlink - verify it points to the right place.
+  if os.path.islink(link_name):
+    if os.path.realpath(link_name) == os.path.realpath(source):
+      return 0
+    os.remove(link_name)
+  elif os.path.exists(link_name):
+    # A real file or directory we shouldn't clobber.
+    print(f'{link_name} already exists and is not a symlink',
+          file=sys.stderr)
+    return 1
+
+  rel = os.path.relpath(source, gclient_root)
+  try:
+    os.symlink(rel, link_name, target_is_directory=True)
+  except OSError as e:
+    print(f'Failed to create symlink {link_name} -> {rel}: {e}',
+          file=sys.stderr)
+    if sys.platform == 'win32':
+      print('On Windows, creating symlinks requires Developer Mode '
+            'or administrator privileges.', file=sys.stderr)
+    return 1
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -7,13 +7,10 @@ $ node ./script/gn-check.js [--outDir=dirName]
 const minimist = require('minimist');
 
 const cp = require('node:child_process');
-const path = require('node:path');
 
 const args = minimist(process.argv.slice(2), { string: ['outDir'] });
 
 const { getDepotToolsEnv, getOutDir } = require('./lib/utils');
-
-const SOURCE_ROOT = path.normalize(path.dirname(__dirname));
 
 const OUT_DIR = getOutDir({ outDir: args.outDir });
 if (!OUT_DIR) {
@@ -22,7 +19,6 @@ if (!OUT_DIR) {
 
 const env = {
   ...getDepotToolsEnv(),
-  CHROMIUM_BUILDTOOLS_PATH: path.resolve(SOURCE_ROOT, '..', 'buildtools'),
   DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
 };
 

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -233,9 +233,4 @@ def get_depot_tools_env():
   if depot_tools_env is None:
     raise RuntimeError("Couldn't find depot_tools, ensure it's on your PATH")
 
-  if 'CHROMIUM_BUILDTOOLS_PATH' not in depot_tools_env:
-    raise RuntimeError(
-      'CHROMIUM_BUILDTOOLS_PATH environment variable must be set'
-    )
-
   return depot_tools_env

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -194,10 +194,6 @@ function getDepotToolsEnv() {
     throw new Error("Couldn't find depot_tools, ensure it's on your PATH");
   }
 
-  if (!('CHROMIUM_BUILDTOOLS_PATH' in depotToolsEnv)) {
-    throw new Error('CHROMIUM_BUILDTOOLS_PATH environment variable must be set');
-  }
-
   return depotToolsEnv;
 }
 

--- a/script/lint.js
+++ b/script/lint.js
@@ -116,13 +116,11 @@ const LINTERS = [
     roots: ['shell'],
     test: (filename) => filename.endsWith('.cc') || (filename.endsWith('.h') && !isObjCHeader(filename)),
     run: (opts, filenames) => {
-      const env = {
-        ...getDepotToolsEnv(),
-        CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools')
-      };
       const clangFormatFlags = opts.fix ? ['--fix'] : [];
       for (const chunk of chunkFilenames(filenames)) {
-        spawnAndCheckExitCode('python3', ['script/run-clang-format.py', ...clangFormatFlags, ...chunk], { env });
+        spawnAndCheckExitCode('python3', ['script/run-clang-format.py', ...clangFormatFlags, ...chunk], {
+          env: getDepotToolsEnv()
+        });
         cpplint([`--filter=${CPPLINT_FILTERS.join(',')}`, ...chunk]);
       }
     }
@@ -132,13 +130,9 @@ const LINTERS = [
     roots: ['shell'],
     test: (filename) => filename.endsWith('.mm') || (filename.endsWith('.h') && isObjCHeader(filename)),
     run: (opts, filenames) => {
-      const env = {
-        ...getDepotToolsEnv(),
-        CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools')
-      };
       const clangFormatFlags = opts.fix ? ['--fix'] : [];
       spawnAndCheckExitCode('python3', ['script/run-clang-format.py', '-r', ...clangFormatFlags, ...filenames], {
-        env
+        env: getDepotToolsEnv()
       });
       const filter = [...CPPLINT_FILTERS, '-readability/braces'];
       cpplint(['--extensions=mm,h', `--filter=${filter.join(',')}`, ...filenames]);
@@ -175,7 +169,6 @@ const LINTERS = [
         .map((filename) => {
           const env = {
             ...getDepotToolsEnv(),
-            CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools'),
             DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
           };
           const args = ['format', filename];


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We use `CHROMIUM_BUILDTOOLS_PATH` pretty aggressively, but recent upstream changes have made it clear that they consider it "highly unsupported" so we need to switch to a better method.

@codebytere put up electron/build-tools#855, and I agree with the general approach that symlinking it is the cleanest solution we have to work with [`depot_tools/gclient_paths.py`](https://source.chromium.org/chromium/chromium/tools/depot_tools/+/main:gclient_paths.py;drc=656a3095d47a739afbd540bd52d30ea1e7b56bf2). However, that PR would only work for folks using `build-tools`, and we also need to support folks who are building without `build-tools` and bring their own `depot_tools`.

This PR puts the symlink creation in as part of the sync process, so it will always exist whether you're building with `build-tools` or not. I'll follow up with a PR for `build-tools` to detect if the symlink exists and matches `CHROMIUM_BUILDTOOLS_PATH`, and if so not set the environment variable, otherwise continue to set it for backwards compatibility. After enough time has passed that we're confident all supported builds are using the changes in this PR, we can rip out `CHROMIUM_BUILDTOOLS_PATH` from `build-tools` as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
