### PR TITLE
feat: add enableMenuBarAltFocus option to BrowserWindow

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -420,6 +420,12 @@ A `boolean` property that determines whether the window menu bar should hide its
 If the menu bar is already visible, setting this property to `true` won't
 hide it immediately.
 
+#### `win.enableMenuBarAltFocus` _Linux_ _Windows_
+
+A `boolean` property that determines whether pressing the `Alt` key alone will toggle focus on the menu bar. Default is `true`.
+
+When set to `false`, pressing `Alt` will no longer steal focus from the web content to the menu bar. This is useful for applications like terminal emulators or code editors where `Alt` key presses should be handled by the web content.
+
 #### `win.simpleFullScreen`
 
 A `boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -526,6 +526,12 @@ A `boolean` property that determines whether the window menu bar should hide its
 If the menu bar is already visible, setting this property to `true` won't
 hide it immediately.
 
+#### `win.enableMenuBarAltFocus` _Linux_ _Windows_
+
+A `boolean` property that determines whether pressing the `Alt` key alone will toggle focus on the menu bar. Default is `true`.
+
+When set to `false`, pressing `Alt` will no longer steal focus from the web content to the menu bar. This is useful for applications like terminal emulators or code editors where `Alt` key presses should be handled by the web content.
+
 #### `win.simpleFullScreen`
 
 A `boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -60,6 +60,8 @@
   Default is `false`.
 * `autoHideMenuBar` boolean (optional) _Linux_ _Windows_ - Auto hide the menu bar
   unless the `Alt` key is pressed. Default is `false`.
+* `enableMenuBarAltFocus` boolean (optional) _Linux_ _Windows_ - Whether pressing
+  the `Alt` key alone toggles focus on the menu bar. Default is `true`.
 * `enableLargerThanScreen` boolean (optional) _macOS_ - Enable the window to
   be resized larger than screen. Only relevant for macOS, as other OSes
   allow larger-than-screen windows by default. Default is `false`.

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -33,6 +33,15 @@ Object.defineProperty(BaseWindow.prototype, 'autoHideMenuBar', {
   }
 });
 
+Object.defineProperty(BaseWindow.prototype, 'enableMenuBarAltFocus', {
+  get: function () {
+    return this.isMenuBarAltFocusEnabled();
+  },
+  set: function (enable) {
+    this.setEnableMenuBarAltFocus(enable);
+  }
+});
+
 Object.defineProperty(BaseWindow.prototype, 'visibleOnAllWorkspaces', {
   get: function () {
     return this.isVisibleOnAllWorkspaces();

--- a/lib/browser/parse-features-string.ts
+++ b/lib/browser/parse-features-string.ts
@@ -131,6 +131,7 @@ const allowedWindowOptions = new Set<string>([
   'modal',
   'acceptFirstMouse',
   'autoHideMenuBar',
+  'enableMenuBarAltFocus',
   'enableLargerThanScreen',
   'paintWhenInitiallyHidden',
   'roundedCorners',

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -953,6 +953,14 @@ bool BaseWindow::IsMenuBarVisible() const {
   return window_->IsMenuBarVisible();
 }
 
+void BaseWindow::SetEnableMenuBarAltFocus(bool enable) {
+  window_->SetEnableMenuBarAltFocus(enable);
+}
+
+bool BaseWindow::IsMenuBarAltFocusEnabled() const {
+  return window_->IsMenuBarAltFocusEnabled();
+}
+
 void BaseWindow::SetAspectRatio(const double aspect_ratio,
                                 gin::Arguments* const args) {
   gfx::Size extra_size;
@@ -1299,6 +1307,10 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isMenuBarAutoHide", &BaseWindow::IsMenuBarAutoHide)
       .SetMethod("setMenuBarVisibility", &BaseWindow::SetMenuBarVisibility)
       .SetMethod("isMenuBarVisible", &BaseWindow::IsMenuBarVisible)
+      .SetMethod("setEnableMenuBarAltFocus",
+                 &BaseWindow::SetEnableMenuBarAltFocus)
+      .SetMethod("isMenuBarAltFocusEnabled",
+                 &BaseWindow::IsMenuBarAltFocusEnabled)
       .SetMethod("setAspectRatio", &BaseWindow::SetAspectRatio)
       .SetMethod("previewFile", &BaseWindow::PreviewFile)
       .SetMethod("closeFilePreview", &BaseWindow::CloseFilePreview)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -228,6 +228,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsMenuBarAutoHide() const;
   void SetMenuBarVisibility(bool visible);
   bool IsMenuBarVisible() const;
+  void SetEnableMenuBarAltFocus(bool enable);
+  bool IsMenuBarAltFocusEnabled() const;
   void SetAspectRatio(double aspect_ratio, gin::Arguments* args);
   void PreviewFile(const std::string& path, gin::Arguments* args);
   void CloseFilePreview();

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -441,6 +441,10 @@ bool NativeWindow::IsMenuBarVisible() const {
   return true;
 }
 
+bool NativeWindow::IsMenuBarAltFocusEnabled() const {
+  return true;
+}
+
 void NativeWindow::SetAspectRatio(double aspect_ratio,
                                   const gfx::Size& extra_size) {
   aspect_ratio_ = aspect_ratio;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -270,6 +270,8 @@ class NativeWindow : public views::WidgetDelegate {
   virtual bool IsMenuBarAutoHide() const;
   virtual void SetMenuBarVisibility(bool visible) {}
   virtual bool IsMenuBarVisible() const;
+  virtual void SetEnableMenuBarAltFocus(bool enable) {}
+  virtual bool IsMenuBarAltFocusEnabled() const;
 
   virtual bool IsSnapped() const;
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -213,6 +213,9 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   if (bool val; options.Get(options::kAutoHideMenuBar, &val))
     root_view_.SetAutoHideMenuBar(val);
 
+  if (bool val; options.Get(options::kEnableMenuBarAltFocus, &val))
+    root_view_.SetEnableMenuBarAltFocus(val);
+
 #if BUILDFLAG(IS_WIN)
   // On Windows we rely on the CanResize() to indicate whether window can be
   // resized, and it should be set before window is created.
@@ -1564,6 +1567,14 @@ void NativeWindowViews::SetMenuBarVisibility(bool visible) {
 
 bool NativeWindowViews::IsMenuBarVisible() const {
   return root_view_.is_menu_bar_visible();
+}
+
+void NativeWindowViews::SetEnableMenuBarAltFocus(bool enable) {
+  root_view_.SetEnableMenuBarAltFocus(enable);
+}
+
+bool NativeWindowViews::IsMenuBarAltFocusEnabled() const {
+  return root_view_.is_menu_bar_alt_focus_enabled();
 }
 
 bool NativeWindowViews::IsSnapped() const {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -146,6 +146,8 @@ class NativeWindowViews : public NativeWindow,
   bool IsMenuBarAutoHide() const override;
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() const override;
+  void SetEnableMenuBarAltFocus(bool enable) override;
+  bool IsMenuBarAltFocusEnabled() const override;
   bool IsSnapped() const override;
   void SetBackgroundMaterial(const std::string& type) override;
 

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -79,6 +79,10 @@ void RootView::SetAutoHideMenuBar(bool auto_hide) {
   menu_bar_autohide_ = auto_hide;
 }
 
+void RootView::SetEnableMenuBarAltFocus(bool enable) {
+  enable_alt_focus_ = enable;
+}
+
 void RootView::SetMenuBarVisibility(bool visible) {
   if (!window_->content_view() || !menu_bar_ || menu_bar_visible_ == visible)
     return;
@@ -128,15 +132,19 @@ void RootView::HandleKeyEvent(const input::NativeWebKeyboardEvent& event) {
              IsAltKey(event) && menu_bar_alt_pressed_) {
     // When a single Alt is released right after a Alt is pressed:
     menu_bar_alt_pressed_ = false;
-    if (menu_bar_autohide_)
-      SetMenuBarVisibility(!menu_bar_visible_);
 
-    View* focused_view = GetFocusManager()->GetFocusedView();
-    last_focused_view_tracker_.SetView(focused_view);
-    if (menu_bar_visible_) {
-      menu_bar_->RequestFocus();
-      // Show accelerators when menu bar is focused
-      menu_bar_->SetAcceleratorVisibility(true);
+    // Only toggle menu bar focus if alt focus is enabled.
+    if (enable_alt_focus_) {
+      if (menu_bar_autohide_)
+        SetMenuBarVisibility(!menu_bar_visible_);
+
+      View* focused_view = GetFocusManager()->GetFocusedView();
+      last_focused_view_tracker_.SetView(focused_view);
+      if (menu_bar_visible_) {
+        menu_bar_->RequestFocus();
+        // Show accelerators when menu bar is focused
+        menu_bar_->SetAcceleratorVisibility(true);
+      }
     }
   } else {
     // When any other keys except single Alt have been pressed/released:

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -36,6 +36,8 @@ class RootView : public views::View {
   int GetMenuBarHeight() const;
   void SetAutoHideMenuBar(bool auto_hide);
   bool is_menu_bar_auto_hide() const { return menu_bar_autohide_; }
+  void SetEnableMenuBarAltFocus(bool enable);
+  bool is_menu_bar_alt_focus_enabled() const { return enable_alt_focus_; }
   void SetMenuBarVisibility(bool visible);
   bool is_menu_bar_visible() const { return menu_bar_visible_; }
   void HandleKeyEvent(const input::NativeWebKeyboardEvent& event);
@@ -61,6 +63,7 @@ class RootView : public views::View {
   bool menu_bar_autohide_ = false;
   bool menu_bar_visible_ = false;
   bool menu_bar_alt_pressed_ = false;
+  bool enable_alt_focus_ = true;
 
   // Main view area.
   const raw_ref<views::View> main_view_;

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -75,6 +75,9 @@ inline constexpr std::string_view kTabbingIdentifier = "tabbingIdentifier";
 // The menu bar is hidden unless "Alt" is pressed.
 inline constexpr std::string_view kAutoHideMenuBar = "autoHideMenuBar";
 
+// Whether pressing the Alt key toggles focus on the menu bar.
+inline constexpr std::string_view kEnableMenuBarAltFocus = "enableMenuBarAltFocus";
+
 // Enable window to be resized larger than screen.
 inline constexpr std::string_view kEnableLargerThanScreen =
     "enableLargerThanScreen";

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2625,6 +2625,52 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  ifdescribe(process.platform !== 'darwin')('enableMenuBarAltFocus state', () => {
+    afterEach(closeAllWindows);
+
+    describe('for properties', () => {
+      it('defaults to true', () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.enableMenuBarAltFocus).to.be.true('enableMenuBarAltFocus');
+      });
+
+      it('can be set with enableMenuBarAltFocus constructor option', () => {
+        const w = new BrowserWindow({ show: false, enableMenuBarAltFocus: false });
+        expect(w.enableMenuBarAltFocus).to.be.false('enableMenuBarAltFocus');
+      });
+
+      it('can be changed', () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.enableMenuBarAltFocus).to.be.true('enableMenuBarAltFocus');
+        w.enableMenuBarAltFocus = false;
+        expect(w.enableMenuBarAltFocus).to.be.false('enableMenuBarAltFocus');
+        w.enableMenuBarAltFocus = true;
+        expect(w.enableMenuBarAltFocus).to.be.true('enableMenuBarAltFocus');
+      });
+    });
+
+    describe('for functions', () => {
+      it('defaults to true', () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.isMenuBarAltFocusEnabled()).to.be.true('enableMenuBarAltFocus');
+      });
+
+      it('can be set with enableMenuBarAltFocus constructor option', () => {
+        const w = new BrowserWindow({ show: false, enableMenuBarAltFocus: false });
+        expect(w.isMenuBarAltFocusEnabled()).to.be.false('enableMenuBarAltFocus');
+      });
+
+      it('can be changed', () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.isMenuBarAltFocusEnabled()).to.be.true('enableMenuBarAltFocus');
+        w.setEnableMenuBarAltFocus(false);
+        expect(w.isMenuBarAltFocusEnabled()).to.be.false('enableMenuBarAltFocus');
+        w.setEnableMenuBarAltFocus(true);
+        expect(w.isMenuBarAltFocusEnabled()).to.be.true('enableMenuBarAltFocus');
+      });
+    });
+  });
+
   describe('BrowserWindow.capturePage(rect)', () => {
     afterEach(closeAllWindows);
 


### PR DESCRIPTION
#### Description of Change

On Linux and Windows, pressing Alt alone focuses the menu bar. This is a problem for apps that use Alt as part of their own keybindings — terminal emulators, code editors, vim-style navigation, etc. There's currently no way to disable it.

This PR adds `enableMenuBarAltFocus` (defaults to `true` so nothing breaks) that lets devs turn off the solo-Alt menu focus behavior. Alt+key combos like Alt+F still work fine.

```js
const win = new BrowserWindow({ enableMenuBarAltFocus: false })

// also available at runtime
win.enableMenuBarAltFocus = false
win.setEnableMenuBarAltFocus(false)
win.isMenuBarAltFocusEnabled()
```

The implementation mirrors how `autoHideMenuBar` is wired — flag in `RootView`, plumbed through `NativeWindow`/`NativeWindowViews`, exposed via the JS API.

Fixes #34211

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `enableMenuBarAltFocus` option to `BrowserWindow` to control whether pressing Alt alone focuses the menu bar.