### PR TITLE
fix: use v8::Global instead of TracedReference in PromiseHandle

### DIFF
--- a/shell/common/gin_helper/promise.cc
+++ b/shell/common/gin_helper/promise.cc
@@ -13,10 +13,20 @@
 #include "v8/include/cppgc/name-provider.h"
 #include "v8/include/v8-context.h"
 #include "v8/include/v8-cppgc.h"
-#include "v8/include/v8-traced-handle.h"
 
 namespace gin_helper {
 
+// PromiseHandle prevents premature garbage collection of V8 handles that
+// back a Promise.
+//
+// TracedReference handles inside cppgc objects can be cleared during minor
+// (Scavenge) GC when write-barrier bookkeeping is missed — for example when
+// the reference is stored during MakeGarbageCollected construction, which
+// uses kInitializingStore and skips the remembered-set write barrier.
+//
+// v8::Global is an unconditionally strong root that no GC of any kind can
+// collect.  That is the correct semantic for a Promise resolver, which must
+// stay alive until it is settled or explicitly discarded.
 class PromiseHandle final : public cppgc::GarbageCollected<PromiseHandle>,
                             public cppgc::NameProvider {
  public:
@@ -25,10 +35,9 @@ class PromiseHandle final : public cppgc::GarbageCollected<PromiseHandle>,
                 v8::Local<v8::Promise::Resolver> resolver)
       : context_(isolate, context), resolver_(isolate, resolver) {}
 
-  void Trace(cppgc::Visitor* visitor) const {
-    visitor->Trace(context_);
-    visitor->Trace(resolver_);
-  }
+  // v8::Global pointers are strong roots independent of cppgc tracing;
+  // they are released by ~Global when cppgc destructs this object.
+  void Trace(cppgc::Visitor* visitor) const {}
 
   const char* GetHumanReadableName() const final {
     return "Electron / PromiseHandle";
@@ -45,8 +54,8 @@ class PromiseHandle final : public cppgc::GarbageCollected<PromiseHandle>,
   }
 
  private:
-  v8::TracedReference<v8::Context> context_;
-  v8::TracedReference<v8::Promise::Resolver> resolver_;
+  v8::Global<v8::Context> context_;
+  v8::Global<v8::Promise::Resolver> resolver_;
 };
 
 PromiseBase::SettleScope::SettleScope(const PromiseBase& base)


### PR DESCRIPTION
#### Description of Change

Experimental PR to test a theory about #51462.

The theory here is that the Promise's resolver is being collected before the promise resolves, causing `isAlive()` to return false and make `Resolve()` and `Reject()` no-ops.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none