### PR TITLE
ci: run brew update before trying to use homebrew

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -81,6 +81,7 @@ runs:
 
         # remove homebrew packages we don't need
         if command -v brew &> /dev/null; then
+          brew update
           brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 llvm@18 gradle maven ant azure-cli
           brew autoremove
         fi


### PR DESCRIPTION
#### Description of Change
This PR fixes an error on our macOS runners when trying to interact with homebrew:
```
Error: undefined method 'to_sym' for nil
/opt/homebrew/Library/Homebrew/api/cask/cask_struct_generator.rb:100:in 'block in Homebrew::API::Cask::CaskStructGenerator.process_depends_on'
/opt/homebrew/Library/Homebrew/api/cask/cask_struct_generator.rb:87:in 'Hash#to_h'
/opt/homebrew/Library/Homebrew/api/cask/cask_struct_generator.rb:87:in 'Homebrew::API::Cask::CaskStructGenerator.process_depends_on'
/opt/homebrew/Library/Homebrew/api/cask/cask_struct_generator.rb:26:in 'Homebrew::API::Cask::CaskStructGenerator.generate_cask_struct_hash'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:438:in 'Cask::CaskLoader::FromAPILoader#load_from_api'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:428:in 'Cask::CaskLoader::FromAPILoader#load'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:653:in 'Cask::CaskLoader.load'
/opt/homebrew/Library/Homebrew/cli/named_args.rb:381:in 'block in Homebrew::CLI::NamedArgs#load_formula_or_cask'
/opt/homebrew/Library/Homebrew/api.rb:379:in 'Homebrew.with_no_api_env_if_needed'
/opt/homebrew/Library/Homebrew/cli/named_args.rb:336:in 'Homebrew::CLI::NamedArgs#load_formula_or_cask'
/opt/homebrew/Library/Homebrew/cli/named_args.rb:158:in 'block in Homebrew::CLI::NamedArgs#to_formulae_and_casks_and_unavailable'
/opt/homebrew/Library/Homebrew/cli/named_args.rb:157:in 'Array#map'
/opt/homebrew/Library/Homebrew/cli/named_args.rb:157:in 'Homebrew::CLI::NamedArgs#to_formulae_and_casks_and_unavailable'
/opt/homebrew/Library/Homebrew/cmd/uninstall.rb:45:in 'Homebrew::Cmd::UninstallCmd#run'
/opt/homebrew/Library/Homebrew/brew.rb:114:in '<main>'
```
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
