### PR TITLE
feat: support per-corner radii in View.setBorderRadius()

### DIFF
--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -112,7 +112,21 @@ Examples of valid `color` values:
 
 #### `view.setBorderRadius(radius)`
 
-* `radius` Integer - Border radius size in pixels.
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/51472
+    description: "`setBorderRadius` now accepts an object with per-corner radii."
+```
+-->
+
+* `radius` Integer | Object - Border radius. When an `Integer`, it is applied
+  uniformly to all four corners. When an `Object`, it can contain the following
+  properties (all optional, default `0`):
+  * `topLeft` Integer (optional) - Radius of the top-left corner, in pixels.
+  * `topRight` Integer (optional) - Radius of the top-right corner, in pixels.
+  * `bottomRight` Integer (optional) - Radius of the bottom-right corner, in pixels.
+  * `bottomLeft` Integer (optional) - Radius of the bottom-left corner, in pixels.
 
 > [!NOTE]
 > The area cutout of the view's border still captures clicks.

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -110,7 +110,7 @@ Examples of valid `color` values:
 > [!NOTE]
 > Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.
 
-#### `view.setBorderRadius(radius)`
+#### `view.setBorderRadius(borderRadius)`
 
 <!--
 ```YAML history
@@ -120,7 +120,7 @@ changes:
 ```
 -->
 
-* `radius` Integer | Object - Border radius. When an `Integer`, it is applied
+* `borderRadius` Integer | Object - Border radius. When an `Integer`, it is applied
   uniformly to all four corners. When an `Object`, it can contain the following
   properties (all optional, default `0`):
   * `topLeft` Integer (optional) - Radius of the top-left corner, in pixels.

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -121,12 +121,12 @@ changes:
 -->
 
 * `borderRadius` Integer | Object - Border radius. When an `Integer`, it is applied
-  uniformly to all four corners. When an `Object`, it can contain the following
-  properties (all optional, default `0`):
-  * `topLeft` Integer (optional) - Radius of the top-left corner, in pixels.
-  * `topRight` Integer (optional) - Radius of the top-right corner, in pixels.
-  * `bottomRight` Integer (optional) - Radius of the bottom-right corner, in pixels.
-  * `bottomLeft` Integer (optional) - Radius of the bottom-left corner, in pixels.
+  uniformly to all four corners. When an `Object`, it must contain the following
+  properties:
+  * `topLeft` Integer - Radius of the top-left corner, in pixels.
+  * `topRight` Integer - Radius of the top-right corner, in pixels.
+  * `bottomRight` Integer - Radius of the bottom-right corner, in pixels.
+  * `bottomLeft` Integer - Radius of the bottom-left corner, in pixels.
 
 > [!NOTE]
 > The area cutout of the view's border still captures clicks.

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -10,16 +10,17 @@
 #include <string>
 #include <utility>
 
-#include "ash/style/rounded_rect_cutout_path_builder.h"
 #include "gin/data_object_builder.h"
 #include "gin/wrappable.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
+#include "third_party/skia/include/core/SkRRect.h"
 #include "ui/compositor/layer.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
@@ -485,36 +486,71 @@ void View::SetBackgroundColor(std::optional<WrappedSkColor> color) {
                              : nullptr);
 }
 
-void View::SetBorderRadius(int radius) {
-  border_radius_ = radius;
+void View::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                           v8::Local<v8::Value> value) {
+  v8::Isolate* const isolate = JavascriptEnvironment::GetIsolate();
+  if (value->IsNumber()) {
+    int radius = 0;
+    if (!gin::ConvertFromV8(isolate, value, &radius))
+      return;
+    border_radii_ = gfx::RoundedCornersF(static_cast<float>(radius));
+  } else if (value->IsObject()) {
+    gin_helper::Dictionary dict;
+    if (!gin::ConvertFromV8(isolate, value, &dict))
+      return;
+    int top_left = 0;
+    int top_right = 0;
+    int bottom_right = 0;
+    int bottom_left = 0;
+    dict.Get("topLeft", &top_left);
+    dict.Get("topRight", &top_right);
+    dict.Get("bottomRight", &bottom_right);
+    dict.Get("bottomLeft", &bottom_left);
+    border_radii_ = gfx::RoundedCornersF(
+        static_cast<float>(top_left), static_cast<float>(top_right),
+        static_cast<float>(bottom_right), static_cast<float>(bottom_left));
+  } else {
+    thrower.ThrowTypeError(
+        "setBorderRadius requires a number or an object with topLeft, "
+        "topRight, bottomRight, and/or bottomLeft properties");
+    return;
+  }
   ApplyBorderRadius();
 }
 
 void View::ApplyBorderRadius() {
-  if (!border_radius_.has_value() || !view_)
+  if (!border_radii_.has_value() || !view_)
     return;
 
-  auto size = view_->bounds().size();
+  const auto size = view_->bounds().size();
+  // Each corner is independently clamped to half of the smaller dimension so
+  // the rounded rect remains representable. Clamping is computed locally and
+  // doesn't mutate the stored radii — a future resize back up restores them.
+  const float max_r =
+      std::max(0.f, std::min(size.width(), size.height()) / 2.f);
+  const auto clamp = [max_r](float r) {
+    return std::max(0.f, std::min(r, max_r));
+  };
+  const gfx::RoundedCornersF r(clamp(border_radii_->upper_left()),
+                               clamp(border_radii_->upper_right()),
+                               clamp(border_radii_->lower_right()),
+                               clamp(border_radii_->lower_left()));
 
-  // Restrict border radius to the constraints set in the path builder class.
-  // If the constraints are exceeded, the builder will crash.
-  int radius;
-  {
-    float r = border_radius_.value() * 1.f;
-    r = std::min(r, size.width() / 2.f);
-    r = std::min(r, size.height() / 2.f);
-    r = std::max(r, 0.f);
-    radius = std::floor(r);
-  }
-
-  // RoundedRectCutoutPathBuilder has a minimum size of 32 x 32.
-  if (radius > 0 && size.width() >= 32 && size.height() >= 32) {
-    auto builder = ash::RoundedRectCutoutPathBuilder(gfx::SizeF(size));
-    builder.CornerRadius(radius);
-    view_->SetClipPath(builder.Build());
-  } else {
+  if (r.IsEmpty() || size.IsEmpty()) {
     view_->SetClipPath(SkPath());
+    return;
   }
+
+  const SkRect rect =
+      SkRect::MakeWH(static_cast<SkScalar>(size.width()),
+                     static_cast<SkScalar>(size.height()));
+  const SkVector radii[4] = {{r.upper_left(), r.upper_left()},
+                             {r.upper_right(), r.upper_right()},
+                             {r.lower_right(), r.lower_right()},
+                             {r.lower_left(), r.lower_left()}};
+  SkRRect rrect;
+  rrect.setRectRadii(rect, radii);
+  view_->SetClipPath(SkPath::RRect(rrect));
 }
 
 void View::SetBackgroundBlur(int blur_radius) {

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -531,19 +531,17 @@ void View::ApplyBorderRadius() {
   const auto clamp = [max_r](float r) {
     return std::max(0.f, std::min(r, max_r));
   };
-  const gfx::RoundedCornersF r(clamp(border_radii_->upper_left()),
-                               clamp(border_radii_->upper_right()),
-                               clamp(border_radii_->lower_right()),
-                               clamp(border_radii_->lower_left()));
+  const gfx::RoundedCornersF r(
+      clamp(border_radii_->upper_left()), clamp(border_radii_->upper_right()),
+      clamp(border_radii_->lower_right()), clamp(border_radii_->lower_left()));
 
   if (r.IsEmpty() || size.IsEmpty()) {
     view_->SetClipPath(SkPath());
     return;
   }
 
-  const SkRect rect =
-      SkRect::MakeWH(static_cast<SkScalar>(size.width()),
-                     static_cast<SkScalar>(size.height()));
+  const SkRect rect = SkRect::MakeWH(static_cast<SkScalar>(size.width()),
+                                     static_cast<SkScalar>(size.height()));
   const SkVector radii[4] = {{r.upper_left(), r.upper_left()},
                              {r.upper_right(), r.upper_right()},
                              {r.lower_right(), r.lower_right()},

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -172,6 +172,10 @@ struct Converter<gfx::Tween::Type> {
 
 namespace electron::api {
 
+constexpr char kBorderRadiusTypeError[] =
+    "`borderRadius` must be an integer or an object with integer `topLeft`, "
+    "`topRight`, `bottomRight`, and `bottomLeft` properties";
+
 using LayoutCallback = base::RepeatingCallback<views::ProposedLayout(
     const views::SizeBounds& size_bounds)>;
 
@@ -488,31 +492,35 @@ void View::SetBackgroundColor(std::optional<WrappedSkColor> color) {
 
 void View::SetBorderRadius(gin_helper::ErrorThrower thrower,
                            v8::Local<v8::Value> value) {
-  v8::Isolate* const isolate = JavascriptEnvironment::GetIsolate();
+  v8::Isolate* const isolate = thrower.isolate();
   if (value->IsNumber()) {
     int radius = 0;
-    if (!gin::ConvertFromV8(isolate, value, &radius))
+    if (!gin::ConvertFromV8(isolate, value, &radius)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
       return;
+    }
     border_radii_ = gfx::RoundedCornersF(static_cast<float>(radius));
   } else if (value->IsObject()) {
     gin_helper::Dictionary dict;
-    if (!gin::ConvertFromV8(isolate, value, &dict))
+    if (!gin::ConvertFromV8(isolate, value, &dict)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
       return;
+    }
     int top_left = 0;
     int top_right = 0;
     int bottom_right = 0;
     int bottom_left = 0;
-    dict.Get("topLeft", &top_left);
-    dict.Get("topRight", &top_right);
-    dict.Get("bottomRight", &bottom_right);
-    dict.Get("bottomLeft", &bottom_left);
+    if (!dict.Get("topLeft", &top_left) || !dict.Get("topRight", &top_right) ||
+        !dict.Get("bottomRight", &bottom_right) ||
+        !dict.Get("bottomLeft", &bottom_left)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
+      return;
+    }
     border_radii_ = gfx::RoundedCornersF(
         static_cast<float>(top_left), static_cast<float>(top_right),
         static_cast<float>(bottom_right), static_cast<float>(bottom_left));
   } else {
-    thrower.ThrowTypeError(
-        "setBorderRadius requires a number or an object with topLeft, "
-        "topRight, bottomRight, and/or bottomLeft properties");
+    thrower.ThrowTypeError(kBorderRadiusTypeError);
     return;
   }
   ApplyBorderRadius();
@@ -537,6 +545,7 @@ void View::ApplyBorderRadius() {
 
   if (r.IsEmpty() || size.IsEmpty()) {
     view_->SetClipPath(SkPath());
+    OnBorderRadiusApplied(r);
     return;
   }
 
@@ -549,7 +558,10 @@ void View::ApplyBorderRadius() {
   SkRRect rrect;
   rrect.setRectRadii(rect, radii);
   view_->SetClipPath(SkPath::RRect(rrect));
+  OnBorderRadiusApplied(r);
 }
+
+void View::OnBorderRadiusApplied(const gfx::RoundedCornersF&) {}
 
 void View::SetBackgroundBlur(int blur_radius) {
   if (!view_)

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -10,11 +10,13 @@
 #include "base/memory/raw_ptr.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/event_emitter.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
 #include "v8/include/v8-value.h"
 
 namespace gin_helper {
+class ErrorThrower;
 template <typename T>
 class Handle;
 }  // namespace gin_helper
@@ -42,13 +44,16 @@ class View : public gin_helper::EventEmitter<View>,
   void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
   void SetBackgroundBlur(int blur_radius);
   void SetVisible(bool visible);
   bool GetVisible() const;
 
   views::View* view() const { return view_; }
-  std::optional<int> border_radius() const { return border_radius_; }
+  const std::optional<gfx::RoundedCornersF>& border_radii() const {
+    return border_radii_;
+  }
 
   // disable copy
   View(const View&) = delete;
@@ -76,7 +81,7 @@ class View : public gin_helper::EventEmitter<View>,
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 
   std::vector<ChildPair> child_views_;
-  std::optional<int> border_radius_;
+  std::optional<gfx::RoundedCornersF> border_radii_;
 
   bool delete_view_ = true;
   raw_ptr<views::View> view_ = nullptr;

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -67,6 +67,9 @@ class View : public gin_helper::EventEmitter<View>,
   // Should delete the |view_| in destructor.
   void set_delete_view(bool should) { delete_view_ = should; }
 
+  void ApplyBorderRadius();
+  virtual void OnBorderRadiusApplied(const gfx::RoundedCornersF& border_radii);
+
  private:
   using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
 
@@ -77,7 +80,6 @@ class View : public gin_helper::EventEmitter<View>,
                           views::View* child) override;
 
   ui::Layer* GetLayer();
-  void ApplyBorderRadius();
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 
   std::vector<ChildPair> child_views_;

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -16,7 +16,7 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/handle.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
@@ -70,15 +70,16 @@ void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
   }
 }
 
-void WebContentsView::SetBorderRadius(int radius) {
-  View::SetBorderRadius(radius);
+void WebContentsView::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                                      v8::Local<v8::Value> value) {
+  View::SetBorderRadius(thrower, value);
   ApplyBorderRadius();
 }
 
 void WebContentsView::ApplyBorderRadius() {
-  if (border_radius().has_value() && api_web_contents_ && view()->GetWidget()) {
+  if (border_radii().has_value() && api_web_contents_ && view()->GetWidget()) {
     auto* view = api_web_contents_->inspectable_web_contents()->GetView();
-    view->SetCornerRadii(gfx::RoundedCornersF(border_radius().value()));
+    view->SetCornerRadii(border_radii().value());
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -17,6 +17,7 @@
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
@@ -73,13 +74,13 @@ void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
 void WebContentsView::SetBorderRadius(gin_helper::ErrorThrower thrower,
                                       v8::Local<v8::Value> value) {
   View::SetBorderRadius(thrower, value);
-  ApplyBorderRadius();
 }
 
-void WebContentsView::ApplyBorderRadius() {
-  if (border_radii().has_value() && api_web_contents_ && view()->GetWidget()) {
+void WebContentsView::OnBorderRadiusApplied(
+    const gfx::RoundedCornersF& border_radii) {
+  if (api_web_contents_ && view()->GetWidget()) {
     auto* view = api_web_contents_->inspectable_web_contents()->GetView();
-    view->SetCornerRadii(border_radii().value());
+    view->SetCornerRadii(border_radii);
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -14,6 +14,7 @@
 
 namespace gin_helper {
 class Dictionary;
+class ErrorThrower;
 }
 
 namespace electron::api {
@@ -39,7 +40,8 @@ class WebContentsView : public View,
   // Public APIs.
   gin_helper::Handle<WebContents> GetWebContents(v8::Isolate* isolate);
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
 
   int NonClientHitTest(const gfx::Point& point) override;
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -15,7 +15,7 @@
 namespace gin_helper {
 class Dictionary;
 class ErrorThrower;
-}
+}  // namespace gin_helper
 
 namespace electron::api {
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -61,7 +61,7 @@ class WebContentsView : public View,
  private:
   static gin_helper::WrappableBase* New(gin::Arguments* args);
 
-  void ApplyBorderRadius();
+  void OnBorderRadiusApplied(const gfx::RoundedCornersF& border_radii) override;
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -80,6 +80,48 @@ describe('View', () => {
     v.setBorderRadius(-9999999);
   });
 
+  it('allows setting per-corner border radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: 10, topRight: 8, bottomRight: 6, bottomLeft: 4 });
+    v.setBorderRadius({ topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 });
+  });
+
+  it('defaults missing per-corner keys to zero', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: 5 });
+    v.setBorderRadius({ bottomRight: 12 });
+    v.setBorderRadius({});
+  });
+
+  it('clamps negative and oversize per-corner radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: -10, topRight: 9999, bottomRight: 0, bottomLeft: 5 });
+    v.setBorderRadius({ topLeft: -9999999, topRight: -1, bottomRight: -1, bottomLeft: -1 });
+  });
+
+  it('allows mixing integer and object forms', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius(8);
+    v.setBorderRadius({ topLeft: 16, topRight: 16, bottomRight: 0, bottomLeft: 0 });
+    v.setBorderRadius(0);
+    v.setBorderRadius({});
+  });
+
+  it('throws on invalid border radius input', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    expect(() => v.setBorderRadius('not valid' as any)).to.throw(/number or/);
+  });
+
   describe('view.getVisible|setVisible', () => {
     it('is visible by default', () => {
       const v = new View();

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -88,13 +88,19 @@ describe('View', () => {
     v.setBorderRadius({ topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 });
   });
 
-  it('defaults missing per-corner keys to zero', () => {
+  it('throws when per-corner keys are missing', () => {
     w = new BaseWindow({ show: false });
     const v = new View();
     w.setContentView(v);
-    v.setBorderRadius({ topLeft: 5 });
-    v.setBorderRadius({ bottomRight: 12 });
-    v.setBorderRadius({});
+    const borderRadiusError = /must be an integer or an object/;
+    const borderRadius = { topLeft: 5, topRight: 5, bottomRight: 5, bottomLeft: 5 };
+    const keys = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'] as const;
+
+    for (const key of keys) {
+      const missing = { ...borderRadius } as Partial<typeof borderRadius>;
+      delete missing[key];
+      expect(() => v.setBorderRadius(missing as any)).to.throw(TypeError, borderRadiusError);
+    }
   });
 
   it('clamps negative and oversize per-corner radii', () => {
@@ -112,14 +118,14 @@ describe('View', () => {
     v.setBorderRadius(8);
     v.setBorderRadius({ topLeft: 16, topRight: 16, bottomRight: 0, bottomLeft: 0 });
     v.setBorderRadius(0);
-    v.setBorderRadius({});
   });
 
   it('throws on invalid border radius input', () => {
     w = new BaseWindow({ show: false });
     const v = new View();
     w.setContentView(v);
-    expect(() => v.setBorderRadius('not valid' as any)).to.throw(/number or/);
+    expect(() => v.setBorderRadius('not valid' as any)).to.throw(TypeError, /must be an integer or an object/);
+    expect(() => v.setBorderRadius(1.5 as any)).to.throw(TypeError, /must be an integer or an object/);
   });
 
   describe('view.getVisible|setVisible', () => {

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -501,6 +501,23 @@ describe('WebContentsView', () => {
         await screenCapture.expectColorAtCenterMatches(HexColors.GREEN);
       });
 
+      it('should keep the clip and compositor radii in sync after resizing', async () => {
+        const parent = new View();
+        w.setContentView(parent);
+        parent.addChildView(v);
+        v.setBorderRadius(100);
+
+        const corner = corners[0];
+        const screenCapture = new ScreenCapture(display);
+        v.setBounds({ x: 0, y: 0, width: 40, height: 40 });
+        await nextFrameTime();
+        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.GREEN, () => corner);
+
+        v.setBounds({ x: 0, y: 0, width: 200, height: 200 });
+        await nextFrameTime();
+        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.BLUE, () => corner);
+      });
+
       it('should render when set before attached', async () => {
         v = new WebContentsView();
         v.setBorderRadius(100); // must set before


### PR DESCRIPTION
#### Description of Change

`View.setBorderRadius()` now accepts an object form `{ topLeft, topRight, bottomRight, bottomLeft }` in addition to the existing single integer, so apps can build browser-shell layouts (rounded top corners on a toolbar, rounded bottom corners on a content pane) without workarounds. Each property defaults to `0` when missing; the integer form is unchanged.

The change also flows through `WebContentsView` via the existing `InspectableWebContentsView::SetCornerRadii(gfx::RoundedCornersF)`, so per-corner radii reach the WebView compositor with no additional plumbing.

Internally, `View::ApplyBorderRadius` was switched from `ash::RoundedRectCutoutPathBuilder` to `SkRRect::setRectRadii` + `SkPath::RRect`, which is a strictly simpler primitive (the cutout builder is for corner *cutouts* / notches, not plain rounded rects, and its 32×32 minimum-size restriction was an artifact of cutout defaults). As a side benefit, small (<32×32) views now correctly get the clip they asked for.

Resolves #51342. Supersedes #51471 (auto-closed by template-checker bot due to a heading-level mistake in the original description).

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added support for per-corner radii in \`View.setBorderRadius()\` via \`{ topLeft, topRight, bottomRight, bottomLeft }\`.