### PR TITLE
refactor: use GetWebContents() from WebContentsUserData

### DIFF
--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -206,8 +206,7 @@ void OnPermissionResponse(base::OnceCallback<void(bool)> callback,
 
 WebContentsPermissionHelper::WebContentsPermissionHelper(
     content::WebContents* web_contents)
-    : content::WebContentsUserData<WebContentsPermissionHelper>(*web_contents),
-      web_contents_(web_contents) {}
+    : content::WebContentsUserData<WebContentsPermissionHelper>(*web_contents) {}
 
 WebContentsPermissionHelper::~WebContentsPermissionHelper() = default;
 
@@ -218,7 +217,7 @@ void WebContentsPermissionHelper::RequestPermission(
     bool user_gesture,
     base::DictValue details) {
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
-      web_contents_->GetBrowserContext()->GetPermissionControllerDelegate());
+      GetWebContents().GetBrowserContext()->GetPermissionControllerDelegate());
   auto origin = requesting_frame->GetLastCommittedOrigin().GetURL();
   permission_manager->RequestPermissionWithDetails(
       content::PermissionDescriptorUtil::
@@ -232,7 +231,7 @@ bool WebContentsPermissionHelper::CheckPermission(
     blink::PermissionType permission,
     base::DictValue details) const {
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
-      web_contents_->GetBrowserContext()->GetPermissionControllerDelegate());
+      GetWebContents().GetBrowserContext()->GetPermissionControllerDelegate());
   auto origin = requesting_frame->GetLastCommittedOrigin().GetURL();
   return permission_manager->CheckPermissionWithDetails(
       permission, requesting_frame, origin, std::move(details));
@@ -285,9 +284,9 @@ void WebContentsPermissionHelper::RequestPointerLockPermission(
     bool last_unlocked_by_target,
     base::OnceCallback<void(content::WebContents*, bool, bool, bool)>
         callback) {
-  RequestPermission(web_contents_->GetPrimaryMainFrame(),
+  RequestPermission(GetWebContents().GetPrimaryMainFrame(),
                     blink::PermissionType::POINTER_LOCK,
-                    base::BindOnce(std::move(callback), web_contents_,
+                    base::BindOnce(std::move(callback), &GetWebContents(),
                                    user_gesture, last_unlocked_by_target),
                     user_gesture);
 }
@@ -296,9 +295,9 @@ void WebContentsPermissionHelper::RequestKeyboardLockPermission(
     bool esc_key_locked,
     base::OnceCallback<void(content::WebContents*, bool, bool)> callback) {
   RequestPermission(
-      web_contents_->GetPrimaryMainFrame(),
+      GetWebContents().GetPrimaryMainFrame(),
       blink::PermissionType::KEYBOARD_LOCK,
-      base::BindOnce(std::move(callback), web_contents_, esc_key_locked));
+      base::BindOnce(std::move(callback), &GetWebContents(), esc_key_locked));
 }
 
 void WebContentsPermissionHelper::RequestOpenExternalPermission(

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -67,9 +67,7 @@ class WebContentsPermissionHelper
                        blink::PermissionType permission,
                        base::DictValue details) const;
 
-  // TODO(clavin): refactor to use the WebContents provided by the
-  // WebContentsUserData base class instead of storing a duplicate ref
-  raw_ptr<content::WebContents> web_contents_;
+
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -85,15 +85,14 @@ std::vector<WebContentsPreferences*>& Instances() {
 WebContentsPreferences::WebContentsPreferences(
     content::WebContents* web_contents,
     const gin_helper::Dictionary& web_preferences)
-    : content::WebContentsUserData<WebContentsPreferences>(*web_contents),
-      web_contents_(web_contents) {
+    : content::WebContentsUserData<WebContentsPreferences>(*web_contents) {
   web_contents->SetUserData(UserDataKey(), base::WrapUnique(this));
   Instances().push_back(this);
   SetFromDictionary(web_preferences);
 
   // If this is a <webview> tag, and the embedder is offscreen-rendered, then
   // this WebContents is also offscreen-rendered.
-  if (auto* api_web_contents = api::WebContents::From(web_contents_)) {
+  if (auto* api_web_contents = api::WebContents::From(&GetWebContents())) {
     if (electron::api::WebContents* embedder = api_web_contents->embedder()) {
       auto* embedder_preferences =
           WebContentsPreferences::From(embedder->web_contents());
@@ -290,7 +289,7 @@ bool WebContentsPreferences::IsSandboxed() const {
 content::WebContents* WebContentsPreferences::GetWebContentsFromProcessID(
     content::ChildProcessId process_id) {
   for (WebContentsPreferences* preferences : Instances()) {
-    content::WebContents* web_contents = preferences->web_contents_;
+    content::WebContents* web_contents = &preferences->GetWebContents();
     if (web_contents->GetPrimaryMainFrame()->GetProcess()->GetID() ==
         process_id)
       return web_contents;
@@ -441,7 +440,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->hidden_page = false;
   // Webview `document.visibilityState` tracks window visibility so we need
   // to let it know if the window happens to be hidden right now.
-  if (auto* api_web_contents = api::WebContents::From(web_contents_)) {
+  if (auto* api_web_contents = api::WebContents::From(&GetWebContents())) {
     if (electron::api::WebContents* embedder = api_web_contents->embedder()) {
       if (auto* relay =
               NativeWindowRelay::FromWebContents(embedder->web_contents())) {

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -92,9 +92,6 @@ class WebContentsPreferences
   void Clear();
   void SaveLastPreferences();
 
-  // TODO(clavin): refactor to use the WebContents provided by the
-  // WebContentsUserData base class instead of storing a duplicate ref
-  raw_ptr<content::WebContents> web_contents_;
 
   bool plugins_;
   bool experimental_features_;

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "electron/buildflags/buildflags.h"


### PR DESCRIPTION
#### Description of Change

Eliminated duplicate `raw_ptr<content::WebContents> web_contents_` fields in `WebContentsPreferences` and `WebContentsPermissionHelper`. The classes now correctly use the Chromium base class's `GetWebContents()` method, explicitly resolving two duplicate `TODO(clavin)` comments.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md
NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
