### PR TITLE
fix: improve resize band positioning and scaling for frameless windows on Windows

### DIFF
--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -16,7 +16,6 @@ namespace electron {
 
 namespace {
 
-const int kResizeInsideBoundsSize = 5;
 const int kResizeAreaCornerSize = 16;
 
 }  // namespace

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -33,6 +33,9 @@ class FramelessView : public views::FrameView {
   FramelessView(const FramelessView&) = delete;
   FramelessView& operator=(const FramelessView&) = delete;
 
+  // Width in DIPs of the inside resize border for frameless windows.
+  static constexpr int kResizeInsideBoundsSize = 5;
+
   // Returns whether the |point| is on frameless window's resizing border.
   virtual int ResizingBorderHitTest(const gfx::Point& point);
 

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -280,13 +280,29 @@ gfx::Size WinFrameView::GetMaximumSize() const {
   return size.IsEmpty() ? gfx::Size(INT_MAX, INT_MAX) : size;
 }
 
+int WinFrameView::ResizingBorderHitTest(const gfx::Point& point) {
+  if (RestoredFrameBorderInsets().IsEmpty())
+    return FramelessView::ResizingBorderHitTest(point);
+
+  // With insets, side/bottom resize targets sit outside the frame and are
+  // handled by WM_NCHITTEST, so the internal hit test can be zero-ed out.
+  // The exception is the top edge for frameless windows, which still need
+  // an inner resize band since there is no non-client titlebar to provide one.
+  const gfx::Insets inside =
+      window_->has_frame()
+          ? gfx::Insets()
+          : gfx::Insets::TLBR(kResizeInsideBoundsSize, 0, 0, 0);
+  return ResizingBorderHitTestImpl(point, inside);
+}
+
 gfx::Insets WinFrameView::RestoredFrameBorderInsets() const {
   if (window_->has_frame() || !window_->has_thick_frame())
     return {};
 
-  const int thickness =
-      display::win::GetScreenWin()->GetSystemMetricsInDIP(SM_CXSIZEFRAME) +
-      display::win::GetScreenWin()->GetSystemMetricsInDIP(SM_CXPADDEDBORDER);
+  // TODO(mitchchn): despite the name, this method gives the correct
+  // DPI-adjusted insets for the sides, not the top, when restored.
+  const int thickness = FrameTopBorderThickness(/*restored=*/true);
+  // Inverse of ResizingBorderHitTest: resize insets go on sides but not top.
   return gfx::Insets::TLBR(0, thickness, thickness, thickness);
 }
 

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -36,6 +36,7 @@ class WinFrameView : public FramelessView {
   gfx::Size GetMaximumSize() const override;
 
   // views::FramelessView:
+  int ResizingBorderHitTest(const gfx::Point& point) override;
   gfx::Insets RestoredFrameBorderInsets() const override;
 
   WinCaptionButtonContainer* caption_button_container() {

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -106,9 +106,6 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
     return false;
 
   if (!native_window_view_->has_frame()) {
-    const int thickness = ::GetSystemMetrics(SM_CXSIZEFRAME) +
-                          ::GetSystemMetrics(SM_CXPADDEDBORDER);
-
     if (IsMaximized()) {
       // Windows by default extends the maximized window slightly larger than
       // current workspace, for frameless window since the standard frame has
@@ -122,6 +119,8 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       //
       // Please make sure you tested maximized frameless window under multiple
       // monitors with different DPIs before changing this code.
+      const int thickness = ::GetSystemMetrics(SM_CXSIZEFRAME) +
+                            ::GetSystemMetrics(SM_CXPADDEDBORDER);
       *insets = gfx::Insets::TLBR(thickness, thickness, thickness, thickness);
       return true;
     } else if (native_window_view_->has_thick_frame()) {
@@ -129,7 +128,8 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       // windows with standard frames. Non-resizable windows still get input
       // insets for stable bounds and so they can be dragged from outer edges,
       // also like in windows with standard frames.
-      *insets = gfx::Insets::TLBR(0, thickness, thickness, thickness);
+      *insets = gfx::Insets::TLBR(0, frame_thickness, frame_thickness,
+                                  frame_thickness);
       return true;
     }
   }


### PR DESCRIPTION
#### Description of Change

Fixes #51497, fixes #51385.

External resize bands on frameless windows are now larger at higher display scales instead of always using the DIP value. They also no longer appear inside the window except at the top (the old hit test logic is suppressed).

41.x,42.x

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Improved external resize band positioning and scaling for frameless windows on Windows.