### PR TITLE
build: make patch failures more obvious

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -104,22 +104,38 @@ def am(repo, patch_data, threeway=False, directory=None, exclude=None,
       proc.stdin.write(patch_data.encode('utf-8'))
       proc.stdin.close()
     if output_prefix is not None:
+      output_lines = []
       writer = threading.Thread(target=feed_stdin)
       writer.start()
       for line in proc.stdout:
+        decoded = line.decode("utf-8", "replace")
+        output_lines.append(decoded)
         try:
-          sys.stdout.write(
-            f'{output_prefix}{line.decode("utf-8", "replace")}')
+          sys.stdout.write(f'{output_prefix}{decoded}')
           sys.stdout.flush()
         except BrokenPipeError:
-          pass
+          # stdout is broken; fall back to stderr so diagnostic output
+          # (e.g. conflict details) is not silently lost.
+          try:
+            sys.stderr.write(f'{output_prefix}{decoded}')
+            sys.stderr.flush()
+          except BrokenPipeError:
+            pass
       writer.join()
       proc.wait()
     else:
-      feed_stdin()
+      output_lines = None
+      try:
+        feed_stdin()
+      except BrokenPipeError:
+        pass  # git am exited early; returncode check below will catch the failure
       proc.wait()
     if proc.returncode != 0:
-      raise RuntimeError(f"Command {command} returned {proc.returncode}")
+      detail = (''.join(output_lines) if output_lines else '')
+      raise RuntimeError(
+        f"Command {command} returned {proc.returncode}"
+        + (f"\n{detail}" if detail else '')
+      )
 
 
 def import_patches(repo, ref=UPSTREAM_HEAD, **kwargs):


### PR DESCRIPTION
#### Description of Change
- follow up to #50417.  With that change it became less obvious when patches failed to apply or there was a patch conflict.  This PR adds a bit more output to highlight the patch failure.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
