### PR TITLE
fix: improve resize band positioning and scaling for frameless windows on Windows

### DIFF
--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -16,7 +16,6 @@ namespace electron {
 
 namespace {
 
-const int kResizeInsideBoundsSize = 5;
 const int kResizeAreaCornerSize = 16;
 
 }  // namespace

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -35,6 +35,9 @@ class FramelessView : public views::FrameView {
 
   virtual void Init(NativeWindowViews* window, views::Widget* frame);
 
+  // Width in DIPs of the inside resize border for frameless windows.
+  static constexpr int kResizeInsideBoundsSize = 5;
+
   // Returns whether the |point| is on frameless window's resizing border.
   virtual int ResizingBorderHitTest(const gfx::Point& point);
 

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -294,13 +294,29 @@ gfx::Size WinFrameView::GetMaximumSize() const {
   return size.IsEmpty() ? gfx::Size(INT_MAX, INT_MAX) : size;
 }
 
+int WinFrameView::ResizingBorderHitTest(const gfx::Point& point) {
+  if (RestoredFrameBorderInsets().IsEmpty())
+    return FramelessView::ResizingBorderHitTest(point);
+
+  // With insets, side/bottom resize targets sit outside the frame and are
+  // handled by WM_NCHITTEST, so the internal hit test can be zero-ed out.
+  // The exception is the top edge for frameless windows, which still need
+  // an inner resize band since there is no non-client titlebar to provide one.
+  const gfx::Insets inside =
+      window_->has_frame()
+          ? gfx::Insets()
+          : gfx::Insets::TLBR(kResizeInsideBoundsSize, 0, 0, 0);
+  return ResizingBorderHitTestImpl(point, inside);
+}
+
 gfx::Insets WinFrameView::RestoredFrameBorderInsets() const {
   if (window_->has_frame() || !window_->has_thick_frame())
     return {};
 
-  const int thickness =
-      display::win::GetScreenWin()->GetSystemMetricsInDIP(SM_CXSIZEFRAME) +
-      display::win::GetScreenWin()->GetSystemMetricsInDIP(SM_CXPADDEDBORDER);
+  // TODO(mitchchn): despite the name, this method gives the correct
+  // DPI-adjusted insets for the sides, not the top, when restored.
+  const int thickness = FrameTopBorderThickness(/*restored=*/true);
+  // Inverse of ResizingBorderHitTest: resize insets go on sides but not top.
   return gfx::Insets::TLBR(0, thickness, thickness, thickness);
 }
 

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -39,6 +39,7 @@ class WinFrameView : public FramelessView {
   gfx::Size GetMaximumSize() const override;
 
   // views::FramelessView:
+  int ResizingBorderHitTest(const gfx::Point& point) override;
   gfx::Insets RestoredFrameBorderInsets() const override;
 
   WinCaptionButtonContainer* caption_button_container() {

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -106,9 +106,6 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
     return false;
 
   if (!native_window_view_->has_frame()) {
-    const int thickness = ::GetSystemMetrics(SM_CXSIZEFRAME) +
-                          ::GetSystemMetrics(SM_CXPADDEDBORDER);
-
     if (IsMaximized()) {
       // Windows by default extends the maximized window slightly larger than
       // current workspace, for frameless window since the standard frame has
@@ -122,6 +119,8 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       //
       // Please make sure you tested maximized frameless window under multiple
       // monitors with different DPIs before changing this code.
+      const int thickness = ::GetSystemMetrics(SM_CXSIZEFRAME) +
+                            ::GetSystemMetrics(SM_CXPADDEDBORDER);
       *insets = gfx::Insets::TLBR(thickness, thickness, thickness, thickness);
       return true;
     } else if (native_window_view_->has_thick_frame()) {
@@ -129,7 +128,8 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       // windows with standard frames. Non-resizable windows still get input
       // insets for stable bounds and so they can be dragged from outer edges,
       // also like in windows with standard frames.
-      *insets = gfx::Insets::TLBR(0, thickness, thickness, thickness);
+      *insets = gfx::Insets::TLBR(0, frame_thickness, frame_thickness,
+                                  frame_thickness);
       return true;
     }
   }


### PR DESCRIPTION
Manual backport of #51503.

See that PR for details.

Notes: Improved external resize band positioning and scaling for frameless windows on Windows.