### PR TITLE
build: only fallback to CHROMIUM_BUILDTOOLS_PATH if needed

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -54,7 +54,6 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"out\": \"Testing\"
             },
             \"env\": {
-                \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=67979ae1cadad053d2f13e2fb5d1559b923484c7
+      export BUILD_TOOLS_SHA=c22d659a081014dc1b847bd3af23c449fdba09ca
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -80,8 +80,9 @@ jobs:
         # gn.py tries to find a gclient root folder starting from the current dir.
         # When it fails and returns "None" path, the whole script fails. Let's "fix" it.
         touch .gclient
-        # Another option would be to checkout "buildtools" inside the Electron checkout,
-        # but then we would lint its contents (at least gn format), and it doesn't pass it.
+
+        # Clean things up so `depot_tools/gclient_paths.py` finds src/buildtools properly
+        rm -f .gclient_entries
 
         cd src/electron
         node script/yarn.js install --immutable

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -57,9 +57,6 @@ jobs:
         @Subdir src/buildtools/linux64
         gn/gn/linux-amd64 $gn_version
         CIPD
-
-        buildtools_path="$(pwd)/src/buildtools"
-        echo "CHROMIUM_BUILDTOOLS_PATH=$buildtools_path" >> $GITHUB_ENV
     - name: Download clang-format Binary
       shell: bash
       run: |

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -192,8 +192,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Free up space (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -111,8 +111,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Checkout Electron
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -112,8 +112,6 @@ jobs:
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
         echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-    - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-      run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
     - name: Checkout Electron
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -205,8 +205,6 @@ jobs:
           src/electron/script/generate-deps-hash.js
 
           echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
-      - name: Add CHROMIUM_BUILDTOOLS_PATH to env
-        run: echo "CHROMIUM_BUILDTOOLS_PATH=$(pwd)/src/buildtools" >> $GITHUB_ENV
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -173,27 +173,6 @@ $ gclient sync -f
 
 ### Building
 
-**Set the environment variable for chromium build tools**
-
-On Linux & MacOS
-
-```sh
-$ cd src
-$ export CHROMIUM_BUILDTOOLS_PATH=`pwd`/buildtools
-```
-
-On Windows:
-
-```sh
-# cmd
-$ cd src
-$ set CHROMIUM_BUILDTOOLS_PATH=%cd%\buildtools
-
-# PowerShell
-$ cd src
-$ $env:CHROMIUM_BUILDTOOLS_PATH = "$(Get-Location)\buildtools"
-```
-
 **To generate Testing build config of Electron:**
 
 On Linux & MacOS

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -7,13 +7,10 @@ $ node ./script/gn-check.js [--outDir=dirName]
 const minimist = require('minimist');
 
 const cp = require('node:child_process');
-const path = require('node:path');
 
 const args = minimist(process.argv.slice(2), { string: ['outDir'] });
 
 const { getDepotToolsEnv, getOutDir } = require('./lib/utils');
-
-const SOURCE_ROOT = path.normalize(path.dirname(__dirname));
 
 const OUT_DIR = getOutDir({ outDir: args.outDir });
 if (!OUT_DIR) {
@@ -22,7 +19,6 @@ if (!OUT_DIR) {
 
 const env = {
   ...getDepotToolsEnv(),
-  CHROMIUM_BUILDTOOLS_PATH: path.resolve(SOURCE_ROOT, '..', 'buildtools'),
   DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
 };
 

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -205,37 +205,45 @@ def get_buildtools_executable(name):
     path += '.exe'
   return path
 
-def get_depot_tools_env():
+def get_chromium_buildtools_path_value():
   def find_depot_tools_on_path():
     cmd = 'where' if sys.platform == 'win32' else 'which'
     try:
-      subprocess.check_call([cmd, 'gclient'])
-      return os.environ.copy()
+      depot_tools_path = subprocess.check_output(
+        [cmd, 'gclient'],
+        stderr=subprocess.DEVNULL, encoding='utf-8'
+      ).strip()
+      return os.path.dirname(depot_tools_path)
     except subprocess.CalledProcessError:
       return None
 
   def check_for_build_tools():
     try:
-      output = subprocess.check_output(
-        'electron-build-tools show env --json',
-        shell=True, stderr=subprocess.DEVNULL
-      )
-      env = os.environ.copy()
-      env.update(json.loads(output.decode().strip()))
-      return env
+      depot_tools_path = subprocess.check_output(
+        'electron-build-tools show depotdir',
+        shell=True, stderr=subprocess.DEVNULL, encoding='utf-8'
+      ).strip()
+      return depot_tools_path
     except subprocess.CalledProcessError:
       return None
 
-  depot_tools_env = check_for_build_tools()
-  if depot_tools_env is None:
-    depot_tools_env = find_depot_tools_on_path()
+  depot_tools_path = check_for_build_tools()
+  if depot_tools_path is None:
+    depot_tools_path = find_depot_tools_on_path()
 
-  if depot_tools_env is None:
+  if depot_tools_path is None:
     raise RuntimeError("Couldn't find depot_tools, ensure it's on your PATH")
 
-  if 'CHROMIUM_BUILDTOOLS_PATH' not in depot_tools_env:
-    raise RuntimeError(
-      'CHROMIUM_BUILDTOOLS_PATH environment variable must be set'
-    )
+  sys.path.append(depot_tools_path)
+  # If CHROMIUM_BUILDTOOLS_PATH is in the environment variables, remove it
+  # so we can see if we're on a version of depot_tools which doesn't need it
+  CHROMIUM_BUILDTOOLS_PATH = os.environ.pop('CHROMIUM_BUILDTOOLS_PATH', None)
+  try:
+    from gclient_paths import GetBuildtoolsPath # pylint: disable=import-outside-toplevel
+    if GetBuildtoolsPath() is None:
+      return CHROMIUM_BUILDTOOLS_PATH or os.path.join(SRC_DIR, 'buildtools')
+  finally:
+    if CHROMIUM_BUILDTOOLS_PATH:
+      os.environ['CHROMIUM_BUILDTOOLS_PATH'] = CHROMIUM_BUILDTOOLS_PATH
 
-  return depot_tools_env
+  return None

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -194,8 +194,23 @@ function getDepotToolsEnv() {
     throw new Error("Couldn't find depot_tools, ensure it's on your PATH");
   }
 
-  if (!('CHROMIUM_BUILDTOOLS_PATH' in depotToolsEnv)) {
-    throw new Error('CHROMIUM_BUILDTOOLS_PATH environment variable must be set');
+  const result = childProcess.spawnSync(
+    'python3',
+    [
+      '-c',
+      '\'from lib.util import get_chromium_buildtools_path_value; print(get_chromium_buildtools_path_value() or "")\''
+    ],
+    { env: depotToolsEnv, shell: true, encoding: 'utf8', cwd: path.join(ELECTRON_DIR, 'script') }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr);
+  }
+
+  const chromiumBuildtoolsPathValue = result.status === 0 ? result.stdout.trim() : null;
+
+  // Only set CHROMIUM_BUILDTOOLS_PATH if we're on an older version of depot_tools which requires it
+  if (chromiumBuildtoolsPathValue) {
+    depotToolsEnv.CHROMIUM_BUILDTOOLS_PATH = chromiumBuildtoolsPathValue;
   }
 
   return depotToolsEnv;

--- a/script/lint.js
+++ b/script/lint.js
@@ -116,13 +116,11 @@ const LINTERS = [
     roots: ['shell'],
     test: (filename) => filename.endsWith('.cc') || (filename.endsWith('.h') && !isObjCHeader(filename)),
     run: (opts, filenames) => {
-      const env = {
-        ...getDepotToolsEnv(),
-        CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools')
-      };
       const clangFormatFlags = opts.fix ? ['--fix'] : [];
       for (const chunk of chunkFilenames(filenames)) {
-        spawnAndCheckExitCode('python3', ['script/run-clang-format.py', ...clangFormatFlags, ...chunk], { env });
+        spawnAndCheckExitCode('python3', ['script/run-clang-format.py', ...clangFormatFlags, ...chunk], {
+          env: getDepotToolsEnv()
+        });
         cpplint([`--filter=${CPPLINT_FILTERS.join(',')}`, ...chunk]);
       }
     }
@@ -132,13 +130,9 @@ const LINTERS = [
     roots: ['shell'],
     test: (filename) => filename.endsWith('.mm') || (filename.endsWith('.h') && isObjCHeader(filename)),
     run: (opts, filenames) => {
-      const env = {
-        ...getDepotToolsEnv(),
-        CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools')
-      };
       const clangFormatFlags = opts.fix ? ['--fix'] : [];
       spawnAndCheckExitCode('python3', ['script/run-clang-format.py', '-r', ...clangFormatFlags, ...filenames], {
-        env
+        env: getDepotToolsEnv()
       });
       const filter = [...CPPLINT_FILTERS, '-readability/braces'];
       cpplint(['--extensions=mm,h', `--filter=${filter.join(',')}`, ...filenames]);
@@ -175,7 +169,6 @@ const LINTERS = [
         .map((filename) => {
           const env = {
             ...getDepotToolsEnv(),
-            CHROMIUM_BUILDTOOLS_PATH: path.resolve(ELECTRON_ROOT, '..', 'buildtools'),
             DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
           };
           const args = ['format', filename];


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Alternative to #51440. I landed [an upstream change](https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/7813342) which properly finds `src/buildtools` for us in `depot_tools`, so we can drop our usage of `CHROMIUM_BUILDTOOLS_PATH`. The changes in this PR will do a functional test with `depot_tools` to determine if we have that upstream fix, and fallback to setting `CHROMIUM_BUILDTOOLS_PATH` if we don't.

~This is safe to land on its own, but will not be a complete migration until electron/build-tools#859 lands and we bump the `build-tools` SHA here.~

This PR also removes `get_depot_tools_env` from `util.py` as the only usage was removed in #51263.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
