### PR TITLE
fix: handle `createWindow()` rejection in import-meta test fixture

### DIFF
--- a/spec/fixtures/esm/import-meta/main.mjs
+++ b/spec/fixtures/esm/import-meta/main.mjs
@@ -23,12 +23,6 @@ async function createWindow() {
 
 app.whenReady().then(() => {
   createWindow();
-
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
 });
 
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);

--- a/spec/fixtures/esm/import-meta/main.mjs
+++ b/spec/fixtures/esm/import-meta/main.mjs
@@ -21,8 +21,9 @@ async function createWindow() {
   process.exit(importMetaPreload === expected ? 0 : 1);
 }
 
-app.whenReady().then(() => {
-  createWindow();
-});
+app
+  .whenReady()
+  .then(() => createWindow())
+  .catch(() => process.exit(1));
 
 app.on('window-all-closed', app.quit);


### PR DESCRIPTION
#### Description of Change

Potential fix for an esm-spec.ts test flake in "should use import.meta callback handling from Node.js for Node.js modules".

The `import-meta` fixture's `createWindow()` is async but was called fire-and-forget. If `loadFile()` or `executeJavaScript()` rejects transiently, `process.exit()` is never reached. On `macOS` the process hangs indefinitely because `'window-all-closed'` had a `process.platform !== 'darwin'` guard that skipped `app.quit()`.

It's hard to prove that a test flake is fixed, but this theory matches the behavior and is worthwhile as a spec cleanup either way. *edit:* only a cleanup, unfortunately. The CI failure is still there.

Sample CI failure:

```
2026-05-01T20:20:27.6600380Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts)
2026-05-01T20:20:27.6603310Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-05-01T20:20:27.6605350Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-05-01T20:20:27.6607200Z Retrying test (1/3)...
2026-05-01T20:20:57.6695430Z Failure in test: "esm renderer process nodeIntegration without context isolation should use import.meta callback handling from Node.js for Node.js modules"
2026-05-01T20:20:57.6702120Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts)
2026-05-01T20:20:57.6704730Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-05-01T20:20:57.6706870Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10)
2026-05-01T20:20:57.6708420Z Retrying test (2/3)...
2026-05-01T20:21:27.6770530Z Failure in test: "esm renderer process nodeIntegration without context isolation should use import.meta callback handling from Node.js for Node.js modules"
2026-05-01T20:21:27.6774450Z Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts)
2026-05-01T20:21:27.6777380Z     at createTimeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/errors.js:498:15)
2026-05-01T20:21:27.6779620Z     at Test.Runnable._timeoutError (/Users/runner/work/electron/electron/src/electron/spec/node_modules/mocha/lib/runnable.js:429:10) 
2026-05-01T20:21:27.6781470Z Retrying test (3/3)...
2026-05-01T20:21:57.6889880Z not ok 912 esm renderer process nodeIntegration without context isolation should use import.meta callback handling from Node.js for Node.js modules
2026-05-01T20:21:57.6893720Z   Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts)
2026-05-01T20:21:57.6896920Z   Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/electron/electron/src/electron/spec/esm-spec.ts)
2026-05-01T20:21:57.6899550Z       at listOnTimeout (node:internal/timers:605:17)
2026-05-01T20:21:57.6900560Z       at processTimers (node:internal/timers:541:7)
...
2026-05-01T21:06:04.6242770Z ##[error]The action 'Run Electron Tests' has timed out after 60 minutes.
```

Complements #51432. This PR is "try to fix the test", and 51432 is "try to fix the runner to not hang on a failed test".

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.