### PR TITLE
fix: avoid mutating caller-provided webPreferences objects

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -32,6 +32,8 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   v8::Isolate* isolate = args->isolate();
   auto web_preferences = gin_helper::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
+  // Clone to avoid mutating the caller's object.
+  web_preferences = web_preferences.ShallowClone();
 
   // Copy the backgroundColor to webContents.
   std::string color;

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -207,6 +207,8 @@ gin_helper::WrappableBase* WebContentsView::New(gin::Arguments* const args) {
 
   if (web_preferences.IsEmpty())
     web_preferences = gin_helper::Dictionary::CreateEmpty(isolate);
+  // Clone to avoid mutating the caller's object.
+  web_preferences = web_preferences.ShallowClone();
   if (!web_preferences.Has(options::kShow))
     web_preferences.Set(options::kShow, false);
 

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -192,6 +192,22 @@ class Dictionary : public gin::Dictionary {
 
   bool IsEmpty() const { return isolate() == nullptr || GetHandle().IsEmpty(); }
 
+  // Returns a shallow copy of this dictionary's own enumerable properties.
+  [[nodiscard]] Dictionary ShallowClone() const {
+    v8::Isolate* const iso = isolate();
+    v8::Local<v8::Context> context = iso->GetCurrentContext();
+    v8::Local<v8::Object> src = GetHandle();
+    v8::Local<v8::Object> dst = v8::Object::New(iso);
+    v8::Local<v8::Array> keys =
+        src->GetOwnPropertyNames(context).ToLocalChecked();
+    for (uint32_t i = 0; i < keys->Length(); i++) {
+      v8::Local<v8::Value> key = keys->Get(context, i).ToLocalChecked();
+      v8::Local<v8::Value> value = src->Get(context, key).ToLocalChecked();
+      dst->Set(context, key, value).Check();
+    }
+    return Dictionary{iso, dst};
+  }
+
   bool IsEmptyObject() const {
     if (IsEmpty())
       return true;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -104,7 +104,7 @@ describe('BrowserWindow module', () => {
       }).not.to.throw();
     });
 
-    it('does not mutate a shared webPreferences object', () => {
+    it('does not leak BrowserWindow backgroundColor into shared webPreferences', () => {
       const sharedPrefs: Electron.WebPreferences = {};
       const w = new BrowserWindow({
         show: false,
@@ -112,6 +112,10 @@ describe('BrowserWindow module', () => {
         webPreferences: sharedPrefs
       });
       const view = new WebContentsView({ webPreferences: sharedPrefs });
+      const windowPrefs = w.webContents.getLastWebPreferences() as any;
+      const viewPrefs = view.webContents.getLastWebPreferences() as any;
+      expect(windowPrefs!.backgroundColor).to.equal('#00f');
+      expect(viewPrefs!.backgroundColor).to.be.undefined();
       expect(Object.keys(sharedPrefs)).to.have.lengthOf(0);
       view.webContents.close();
       w.destroy();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -13,6 +13,7 @@ import {
   session,
   systemPreferences,
   WebContents,
+  WebContentsView,
   WebFrameMain
 } from 'electron/main';
 
@@ -101,6 +102,19 @@ describe('BrowserWindow module', () => {
         } as any);
         w.destroy();
       }).not.to.throw();
+    });
+
+    it('does not mutate a shared webPreferences object', () => {
+      const sharedPrefs: Electron.WebPreferences = {};
+      const w = new BrowserWindow({
+        show: false,
+        backgroundColor: '#00f',
+        webPreferences: sharedPrefs
+      });
+      const view = new WebContentsView({ webPreferences: sharedPrefs });
+      expect(Object.keys(sharedPrefs)).to.have.lengthOf(0);
+      view.webContents.close();
+      w.destroy();
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Fixes #51337.

Constructors for BrowserWindow and WebContentsView set internal properties into the webPreferences dictionary passed in, mutating the original JS object. If the same object is reused across multiple constructors, properties from one can leak into another.

Fix this by using a shallow clone of the dictionary.

Related: #51537

#### Checklist

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
