### PR TITLE
fix: prevent border artifacts on frameless windows on Wayland

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -97,6 +97,16 @@ gfx::Insets ElectronDesktopWindowTreeHostLinux::CalculateInsetsInDIP(
   if (!IsShowingFrame(window_state))
     return gfx::Insets();
 
+  // Frameless windows should not have any decoration insets.
+  // Without this check, the frame layout may return non-zero insets for a
+  // frameless window when a framed window was previously created in the same
+  // process, causing the Wayland compositor to render a visible border
+  // artifact around the frameless window's shadow area.
+  // See https://github.com/electron/electron/issues/51456
+  if (!native_window_view_->has_frame() &&
+      !native_window_view_->has_client_frame())
+    return gfx::Insets();
+
   return GetRestoredFrameBorderInsets();
 }
 
@@ -240,6 +250,13 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     auto insets = CalculateInsetsInDIP(window_state);
     if (insets.IsEmpty()) {
       window->SetInputRegion(std::nullopt);
+      // Clear decoration insets so the compositor does not draw a border
+      // for frameless windows.  This is needed because a previously
+      // created framed window may have set non-zero decoration insets on
+      // the compositor-level that persist across windows.
+      // See https://github.com/electron/electron/issues/51456
+      if (window->CanSetDecorationInsets())
+        window->SetDecorationInsets(nullptr);
     } else {
       gfx::Rect input_bounds(widget_size);
       input_bounds.Inset(insets - layout->GetInputInsets());

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7476,6 +7476,33 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  // Regression test for https://github.com/electron/electron/issues/51456
+  ifdescribe(process.platform === 'linux')('frameless window after framed window', () => {
+    afterEach(closeAllWindows);
+
+    it('should create a frameless window without border artifacts after a framed window', () => {
+      // Create a normal framed window first.
+      const framed = new BrowserWindow({ show: false, frame: true });
+      const framedBounds = framed.getBounds();
+      expect(framedBounds.width).to.be.greaterThan(0);
+
+      // Now create a frameless window — this should not inherit any
+      // frame decoration insets from the previously created framed window.
+      const frameless = new BrowserWindow({ show: false, frame: false });
+      const framelessBounds = frameless.getBounds();
+      expect(framelessBounds.width).to.be.greaterThan(0);
+
+      // The frameless window's content size should match its full bounds
+      // (no decoration insets should be subtracted).
+      const contentSize = frameless.getContentSize();
+      expect(contentSize[0]).to.equal(framelessBounds.width);
+      expect(contentSize[1]).to.equal(framelessBounds.height);
+
+      framed.close();
+      frameless.close();
+    });
+  });
+
   describe('"backgroundColor" option', () => {
     afterEach(closeAllWindows);
 


### PR DESCRIPTION
#### Description of Change

On Wayland, creating a normal framed window before a frameless window caused a visible border to appear around the frameless window's shadow area. This was a regression introduced in v41.

The root cause is in `CalculateInsetsInDIP()` inside `ElectronDesktopWindowTreeHostLinux`. When a framed window is created first, the frame layout stores non-zero CSD (client-side decoration) insets. When a frameless window is created afterward in the same process, `CalculateInsetsInDIP()` still returned those non-zero insets from the frame layout because there was no explicit check for frameless windows. The Wayland compositor then rendered a visible border in that inset region around the frameless window.

The fix adds two guards:

1. **`CalculateInsetsInDIP()`** — Returns zero insets immediately for windows where `has_frame()` and `has_client_frame()` are both false, preventing stale frame layout insets from being used.

2. **`UpdateFrameHints()`** — When insets are empty, explicitly clears decoration insets on the compositor via `SetDecorationInsets(nullptr)` so any previously set compositor-level insets do not persist across windows.

Fixes #51456

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a regression on Wayland where creating a framed window before a frameless window caused a visible border artifact around the frameless window's shadow area.
