### PR TITLE
.2385318931605690:284e8a794a1a0b1f6359df097c896646_69f70b9feb4415a9574e5f02.69f70beceb4415a9574e5f23.69f70bebc073882e7bd33c27:Trae CN.T(2026/5/3 16:48:44)

### DIFF
--- a/lib/browser/api/ipc-stream-main.ts
+++ b/lib/browser/api/ipc-stream-main.ts
@@ -1,0 +1,292 @@
+import { EventEmitter } from 'events';
+import { MessageChannelMain, MessagePortMain } from '@electron/internal/browser/message-port-main';
+import { ipcMain, WebContents } from 'electron/main';
+
+export interface IpcStreamMessage {
+  type: 'data' | 'end' | 'error' | 'ping' | 'pong';
+  data?: any;
+  error?: string;
+  id: string;
+}
+
+export interface IpcStreamOptions {
+  highWaterMark?: number;
+  objectMode?: boolean;
+  encoding?: string;
+}
+
+class IpcStreamPort extends EventEmitter {
+  private _port: MessagePortMain;
+  private _id: string;
+  private _isOpen: boolean = true;
+  private _buffer: any[] = [];
+  private _highWaterMark: number;
+  private _objectMode: boolean;
+
+  constructor(port: MessagePortMain, id: string, options: IpcStreamOptions = {}) {
+    super();
+    this._port = port;
+    this._id = id;
+    this._highWaterMark = options.highWaterMark || 16;
+    this._objectMode = options.objectMode || false;
+
+    this._setupPortListeners();
+  }
+
+  private _setupPortListeners(): void {
+    this._port.on('message', (event: { data: IpcStreamMessage }) => {
+      this._handleMessage(event.data);
+    });
+
+    this._port.on('close', () => {
+      this._isOpen = false;
+      this.emit('close');
+    });
+
+    this._port.start();
+  }
+
+  private _handleMessage(message: IpcStreamMessage): void {
+    if (message.id !== this._id) return;
+
+    switch (message.type) {
+      case 'data':
+        this._handleData(message.data);
+        break;
+      case 'end':
+        this._handleEnd();
+        break;
+      case 'error':
+        this._handleError(message.error || 'Unknown error');
+        break;
+      case 'ping':
+        this._sendPong();
+        break;
+      case 'pong':
+        this.emit('pong');
+        break;
+    }
+  }
+
+  private _handleData(data: any): void {
+    if (!this._objectMode && typeof data === 'string') {
+      this._buffer.push(Buffer.from(data));
+    } else {
+      this._buffer.push(data);
+    }
+
+    this.emit('data', data);
+
+    if (this._buffer.length >= this._highWaterMark) {
+      this.emit('drain');
+    }
+  }
+
+  private _handleEnd(): void {
+    this._isOpen = false;
+    this.emit('end');
+  }
+
+  private _handleError(error: string): void {
+    this.emit('error', new Error(error));
+  }
+
+  private _sendPong(): void {
+    this._port.postMessage({
+      type: 'pong',
+      id: this._id
+    } as IpcStreamMessage);
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get isOpen(): boolean {
+    return this._isOpen;
+  }
+
+  write(data: any): boolean {
+    if (!this._isOpen) {
+      this.emit('error', new Error('Stream is closed'));
+      return false;
+    }
+
+    const message: IpcStreamMessage = {
+      type: 'data',
+      data,
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    return true;
+  }
+
+  end(data?: any): void {
+    if (data !== undefined) {
+      this.write(data);
+    }
+
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'end',
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    this._isOpen = false;
+    this._port.close();
+  }
+
+  error(error: Error): void {
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'error',
+      error: error.message,
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    this._isOpen = false;
+    this._port.close();
+  }
+
+  ping(): void {
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'ping',
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+  }
+
+  close(): void {
+    if (!this._isOpen) return;
+
+    this._isOpen = false;
+    this._port.close();
+  }
+}
+
+class IpcStreamServer extends EventEmitter {
+  private _channels: Map<string, (stream: IpcStreamPort) => void> = new Map();
+  private _isListening: boolean = false;
+
+  constructor() {
+    super();
+    this._setupListeners();
+  }
+
+  private _setupListeners(): void {
+    ipcMain.on('electron-ipc-stream-connect', (event, channel: string, id: string) => {
+      this._handleConnection(event, channel, id);
+    });
+  }
+
+  private _handleConnection(event: any, channel: string, id: string): void {
+    const handler = this._channels.get(channel);
+    if (!handler) {
+      event.senderFrame.postMessage('electron-ipc-stream-reject', { id, error: `Channel '${channel}' not found` });
+      return;
+    }
+
+    const { port1, port2 } = new MessageChannelMain();
+    const stream = new IpcStreamPort(port1, id);
+
+    event.senderFrame.postMessage('electron-ipc-stream-accept', { id }, [port2]);
+
+    handler(stream);
+    this.emit('connection', stream, channel);
+  }
+
+  listen(channel: string, handler: (stream: IpcStreamPort) => void): void {
+    if (this._channels.has(channel)) {
+      throw new Error(`Channel '${channel}' is already in use`);
+    }
+
+    this._channels.set(channel, handler);
+  }
+
+  unlisten(channel: string): void {
+    this._channels.delete(channel);
+  }
+
+  isListening(channel: string): boolean {
+    return this._channels.has(channel);
+  }
+
+  close(): void {
+    this._channels.clear();
+    this._isListening = false;
+  }
+}
+
+class IpcStreamClient {
+  private _pendingConnections: Map<string, { resolve: (stream: IpcStreamPort) => void; reject: (error: Error) => void; options: IpcStreamOptions }> = new Map();
+  private _isSetup: boolean = false;
+
+  constructor() {
+    this._setupListeners();
+  }
+
+  private _setupListeners(): void {
+    if (this._isSetup) return;
+
+    ipcMain.on('electron-ipc-stream-accept', (event, { id }) => {
+      this._handleAccept(event, id);
+    });
+
+    ipcMain.on('electron-ipc-stream-reject', (event, { id, error }) => {
+      this._handleReject(id, error);
+    });
+
+    this._isSetup = true;
+  }
+
+  private _generateId(): string {
+    return `stream-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  private _handleAccept(event: any, id: string): void {
+    const pending = this._pendingConnections.get(id);
+    if (!pending) return;
+
+    const port = event.ports[0] as MessagePortMain;
+    const stream = new IpcStreamPort(port, id, pending.options);
+
+    pending.resolve(stream);
+    this._pendingConnections.delete(id);
+  }
+
+  private _handleReject(id: string, error: string): void {
+    const pending = this._pendingConnections.get(id);
+    if (!pending) return;
+
+    pending.reject(new Error(error));
+    this._pendingConnections.delete(id);
+  }
+
+  connect(webContents: WebContents, channel: string, options: IpcStreamOptions = {}): Promise<IpcStreamPort> {
+    return new Promise((resolve, reject) => {
+      const id = this._generateId();
+
+      this._pendingConnections.set(id, { resolve, reject, options });
+
+      webContents.postMessage('electron-ipc-stream-connect', { channel, id });
+    });
+  }
+}
+
+export const ipcStreamMain = {
+  createServer: (): IpcStreamServer => new IpcStreamServer(),
+  createClient: (): IpcStreamClient => new IpcStreamClient(),
+  IpcStreamPort,
+  IpcStreamServer,
+  IpcStreamClient
+};
+
+export default ipcStreamMain;

--- a/lib/browser/api/module-list.ts
+++ b/lib/browser/api/module-list.ts
@@ -14,6 +14,7 @@ export const browserModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'dialog', loader: () => require('./dialog') },
   { name: 'globalShortcut', loader: () => require('./global-shortcut') },
   { name: 'ipcMain', loader: () => require('./ipc-main') },
+  { name: 'ipcStreamMain', loader: () => require('./ipc-stream-main') },
   { name: 'ImageView', loader: () => require('./views/image-view') },
   { name: 'inAppPurchase', loader: () => require('./in-app-purchase') },
   { name: 'Menu', loader: () => require('./menu') },

--- a/lib/renderer/api/ipc-stream-renderer.ts
+++ b/lib/renderer/api/ipc-stream-renderer.ts
@@ -1,0 +1,291 @@
+import { EventEmitter } from 'events';
+import { ipcRenderer } from 'electron/renderer';
+
+export interface IpcStreamMessage {
+  type: 'data' | 'end' | 'error' | 'ping' | 'pong';
+  data?: any;
+  error?: string;
+  id: string;
+}
+
+export interface IpcStreamOptions {
+  highWaterMark?: number;
+  objectMode?: boolean;
+  encoding?: string;
+}
+
+class IpcStreamPort extends EventEmitter {
+  private _port: MessagePort;
+  private _id: string;
+  private _isOpen: boolean = true;
+  private _buffer: any[] = [];
+  private _highWaterMark: number;
+  private _objectMode: boolean;
+
+  constructor(port: MessagePort, id: string, options: IpcStreamOptions = {}) {
+    super();
+    this._port = port;
+    this._id = id;
+    this._highWaterMark = options.highWaterMark || 16;
+    this._objectMode = options.objectMode || false;
+
+    this._setupPortListeners();
+  }
+
+  private _setupPortListeners(): void {
+    this._port.onmessage = (event: MessageEvent<IpcStreamMessage>) => {
+      this._handleMessage(event.data);
+    };
+
+    this._port.onclose = () => {
+      this._isOpen = false;
+      this.emit('close');
+    };
+
+    this._port.start();
+  }
+
+  private _handleMessage(message: IpcStreamMessage): void {
+    if (message.id !== this._id) return;
+
+    switch (message.type) {
+      case 'data':
+        this._handleData(message.data);
+        break;
+      case 'end':
+        this._handleEnd();
+        break;
+      case 'error':
+        this._handleError(message.error || 'Unknown error');
+        break;
+      case 'ping':
+        this._sendPong();
+        break;
+      case 'pong':
+        this.emit('pong');
+        break;
+    }
+  }
+
+  private _handleData(data: any): void {
+    if (!this._objectMode && typeof data === 'string') {
+      this._buffer.push(Buffer.from(data));
+    } else {
+      this._buffer.push(data);
+    }
+
+    this.emit('data', data);
+
+    if (this._buffer.length >= this._highWaterMark) {
+      this.emit('drain');
+    }
+  }
+
+  private _handleEnd(): void {
+    this._isOpen = false;
+    this.emit('end');
+  }
+
+  private _handleError(error: string): void {
+    this.emit('error', new Error(error));
+  }
+
+  private _sendPong(): void {
+    this._port.postMessage({
+      type: 'pong',
+      id: this._id
+    } as IpcStreamMessage);
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get isOpen(): boolean {
+    return this._isOpen;
+  }
+
+  write(data: any): boolean {
+    if (!this._isOpen) {
+      this.emit('error', new Error('Stream is closed'));
+      return false;
+    }
+
+    const message: IpcStreamMessage = {
+      type: 'data',
+      data,
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    return true;
+  }
+
+  end(data?: any): void {
+    if (data !== undefined) {
+      this.write(data);
+    }
+
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'end',
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    this._isOpen = false;
+    this._port.close();
+  }
+
+  error(error: Error): void {
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'error',
+      error: error.message,
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+    this._isOpen = false;
+    this._port.close();
+  }
+
+  ping(): void {
+    if (!this._isOpen) return;
+
+    const message: IpcStreamMessage = {
+      type: 'ping',
+      id: this._id
+    };
+
+    this._port.postMessage(message);
+  }
+
+  close(): void {
+    if (!this._isOpen) return;
+
+    this._isOpen = false;
+    this._port.close();
+  }
+}
+
+class IpcStreamServer extends EventEmitter {
+  private _channels: Map<string, (stream: IpcStreamPort) => void> = new Map();
+  private _isListening: boolean = false;
+
+  constructor() {
+    super();
+    this._setupListeners();
+  }
+
+  private _setupListeners(): void {
+    ipcRenderer.on('electron-ipc-stream-connect', (event, { channel, id }) => {
+      this._handleConnection(event, channel, id);
+    });
+  }
+
+  private _handleConnection(event: any, channel: string, id: string): void {
+    const handler = this._channels.get(channel);
+    if (!handler) {
+      ipcRenderer.postMessage('electron-ipc-stream-reject', { id, error: `Channel '${channel}' not found` });
+      return;
+    }
+
+    const messageChannel = new MessageChannel();
+    const stream = new IpcStreamPort(messageChannel.port1, id);
+
+    ipcRenderer.postMessage('electron-ipc-stream-accept', { id }, [messageChannel.port2]);
+
+    handler(stream);
+    this.emit('connection', stream, channel);
+  }
+
+  listen(channel: string, handler: (stream: IpcStreamPort) => void): void {
+    if (this._channels.has(channel)) {
+      throw new Error(`Channel '${channel}' is already in use`);
+    }
+
+    this._channels.set(channel, handler);
+  }
+
+  unlisten(channel: string): void {
+    this._channels.delete(channel);
+  }
+
+  isListening(channel: string): boolean {
+    return this._channels.has(channel);
+  }
+
+  close(): void {
+    this._channels.clear();
+    this._isListening = false;
+  }
+}
+
+class IpcStreamClient {
+  private _pendingConnections: Map<string, { resolve: (stream: IpcStreamPort) => void; reject: (error: Error) => void; options: IpcStreamOptions }> = new Map();
+  private _isSetup: boolean = false;
+
+  constructor() {
+    this._setupListeners();
+  }
+
+  private _setupListeners(): void {
+    if (this._isSetup) return;
+
+    ipcRenderer.on('electron-ipc-stream-accept', (event, { id }) => {
+      this._handleAccept(event, id);
+    });
+
+    ipcRenderer.on('electron-ipc-stream-reject', (event, { id, error }) => {
+      this._handleReject(id, error);
+    });
+
+    this._isSetup = true;
+  }
+
+  private _generateId(): string {
+    return `stream-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  private _handleAccept(event: any, id: string): void {
+    const pending = this._pendingConnections.get(id);
+    if (!pending) return;
+
+    const port = event.ports[0] as MessagePort;
+    const stream = new IpcStreamPort(port, id, pending.options);
+
+    pending.resolve(stream);
+    this._pendingConnections.delete(id);
+  }
+
+  private _handleReject(id: string, error: string): void {
+    const pending = this._pendingConnections.get(id);
+    if (!pending) return;
+
+    pending.reject(new Error(error));
+    this._pendingConnections.delete(id);
+  }
+
+  connect(channel: string, options: IpcStreamOptions = {}): Promise<IpcStreamPort> {
+    return new Promise((resolve, reject) => {
+      const id = this._generateId();
+
+      this._pendingConnections.set(id, { resolve, reject, options });
+
+      ipcRenderer.postMessage('electron-ipc-stream-connect', { channel, id });
+    });
+  }
+}
+
+export const ipcStreamRenderer = {
+  createServer: (): IpcStreamServer => new IpcStreamServer(),
+  createClient: (): IpcStreamClient => new IpcStreamClient(),
+  IpcStreamPort,
+  IpcStreamServer,
+  IpcStreamClient
+};
+
+export default ipcStreamRenderer;

--- a/lib/renderer/api/module-list.ts
+++ b/lib/renderer/api/module-list.ts
@@ -4,6 +4,7 @@ export const rendererModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'contextBridge', loader: () => require('./context-bridge') },
   { name: 'crashReporter', loader: () => require('./crash-reporter') },
   { name: 'ipcRenderer', loader: () => require('./ipc-renderer') },
+  { name: 'ipcStreamRenderer', loader: () => require('./ipc-stream-renderer') },
   { name: 'sharedTexture', loader: () => require('./shared-texture') },
   { name: 'webFrame', loader: () => require('./web-frame') },
   { name: 'webUtils', loader: () => require('./web-utils') }

--- a/spec/api-ipc-stream-spec.ts
+++ b/spec/api-ipc-stream-spec.ts
@@ -1,0 +1,413 @@
+import { BrowserWindow, ipcMain, IpcMainInvokeEvent, MessageChannelMain, WebContents, ipcStreamMain } from 'electron/main';
+
+import { expect } from 'chai';
+
+import { EventEmitter, once } from 'node:events';
+import * as http from 'node:http';
+import * as path from 'node:path';
+
+import { defer, listen } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
+
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
+describe('ipc-stream module', () => {
+  afterEach(closeAllWindows);
+
+  describe('basic functionality', () => {
+    it('should create a server and client', () => {
+      const server = ipcStreamMain.createServer();
+      const client = ipcStreamMain.createClient();
+      
+      expect(server).to.be.an.instanceOf(EventEmitter);
+      expect(client).to.be.an('object');
+    });
+
+    it('should listen on a channel', () => {
+      const server = ipcStreamMain.createServer();
+      
+      expect(server.isListening('test-channel')).to.be.false();
+      
+      server.listen('test-channel', () => {});
+      expect(server.isListening('test-channel')).to.be.true();
+      
+      server.unlisten('test-channel');
+      expect(server.isListening('test-channel')).to.be.false();
+    });
+
+    it('should throw when listening on the same channel twice', () => {
+      const server = ipcStreamMain.createServer();
+      
+      server.listen('test-channel', () => {});
+      
+      expect(() => {
+        server.listen('test-channel', () => {});
+      }).to.throw(/already in use/);
+    });
+  });
+
+  describe('main process to renderer communication', () => {
+    it('should establish a stream connection between main and renderer', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const connectionPromise = new Promise<void>((resolve) => {
+        server.listen('test-stream', (stream) => {
+          expect(stream).to.be.an.instanceOf(EventEmitter);
+          expect(stream.id).to.be.a('string');
+          expect(stream.isOpen).to.be.true();
+          resolve();
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          client.connect('test-stream');
+        }})()
+      `);
+
+      await connectionPromise;
+    });
+
+    it('should send and receive data through the stream', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const dataPromise = new Promise<any>((resolve) => {
+        server.listen('data-stream', (stream) => {
+          stream.on('data', (data) => {
+            resolve(data);
+          });
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          const stream = await client.connect('data-stream');
+          stream.write({ test: 'data', number: 42 });
+        }})()
+      `);
+
+      const receivedData = await dataPromise;
+      expect(receivedData).to.deep.equal({ test: 'data', number: 42 });
+    });
+
+    it('should handle stream end event', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const endPromise = new Promise<void>((resolve) => {
+        server.listen('end-stream', (stream) => {
+          stream.on('end', () => {
+            resolve();
+          });
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          const stream = await client.connect('end-stream');
+          stream.end();
+        }})()
+      `);
+
+      await endPromise;
+    });
+
+    it('should handle stream error event', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const errorPromise = new Promise<Error>((resolve) => {
+        server.listen('error-stream', (stream) => {
+          stream.on('error', (error) => {
+            resolve(error);
+          });
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          const stream = await client.connect('error-stream');
+          stream.error(new Error('Test error message'));
+        }})()
+      `);
+
+      const error = await errorPromise;
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('Test error message');
+    });
+
+    it('should support ping/pong mechanism', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const pongPromise = new Promise<void>((resolve) => {
+        server.listen('ping-stream', (stream) => {
+          stream.on('pong', () => {
+            resolve();
+          });
+          stream.ping();
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          await client.connect('ping-stream');
+        }})()
+      `);
+
+      await pongPromise;
+    });
+
+    it('should send data from main to renderer', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      
+      // Set up listener in renderer first
+      await w.webContents.executeJavaScript(`
+        (${function () {
+          const { ipcStreamRenderer } = require('electron');
+          const server = ipcStreamRenderer.createServer();
+          server.listen('main-to-renderer', (stream) => {
+            stream.on('data', (data) => {
+              require('electron').ipcRenderer.send('received-data', data);
+            });
+          });
+        }})()
+      `);
+
+      const dataPromise = once(ipcMain, 'received-data');
+      
+      // Connect from main process
+      const client = ipcStreamMain.createClient();
+      const stream = await client.connect(w.webContents, 'main-to-renderer');
+      stream.write({ from: 'main', message: 'Hello from main process!' });
+
+      const [, receivedData] = await dataPromise;
+      expect(receivedData).to.deep.equal({ from: 'main', message: 'Hello from main process!' });
+    });
+  });
+
+  describe('stream options', () => {
+    it('should support object mode', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const objectPromise = new Promise<any>((resolve) => {
+        server.listen('object-stream', (stream) => {
+          stream.on('data', (data) => {
+            resolve(data);
+          });
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          const stream = await client.connect('object-stream', { objectMode: true });
+          
+          // Send complex objects
+          const complexObject = {
+            nested: {
+              array: [1, 2, 3],
+              obj: { key: 'value' }
+            },
+            date: new Date('2023-01-01'),
+            regex: /test/gi
+          };
+          
+          stream.write(complexObject);
+        }})()
+      `);
+
+      const received = await objectPromise;
+      expect(received.nested.array).to.deep.equal([1, 2, 3]);
+      expect(received.nested.obj.key).to.equal('value');
+    });
+
+    it('should reject connection to non-existent channel', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const errorPromise = new Promise<string>((resolve) => {
+        ipcMain.once('connection-error', (event, errorMessage) => {
+          resolve(errorMessage);
+        });
+      });
+
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          try {
+            await client.connect('non-existent-channel');
+          } catch (error) {
+            require('electron').ipcRenderer.send('connection-error', error.message);
+          }
+        }})()
+      `);
+
+      const errorMessage = await errorPromise;
+      expect(errorMessage).to.include('non-existent-channel');
+    });
+  });
+
+  describe('bidirectional communication', () => {
+    it('should support bidirectional data flow', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const responsePromise = new Promise<number>((resolve) => {
+        server.listen('echo-stream', (stream) => {
+          stream.on('data', (data) => {
+            // Echo back the data multiplied by 2
+            stream.write(data * 2);
+          });
+        });
+      });
+
+      // Set up renderer to send data and listen for response
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          const stream = await client.connect('echo-stream');
+          
+          stream.on('data', (data) => {
+            require('electron').ipcRenderer.send('echo-response', data);
+          });
+          
+          stream.write(21);
+        }})()
+      `);
+
+      const [, response] = await once(ipcMain, 'echo-response');
+      expect(response).to.equal(42);
+    });
+
+    it('should handle multiple concurrent streams', async () => {
+      const w = new BrowserWindow({ 
+        show: false, 
+        webPreferences: { 
+          nodeIntegration: true, 
+          contextIsolation: false 
+        } 
+      });
+      await w.loadURL('about:blank');
+
+      const server = ipcStreamMain.createServer();
+      const streams: any[] = [];
+      
+      server.listen('multi-stream', (stream) => {
+        streams.push(stream);
+        stream.on('data', (data) => {
+          stream.write(`Received: ${data}`);
+        });
+      });
+
+      // Set up renderer to create multiple connections
+      await w.webContents.executeJavaScript(`
+        (${async function () {
+          const { ipcStreamRenderer } = require('electron');
+          const client = ipcStreamRenderer.createClient();
+          
+          // Create 3 concurrent streams
+          for (let i = 0; i < 3; i++) {
+            const stream = await client.connect('multi-stream');
+            stream.on('data', (data) => {
+              require('electron').ipcRenderer.send('multi-response', data);
+            });
+            stream.write(\`Message \${i}\`);
+          }
+        }})()
+      `);
+
+      // Wait for all 3 responses
+      const responses: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const [, data] = await once(ipcMain, 'multi-response');
+        responses.push(data);
+      }
+
+      expect(responses).to.have.length(3);
+      expect(responses[0]).to.include('Received');
+      expect(responses[1]).to.include('Received');
+      expect(responses[2]).to.include('Received');
+    });
+  });
+});

--- a/typings/ipc-stream.d.ts
+++ b/typings/ipc-stream.d.ts
@@ -1,0 +1,79 @@
+
+declare namespace Electron {
+  export interface IpcStreamMessage {
+    type: 'data' | 'end' | 'error' | 'ping' | 'pong';
+    data?: any;
+    error?: string;
+    id: string;
+  }
+
+  export interface IpcStreamOptions {
+    highWaterMark?: number;
+    objectMode?: boolean;
+    encoding?: string;
+  }
+
+  export interface IpcStreamPort extends NodeJS.EventEmitter {
+    readonly id: string;
+    readonly isOpen: boolean;
+    
+    write(data: any): boolean;
+    end(data?: any): void;
+    error(error: Error): void;
+    ping(): void;
+    close(): void;
+    
+    on(event: 'data', listener: (data: any) => void): this;
+    on(event: 'end', listener: () => void): this;
+    on(event: 'error', listener: (error: Error) => void): this;
+    on(event: 'close', listener: () => void): this;
+    on(event: 'drain', listener: () => void): this;
+    on(event: 'pong', listener: () => void): this;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    
+    once(event: 'data', listener: (data: any) => void): this;
+    once(event: 'end', listener: () => void): this;
+    once(event: 'error', listener: (error: Error) => void): this;
+    once(event: 'close', listener: () => void): this;
+    once(event: 'drain', listener: () => void): this;
+    once(event: 'pong', listener: () => void): this;
+    once(event: string | symbol, listener: (...args: any[]) => void): this;
+  }
+
+  export interface IpcStreamServer extends NodeJS.EventEmitter {
+    listen(channel: string, handler: (stream: IpcStreamPort) => void): void;
+    unlisten(channel: string): void;
+    isListening(channel: string): boolean;
+    close(): void;
+    
+    on(event: 'connection', listener: (stream: IpcStreamPort, channel: string) => void): this;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    
+    once(event: 'connection', listener: (stream: IpcStreamPort, channel: string) => void): this;
+    once(event: string | symbol, listener: (...args: any[]) => void): this;
+  }
+
+  export interface IpcStreamClient {
+    connect(channel: string, options?: IpcStreamOptions): Promise<IpcStreamPort>;
+  }
+
+  export interface IpcStreamMain {
+    createServer(): IpcStreamServer;
+    createClient(): IpcStreamClient;
+    IpcStreamPort: new (port: any, id: string, options?: IpcStreamOptions) => IpcStreamPort;
+    IpcStreamServer: new () => IpcStreamServer;
+    IpcStreamClient: new () => IpcStreamClient;
+  }
+
+  export interface IpcStreamRenderer {
+    createServer(): IpcStreamServer;
+    createClient(): IpcStreamClient;
+    IpcStreamPort: new (port: any, id: string, options?: IpcStreamOptions) => IpcStreamPort;
+    IpcStreamServer: new () => IpcStreamServer;
+    IpcStreamClient: new () => IpcStreamClient;
+  }
+}
+
+declare namespace ElectronInternal {
+  // 内部类型定义
+}


### PR DESCRIPTION
feat(ipc): 新增IPC流式通信功能

添加IPC流式通信模块，支持主进程和渲染进程之间的双向流式数据传输。包含以下主要功能：
- 实现IpcStreamPort流式端口类，支持数据读写、结束、错误处理等操作
- 提供IpcStreamServer和IpcStreamClient用于建立和管理流式连接
- 支持对象模式、高水位标记等流式选项配置
- 添加完整的类型定义和单元测试