### PR TITLE
feat: support per-corner radii in View.setBorderRadius()

### DIFF
--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -112,7 +112,13 @@ Examples of valid `color` values:
 
 #### `view.setBorderRadius(radius)`
 
-* `radius` Integer - Border radius size in pixels.
+* `radius` Integer | Object - Border radius. When an `Integer`, it is applied
+  uniformly to all four corners. When an `Object`, it can contain the following
+  properties (all optional, default `0`):
+  * `topLeft` Integer (optional) - Radius of the top-left corner, in pixels.
+  * `topRight` Integer (optional) - Radius of the top-right corner, in pixels.
+  * `bottomRight` Integer (optional) - Radius of the bottom-right corner, in pixels.
+  * `bottomLeft` Integer (optional) - Radius of the bottom-left corner, in pixels.
 
 > [!NOTE]
 > The area cutout of the view's border still captures clicks.

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -10,16 +10,17 @@
 #include <string>
 #include <utility>
 
-#include "ash/style/rounded_rect_cutout_path_builder.h"
 #include "gin/data_object_builder.h"
 #include "gin/wrappable.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
+#include "third_party/skia/include/core/SkRRect.h"
 #include "ui/compositor/layer.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
@@ -485,36 +486,71 @@ void View::SetBackgroundColor(std::optional<WrappedSkColor> color) {
                              : nullptr);
 }
 
-void View::SetBorderRadius(int radius) {
-  border_radius_ = radius;
+void View::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                           v8::Local<v8::Value> value) {
+  v8::Isolate* const isolate = JavascriptEnvironment::GetIsolate();
+  if (value->IsNumber()) {
+    int radius = 0;
+    if (!gin::ConvertFromV8(isolate, value, &radius))
+      return;
+    border_radii_ = gfx::RoundedCornersF(static_cast<float>(radius));
+  } else if (value->IsObject()) {
+    gin_helper::Dictionary dict;
+    if (!gin::ConvertFromV8(isolate, value, &dict))
+      return;
+    int top_left = 0;
+    int top_right = 0;
+    int bottom_right = 0;
+    int bottom_left = 0;
+    dict.Get("topLeft", &top_left);
+    dict.Get("topRight", &top_right);
+    dict.Get("bottomRight", &bottom_right);
+    dict.Get("bottomLeft", &bottom_left);
+    border_radii_ = gfx::RoundedCornersF(
+        static_cast<float>(top_left), static_cast<float>(top_right),
+        static_cast<float>(bottom_right), static_cast<float>(bottom_left));
+  } else {
+    thrower.ThrowTypeError(
+        "setBorderRadius requires a number or an object with topLeft, "
+        "topRight, bottomRight, and/or bottomLeft properties");
+    return;
+  }
   ApplyBorderRadius();
 }
 
 void View::ApplyBorderRadius() {
-  if (!border_radius_.has_value() || !view_)
+  if (!border_radii_.has_value() || !view_)
     return;
 
-  auto size = view_->bounds().size();
+  const auto size = view_->bounds().size();
+  // Each corner is independently clamped to half of the smaller dimension so
+  // the rounded rect remains representable. Clamping is computed locally and
+  // doesn't mutate the stored radii — a future resize back up restores them.
+  const float max_r =
+      std::max(0.f, std::min(size.width(), size.height()) / 2.f);
+  const auto clamp = [max_r](float r) {
+    return std::max(0.f, std::min(r, max_r));
+  };
+  const gfx::RoundedCornersF r(clamp(border_radii_->upper_left()),
+                               clamp(border_radii_->upper_right()),
+                               clamp(border_radii_->lower_right()),
+                               clamp(border_radii_->lower_left()));
 
-  // Restrict border radius to the constraints set in the path builder class.
-  // If the constraints are exceeded, the builder will crash.
-  int radius;
-  {
-    float r = border_radius_.value() * 1.f;
-    r = std::min(r, size.width() / 2.f);
-    r = std::min(r, size.height() / 2.f);
-    r = std::max(r, 0.f);
-    radius = std::floor(r);
-  }
-
-  // RoundedRectCutoutPathBuilder has a minimum size of 32 x 32.
-  if (radius > 0 && size.width() >= 32 && size.height() >= 32) {
-    auto builder = ash::RoundedRectCutoutPathBuilder(gfx::SizeF(size));
-    builder.CornerRadius(radius);
-    view_->SetClipPath(builder.Build());
-  } else {
+  if (r.IsEmpty() || size.IsEmpty()) {
     view_->SetClipPath(SkPath());
+    return;
   }
+
+  const SkRect rect =
+      SkRect::MakeWH(static_cast<SkScalar>(size.width()),
+                     static_cast<SkScalar>(size.height()));
+  const SkVector radii[4] = {{r.upper_left(), r.upper_left()},
+                             {r.upper_right(), r.upper_right()},
+                             {r.lower_right(), r.lower_right()},
+                             {r.lower_left(), r.lower_left()}};
+  SkRRect rrect;
+  rrect.setRectRadii(rect, radii);
+  view_->SetClipPath(SkPath::RRect(rrect));
 }
 
 void View::SetBackgroundBlur(int blur_radius) {

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -10,11 +10,13 @@
 #include "base/memory/raw_ptr.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/event_emitter.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
 #include "v8/include/v8-value.h"
 
 namespace gin_helper {
+class ErrorThrower;
 template <typename T>
 class Handle;
 }  // namespace gin_helper
@@ -42,13 +44,16 @@ class View : public gin_helper::EventEmitter<View>,
   void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
   void SetBackgroundBlur(int blur_radius);
   void SetVisible(bool visible);
   bool GetVisible() const;
 
   views::View* view() const { return view_; }
-  std::optional<int> border_radius() const { return border_radius_; }
+  const std::optional<gfx::RoundedCornersF>& border_radii() const {
+    return border_radii_;
+  }
 
   // disable copy
   View(const View&) = delete;
@@ -76,7 +81,7 @@ class View : public gin_helper::EventEmitter<View>,
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 
   std::vector<ChildPair> child_views_;
-  std::optional<int> border_radius_;
+  std::optional<gfx::RoundedCornersF> border_radii_;
 
   bool delete_view_ = true;
   raw_ptr<views::View> view_ = nullptr;

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -16,6 +16,7 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
@@ -69,15 +70,16 @@ void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
   }
 }
 
-void WebContentsView::SetBorderRadius(int radius) {
-  View::SetBorderRadius(radius);
+void WebContentsView::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                                      v8::Local<v8::Value> value) {
+  View::SetBorderRadius(thrower, value);
   ApplyBorderRadius();
 }
 
 void WebContentsView::ApplyBorderRadius() {
-  if (border_radius().has_value() && api_web_contents_ && view()->GetWidget()) {
+  if (border_radii().has_value() && api_web_contents_ && view()->GetWidget()) {
     auto* view = api_web_contents_->inspectable_web_contents()->GetView();
-    view->SetCornerRadii(gfx::RoundedCornersF(border_radius().value()));
+    view->SetCornerRadii(border_radii().value());
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -14,6 +14,7 @@
 
 namespace gin_helper {
 class Dictionary;
+class ErrorThrower;
 }
 
 namespace electron::api {
@@ -39,7 +40,8 @@ class WebContentsView : public View,
   // Public APIs.
   gin_helper::Handle<WebContents> GetWebContents(v8::Isolate* isolate);
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
 
   int NonClientHitTest(const gfx::Point& point) override;
 

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -80,6 +80,48 @@ describe('View', () => {
     v.setBorderRadius(-9999999);
   });
 
+  it('allows setting per-corner border radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: 10, topRight: 8, bottomRight: 6, bottomLeft: 4 });
+    v.setBorderRadius({ topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 });
+  });
+
+  it('defaults missing per-corner keys to zero', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: 5 });
+    v.setBorderRadius({ bottomRight: 12 });
+    v.setBorderRadius({});
+  });
+
+  it('clamps negative and oversize per-corner radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: -10, topRight: 9999, bottomRight: 0, bottomLeft: 5 });
+    v.setBorderRadius({ topLeft: -9999999, topRight: -1, bottomRight: -1, bottomLeft: -1 });
+  });
+
+  it('allows mixing integer and object forms', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius(8);
+    v.setBorderRadius({ topLeft: 16, topRight: 16, bottomRight: 0, bottomLeft: 0 });
+    v.setBorderRadius(0);
+    v.setBorderRadius({});
+  });
+
+  it('throws on invalid border radius input', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    expect(() => v.setBorderRadius('not valid' as any)).to.throw(/number or/);
+  });
+
   describe('view.getVisible|setVisible', () => {
     it('is visible by default', () => {
       const v = new View();


### PR DESCRIPTION
#### Description of Change

`View.setBorderRadius()` now accepts an object form `{ topLeft, topRight, bottomRight, bottomLeft }` in addition to the existing single integer, so apps can build browser-shell layouts (rounded top corners on a toolbar, rounded bottom corners on a content pane) without workarounds. Each property defaults to `0` when missing; the integer form is unchanged.

The change also flows through `WebContentsView` via the existing `InspectableWebContentsView::SetCornerRadii(gfx::RoundedCornersF)`, so per-corner radii reach the WebView compositor with no additional plumbing.

Internally, `View::ApplyBorderRadius` was switched from `ash::RoundedRectCutoutPathBuilder` to `SkRRect::setRectRadii` + `SkPath::RRect`, which is a strictly simpler primitive (the cutout builder is for corner *cutouts* / notches, not plain rounded rects, and its 32×32 minimum-size restriction was an artifact of cutout defaults). As a side benefit, small (<32×32) views now correctly get the clip they asked for.

Resolves #51342.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for per-corner radii in \`View.setBorderRadius()\` via \`{ topLeft, topRight, bottomRight, bottomLeft }\`.