### PR TITLE
ci: skip job in rerun apply patches if too old

### DIFF
--- a/.github/workflows/rerun-apply-patches.yml
+++ b/.github/workflows/rerun-apply-patches.yml
@@ -59,6 +59,15 @@ jobs:
               continue
             fi
 
+            # Skip runs older than 25 days (GitHub does not allow rerunning after ~1 month)
+            RUN_CREATED=$(gh run view "$RUN_ID" --json createdAt --jq '.createdAt')
+            RUN_AGE_DAYS=$(( ($(date +%s) - $(date -d "$RUN_CREATED" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$RUN_CREATED" +%s)) / 86400 ))
+
+            if [ "$RUN_AGE_DAYS" -gt 25 ]; then
+              echo "  Skipping run ${RUN_ID} for PR #${PR_NUMBER}: run is ${RUN_AGE_DAYS} days old (max 25)"
+              continue
+            fi
+
             # Check if the workflow is currently in progress
             RUN_STATUS=$(gh run view "$RUN_ID" --json status --jq '.status')
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We ran into [a failure on this workflow](https://github.com/electron/electron/actions/runs/25448928041/job/74660596522) because it tried to rerun a job that's too old to rerun, so let's skip anything too old.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
