### PR TITLE
feat: support win.setOpacity on Linux

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1382,17 +1382,16 @@ Sets whether the window should have a shadow.
 
 Returns `boolean` - Whether the window has a shadow.
 
-#### `win.setOpacity(opacity)` _Windows_ _macOS_
+#### `win.setOpacity(opacity)`
 
 * `opacity` number - between 0.0 (fully transparent) and 1.0 (fully opaque)
 
-Sets the opacity of the window. On Linux, does nothing. Out of bound number
-values are clamped to the \[0, 1] range.
+Sets the opacity of the window. Out of bound number values are clamped to the
+\[0, 1] range.
 
 #### `win.getOpacity()`
 
-Returns `number` - between 0.0 (fully transparent) and 1.0 (fully opaque). On
-Linux, always returns 1.
+Returns `number` - between 0.0 (fully transparent) and 1.0 (fully opaque).
 
 #### `win.setShape(rects)` _Windows_ _Linux_ _Experimental_
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1341,14 +1341,15 @@ bool NativeWindowViews::HasShadow() const {
 }
 
 void NativeWindowViews::SetOpacity(const double opacity) {
+  const double bounded_opacity =
+      std::isnan(opacity) ? 1.0 : std::clamp(opacity, 0.0, 1.0);
+  opacity_ = bounded_opacity;
 #if BUILDFLAG(IS_WIN)
-  const double boundedOpacity = std::clamp(opacity, 0.0, 1.0);
   HWND hwnd = GetAcceleratedWidget();
   SetLayered();
-  ::SetLayeredWindowAttributes(hwnd, 0, boundedOpacity * 255, LWA_ALPHA);
-  opacity_ = boundedOpacity;
-#else
-  opacity_ = 1.0;  // setOpacity unsupported on Linux
+  ::SetLayeredWindowAttributes(hwnd, 0, bounded_opacity * 255, LWA_ALPHA);
+#elif BUILDFLAG(IS_LINUX)
+  widget()->SetOpacity(static_cast<float>(bounded_opacity));
 #endif
 }
 

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -212,12 +212,20 @@ void ElectronDesktopWindowTreeHostLinux::OnDeviceScaleFactorChanged() {
   UpdateFrameHints();
 }
 
+void ElectronDesktopWindowTreeHostLinux::SetOpacity(float opacity) {
+  views::DesktopWindowTreeHostLinux::SetOpacity(opacity);
+  UpdateFrameHints();
+}
+
 void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
+  const bool is_non_opaque = native_window_view_->IsTranslucent() ||
+                             native_window_view_->GetOpacity() < 1.0;
+
   auto* fvl = native_window_view_->GetFrameViewLinux();
   if (!fvl || !fvl->ShouldDrawRestoredFrameShadow()) {
     platform_window()->SetInputRegion(std::nullopt);
     if (ui::OzonePlatform::GetInstance()->IsWindowCompositingSupported()) {
-      if (native_window_view_->IsTranslucent()) {
+      if (is_non_opaque) {
         platform_window()->SetOpaqueRegion(std::vector<gfx::Rect>{});
       } else {
         gfx::Size size = GetWidget()->GetWindowBoundsInScreen().size();
@@ -231,9 +239,7 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
   }
 
   views::DesktopWindowTreeHostLinux::UpdateFrameHints();
-  // Clear the opaque region for translucent windows.
-  if (native_window_view_->IsTranslucent() &&
-      views::Widget::IsWindowCompositingSupported()) {
+  if (is_non_opaque && views::Widget::IsWindowCompositingSupported()) {
     platform_window()->SetOpaqueRegion(std::vector<gfx::Rect>{});
   }
   SizeConstraintsChanged();

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -71,6 +71,7 @@ class ElectronDesktopWindowTreeHostLinux
   void AddAdditionalInitProperties(
       const views::Widget::InitParams& params,
       ui::PlatformWindowInitProperties* properties) override;
+  void SetOpacity(float opacity) override;
 
  private:
   void UpdateWindowState(ui::PlatformWindowState new_state);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3364,40 +3364,28 @@ describe('BrowserWindow module', () => {
   describe('BrowserWindow.setOpacity(opacity)', () => {
     afterEach(closeAllWindows);
 
-    ifdescribe(process.platform !== 'linux')('Windows and Mac', () => {
-      it('make window with initial opacity', () => {
-        const w = new BrowserWindow({ show: false, opacity: 0.5 });
-        expect(w.getOpacity()).to.equal(0.5);
-      });
-      it('allows setting the opacity', () => {
-        const w = new BrowserWindow({ show: false });
-        expect(() => {
-          w.setOpacity(0.0);
-          expect(w.getOpacity()).to.equal(0.0);
-          w.setOpacity(0.5);
-          expect(w.getOpacity()).to.equal(0.5);
-          w.setOpacity(1.0);
-          expect(w.getOpacity()).to.equal(1.0);
-        }).to.not.throw();
-      });
-
-      it('clamps opacity to [0.0...1.0]', () => {
-        const w = new BrowserWindow({ show: false, opacity: 0.5 });
-        w.setOpacity(100);
-        expect(w.getOpacity()).to.equal(1.0);
-        w.setOpacity(-100);
+    it('make window with initial opacity', () => {
+      const w = new BrowserWindow({ show: false, opacity: 0.5 });
+      expect(w.getOpacity()).to.equal(0.5);
+    });
+    it('allows setting the opacity', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setOpacity(0.0);
         expect(w.getOpacity()).to.equal(0.0);
-      });
+        w.setOpacity(0.5);
+        expect(w.getOpacity()).to.equal(0.5);
+        w.setOpacity(1.0);
+        expect(w.getOpacity()).to.equal(1.0);
+      }).to.not.throw();
     });
 
-    ifdescribe(process.platform === 'linux')('Linux', () => {
-      it('sets 1 regardless of parameter', () => {
-        const w = new BrowserWindow({ show: false });
-        w.setOpacity(0);
-        expect(w.getOpacity()).to.equal(1.0);
-        w.setOpacity(0.5);
-        expect(w.getOpacity()).to.equal(1.0);
-      });
+    it('clamps opacity to [0.0...1.0]', () => {
+      const w = new BrowserWindow({ show: false, opacity: 0.5 });
+      w.setOpacity(100);
+      expect(w.getOpacity()).to.equal(1.0);
+      w.setOpacity(-100);
+      expect(w.getOpacity()).to.equal(0.0);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Support `win.setOpacity(opacity)` on Linux using `DesktopWindowTreeHostPlatform::SetOpacity(opacity)`. The frame hints logic has been updated to take window opacity into consideration while setting the opaque region.

This is technically an API break when compared to documentation, but it's not one when compared to other platforms. I've chosen to not treat this as a breaking change, but I can document it as so if necessary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for `win.setOpacity(opacity)` on Linux.
