### PR TITLE
chore: use promise's context for memory dump callback.

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4245,12 +4245,11 @@ v8::Local<v8::Promise> WebContents::GetProcessMemoryInfo(v8::Isolate* isolate) {
   }
 
   auto pid = frame_host->GetProcess()->GetProcess().Pid();
-  v8::Global<v8::Context> context(isolate, isolate->GetCurrentContext());
   memory_instrumentation::MemoryInstrumentation::GetInstance()
       ->RequestGlobalDumpForPid(
           pid, std::vector<std::string>(),
           base::BindOnce(&ElectronBindings::DidReceiveMemoryDump,
-                         std::move(context), std::move(promise), pid));
+                         std::move(promise), pid));
   return handle;
 }
 

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -210,13 +210,11 @@ v8::Local<v8::Promise> ElectronBindings::GetProcessMemoryInfo(
     return handle;
   }
 
-  v8::Global<v8::Context> context(isolate, isolate->GetCurrentContext());
   memory_instrumentation::MemoryInstrumentation::GetInstance()
       ->RequestGlobalDumpForPid(
           base::GetCurrentProcId(), {} /* allocator_dump_names */,
           base::BindOnce(&ElectronBindings::DidReceiveMemoryDump,
-                         std::move(context), std::move(promise),
-                         base::GetCurrentProcId()));
+                         std::move(promise), base::GetCurrentProcId()));
   return handle;
 }
 
@@ -234,7 +232,6 @@ v8::Local<v8::Value> ElectronBindings::GetBlinkMemoryInfo(
 
 // static
 void ElectronBindings::DidReceiveMemoryDump(
-    v8::Global<v8::Context> context,
     gin_helper::Promise<gin_helper::Dictionary> promise,
     base::ProcessId target_pid,
     const memory_instrumentation::mojom::RequestOutcome outcome,
@@ -242,8 +239,7 @@ void ElectronBindings::DidReceiveMemoryDump(
   DCHECK(electron::IsBrowserProcess());
   v8::Isolate* isolate = promise.isolate();
   v8::HandleScope handle_scope(isolate);
-  v8::Local<v8::Context> local_context =
-      v8::Local<v8::Context>::New(isolate, context);
+  v8::Local<v8::Context> local_context = promise.GetContext();
   v8::Context::Scope context_scope(local_context);
 
   if (outcome != memory_instrumentation::mojom::RequestOutcome::kSuccess) {

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -57,7 +57,6 @@ class ElectronBindings {
   static void Crash();
 
   static void DidReceiveMemoryDump(
-      v8::Global<v8::Context> context,
       gin_helper::Promise<gin_helper::Dictionary> promise,
       base::ProcessId target_pid,
       memory_instrumentation::mojom::RequestOutcome outcome,


### PR DESCRIPTION
#### Description of Change

When I was doing some crash analysis, I found that the following optimizations can be made to this code.

Remove the redundant `v8::Global<v8::Context>` plumbing from the process memory info callbacks.

`gin_helper::Promise` already retains the V8 context it was created with, so `DidReceiveMemoryDump` can use `promise.GetContext()` directly when settling the promise. This simplifies both the browser process and webContents memory info paths without changing behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
