### PR TITLE
fix: more test fixture cleanups

### DIFF
--- a/spec/fixtures/api/context-bridge/context-bridge-mutability/main.js
+++ b/spec/fixtures/api/context-bridge/context-bridge-mutability/main.js
@@ -3,19 +3,22 @@ const { app, BrowserWindow } = require('electron');
 const path = require('node:path');
 
 let win;
-app.whenReady().then(function () {
-  win = new BrowserWindow({
-    webPreferences: {
-      contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js')
-    }
-  });
+app
+  .whenReady()
+  .then(async function () {
+    win = new BrowserWindow({
+      webPreferences: {
+        contextIsolation: true,
+        preload: path.join(__dirname, 'preload.js')
+      }
+    });
 
-  win.loadFile('index.html');
+    win.webContents.on('console-message', (event) => {
+      console.log(event.message);
+    });
 
-  win.webContents.on('console-message', (event) => {
-    console.log(event.message);
-  });
+    win.webContents.on('did-finish-load', app.quit);
 
-  win.webContents.on('did-finish-load', () => app.quit());
-});
+    await win.loadFile('index.html');
+  })
+  .catch(() => process.exit(1));

--- a/spec/fixtures/api/gpu-info.js
+++ b/spec/fixtures/api/gpu-info.js
@@ -2,20 +2,23 @@ const { app, BrowserWindow } = require('electron');
 
 app.commandLine.appendSwitch('--disable-software-rasterizer');
 
-app.whenReady().then(() => {
-  const infoType = process.argv.pop();
-  const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });
-  w.webContents.once('did-finish-load', () => {
-    app.getGPUInfo(infoType).then(
-      (gpuInfo) => {
-        console.log('HERE COMES THE JSON: ' + JSON.stringify(gpuInfo) + ' AND THERE IT WAS');
-        setImmediate(() => app.exit(0));
-      },
-      (error) => {
-        console.error(error);
-        setImmediate(() => app.exit(1));
-      }
-    );
-  });
-  w.loadURL('data:text/html;<canvas></canvas>');
-});
+app
+  .whenReady()
+  .then(() => {
+    const infoType = process.argv.pop();
+    const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });
+    w.webContents.once('did-finish-load', () => {
+      app.getGPUInfo(infoType).then(
+        (gpuInfo) => {
+          console.log('HERE COMES THE JSON: ' + JSON.stringify(gpuInfo) + ' AND THERE IT WAS');
+          setImmediate(() => app.exit(0));
+        },
+        (error) => {
+          console.error(error);
+          setImmediate(() => app.exit(1));
+        }
+      );
+    });
+    w.loadURL('data:text/html;<canvas></canvas>');
+  })
+  .catch(() => process.exit(1));

--- a/spec/fixtures/api/pdf-reader.mjs
+++ b/spec/fixtures/api/pdf-reader.mjs
@@ -21,4 +21,7 @@ async function getPDFDoc() {
   }
 }
 
-app.whenReady().then(() => getPDFDoc());
+app
+  .whenReady()
+  .then(getPDFDoc)
+  .catch(() => process.exit(1));

--- a/spec/fixtures/apps/libuv-hang/main.js
+++ b/spec/fixtures/apps/libuv-hang/main.js
@@ -14,14 +14,10 @@ async function createWindow() {
   await mainWindow.loadFile('index.html');
 }
 
-app.whenReady().then(() => {
-  createWindow();
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow();
-    }
-  });
-});
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
 let count = 0;
 ipcMain.handle('reload-successful', () => {
@@ -33,6 +29,4 @@ ipcMain.handle('reload-successful', () => {
   }
 });
 
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);

--- a/spec/fixtures/apps/self-module-paths/main.js
+++ b/spec/fixtures/apps/self-module-paths/main.js
@@ -1,7 +1,6 @@
-// Modules to control application life and create native browser window
 const { app, BrowserWindow, ipcMain } = require('electron');
 
-function createWindow() {
+async function createWindow() {
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
@@ -13,21 +12,16 @@ function createWindow() {
     }
   });
 
-  mainWindow.loadFile('index.html');
+  await mainWindow.loadFile('index.html');
 }
 
 ipcMain.handle('module-paths', (e, success) => {
   process.exit(success ? 0 : 1);
 });
 
-app.whenReady().then(() => {
-  createWindow();
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
-});
-
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);

--- a/spec/fixtures/crash-cases/js-execute-iframe/index.js
+++ b/spec/fixtures/crash-cases/js-execute-iframe/index.js
@@ -3,7 +3,7 @@ const { app, BrowserWindow } = require('electron');
 const net = require('node:net');
 const path = require('node:path');
 
-function createWindow() {
+async function createWindow() {
   const mainWindow = new BrowserWindow({
     webPreferences: {
       nodeIntegration: true,
@@ -12,20 +12,15 @@ function createWindow() {
     }
   });
 
-  mainWindow.loadFile('index.html');
+  await mainWindow.loadFile('index.html');
 }
 
-app.whenReady().then(() => {
-  createWindow();
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
-});
-
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);
 
 const server = net.createServer((c) => {
   console.log('client connected');

--- a/spec/fixtures/crash-cases/native-window-open-exit/index.js
+++ b/spec/fixtures/crash-cases/native-window-open-exit/index.js
@@ -3,7 +3,7 @@ const { app, ipcMain, BrowserWindow } = require('electron');
 const http = require('node:http');
 const path = require('node:path');
 
-function createWindow() {
+async function createWindow() {
   const mainWindow = new BrowserWindow({
     webPreferences: {
       webSecurity: false,
@@ -11,10 +11,11 @@ function createWindow() {
     }
   });
 
-  mainWindow.loadFile('index.html');
   mainWindow.webContents.on('render-process-gone', () => {
     process.exit(1);
   });
+
+  await mainWindow.loadFile('index.html');
 }
 
 const server = http
@@ -23,18 +24,12 @@ const server = http
   })
   .listen(7001, '127.0.0.1');
 
-app.whenReady().then(() => {
-  createWindow();
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow();
-    }
-  });
-});
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);
 
 ipcMain.on('test-done', () => {
   console.log('test passed');

--- a/spec/fixtures/crash-cases/utility-process-app-ready/index.js
+++ b/spec/fixtures/crash-cases/utility-process-app-ready/index.js
@@ -2,22 +2,17 @@ const { app, BrowserWindow, utilityProcess } = require('electron');
 
 const path = require('node:path');
 
-function createWindow() {
+async function createWindow() {
   const mainWindow = new BrowserWindow();
-  mainWindow.loadFile('about:blank');
+  await mainWindow.loadFile('about:blank');
 }
 
-app.whenReady().then(() => {
-  createWindow();
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
-  app.on('activate', function () {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
-});
-
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);
 
 try {
   utilityProcess.fork(path.join(__dirname, 'utility.js'));

--- a/spec/fixtures/crash-cases/worker-multiple-destroy/index.js
+++ b/spec/fixtures/crash-cases/worker-multiple-destroy/index.js
@@ -25,14 +25,9 @@ async function createWindow() {
   await mainWindow.loadFile('index.html');
 }
 
-app.whenReady().then(() => {
-  createWindow();
+app
+  .whenReady()
+  .then(createWindow)
+  .catch(() => process.exit(1));
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
-  });
-});
-
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', app.quit);


### PR DESCRIPTION
#### Description of Change

Extends the spec fixture cleanup from 3860a98d to 9 additional fixtures. That commit updated a flaky test's fixtures to remove unnecessary boilerplate and and to catch any thrown errors.

This PR does the same cleanup to other similar fixtures.

CC @jkleinsc @deepak1556 

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.