### PR TITLE
feat: add setDecorationInsets API and tiled state for Linux CSD

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -212,6 +212,12 @@ Emitted when the window is minimized.
 
 Emitted when the window is restored from a minimized state.
 
+#### Event: 'tiled-state-changed' _Linux_
+
+Emitted when the window's tiled state changes — for example, when it is snapped
+to the left or right half of the screen. Use `win.isTiled()` in the handler to
+query the current state.
+
 #### Event: 'will-resize' _macOS_ _Windows_
 
 Returns:
@@ -640,6 +646,12 @@ Sets whether the window should be in fullscreen mode.
 #### `win.isFullScreen()`
 
 Returns `boolean` - Whether the window is in fullscreen mode.
+
+#### `win.isTiled()` _Linux_
+
+Returns `boolean` - Whether the window is tiled by the window manager (e.g.
+snapped to the left or right half of the screen). Only meaningful on Wayland;
+always returns `false` on other platforms.
 
 #### `win.setSimpleFullScreen(flag)` _macOS_
 
@@ -1165,6 +1177,25 @@ Invalidates the window shadow so that it is recomputed based on the current wind
 
 `BaseWindow`s that are transparent can sometimes leave behind visual artifacts on macOS.
 This method can be used to clear these artifacts when, for example, performing an animation.
+
+#### `win.setDecorationInsets(insets)` _Linux_
+
+* `insets` Object
+  * `top` Integer
+  * `left` Integer
+  * `bottom` Integer
+  * `right` Integer
+
+Sets the decoration insets for the window on Wayland. This tells the compositor
+the margins between the window surface edges and the actual content, so that
+areas used for client-side decorations (such as shadows) are excluded from
+window management operations like snapping, tiling, and maximizing.
+
+This is useful for applications that render their own window shadow using
+`transparent: true` and `frame: false` — without decoration insets, the
+compositor treats the shadow area as part of the window content.
+
+On X11 and non-Linux platforms, this method is a no-op.
 
 #### `win.setHasShadow(hasShadow)`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -288,6 +288,12 @@ Emitted when the window is minimized.
 
 Emitted when the window is restored from a minimized state.
 
+#### Event: 'tiled-state-changed' _Linux_
+
+Emitted when the window's tiled state changes — for example, when it is snapped
+to the left or right half of the screen. Use `win.isTiled()` in the handler to
+query the current state.
+
 #### Event: 'will-resize' _macOS_ _Windows_
 
 Returns:
@@ -744,6 +750,12 @@ Returns `boolean` - Whether the window is in fullscreen mode.
 
 > [!NOTE]
 > On macOS, fullscreen transitions take place asynchronously. When querying for a BrowserWindow's fullscreen status, you should ensure that either the ['enter-full-screen'](browser-window.md#event-enter-full-screen) or ['leave-full-screen'](browser-window.md#event-leave-full-screen) events have been emitted.
+
+#### `win.isTiled()` _Linux_
+
+Returns `boolean` - Whether the window is tiled by the window manager (e.g.
+snapped to the left or right half of the screen). Only meaningful on Wayland;
+always returns `false` on other platforms.
 
 #### `win.setSimpleFullScreen(flag)` _macOS_
 
@@ -1371,6 +1383,25 @@ Invalidates the window shadow so that it is recomputed based on the current wind
 
 `BrowserWindows` that are transparent can sometimes leave behind visual artifacts on macOS.
 This method can be used to clear these artifacts when, for example, performing an animation.
+
+#### `win.setDecorationInsets(insets)` _Linux_
+
+* `insets` Object
+  * `top` Integer
+  * `left` Integer
+  * `bottom` Integer
+  * `right` Integer
+
+Sets the decoration insets for the window on Wayland. This tells the compositor
+the margins between the window surface edges and the actual content, so that
+areas used for client-side decorations (such as shadows) are excluded from
+window management operations like snapping, tiling, and maximizing.
+
+This is useful for applications that render their own window shadow using
+`transparent: true` and `frame: false` — without decoration insets, the
+compositor treats the shadow area as part of the window content.
+
+On X11 and non-Linux platforms, this method is a no-op.
 
 #### `win.setHasShadow(hasShadow)`
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -231,6 +231,14 @@ void BaseWindow::OnWindowHide() {
   Emit("hide");
 }
 
+void BaseWindow::OnWindowTiledStateChanged(bool is_tiled) {
+  Emit("tiled-state-changed");
+}
+
+bool BaseWindow::IsTiled() const {
+  return window_->IsTiled();
+}
+
 void BaseWindow::OnWindowMaximize() {
   Emit("maximize");
 }
@@ -669,6 +677,10 @@ std::string BaseWindow::GetBackgroundColor() const {
 
 void BaseWindow::InvalidateShadow() {
   window_->InvalidateShadow();
+}
+
+void BaseWindow::SetDecorationInsets(const gfx::Insets& insets) {
+  window_->SetDecorationInsets(insets);
 }
 
 void BaseWindow::SetHasShadow(bool has_shadow) {
@@ -1180,6 +1192,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("maximize", &BaseWindow::Maximize)
       .SetMethod("unmaximize", &BaseWindow::Unmaximize)
       .SetMethod("isMaximized", &BaseWindow::IsMaximized)
+      .SetMethod("isTiled", &BaseWindow::IsTiled)
       .SetMethod("minimize", &BaseWindow::Minimize)
       .SetMethod("restore", &BaseWindow::Restore)
       .SetMethod("isMinimized", &BaseWindow::IsMinimized)
@@ -1232,6 +1245,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isTabletMode", &BaseWindow::IsTabletMode)
       .SetMethod("setBackgroundColor", &BaseWindow::SetBackgroundColor)
       .SetMethod("getBackgroundColor", &BaseWindow::GetBackgroundColor)
+      .SetMethod("setDecorationInsets", &BaseWindow::SetDecorationInsets)
       .SetMethod("setHasShadow", &BaseWindow::SetHasShadow)
       .SetMethod("hasShadow", &BaseWindow::HasShadow)
       .SetMethod("setOpacity", &BaseWindow::SetOpacity)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -69,6 +69,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowFocus() override;
   void OnWindowShow() override;
   void OnWindowHide() override;
+  void OnWindowTiledStateChanged(bool is_tiled) override;
+  bool IsTiled() const;
   void OnWindowMaximize() override;
   void OnWindowUnmaximize() override;
   void OnWindowMinimize() override;
@@ -172,6 +174,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void SetBackgroundColor(const std::string& color_name);
   std::string GetBackgroundColor() const;
   void InvalidateShadow();
+  void SetDecorationInsets(const gfx::Insets& insets);
   void SetHasShadow(bool has_shadow);
   bool HasShadow() const;
   void SetOpacity(const double opacity);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -531,6 +531,14 @@ void NativeWindow::NotifyWindowUnmaximize() {
   observers_.Notify(&NativeWindowObserver::OnWindowUnmaximize);
 }
 
+void NativeWindow::NotifyWindowTiledStateChanged(bool is_tiled) {
+  observers_.Notify(&NativeWindowObserver::OnWindowTiledStateChanged, is_tiled);
+}
+
+bool NativeWindow::IsTiled() const {
+  return false;
+}
+
 void NativeWindow::NotifyWindowMinimize() {
   observers_.Notify(&NativeWindowObserver::OnWindowMinimize);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -95,6 +95,7 @@ class NativeWindow : public views::WidgetDelegate {
   virtual bool IsMinimized() const = 0;
   virtual void SetFullScreen(bool fullscreen) = 0;
   virtual bool IsFullscreen() const = 0;
+  virtual bool IsTiled() const;
 
   virtual void SetBounds(const gfx::Rect& bounds, bool animate) = 0;
   virtual gfx::Rect GetBounds() const = 0;
@@ -180,6 +181,7 @@ class NativeWindow : public views::WidgetDelegate {
   virtual void SetBackgroundColor(SkColor color) = 0;
   virtual SkColor GetBackgroundColor() const = 0;
   virtual void InvalidateShadow() {}
+  virtual void SetDecorationInsets(const gfx::Insets& insets) {}
 
   virtual void SetHasShadow(bool has_shadow) = 0;
   virtual bool HasShadow() const = 0;
@@ -316,6 +318,7 @@ class NativeWindow : public views::WidgetDelegate {
   void NotifyWindowUnmaximize();
   void NotifyWindowMinimize();
   void NotifyWindowRestore();
+  void NotifyWindowTiledStateChanged(bool is_tiled);
   void NotifyWindowMove();
   void NotifyWindowWillResize(const gfx::Rect& new_bounds,
                               gfx::ResizeEdge edge,

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -77,6 +77,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowUnmaximize() {}
   virtual void OnWindowMinimize() {}
   virtual void OnWindowRestore() {}
+  virtual void OnWindowTiledStateChanged(bool is_tiled) {}
   virtual void OnWindowWillResize(const gfx::Rect& new_bounds,
                                   gfx::ResizeEdge edge,
                                   bool* prevent_default) {}

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -973,8 +973,8 @@ void NativeWindowViews::SetTiled(bool tiled) {
 
 void NativeWindowViews::SetDecorationInsets(const gfx::Insets& insets) {
 #if BUILDFLAG(IS_LINUX)
-  DCHECK(insets.top() >= 0 && insets.left() >= 0 &&
-         insets.bottom() >= 0 && insets.right() >= 0);
+  DCHECK(insets.top() >= 0 && insets.left() >= 0 && insets.bottom() >= 0 &&
+         insets.right() >= 0);
   gfx::Insets old_insets = decoration_insets_;
   decoration_insets_ = insets;
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -958,6 +958,53 @@ extensions::SizeConstraints NativeWindowViews::GetContentSizeConstraints()
 }
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+bool NativeWindowViews::IsTiled() const {
+  return is_tiled_;
+}
+
+void NativeWindowViews::SetTiled(bool tiled) {
+  if (is_tiled_ == tiled)
+    return;
+  is_tiled_ = tiled;
+  NotifyWindowTiledStateChanged(tiled);
+}
+#endif
+
+void NativeWindowViews::SetDecorationInsets(const gfx::Insets& insets) {
+#if BUILDFLAG(IS_LINUX)
+  DCHECK(insets.top() >= 0 && insets.left() >= 0 &&
+         insets.bottom() >= 0 && insets.right() >= 0);
+  gfx::Insets old_insets = decoration_insets_;
+  decoration_insets_ = insets;
+
+  // Grow or shrink the widget so the window geometry (content area)
+  // stays the same size. Without this, setting insets would shrink the
+  // visible content by the shadow amount, and changing insets would
+  // cause the compositor to reposition the window.
+  if (!IsMaximized() && !IsFullscreen() && !IsTiled()) {
+    int dl = insets.left() - old_insets.left();
+    int dt = insets.top() - old_insets.top();
+    int dw = insets.width() - old_insets.width();
+    int dh = insets.height() - old_insets.height();
+    if (dl != 0 || dt != 0 || dw != 0 || dh != 0) {
+      gfx::Rect bounds = GetBounds();
+      bounds.set_x(bounds.x() - dl);
+      bounds.set_y(bounds.y() - dt);
+      bounds.set_width(bounds.width() + dw);
+      bounds.set_height(bounds.height() + dh);
+      SetBounds(bounds, false);
+    }
+  }
+
+  if (auto* tree_host = static_cast<ElectronDesktopWindowTreeHostLinux*>(
+          views::DesktopWindowTreeHostLinux::GetHostForWidget(
+              GetAcceleratedWidget()))) {
+    tree_host->ApplyDecorationInsets();
+  }
+#endif
+}
+
 void NativeWindowViews::SetResizable(bool resizable) {
   if (resizable != resizable_) {
     resizable_ = resizable;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -92,6 +92,7 @@ class NativeWindowViews : public NativeWindow,
 #if BUILDFLAG(IS_WIN)
   extensions::SizeConstraints GetContentSizeConstraints() const override;
 #endif
+  void SetDecorationInsets(const gfx::Insets& insets) override;
   void SetResizable(bool resizable) override;
   bool MoveAbove(const std::string& sourceId) override;
   void MoveTop() override;
@@ -209,6 +210,9 @@ class NativeWindowViews : public NativeWindow,
 #if BUILDFLAG(IS_LINUX)
   LinuxFrameLayout* GetLinuxFrameLayout();
   views::FrameViewLinux* GetFrameViewLinux() const;
+  gfx::Insets GetCustomDecorationInsets() const { return decoration_insets_; }
+  bool IsTiled() const override;
+  void SetTiled(bool tiled);
 #endif
 
  private:
@@ -287,6 +291,11 @@ class NativeWindowViews : public NativeWindow,
 
 #if BUILDFLAG(IS_LINUX)
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_;
+  gfx::Insets decoration_insets_;
+  // Tracks tiled state independently of the frame layout/view (which may
+  // not exist for frameless windows). Used by CalculateInsetsInDIP and
+  // the JS isTiled() API.
+  bool is_tiled_ = false;
 #endif
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -57,6 +57,10 @@ void ElectronDesktopWindowTreeHostLinux::OnWidgetInitDone() {
   UpdateFrameHints();
 }
 
+void ElectronDesktopWindowTreeHostLinux::ApplyDecorationInsets() {
+  UpdateFrameHints();
+}
+
 bool ElectronDesktopWindowTreeHostLinux::IsShowingFrame(
     ui::PlatformWindowState window_state) const {
   return window_state != ui::PlatformWindowState::kFullScreen &&
@@ -96,6 +100,15 @@ gfx::Insets ElectronDesktopWindowTreeHostLinux::CalculateInsetsInDIP(
   // If we are not showing frame, the insets should be zero.
   if (!IsShowingFrame(window_state))
     return gfx::Insets();
+
+  // Tiled windows should not have shadow insets.
+  if (native_window_view_->IsTiled())
+    return gfx::Insets();
+
+  // Use custom decoration insets if set (for app-rendered CSD shadows).
+  auto custom = native_window_view_->GetCustomDecorationInsets();
+  if (!custom.IsEmpty())
+    return custom;
 
   return GetRestoredFrameBorderInsets();
 }
@@ -163,6 +176,7 @@ void ElectronDesktopWindowTreeHostLinux::OnWindowTiledStateChanged(
     fvl->SetTiled(is_tiled);
   else if (auto* layout = native_window_view_->GetLinuxFrameLayout())
     layout->set_tiled(is_tiled);
+  native_window_view_->SetTiled(is_tiled);
   UpdateFrameHints();
   ScheduleRelayout();
   if (GetWidget()->non_client_view()) {
@@ -228,8 +242,19 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
   }
 
   auto* layout = native_window_view_->GetLinuxFrameLayout();
-  if (!layout)
+  if (!layout) {
+    // Frameless window with no layout. If custom decoration insets are set,
+    // ensure the input region covers the full surface (including the shadow
+    // area) so pointer events reach the client for resize hit-testing.
+    // Without this, Wayland won't deliver events in the shadow area.
+    auto custom_insets = native_window_view_->GetCustomDecorationInsets();
+    if (!custom_insets.IsEmpty()) {
+      platform_window()->SetInputRegion(std::nullopt);
+      if (native_window_view_->IsTranslucent())
+        platform_window()->SetOpaqueRegion(std::vector<gfx::Rect>{});
+    }
     return;
+  }
 
   ui::PlatformWindow* window = platform_window();
   auto window_state = window->GetPlatformWindowState();
@@ -238,7 +263,10 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
 
   if (SupportsClientFrameShadow()) {
     auto insets = CalculateInsetsInDIP(window_state);
-    if (insets.IsEmpty()) {
+    // When custom decoration insets are set, the entire surface must receive
+    // input so the shadow area is interactive for resize hit-testing.
+    if (insets.IsEmpty() ||
+        !native_window_view_->GetCustomDecorationInsets().IsEmpty()) {
       window->SetInputRegion(std::nullopt);
     } else {
       gfx::Rect input_bounds(widget_size);

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -41,6 +41,11 @@ class ElectronDesktopWindowTreeHostLinux
 
   bool SupportsClientFrameShadow() const;
 
+  // Re-applies input region, opaque region, and triggers a geometry
+  // recalculation via the Wayland compositor. Public so NativeWindowViews
+  // can call it when custom decoration insets change.
+  void ApplyDecorationInsets();
+
  protected:
   // views::DesktopWindowTreeHostLinuxImpl:
   void OnWidgetInitDone() override;

--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/ui/views/frameless_view.h"
 
+#include "build/build_config.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "ui/aura/window.h"
@@ -30,6 +31,11 @@ gfx::Insets FramelessView::RestoredFrameBorderInsets() const {
 }
 
 int FramelessView::ResizingBorderHitTest(const gfx::Point& point) {
+#if BUILDFLAG(IS_LINUX)
+  auto decoration_insets = window_->GetCustomDecorationInsets();
+  if (!decoration_insets.IsEmpty())
+    return ResizingBorderHitTestImpl(point, decoration_insets);
+#endif
   return ResizingBorderHitTestImpl(point, gfx::Insets(kResizeInsideBoundsSize));
 }
 
@@ -76,12 +82,23 @@ int FramelessView::NonClientHitTest(const gfx::Point& point) {
   if (frame_->IsFullscreen())
     return HTCLIENT;
 
+  // Compute the resize hit once and reuse below.
+  int frame_component = ResizingBorderHitTest(point);
+
+#if BUILDFLAG(IS_LINUX)
+  // When custom decoration insets are set, the shadow area serves as the
+  // resize handle. Check resize FIRST so it takes priority over drag regions
+  // (which would otherwise return HTCAPTION for the headerbar area).
+  if (!window_->GetCustomDecorationInsets().IsEmpty() &&
+      frame_component != HTNOWHERE)
+    return frame_component;
+#endif
+
   int contents_hit_test = window_->NonClientHitTest(point);
   if (contents_hit_test != HTNOWHERE)
     return contents_hit_test;
 
   // Support resizing frameless window by dragging the border.
-  int frame_component = ResizingBorderHitTest(point);
   if (frame_component != HTNOWHERE)
     return frame_component;
 

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/views/opaque_frame_view.h"
 
 #include "base/containers/adapters.h"
+#include "build/build_config.h"
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"  // nogncheck
 #include "chrome/grit/generated_resources.h"
 #include "components/strings/grit/components_strings.h"
@@ -101,6 +102,13 @@ OpaqueFrameView::OpaqueFrameView(NativeWindowViews* window,
 OpaqueFrameView::~OpaqueFrameView() = default;
 
 int OpaqueFrameView::ResizingBorderHitTest(const gfx::Point& point) {
+#if BUILDFLAG(IS_LINUX)
+  // When the app provides custom decoration insets (e.g. for CSD shadow),
+  // use those as the resize border so the entire shadow area is grabbable.
+  auto custom_insets = window()->GetCustomDecorationInsets();
+  if (!custom_insets.IsEmpty())
+    return ResizingBorderHitTestImpl(point, custom_insets);
+#endif
   return ResizingBorderHitTestImpl(
       point, linux_frame_layout_->GetResizeBorderInsets());
 }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6020,6 +6020,45 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('decoration insets', () => {
+    afterEach(closeAllWindows);
+
+    it('does not throw when called', () => {
+      const w = new BrowserWindow({ show: false, frame: false, transparent: true });
+      expect(() => {
+        w.setDecorationInsets({ top: 10, left: 10, bottom: 10, right: 10 });
+      }).to.not.throw();
+    });
+
+    it('accepts zero insets', () => {
+      const w = new BrowserWindow({ show: false, frame: false, transparent: true });
+      expect(() => {
+        w.setDecorationInsets({ top: 0, left: 0, bottom: 0, right: 0 });
+      }).to.not.throw();
+    });
+
+    it('accepts asymmetric insets', () => {
+      const w = new BrowserWindow({ show: false, frame: false, transparent: true });
+      expect(() => {
+        w.setDecorationInsets({ top: 5, left: 10, bottom: 15, right: 20 });
+      }).to.not.throw();
+    });
+  });
+
+  describe('tiled state', () => {
+    afterEach(closeAllWindows);
+
+    it('isTiled() returns a boolean', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w.isTiled()).to.be.a('boolean');
+    });
+
+    ifit(process.platform === 'linux')('isTiled() starts as false', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w.isTiled()).to.equal(false);
+    });
+  });
+
   ifdescribe(process.platform !== 'linux')('window states (excluding Linux)', () => {
     // Not implemented on Linux.
     afterEach(closeAllWindows);


### PR DESCRIPTION
#### Description of Change

Adds `win.setDecorationInsets(insets)` (Linux only) to let apps tell the Wayland compositor which parts of a frameless transparent window are decorations (e.g. CSS-rendered shadows) vs content. This enables correct window snapping, tiling, maximizing, and resize hit-testing for apps that render their own client-side decorations.

The primary use case is libraries like [gtk-js](https://github.com/gtk-js/gtk-js), which render GTK4/Adwaita widgets as CSS in Electron. Its `GtkWindow` component allocates shadow padding around the window content, and this API lets the compositor know those regions are decoration — not content — so window management operations work correctly on Wayland.

Also adds `win.isTiled()` and a `tiled-state-changed` event so apps can respond to window tiling by removing shadows and rounded corners, matching native GTK behavior.

**Changes:**

* **`win.setDecorationInsets({ top, left, bottom, right })`** — stores custom insets and feeds them to `CalculateInsetsInDIP` for Wayland `xdg_surface.set_window_geometry()`. Adjusts widget bounds so the content area stays at the requested size when insets are applied. No-op on X11 and non-Linux platforms.
* **`win.isTiled()`** / **`tiled-state-changed` event** — exposes Wayland tiled state to JS, forwarded from `OnWindowTiledStateChanged`. Tiled windows suppress decoration insets (matching native GTK behavior).
* **Resize hit-testing** — `OpaqueFrameView::ResizingBorderHitTest` and `FramelessView::ResizingBorderHitTest` use custom insets as the resize border so the entire shadow area is grabbable. `NonClientHitTest` checks resize before drag regions when custom insets are set.
* **Input region** — sets `SetInputRegion(std::nullopt)` when custom insets are active so Wayland delivers pointer events to the shadow area.
* **State handling** — `CalculateInsetsInDIP` returns zero insets when maximized, fullscreen, or tiled. `SetDecorationInsets` skips bounds adjustment in those states.

**Files changed:**

| File | What |
|------|------|
| `native_window.h/cc` | Virtual `SetDecorationInsets`, `IsTiled`, `NotifyWindowTiledStateChanged` |
| `native_window_observer.h` | `OnWindowTiledStateChanged` observer method |
| `native_window_views.h/cc` | Implementation + `is_tiled_` / `decoration_insets_` members |
| `electron_desktop_window_tree_host_linux.h/cc` | `ApplyDecorationInsets`, `CalculateInsetsInDIP` custom insets + tiled, `UpdateFrameHints` input region |
| `frameless_view.cc` | Custom insets in `ResizingBorderHitTest` + `NonClientHitTest` |
| `opaque_frame_view.cc` | Custom insets in `ResizingBorderHitTest` |
| `electron_api_base_window.h/cc` | JS bindings for `setDecorationInsets`, `isTiled`, `tiled-state-changed` |
| `docs/api/base-window.md`, `docs/api/browser-window.md` | API documentation |
| `spec/api-browser-window-spec.ts` | Tests for `setDecorationInsets` and `isTiled` |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

> This PR was developed with AI assistance (Claude Code). All changes have been reviewed, understood, and tested by me per Electron's [AI Tool Policy](https://github.com/electron/governance/blob/main/policy/ai.md).

#### Release Notes

Notes: Added `win.setDecorationInsets()` API on Linux to support app-rendered CSD shadows on Wayland, and exposed tiled window state via `win.isTiled()` and the `tiled-state-changed` event.