### PR TITLE
fix: Allow WebSocket connections to be intercepted using `redirectURL`

### DIFF
--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -250,12 +250,47 @@ void ProxyingWebSocket::StartProxying(
   proxy->Start();
 }
 
+void ProxyingWebSocket::HandleBeforeRequestRedirect() {
+  // The WebRequest API requested a redirect. Update the target URL and fire
+  // the OnBeforeRedirect event before proceeding with the new URL.
+  //
+  // Unlike ProxyingURLLoaderFactory, there is no URLLoaderClient to notify via
+  // OnReceiveRedirect, and the receivers are not yet bound at this point, so
+  // no connections need to be torn down. We simply update the URL and
+  // continue to ContinueToStartRequest.
+
+  // Cross-origin redirects must clear |request_initiator| to simulate the
+  // tainted-origin flag per step 10 of "HTTP-redirect fetch":
+  // https://fetch.spec.whatwg.org/#http-redirect-fetch
+  if (request_.request_initiator &&
+      (!url::Origin::Create(redirect_url_)
+            .IsSameOriginWith(url::Origin::Create(request_.url)) &&
+       !request_.request_initiator->IsSameOriginWith(
+           url::Origin::Create(request_.url)))) {
+    request_.request_initiator = url::Origin();
+  }
+
+  // Keep a copy of the redirect URL but unset the property to avoid loops
+  const GURL redirect_url = redirect_url_;
+  redirect_url_ = GURL();
+
+  web_request_->OnBeforeRedirect(&info_, request_, redirect_url);
+
+  request_.url = redirect_url;
+  ContinueToStartRequest(net::OK);
+}
+
 void ProxyingWebSocket::OnBeforeRequestComplete(int error_code) {
   DCHECK(receiver_as_header_client_.is_bound() ||
          !receiver_as_handshake_client_.is_bound());
   DCHECK(info_.url.SchemeIsWSOrWSS());
   if (error_code != net::OK) {
     OnError(error_code);
+    return;
+  }
+
+  if (!redirect_url_.is_empty()) {
+    HandleBeforeRequestRedirect();
     return;
   }
 
@@ -310,6 +345,11 @@ void ProxyingWebSocket::ContinueToStartRequest(int error_code) {
     return;
   }
 
+  if (!redirect_url_.is_empty()) {
+    HandleBeforeRequestRedirect();
+    return;
+  }
+
   base::flat_set<std::string> used_header_names;
   std::vector<network::mojom::HttpHeaderPtr> additional_headers;
   for (net::HttpRequestHeaders::Iterator it(request_headers_); it.GetNext();) {
@@ -332,7 +372,7 @@ void ProxyingWebSocket::ContinueToStartRequest(int error_code) {
   }
 
   std::move(factory_).Run(
-      info_.url, std::move(additional_headers),
+      request_.url, std::move(additional_headers),
       receiver_as_handshake_client_.BindNewPipeAndPassRemote(),
       receiver_as_auth_handler_.BindNewPipeAndPassRemote(),
       std::move(trusted_header_client));

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -111,6 +111,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   void OnHeadersReceivedCompleteForAuth(const net::AuthChallengeInfo& auth_info,
                                         int rv);
   void ContinueToCompleted();
+  void HandleBeforeRequestRedirect();
 
   void PauseIncomingMethodCallProcessing();
   void ResumeIncomingMethodCallProcessing();

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -999,5 +999,75 @@ describe('webRequest module', () => {
 
       expect(message).to.equal('Authenticated!');
     });
+
+    it('can redirect a WebSocket connection via onBeforeRequest', async () => {
+      // Set up two WebSocket servers: portA (the original target) and portB (the redirect target).
+      const serverA = http.createServer();
+      const serverB = http.createServer();
+      const wssA = new WebSocket.Server({ noServer: true });
+      const wssB = new WebSocket.Server({ noServer: true });
+
+      let connectedToA = false;
+      let connectedToB = false;
+
+      wssA.on('connection', () => {
+        connectedToA = true;
+      });
+      wssB.on('connection', (ws) => {
+        connectedToB = true;
+        ws.send('connected-to-B');
+      });
+
+      serverA.on('upgrade', (req, socket, head) => {
+        wssA.handleUpgrade(req, socket as Socket, head, (ws) => wssA.emit('connection', ws, req));
+      });
+      serverB.on('upgrade', (req, socket, head) => {
+        wssB.handleUpgrade(req, socket as Socket, head, (ws) => wssB.emit('connection', ws, req));
+      });
+
+      const { port: portA } = await listen(serverA);
+      const { port: portB } = await listen(serverB);
+
+      const ses = session.fromPartition(`WebRequestWSRedirect-${Date.now()}`);
+
+      const beforeRedirectDetails: Electron.OnBeforeRedirectListenerDetails[] = [];
+      ses.webRequest.onBeforeRedirect((details) => {
+        beforeRedirectDetails.push(details);
+      });
+      ses.webRequest.onBeforeRequest({ urls: [`ws://localhost:${portA}/*`] }, (details, callback) => {
+        callback({ redirectURL: `ws://localhost:${portB}/` });
+      });
+
+      const contents = (webContents as typeof ElectronInternal.WebContents).create({
+        session: ses,
+        sandbox: true
+      });
+
+      defer(() => {
+        contents.destroy();
+        serverA.close();
+        serverB.close();
+        wssA.close();
+        wssB.close();
+        ses.webRequest.onBeforeRequest(null);
+        ses.webRequest.onBeforeRedirect(null);
+      });
+
+      await contents.loadFile(path.join(fixturesPath, 'blank.html'));
+
+      const message = await contents.executeJavaScript(`new Promise((resolve, reject) => {
+        const ws = new WebSocket('ws://localhost:${portA}/');
+        ws.onmessage = e => resolve(e.data);
+        ws.onerror = (err) => reject(new Error('WebSocket error'));
+        setTimeout(() => reject(new Error('timeout')), 5000);
+      });`);
+
+      expect(message).to.equal('connected-to-B');
+      expect(connectedToA).to.equal(false, 'server A should not have received the connection');
+      expect(connectedToB).to.equal(true, 'server B should have received the redirected connection');
+      expect(beforeRedirectDetails).to.have.lengthOf(1);
+      expect(beforeRedirectDetails[0].url).to.equal(`ws://localhost:${portA}/`);
+      expect(beforeRedirectDetails[0].redirectURL).to.equal(`ws://localhost:${portB}/`);
+    });
   });
 });


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/51505

Currently, when intercepting a WebSocket request using `webRequest.onBeforeRequest()` and responding with a `redirectURL` it is silently ignored. This is because the implementation of [`electron/shell/browser/net/proxying_websocket.cc`](https://github.com/electron/electron/blob/99117903fe94b9959f4c26a3b04d3e773749ae7d/shell/browser/net/proxying_websocket.cc#L95-L115) never made use of `redirect_url_`.

This PR implements this, using the structure from `electron/shell/browser/net/proxying_url_loader_factory.cc` as an example.

The one change I am not 100% on is that it is not possible to update the `info_.url` value as it is constant. To side step this, I have changed `ContinueToStartRequest` to use `request_.url` instead. This works, but I'm not sure if not updating `info_` and changing this line will have other consiquences.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
    -  Unable to run reliably on my machine. Many unrelated tests seem to fail
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix to allow WebSockets to be redirected in a `webRequest.onBeforeRequest()` response
