### PR TITLE
fix: reset hover state when disabling mouse event forwarding on Windows

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -677,6 +677,24 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
 
     RemoveWindowSubclass(legacy_window_, SubclassProc, 1);
 
+    // While forwarding was active, SubclassProc swallowed WM_MOUSELEAVE
+    // messages to prevent flickering.  If the cursor has since moved outside
+    // the window, Chromium's internal hover state is now stale (the renderer
+    // still thinks the cursor is inside, keeping :hover CSS active).  Post a
+    // synthetic WM_MOUSELEAVE to correct it.
+    // See https://github.com/electron/electron/issues/51521
+    POINT cursor_pos;
+    if (::GetCursorPos(&cursor_pos)) {
+      RECT client_rect;
+      if (::GetClientRect(legacy_window_, &client_rect)) {
+        POINT client_cursor = cursor_pos;
+        ::ScreenToClient(legacy_window_, &client_cursor);
+        if (!::PtInRect(&client_rect, client_cursor)) {
+          ::PostMessage(legacy_window_, WM_MOUSELEAVE, 0, 0);
+        }
+      }
+    }
+
     if (forwarding_windows_->empty()) {
       // If UnhookWindowsHookEx fails, the hook is still installed in the
       // system. Leave |mouse_hook_| pointing at the existing hook so that a

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7476,6 +7476,39 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  // Regression test for https://github.com/electron/electron/issues/51521
+  ifdescribe(process.platform === 'win32')('setIgnoreMouseEvents with forward', () => {
+    afterEach(closeAllWindows);
+
+    it('should not throw when toggling ignore with forward option', () => {
+      const w = new BrowserWindow({ show: false });
+
+      // Enable ignore with forwarding — should not throw.
+      expect(() => {
+        w.setIgnoreMouseEvents(true, { forward: true });
+      }).to.not.throw();
+
+      // Disable ignore — this previously left hover state stuck.
+      expect(() => {
+        w.setIgnoreMouseEvents(false);
+      }).to.not.throw();
+
+      w.close();
+    });
+
+    it('should allow rapid toggling without crash', () => {
+      const w = new BrowserWindow({ show: false });
+
+      // Rapid toggle should not crash or throw.
+      for (let i = 0; i < 10; i++) {
+        w.setIgnoreMouseEvents(true, { forward: true });
+        w.setIgnoreMouseEvents(false);
+      }
+
+      w.close();
+    });
+  });
+
   describe('"backgroundColor" option', () => {
     afterEach(closeAllWindows);
 


### PR DESCRIPTION
#### Description of Change

When `setIgnoreMouseEvents(true, { forward: true })` was active on Windows, the `SubclassProc` in `native_window_views_win.cc` intentionally swallowed `WM_MOUSELEAVE` messages to prevent flickering caused by rapidly entering and leaving forwarding mode. However, when `setIgnoreMouseEvents(false)` was later called to re-enable mouse events, the swallowed `WM_MOUSELEAVE` was never re-sent. This left Chromium's internal hover tracking in a stale state, causing the `<body>` element's `:hover` CSS selector to remain permanently active even after the cursor left the window.

The fix adds a cursor position check in `SetForwardMouseMessages(false)`. After removing the window subclass, it checks whether the cursor is still inside the window's client area. If the cursor is outside, it posts a synthetic `WM_MOUSELEAVE` to the legacy window. This resets the hover state correctly without reintroducing the flickering that the original swallow was designed to prevent, since at this point forwarding has already been fully disabled.

Fixes #51521

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug on Windows where `setIgnoreMouseEvents(true, { forward: true })` caused the `<body>` element's `:hover` state to remain permanently active after the cursor left the window.
