### PR TITLE
ci: pin Homebrew version in CI runs

### DIFF
--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Homebrew release tag to install'
     required: false
     default: '5.1.10'
+  sha256:
+    description: 'SHA256 checksum of the Homebrew package'
+    required: false
+    default: 'sha256:sha256:ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462'
 runs:
   using: 'composite'
   steps:
@@ -38,6 +42,26 @@ runs:
           curl --fail --location --silent --show-error \
             --output "${pkg_path}" \
             "${download_url}"
+
+          echo "Verifying Homebrew package SHA256 checksum..."
+          if ! echo "${{ inputs.sha256 }}" | shasum -a 256 -c; then
+            echo "Homebrew package SHA256 checksum failed, aborting." >&2
+            exit 1
+          fi
+
+          echo "Verifying Homebrew package with GitHub CLI..."
+          if ! gh release verify-asset "${target_version}" "${pkg_path}" -R Homebrew/brew; then
+            echo "Homebrew package verification failed, aborting." >&2
+            exit 1
+          fi
+
+          echo "Verifying Homebrew package with spctl..."
+          if ! spctl -a -vv --type install "${pkg_path}"; then
+            echo "Homebrew package installation verification failed, aborting." >&2
+            exit 1
+          fi
+
+          echo "Homebrew package verification passed, installing..."
 
           sudo installer -pkg "${pkg_path}" -target /
 

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -49,12 +49,6 @@ runs:
             exit 1
           fi
 
-          echo "Verifying Homebrew package with GitHub CLI..."
-          if ! gh release verify-asset "${target_version}" "${pkg_path}" -R Homebrew/brew; then
-            echo "Homebrew package verification failed, aborting." >&2
-            exit 1
-          fi
-
           echo "Verifying Homebrew package with spctl..."
           if ! spctl -a -vv --type install "${pkg_path}"; then
             echo "Homebrew package installation verification failed, aborting." >&2

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -43,9 +43,8 @@ runs:
             --output "${pkg_path}" \
             "${download_url}"
 
-          expected_sha256='${{ inputs.sha256 }}'
           echo "Verifying Homebrew package SHA256 checksum..."
-          if ! printf '%s  %s\n' "${expected_sha256}" "${pkg_path}" | shasum -a 256 -c; then
+          if ! printf '%s  %s\n' "${{ inputs.sha256 }}" "${pkg_path}" | shasum -a 256 -c; then
             echo "Homebrew package SHA256 checksum failed, aborting." >&2
             exit 1
           fi

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -8,7 +8,7 @@ inputs:
   sha256:
     description: 'SHA256 checksum of the Homebrew package'
     required: false
-    default: 'sha256:sha256:ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462'
+    default: 'ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462'
 runs:
   using: 'composite'
   steps:
@@ -43,8 +43,9 @@ runs:
             --output "${pkg_path}" \
             "${download_url}"
 
+          expected_sha256='${{ inputs.sha256 }}'
           echo "Verifying Homebrew package SHA256 checksum..."
-          if ! echo "${{ inputs.sha256 }}" | shasum -a 256 -c; then
+          if ! printf '%s  %s\n' "${expected_sha256}" "${pkg_path}" | shasum -a 256 -c; then
             echo "Homebrew package SHA256 checksum failed, aborting." >&2
             exit 1
           fi

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -1,0 +1,63 @@
+name: 'Install Homebrew'
+description: 'Installs a pinned Homebrew release on macOS runners'
+inputs:
+  version:
+    description: 'Homebrew release tag to install'
+    required: false
+    default: '5.1.10'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install pinned Homebrew
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ "$(uname -s)" != "Darwin" ]]; then
+          echo "This action only supports macOS runners." >&2
+          exit 1
+        fi
+
+        target_version='${{ inputs.version }}'
+        brew_bin=''
+
+        for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+          if [[ -x "${candidate}" ]]; then
+            current_version="$("${candidate}" --version | awk 'NR == 1 { print $2 }')"
+            if [[ "${current_version}" == "${target_version}" ]]; then
+              brew_bin="${candidate}"
+              break
+            fi
+          fi
+        done
+
+        if [[ -z "${brew_bin}" ]]; then
+          pkg_path="${RUNNER_TEMP}/Homebrew.pkg"
+          download_url="https://github.com/Homebrew/brew/releases/download/${target_version}/Homebrew.pkg"
+
+          curl --fail --location --silent --show-error \
+            --output "${pkg_path}" \
+            "${download_url}"
+
+          sudo installer -pkg "${pkg_path}" -target /
+
+          for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+            if [[ -x "${candidate}" ]]; then
+              current_version="$("${candidate}" --version | awk 'NR == 1 { print $2 }')"
+              if [[ "${current_version}" == "${target_version}" ]]; then
+                brew_bin="${candidate}"
+                break
+              fi
+            fi
+          done
+        fi
+
+        if [[ -z "${brew_bin}" ]]; then
+          echo "Pinned Homebrew ${target_version} was not installed successfully." >&2
+          exit 1
+        fi
+
+        echo "$(dirname "${brew_bin}")" >> "${GITHUB_PATH}"
+        echo "HOMEBREW_NO_AUTO_UPDATE=1" >> "${GITHUB_ENV}"
+
+        "${brew_bin}" --version

--- a/.github/workflows/macos-disk-cleanup.yml
+++ b/.github/workflows/macos-disk-cleanup.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
+            .github/actions/install-homebrew
             .github/actions/free-space-macos
           sparse-checkout-cone-mode: false
 
@@ -40,6 +41,9 @@ jobs:
           df -h /
           FREE_SPACE_BEFORE=$(df -k / | tail -1 | awk '{print $4}')
           echo "free_kb=$FREE_SPACE_BEFORE" >> $GITHUB_OUTPUT
+
+      - name: Install pinned Homebrew
+        uses: ./.github/actions/install-homebrew
 
       - name: Free Space on macOS
         uses: ./.github/actions/free-space-macos

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -104,6 +104,9 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Install pinned Homebrew
+      if: ${{ inputs.target-platform == 'macos' }}
+      uses: ./src/electron/.github/actions/install-homebrew
     - name: Setup SSH Debugging
       if: ${{ inputs.target-platform == 'macos' && (inputs.enable-ssh || env.ACTIONS_STEP_DEBUG == 'true') }}
       uses: ./src/electron/.github/actions/ssh-debug

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -111,6 +111,9 @@ jobs:
           path: src/electron
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install pinned Homebrew
+        if: ${{ inputs.target-platform == 'macos' }}
+        uses: ./src/electron/.github/actions/install-homebrew
       - name: Setup SSH Debugging
         if: ${{ inputs.target-platform == 'macos' && (inputs.enable-ssh ||
           env.ACTIONS_STEP_DEBUG == 'true') }}

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -140,6 +140,9 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Install pinned Homebrew
+      if: ${{ inputs.target-platform == 'macos' }}
+      uses: ./src/electron/.github/actions/install-homebrew
     - name: Turn off screenshot nag on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: |


### PR DESCRIPTION
#### Description of Change

We had a recent macOS build that failed in CI due to a bug in Homebrew: https://github.com/electron/electron/actions/runs/25497330347

This appears to be fixed in a newer version of Homebrew (5.1.10) via this commit: https://github.com/Homebrew/brew/commit/1c8cbf322ebfc3c463306862abb1338209d1e881 (https://github.com/Homebrew/brew/pull/22137)

However, it seems we currently just use whatever version of Homebrew is on our runners. For better control, we might be better served pinning the Homebrew version ourselves and installing it via their published `.pkg` files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description

#### Release Notes

Notes: none.