### PR TITLE
build: update Electron Build Tools in CI to `bcf5e3f8faeeef7981564ba40085d42b083beebf`

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1b7bd25dae4a780bb3170fff56c9327b53aaf7eb
+      export BUILD_TOOLS_SHA=bcf5e3f8faeeef7981564ba40085d42b083beebf
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
#### Description of Change

Modeled after #50786.

I wasn't getting cache hits with `e build` until I used an old checkout to run the output directory generation first. It seems [this `main.star` change is not in CI](https://github.com/electron/build-tools/commit/9d38befdd257e9ce5a17fbfec694d3b0d5929d82), but is in `main`. That seems to be enough to preclude any cache hits from local users on `main`. Getting CI to use this newer checkout might help with cache hits.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.