### PR TITLE
docs: clarify Linux quirks in Tray docs

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -38,7 +38,7 @@ app.whenReady().then(() => {
 
 * Tray icon uses [StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/)
   by default, when it is not available in user's desktop environment the
-  `GtkStatusIcon` will be used instead.
+  `GtkStatusIcon` will be used instead. If StatusNotifierItem is available, the first tray icon created will use SNI, while subsequently-created icons will use `GtkStatusIcon`.
 * The `click` event is emitted when the tray icon receives activation from
   user, however the StatusNotifierItem spec does not specify which action would
   cause an activation, for some environments it is left mouse click, but for


### PR DESCRIPTION
#### Description of Change

This is a quirk I came across a bit ago and I think we should document it. The reason for this quick is that the Chromium SNI implementation which we rely on is only designed for one single Tray icon. Attempts to use it for additional icons will fail, and those failures fall back to `GtkStatusIcon`.

#### Checklist
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
#### Release Notes

Notes: none.
