### PR TITLE
build: fix gn check, revert bump build-tools SHA

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=67979ae1cadad053d2f13e2fb5d1559b923484c7
+      export BUILD_TOOLS_SHA=1b7bd25dae4a780bb3170fff56c9327b53aaf7eb
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -143,10 +143,10 @@ jobs:
           export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
         fi
 
-        e build --gen=only
+        e build --only-gen
 
         # Copy macOS framework headers so clang-tidy can find them via -F.
-        # This must happen after e build since e init -f may
+        # This must happen after e build --only-gen since e init -f may
         # recreate the output directory.
         if [ "${{ inputs.target-platform }}" = "macos" ]; then
           OUT=src/out/${ELECTRON_OUT_DIR}

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -144,7 +144,7 @@ jobs:
             export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
           fi
 
-          e build --gen=only
+          e build --only-gen
 
           e d gn check out/Default //electron:electron_lib
           e d gn check out/Default //electron:electron_app


### PR DESCRIPTION
#### Description of Change

We're seeing gn checks fail across new PRs with the error: `electron/src/third_party/ninja/ninja: unrecognized option '--gen=only'`

This PR reverts commit cf8efcec871396c5795fb65eb7283e0c0b674965.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none