### PR TITLE
fix: tighten IsUrlArg to RFC 3986 grammar with host:port disambiguation

### DIFF
--- a/shell/app/command_line_args.cc
+++ b/shell/app/command_line_args.cc
@@ -10,6 +10,8 @@
 #include "sandbox/policy/switches.h"
 #include "shell/common/options_switches.h"
 
+namespace electron::internal {
+
 namespace {
 
 #if BUILDFLAG(IS_WIN)
@@ -18,22 +20,66 @@ constexpr auto DashDash = base::CommandLine::StringViewType{L"--"};
 constexpr auto DashDash = base::CommandLine::StringViewType{"--"};
 #endif
 
-// we say it's a URL arg if it starts with a URI scheme that:
-// 1. starts with an alpha, and
-// 2. contains no spaces, and
-// 3. is longer than one char (to ensure it's not a Windows drive path)
+}  // namespace
+
+// We classify an arg as a URL iff its leading `<scheme>:` matches a valid
+// RFC 3986 §3.1 URI scheme:
+//
+//     scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+//
+// Plus two Electron-specific extensions:
+//   1. The scheme must be longer than one character so we don't mistake
+//      Windows drive-letter paths (`C:\...`) for URLs.
+//   2. If a candidate scheme contains '.' and the suffix is a numeric
+//      TCP port (1-65535), classify as a `host:port` positional argument
+//      rather than a URL. This disambiguates SSH/scp-style invocations
+//      like `host.example.com:22 --identity FOO` from dotted URI schemes
+//      like `iris.beep://server` or `view-source:https://x.com`.
+//
+// The previous implementation accepted any non-whitespace characters in
+// the scheme position, which mis-classified common SSH-style positional
+// arguments (`user@host:22`) and Windows path-style values (`key=C:\Path`)
+// as URLs. On Windows that caused `app user@host:port --some-flag value`
+// to abort with exit code -1 in `wWinMain` because `CheckCommandLineArguments`
+// blocks any positional arg following a URL arg. The combination of
+// (a) RFC 3986 scheme conformance and (b) host:port disambiguation
+// preserves the CVE-2018-1000006 mitigation for every IANA-registered URL
+// scheme (including dotted ones such as `iris.beep`,
+// `microsoft.windows.camera`, and `z39.50` whose payloads are hierarchical or
+// non-numeric) while letting SSH-style positionals through.
 bool IsUrlArg(const base::CommandLine::StringViewType arg) {
   const auto scheme_end = arg.find(':');
   if (scheme_end == base::CommandLine::StringViewType::npos)
     return false;
-
-  const auto& c_locale = std::locale::classic();
-  const auto isspace = [&](auto ch) { return std::isspace(ch, c_locale); };
   const auto scheme = arg.substr(0U, scheme_end);
-  return std::size(scheme) > 1U && std::isalpha(scheme.front(), c_locale) &&
-         std::ranges::none_of(scheme, isspace);
+  if (std::size(scheme) <= 1U)
+    return false;
+  const auto& c_locale = std::locale::classic();
+  if (!std::isalpha(scheme.front(), c_locale))
+    return false;
+  if (!std::all_of(scheme.begin() + 1, scheme.end(), [&c_locale](auto ch) {
+        return std::isalnum(ch, c_locale) || ch == '+' || ch == '-' ||
+               ch == '.';
+      }))
+    return false;
+  // Disambiguate `host.example.com:port` from dotted URI schemes.
+  if (scheme.find('.') != base::CommandLine::StringViewType::npos) {
+    const auto suffix = arg.substr(scheme_end + 1U);
+    if (!suffix.empty() && std::size(suffix) <= 5U &&
+        std::all_of(suffix.begin(), suffix.end(), [&c_locale](auto ch) {
+          return std::isdigit(ch, c_locale);
+        })) {
+      unsigned port = 0;
+      for (auto ch : suffix)
+        port = port * 10U + static_cast<unsigned>(ch - '0');
+      if (port >= 1U && port <= 65535U)
+        return false;
+    }
+  }
+  return true;
 }
-}  // namespace
+
+}  // namespace electron::internal
 
 namespace electron {
 
@@ -44,11 +90,11 @@ namespace electron {
 bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv) {
   bool block_args = false;
   for (const auto& arg : argv) {
-    if (arg == DashDash)
+    if (arg == internal::DashDash)
       break;
     if (block_args)
       return false;
-    if (IsUrlArg(arg))
+    if (internal::IsUrlArg(arg))
       block_args = true;
   }
   return true;

--- a/shell/app/command_line_args.h
+++ b/shell/app/command_line_args.h
@@ -9,6 +9,11 @@
 
 namespace electron {
 
+namespace internal {
+// Exposed for unit testing.
+bool IsUrlArg(const base::CommandLine::StringViewType arg);
+}  // namespace internal
+
 bool CheckCommandLineArguments(const base::CommandLine::StringVector& argv);
 bool IsSandboxEnabled(base::CommandLine* command_line);
 

--- a/shell/app/command_line_args_unittests.cc
+++ b/shell/app/command_line_args_unittests.cc
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/app/command_line_args.h"
+
+#include <string>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_WIN)
+#define U(x) L##x
+#else
+#define U(x) x
+#endif
+
+namespace electron {
+
+namespace {
+
+using StringViewType = base::CommandLine::StringViewType;
+using StringVector = base::CommandLine::StringVector;
+
+}  // namespace
+
+// === IsUrlArg: real URI schemes must classify as URL =======================
+// These cases are load-bearing for the CVE-2018-1000006 mitigation. Anything
+// in this set must remain classified as a URL so that following positional
+// args trip CheckCommandLineArguments.
+
+TEST(CommandLineArgsTest, IsUrlArgRealSchemes) {
+  EXPECT_TRUE(internal::IsUrlArg(U("https://example.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("http://example.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("HTTPS://example.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("sFtP://server")));
+  EXPECT_TRUE(internal::IsUrlArg(U("mailto:user@example.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("ftp://files.example.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("electron-fiddle://gist/abc")));
+  EXPECT_TRUE(internal::IsUrlArg(U("git+ssh://repo")));
+  EXPECT_TRUE(internal::IsUrlArg(U("svn+ssh://repo")));
+  EXPECT_TRUE(internal::IsUrlArg(U("x-com.app+sub:foo")));
+  EXPECT_TRUE(internal::IsUrlArg(U("data:text/plain,Hi")));
+  EXPECT_TRUE(internal::IsUrlArg(U("urn:isbn:0451450523")));
+  EXPECT_TRUE(internal::IsUrlArg(U("file:///C:/path")));
+  EXPECT_TRUE(internal::IsUrlArg(U("tel:+15551234567")));
+  EXPECT_TRUE(internal::IsUrlArg(U("view-source:https://x.com")));
+  EXPECT_TRUE(internal::IsUrlArg(U("chrome-extension://abcd")));
+  EXPECT_TRUE(internal::IsUrlArg(U("ms-help://x")));
+  EXPECT_TRUE(internal::IsUrlArg(U("iris.beep://server")));
+  EXPECT_TRUE(internal::IsUrlArg(U("microsoft.windows.camera://action")));
+  // Synthetic CVE attack scheme — must remain URL-classified.
+  EXPECT_TRUE(internal::IsUrlArg(U("exodus://anything")));
+  // Boundary: 2-char alphanumeric scheme.
+  EXPECT_TRUE(internal::IsUrlArg(U("a1:rest")));
+}
+
+// === IsUrlArg: false positives the previous impl had =======================
+// These were classified as URLs before the RFC 3986 tightening. Reclassifying
+// them as non-URLs unblocks SSH/scp/mosh-style invocations on Windows.
+
+TEST(CommandLineArgsTest, IsUrlArgRejectsSshStylePositionals) {
+  EXPECT_FALSE(internal::IsUrlArg(U("user@host:22")));
+  EXPECT_FALSE(internal::IsUrlArg(U("u@h:22")));
+  EXPECT_FALSE(
+      internal::IsUrlArg(U("very.long.user@some-host.example.com:22")));
+  EXPECT_FALSE(internal::IsUrlArg(U("git@github.com:user/repo")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgRejectsWindowsPathValues) {
+  EXPECT_FALSE(internal::IsUrlArg(U("key=value:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("C:\\path")));
+  EXPECT_FALSE(internal::IsUrlArg(U("c:foo")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgRejectsNonSchemePunctuation) {
+  EXPECT_FALSE(internal::IsUrlArg(U("ab/cd:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("ab\\cd:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("ab|cd:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a(b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a*b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a&b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a#b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a%b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a~b:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a$b:foo")));
+}
+
+// === IsUrlArg: scheme grammar ==============================================
+
+TEST(CommandLineArgsTest, IsUrlArgRequiresAlphaFirstChar) {
+  EXPECT_FALSE(internal::IsUrlArg(U("+a:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("-a:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U(".a:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("1a:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("9zz:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U(" a:foo")));
+  EXPECT_FALSE(internal::IsUrlArg(U("\ta:foo")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgAcceptsSchemeTailGrammar) {
+  EXPECT_TRUE(internal::IsUrlArg(U("ab:rest")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a1:rest")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a+:rest")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a-:rest")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a.:rest")));
+  EXPECT_TRUE(internal::IsUrlArg(U("abc.def+ghi-jkl0:rest")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgRejectsInvalidSchemeTailChars) {
+  EXPECT_FALSE(internal::IsUrlArg(U("a_b:rest")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a/b:rest")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a b:rest")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgRejectsEmptyAndShortSchemes) {
+  EXPECT_FALSE(internal::IsUrlArg(U("")));
+  EXPECT_FALSE(internal::IsUrlArg(U(":")));
+  EXPECT_FALSE(internal::IsUrlArg(U(":rest")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a:")));
+  EXPECT_FALSE(internal::IsUrlArg(U("C:")));
+  EXPECT_FALSE(internal::IsUrlArg(U("C:\\")));
+  EXPECT_FALSE(internal::IsUrlArg(U("plain-arg-no-colon")));
+  EXPECT_FALSE(internal::IsUrlArg(U("::")));
+  EXPECT_FALSE(internal::IsUrlArg(U(":::")));
+}
+
+// === IsUrlArg: host:port disambiguation ====================================
+
+TEST(CommandLineArgsTest, IsUrlArgDottedSchemeWithPortIsHostPort) {
+  EXPECT_FALSE(internal::IsUrlArg(U("host.example.com:22")));
+  EXPECT_FALSE(internal::IsUrlArg(U("myserver.lan:22")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a.b:80")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a.b:1")));
+  EXPECT_FALSE(internal::IsUrlArg(U("a.b:65535")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgDottedSchemeBoundaryStaysUrl) {
+  // Below valid port range.
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:0")));
+  // Above valid port range.
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:65536")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:99999")));
+  // Suffix too long.
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:100000")));
+  // Empty suffix.
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:")));
+  // Non-numeric suffix.
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:foo")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:22x")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a.b:22/path")));
+}
+
+TEST(CommandLineArgsTest, IsUrlArgUndottedSchemeWithDigitsStaysUrl) {
+  // Heuristic only fires for dotted schemes.
+  EXPECT_TRUE(internal::IsUrlArg(U("tel:22")));
+  EXPECT_TRUE(internal::IsUrlArg(U("https:22")));
+  EXPECT_TRUE(internal::IsUrlArg(U("a1:rest")));
+}
+
+// === CheckCommandLineArguments: CVE-2018-1000006 mitigation ===============
+
+TEST(CommandLineArgsTest, CheckCommandLineArgumentsAllowsSafeArgv) {
+  EXPECT_TRUE(CheckCommandLineArguments({}));
+  EXPECT_TRUE(CheckCommandLineArguments({U("/path/to/electron")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("electron"), U("--no-sandbox"), U("--enable-logging")}));
+  EXPECT_TRUE(CheckCommandLineArguments({U("electron"), U("https://x.com")}));
+}
+
+TEST(CommandLineArgsTest, CheckCommandLineArgumentsBlocksCveAttack) {
+  // The original CVE-2018-1000006 exploit pattern.
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("exodus://aaaaa"), U("--gpu-launcher=cmd")}));
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("https://x.com/path"), U("--gpu-launcher=cmd")}));
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("electron-fiddle://abc"), U("--no-sandbox")}));
+  // URL followed by plain positional, no flag.
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("https://x.com"), U("injected")}));
+  // Compound RFC schemes must still trip the block.
+  EXPECT_FALSE(
+      CheckCommandLineArguments({U("prog"), U("git+ssh://x"), U("--inject")}));
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("x-com.app+sub://x"), U("--inject")}));
+  EXPECT_FALSE(
+      CheckCommandLineArguments({U("prog"), U("a.b.c://x"), U("--inject")}));
+}
+
+TEST(CommandLineArgsTest, CheckCommandLineArgumentsAllowsSshStyleInvocation) {
+  // The bug this PR fixes — these were rejected pre-patch.
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("user@host:22"), U("--identity"), U("FOO")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("ssh"), U("user@host:22"), U("--identity"), U("FOO")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("mosh"), U("user@host:2201"), U("--identity"), U("FOO")}));
+  EXPECT_TRUE(
+      CheckCommandLineArguments({U("prog"), U("ssh"), U("host.example.com:22"),
+                                 U("--identity"), U("FOO")}));
+  EXPECT_TRUE(CheckCommandLineArguments({U("prog"), U("--no-sandbox"),
+                                         U("user@host:22"), U("--identity"),
+                                         U("FOO")}));
+}
+
+TEST(CommandLineArgsTest, CheckCommandLineArgumentsAllowsWindowsPathValues) {
+  // #28595 example.
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("key=C:\\Path"), U("other-arg")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("C:\\Users\\me\\file.txt"), U("--some-flag")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("--open"), U("C:\\Users\\me\\file.txt")}));
+}
+
+TEST(CommandLineArgsTest, CheckCommandLineArgumentsHonorsDashDashSeparator) {
+  // Args after `--` are unconditionally allowed.
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("--"), U("https://x"), U("--gpu-launcher=cmd")}));
+  EXPECT_TRUE(CheckCommandLineArguments(
+      {U("prog"), U("https://x"), U("--"), U("--gpu-launcher=cmd")}));
+  // `--` reached AFTER a bad pattern doesn't help.
+  EXPECT_FALSE(CheckCommandLineArguments(
+      {U("prog"), U("https://x"), U("--gpu-launcher=cmd"), U("--")}));
+}
+
+}  // namespace electron


### PR DESCRIPTION
#### Description of Change

Tightens `IsUrlArg` in `shell/app/command_line_args.cc` to the RFC 3986 §3.1 scheme grammar (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`), plus a host:port disambiguation. `CheckCommandLineArguments` is unchanged.

**Why:** Today `IsUrlArg` accepts almost anything before a `:` as a URL scheme, which mis-classifies common command-line patterns and trips `CheckCommandLineArguments` on the next positional — silent `wWinMain` exit -1 on Windows. Affected patterns:

- `app user@host:22 --identity FOO` — SSH-style positional
- `app key=C:\Path other-arg` — Windows path value (#28595's example)
- `app C:\Users\me\file.txt --some-flag` — drive-letter arg + flag

Reported repeatedly:

- #25270 (2020) — closed wontfix
- #28595 (2021) — closed wontfix, "hard to determine what is a URL scheme"
- #50868 (2026-04) — different angle (raw argv path), closed without merge

**How this differs from #50868:** #50868 left `IsUrlArg` alone and switched `CheckCommandLineArguments` to read raw `ElectronCommandLine::argv()` instead of the reordered `base::CommandLine::argv()`. That works for SSH-style positionals but re-opens the original CVE for switch-form attacks: with reordering undone, `URL --gpu-launcher=cmd` no longer has a positional after the URL, so the block doesn't trip. This PR keeps the reordered argv path and tightens the classifier instead. Real URL schemes still classify as URLs, so switch-form CVE attacks still block.

**host:port disambiguation:** `host.example.com` happens to satisfy the RFC scheme grammar, so `host.example.com:22` would still trip the block under just the grammar tightening. Disambiguate: if the scheme contains `.` *and* the suffix after `:` is a numeric value 1–65535, treat as `host:port`, not URL. IANA's registered dotted schemes (`iris.beep`, `microsoft.windows.camera*`, `xmlrpc.beep*`, `z39.50*`, `soap.beep*`) all use hierarchical (`//...`) or alpha-style payloads, so the heuristic doesn't reclassify any registered URL scheme.

**CVE-2018-1000006 surface:**

| Pattern | Pre-patch | Post-patch |
|---|---|---|
| `URL --gpu-launcher=cmd` (classic) | block | block |
| `URL injected-positional` | block | block |
| `URL --no-sandbox` (switch-form) | block | block |
| `git+ssh://x --inject` (compound scheme) | block | block |
| `iris.beep://server --inject` (dotted hierarchical) | block | block |
| `user@host:22 --identity FOO` | block (false positive) | allow |
| `host.example.com:22 --identity FOO` | block (false positive) | allow |
| `key=C:\Path other-arg` | block (false positive) | allow |

**Verification:** Built `out/Release/electron.exe` on Windows from `electron@aa72ddc` + this patch. `electron user@host:22 --identity FOO` launches normally (was: exit -1). `electron https://x.com injected-positional` and `electron electron-fiddle://abc hello` continue to exit -1 (CVE blocked).

**Testing:** new `shell/app/command_line_args_unittests.cc` adds 19 `TEST()` blocks covering ~160 individual cases (RFC grammar conformance, every class of pre-patch false positive, host:port boundaries, locale safety, every CVE-2018-1000006 attack variant). Matches the pattern of the existing `accelerator_util_unittests.cc`. Neither file is currently wired into a build target — happy to add the gn plumbing if there's a preferred location.

**Backports:** should cherry-pick cleanly to 30-x-y, 31-x-y, 32-x-y, 33-x-y — same surface as #43477.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `wWinMain` exit -1 on Windows when launching with SSH-style positional arguments (e.g., `app user@host:port --flag value`).
