### PR TITLE
ci: suppress macOS 'reopen windows' prompt for Electron test bundle

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -122,6 +122,15 @@ jobs:
     - name: Turn off the unexpectedly quit dialog on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: defaults write com.apple.CrashReporter DialogType server
+    - name: Turn off the reopen windows prompt on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      # Tests spawn Electron child apps and SIGINT them; after enough abnormal
+      # exits AppKit shows a modal "...unexpectedly quit while reopening
+      # windows. Do you want to try to reopen its windows again?" alert inside
+      # the open-application AppleEvent handler, which blocks before
+      # applicationDidFinishLaunching: and hangs app.whenReady() forever.
+      # See https://github.com/electron/electron/issues/51462.
+      run: defaults write com.github.Electron ApplePersistenceIgnoreState YES
     - name: Set xcode to 16.4
       if: ${{ inputs.target-platform == 'macos' }}
       run: sudo xcode-select --switch /Applications/Xcode_16.4.app


### PR DESCRIPTION
#### Description of Change

Tests spawn child `Electron.app` instances and kill them with `SIGINT` (e.g. `startRemoteControlApp`). After enough abnormal exits of the same bundle ID, AppKit shows a modal alert inside the open-application AppleEvent handler:

> The last time you opened Electron, it unexpectedly quit while reopening windows. Do you want to try to reopen its windows again?

That handler runs **before** `applicationDidFinishLaunching:` is posted, so the alert blocks `app.whenReady()` forever and the next spawned fixture that waits for ready hangs until the 60-minute job timeout.

##### Why this started at #51279, why `main` is green right now, and why this PR is still needed

`script/split-tests.js` sorts spec files by their `it(`-substring count and round-robins into shards, so any test-count change can reshuffle which files share a shard.

| commit | what changed | macOS-x64 shard-2 victim |
|---|---|---|
| `8f0f08e818` (#51279) | +17 tests in `api-utility-process-spec.ts` → it moved onto shard 2 ahead of `esm-spec.ts` | `esm-spec` import-meta fixture — first failure |
| `0f77f20d4f` (#51432) | refactored `esm-spec.ts` `runFixture` → its `it(`-count tied with `guest-window-manager-spec.ts` → `esm-spec` moved off shard 2 | bug moved to `node-spec.ts` "does not hang when using the fs module in the renderer process" — its `libuv-hang` fixture is the next child that does `app.whenReady().then(...)` after `api-utility-process-spec` |
| `f9635f7b3a` (#51476) | orphan-process killer | green run, but not a fix — the orphan killer can't clear `talagentd`'s abnormal-exit flag (and its `SIGKILL`s add to it). Either lucky timing or the 5 kills it logged were late enough not to matter |

So `main` going green was a shard reshuffle, not a fix. The next test-count change that reshuffles will surface it again on whichever child-Electron-that-awaits-`whenReady()` lands after a SIGINT-heavy spec. This PR fixes it for all of them regardless of shard order.

##### Evidence (debug branch #51483)

- spindump: child blocked in `AEProcessAppleEvent` → `-[NSAppleEventManager dispatchRawAppleEvent:…]` → nested `_BlockUntilNextEventMatchingListInModeWithFilter`
- screenshot at hang shows the alert
- A/B: stock=HANG, `-ApplePersistenceIgnoreState YES`=PASS, `rm -rf …/com.github.Electron.savedState`=HANG (the crash flag is held by `talagentd`, not on disk)
- #51386 / #51463 are unrelated — `PromiseBase::Resolve` is never called, no GC runs in the relevant window

Setting `ApplePersistenceIgnoreState` once for `com.github.Electron` disables the persistent-UI machinery (including this prompt) for every Electron launch in the test job, mirroring the existing `CrashReporter DialogType` suppression directly above it.

Fixes #51462.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: none