### PR TITLE
fix: prevent BrowserWindow from mutating shared webPreferences object

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -30,8 +30,31 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     : BaseWindow(args->isolate(), options) {
   // Use options.webPreferences in WebContents.
   v8::Isolate* isolate = args->isolate();
+
+  // Clone the user's webPreferences to avoid mutating the original object.
+  // Without this, BrowserWindow-specific options like backgroundColor get
+  // written into the user's object via SetHidden(), causing them to leak
+  // into other constructors that reuse the same webPreferences reference.
+  // See https://github.com/electron/electron/issues/51337
+  gin_helper::Dictionary user_web_preferences;
+  options.Get(options::kWebPreferences, &user_web_preferences);
+
   auto web_preferences = gin_helper::Dictionary::CreateEmpty(isolate);
-  options.Get(options::kWebPreferences, &web_preferences);
+  if (!user_web_preferences.IsEmpty()) {
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Array> keys =
+        user_web_preferences.GetHandle()
+            ->GetOwnPropertyNames(context)
+            .ToLocalChecked();
+    for (uint32_t i = 0; i < keys->Length(); i++) {
+      v8::Local<v8::Value> key = keys->Get(context, i).ToLocalChecked();
+      v8::Local<v8::Value> value =
+          user_web_preferences.GetHandle()
+              ->Get(context, key)
+              .ToLocalChecked();
+      web_preferences.GetHandle()->Set(context, key, value).Check();
+    }
+  }
 
   // Copy the backgroundColor to webContents.
   std::string color;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7494,5 +7494,22 @@ describe('BrowserWindow module', () => {
       const screenCapture = new ScreenCapture(display);
       await screenCapture.expectColorAtCenterMatches(HexColors.BLUE);
     });
+
+    // Regression test for https://github.com/electron/electron/issues/51337
+    it('should not mutate a shared webPreferences object', () => {
+      const sharedWebPreferences: Record<string, unknown> = {};
+
+      const w = new BrowserWindow({
+        show: false,
+        backgroundColor: '#00f',
+        webPreferences: sharedWebPreferences
+      });
+
+      // The original webPreferences object should not have any new
+      // enumerable properties added by the BrowserWindow constructor.
+      expect(Object.keys(sharedWebPreferences)).to.have.lengthOf(0);
+
+      w.close();
+    });
   });
 });


### PR DESCRIPTION
#### Description of Change

When a user passes the same `webPreferences` object to both `new BrowserWindow()` and `new WebContentsView()`, the `backgroundColor` option from the BrowserWindow leaks into the WebContentsView. This happens because the BrowserWindow constructor takes a direct reference to the user's `webPreferences` V8 object and writes BrowserWindow-specific options into it via `SetHidden()` and `Set()`.

For example:

```js
const sharedPrefs = {};

const win = new BrowserWindow({
  backgroundColor: '#00f',
  webPreferences: sharedPrefs
});

// sharedPrefs now has a hidden backgroundColor field
const view = new WebContentsView({
  webPreferences: sharedPrefs // inherits blue background unexpectedly
});
```

The fix shallow-clones the user's `webPreferences` into a new V8 object before performing any mutations. This way the original object is never modified and can be safely reused across multiple constructors.

The clone only copies own enumerable properties. The hidden/private fields (`backgroundColor`, `webContents`, `show`) are then written exclusively to the cloned copy.

Fixes #51337

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug where sharing the same `webPreferences` object between `BrowserWindow` and `WebContentsView` caused BrowserWindow-specific options like `backgroundColor` to leak into the view.