### PR TITLE
docs: update Notification 'failed' support info

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -293,7 +293,7 @@ app.whenReady().then(() => {
 })
 ```
 
-#### Event: 'failed' _Windows_
+#### Event: 'failed' _macOS_ _Windows_
 
 Returns:
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This is a follow-up to
https://github.com/electron/electron/pull/47817.

According to https://www.electronjs.org/blog/electron-42-0#behavior-changed-macos-notifications-now-use-unnotification-api
> If an application is not code-signed, notifications will emit a `failed` event on the `Notification` object.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: Updated docs about Notification 'failed' event platform support

<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
