### PR TITLE
fix: defer getAppPath() call to after app ready

### DIFF
--- a/spec/fixtures/api/app-path/lib/index.js
+++ b/spec/fixtures/api/app-path/lib/index.js
@@ -1,10 +1,7 @@
-const { app } = require('electron');
-
-const payload = {
-  appPath: app.getAppPath()
-};
-
-process.stdout.write(JSON.stringify(payload));
-process.stdout.end();
-
-process.exit();
+app.whenReady().then(() => {
+  
+  const payload = { appPath: app.getAppPath() };
+  console.log(JSON.stringify(payload));
+  app.quit();
+  
+});


### PR DESCRIPTION
 I have built and tested this change

 I have filled out the PR description

 I have reviewed and verified the changes

 npm test passes

 tests are changed or added (not applicable – no functional logic change)

 relevant API documentation, tutorials, and examples are updated (not applicable)

 PR release notes describe the change