### PR TITLE
feat: introduce middleware semantics to `protocol.handle` (with better continuation)

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -548,3 +548,11 @@ deprecated:
 Returns `boolean` - Whether `scheme` is already intercepted.
 
 [file-system-api]: https://developer.mozilla.org/en-US/docs/Web/API/LocalFileSystem
+
+## Properties
+
+The `protocol` module has the following properties:
+
+### `protocol.session` _Readonly_
+
+A [`Session`](session.md) object for this protocol.

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -242,6 +242,9 @@ Protocol.prototype.isProtocolHandled = function (this: Electron.Protocol, scheme
 const protocol = {
   registerSchemesAsPrivileged,
   getStandardSchemes,
+  get session() {
+    return session.defaultSession;
+  },
   registerStringProtocol: (...args) => session.defaultSession.protocol.registerStringProtocol(...args),
   registerBufferProtocol: (...args) => session.defaultSession.protocol.registerBufferProtocol(...args),
   registerStreamProtocol: (...args) => session.defaultSession.protocol.registerStreamProtocol(...args),

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -186,8 +186,8 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
   const chains = getOrCreateProtocolHandlerChains(this);
   let chain = chains.get(scheme);
   if (!chain) {
-    const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
-    const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
+    const handleProtocol = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
+    const success = handleProtocol.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
       try {
         const body = convertToRequestBody(preq.uploadData);
         const headers = new Headers(preq.headers);
@@ -220,15 +220,15 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
         cb({ error: ERR_UNEXPECTED });
       }
     });
-    if (!success) throw new Error(`Failed to register protocol: ${scheme}`);
+    if (!success) throw new Error(`Failed to handle protocol: ${scheme}`);
     chain = getOrCreateProtocolHandlerChain(this, scheme);
   }
   chain.handlers.push(handler);
 };
 
 Protocol.prototype.unhandle = function (this: Electron.Protocol, scheme: string) {
-  const unregister = isBuiltInScheme(scheme) ? this.uninterceptProtocol : this.unregisterProtocol;
-  if (!unregister.call(this, scheme)) {
+  const unhandleProtocol = isBuiltInScheme(scheme) ? this.uninterceptProtocol : this.unregisterProtocol;
+  if (!unhandleProtocol.call(this, scheme)) {
     throw new Error(`Failed to unhandle protocol: ${scheme}`);
   }
   getOrCreateProtocolHandlerChains(this).delete(scheme);

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,19 +1,35 @@
-import { ProtocolRequest, session, net } from 'electron/main';
+import { ProtocolRequest, session } from 'electron/main';
 
 import { createReadStream } from 'fs';
+import { STATUS_CODES } from 'http';
 import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
 
-import type { ReadableStreamDefaultReader } from 'stream/web';
+import type { ReadableStreamDefaultController, ReadableStreamDefaultReader } from 'stream/web';
 
 // Global protocol APIs.
 const { registerSchemesAsPrivileged, getStandardSchemes, Protocol } =
   process._linkedBinding('electron_browser_protocol');
 
+const { createURLLoader } = process._linkedBinding('electron_common_net');
+
 const ERR_FAILED = -2;
 const ERR_UNEXPECTED = -9;
 
 const isBuiltInScheme = (scheme: string) => ['http', 'https', 'file'].includes(scheme);
+
+function setResponseMetadata(response: Response, url: string, redirected: boolean) {
+  Object.defineProperties(response, {
+    url: {
+      value: url,
+      configurable: true
+    },
+    redirected: {
+      value: redirected,
+      configurable: true
+    }
+  });
+}
 
 function makeStreamFromPipe(pipe: any): ReadableStream<Uint8Array> {
   const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
@@ -101,6 +117,179 @@ function convertToRequestBody(uploadData: ProtocolRequest['uploadData']): Reques
   }) as RequestInit['body'];
 }
 
+// This isn't a true continuation, but it's a best-effort given upstream constraints.
+function continueInterceptedRequest(protocol: Electron.Protocol, req: Request): Promise<Response> {
+  const body = req.body;
+  const loader = createURLLoader({
+    bypassCustomProtocolHandlers: true,
+    method: req.method,
+    url: req.url,
+    session: protocol.session,
+    extraHeaders: Object.fromEntries(req.headers),
+    referrer: req.referrer === 'about:client' ? '' : req.referrer,
+    origin: req.headers.get('origin') ?? '',
+    body: body
+      ? (pipe) => {
+          (async () => {
+            const reader = (body as ReadableStream<Uint8Array>).getReader();
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) await pipe.write(value);
+              }
+            } catch {
+              // Closing the pipe lets the network stack surface the underlying failure.
+            } finally {
+              reader.releaseLock();
+              pipe.done();
+            }
+          })();
+        }
+      : undefined
+  });
+
+  return new Promise<Response>((resolve, reject) => {
+    let responseStarted = false;
+    let settled = false;
+    let streamFinished = false;
+    let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+    const bodyStream = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+      },
+      cancel() {
+        if (!streamFinished) {
+          streamFinished = true;
+          loader.cancel();
+        }
+      }
+    });
+
+    const closeBody = () => {
+      if (!streamFinished && controller) {
+        streamFinished = true;
+        controller.close();
+      }
+    };
+
+    const errorBody = (error: Error) => {
+      if (!streamFinished && controller) {
+        streamFinished = true;
+        controller.error(error);
+      }
+    };
+
+    const resolveResponse = (response: Response) => {
+      if (settled) return;
+      settled = true;
+      resolve(response);
+    };
+
+    const rejectResponse = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    loader.on('response-started', (event, finalUrl, responseHead) => {
+      if (settled) return;
+      responseStarted = true;
+
+      const headers = new Headers();
+      for (const [key, values] of Object.entries(responseHead.headers)) {
+        for (const value of values) {
+          headers.append(key, value);
+        }
+      }
+
+      const nullBodyStatus = [101, 204, 205, 304];
+      const body = nullBodyStatus.includes(responseHead.statusCode) || req.method === 'HEAD' ? null : bodyStream;
+
+      const response = new Response(body as any, {
+        headers,
+        status: responseHead.statusCode,
+        statusText: responseHead.statusMessage
+      });
+      setResponseMetadata(response, finalUrl, finalUrl !== req.url);
+
+      (response as any).__original_resp = {
+        _responseHead: responseHead,
+        url: finalUrl
+      };
+
+      resolveResponse(response);
+    });
+
+    loader.on('redirect', (event, redirectInfo, headersObject) => {
+      if (settled) return;
+
+      const headers = new Headers();
+      const headerEntries: Record<string, string[]> = {};
+
+      for (const [key, value] of Object.entries(headersObject)) {
+        const values = Array.isArray(value) ? value : [value];
+        headerEntries[key] = values;
+        for (const headerValue of values) {
+          headers.append(key, headerValue);
+        }
+      }
+
+      const response = new Response(null, {
+        headers,
+        status: redirectInfo.statusCode,
+        statusText: STATUS_CODES[redirectInfo.statusCode] ?? ''
+      });
+      setResponseMetadata(response, req.url, false);
+
+      (response as any).__original_resp = {
+        _responseHead: {
+          statusCode: redirectInfo.statusCode,
+          statusMessage: STATUS_CODES[redirectInfo.statusCode] ?? '',
+          headers: headerEntries,
+          mimeType: ''
+        },
+        url: req.url
+      };
+
+      resolveResponse(response);
+      loader.cancel();
+    });
+
+    loader.on('data', (event, data, resume) => {
+      try {
+        if (!streamFinished && controller) {
+          controller.enqueue(new Uint8Array(data));
+        }
+      } finally {
+        resume();
+      }
+    });
+
+    loader.on('complete', () => {
+      if (settled && !responseStarted) return;
+      if (!responseStarted) {
+        rejectResponse(new Error('Response completed before headers were received'));
+        return;
+      }
+
+      closeBody();
+    });
+
+    loader.on('error', (event, netErrorString) => {
+      const error = new Error(netErrorString);
+      if (settled && !responseStarted) return;
+      if (!responseStarted) {
+        rejectResponse(error);
+        return;
+      }
+
+      errorBody(error);
+    });
+  });
+}
+
 function validateResponse(res: Response) {
   if (!res || typeof res !== 'object') return false;
 
@@ -121,14 +310,14 @@ function validateResponse(res: Response) {
 }
 
 type ProtocolHandler = (req: Request, next: () => Promise<Response>) => Response | Promise<Response>;
-type ProtocolHandlerTerminal = (req: Request) => Response | Promise<Response>;
+type ProtocolHandlerTerminal = (protocol: Electron.Protocol, req: Request) => Response | Promise<Response>;
 type ProtocolHandlerChain = {
   handlers: ProtocolHandler[];
   terminal: ProtocolHandlerTerminal;
 };
 
-const interceptedSchemeTerminal: ProtocolHandlerTerminal = (req) => {
-  return net.fetch(req, { bypassCustomProtocolHandlers: true }); // TODO: Use a better terminal.
+const interceptedSchemeTerminal: ProtocolHandlerTerminal = (protocol, req) => {
+  return continueInterceptedRequest(protocol, req);
 };
 
 const registeredSchemeTerminal: ProtocolHandlerTerminal = () => {
@@ -171,7 +360,7 @@ async function dispatchProtocolHandlerChain(
   };
   async function run(index: number): Promise<Response> {
     if (index > chain.handlers.length) throw new Error('Internal overflow in protocol handler chain');
-    if (index === chain.handlers.length) return chain.terminal(req);
+    if (index === chain.handlers.length) return chain.terminal(protocol, req);
     let called = false;
     return await chain.handlers[index](req, async () => {
       if (called) throw new Error('next() called multiple times in protocol handler chain');
@@ -207,9 +396,10 @@ Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, h
         } else if (res.type === 'error') {
           cb({ error: ERR_FAILED });
         } else {
+          const originalHeaders = (res as any).__original_resp?._responseHead?.headers;
           cb({
             data: res.body ? Readable.fromWeb(res.body as ReadableStream<ArrayBufferView>) : null,
-            headers: res.headers ? Object.fromEntries(res.headers) : {},
+            headers: originalHeaders ?? (res.headers ? Object.fromEntries(res.headers) : {}),
             statusCode: res.status,
             statusText: res.statusText,
             mimeType: (res as any).__original_resp?._responseHead?.mimeType

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,4 +1,4 @@
-import { ProtocolRequest, session } from 'electron/main';
+import { ProtocolRequest, session, net } from 'electron/main';
 
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
@@ -120,46 +120,110 @@ function validateResponse(res: Response) {
   return true;
 }
 
-Protocol.prototype.handle = function (
-  this: Electron.Protocol,
+type ProtocolHandler = (req: Request, next: () => Promise<Response>) => Response | Promise<Response>;
+type ProtocolHandlerTerminal = (req: Request) => Response | Promise<Response>;
+type ProtocolHandlerChain = {
+  handlers: ProtocolHandler[];
+  terminal: ProtocolHandlerTerminal;
+};
+
+const interceptedSchemeTerminal: ProtocolHandlerTerminal = (req) => {
+  return net.fetch(req, { bypassCustomProtocolHandlers: true }); // TODO: Use a better terminal.
+};
+
+const registeredSchemeTerminal: ProtocolHandlerTerminal = () => {
+  throw new Error('next() called inside the last handler for a registered protocol');
+};
+
+const chainsByProtocol = new WeakMap<Electron.Protocol, Map<string, ProtocolHandlerChain>>();
+
+function getOrCreateProtocolHandlerChains(protocol: Electron.Protocol): Map<string, ProtocolHandlerChain> {
+  const chains = chainsByProtocol.get(protocol);
+  if (!chains) {
+    chainsByProtocol.set(protocol, new Map<string, ProtocolHandlerChain>());
+    return chainsByProtocol.get(protocol)!;
+  }
+  return chains;
+}
+
+function getOrCreateProtocolHandlerChain(protocol: Electron.Protocol, scheme: string): ProtocolHandlerChain {
+  const chains = getOrCreateProtocolHandlerChains(protocol);
+  const chain = chains.get(scheme);
+  if (!chain) {
+    chains.set(scheme, {
+      handlers: [],
+      terminal: isBuiltInScheme(scheme) ? interceptedSchemeTerminal : registeredSchemeTerminal
+    });
+    return chains.get(scheme)!;
+  }
+  return chain;
+}
+
+async function dispatchProtocolHandlerChain(
+  protocol: Electron.Protocol,
   scheme: string,
-  handler: (req: Request) => Response | Promise<Response>
-) {
-  const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
-  const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
-    try {
-      const body = convertToRequestBody(preq.uploadData);
-      const headers = new Headers(preq.headers);
-      if (headers.get('origin') === 'null') {
-        headers.delete('origin');
+  req: Request
+): Promise<Response> {
+  const original = getOrCreateProtocolHandlerChain(protocol, scheme);
+  const chain: ProtocolHandlerChain = {
+    handlers: [...original.handlers],
+    terminal: original.terminal
+  };
+  async function run(index: number): Promise<Response> {
+    if (index > chain.handlers.length) throw new Error('Internal overflow in protocol handler chain');
+    if (index === chain.handlers.length) return chain.terminal(req);
+    let called = false;
+    return await chain.handlers[index](req, async () => {
+      if (called) throw new Error('next() called multiple times in protocol handler chain');
+      called = true;
+      return await run(index + 1);
+    });
+  }
+  return run(0);
+}
+
+Protocol.prototype.handle = function (this: Electron.Protocol, scheme: string, handler: ProtocolHandler) {
+  const chains = getOrCreateProtocolHandlerChains(this);
+  let chain = chains.get(scheme);
+  if (!chain) {
+    const register = isBuiltInScheme(scheme) ? this.interceptProtocol : this.registerProtocol;
+    const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
+      try {
+        const body = convertToRequestBody(preq.uploadData);
+        const headers = new Headers(preq.headers);
+        if (headers.get('origin') === 'null') {
+          headers.delete('origin');
+        }
+        const req = new Request(preq.url, {
+          headers,
+          method: preq.method,
+          referrer: preq.referrer,
+          body,
+          duplex: body instanceof ReadableStream ? 'half' : undefined
+        } as any);
+        const res = await dispatchProtocolHandlerChain(this, scheme, req);
+        if (!validateResponse(res)) {
+          return cb({ error: ERR_UNEXPECTED });
+        } else if (res.type === 'error') {
+          cb({ error: ERR_FAILED });
+        } else {
+          cb({
+            data: res.body ? Readable.fromWeb(res.body as ReadableStream<ArrayBufferView>) : null,
+            headers: res.headers ? Object.fromEntries(res.headers) : {},
+            statusCode: res.status,
+            statusText: res.statusText,
+            mimeType: (res as any).__original_resp?._responseHead?.mimeType
+          });
+        }
+      } catch (e) {
+        console.error(e);
+        cb({ error: ERR_UNEXPECTED });
       }
-      const req = new Request(preq.url, {
-        headers,
-        method: preq.method,
-        referrer: preq.referrer,
-        body,
-        duplex: body instanceof ReadableStream ? 'half' : undefined
-      } as any);
-      const res = await handler(req);
-      if (!validateResponse(res)) {
-        return cb({ error: ERR_UNEXPECTED });
-      } else if (res.type === 'error') {
-        cb({ error: ERR_FAILED });
-      } else {
-        cb({
-          data: res.body ? Readable.fromWeb(res.body as ReadableStream<ArrayBufferView>) : null,
-          headers: res.headers ? Object.fromEntries(res.headers) : {},
-          statusCode: res.status,
-          statusText: res.statusText,
-          mimeType: (res as any).__original_resp?._responseHead?.mimeType
-        });
-      }
-    } catch (e) {
-      console.error(e);
-      cb({ error: ERR_UNEXPECTED });
-    }
-  });
-  if (!success) throw new Error(`Failed to register protocol: ${scheme}`);
+    });
+    if (!success) throw new Error(`Failed to register protocol: ${scheme}`);
+    chain = getOrCreateProtocolHandlerChain(this, scheme);
+  }
+  chain.handlers.push(handler);
 };
 
 Protocol.prototype.unhandle = function (this: Electron.Protocol, scheme: string) {
@@ -167,6 +231,7 @@ Protocol.prototype.unhandle = function (this: Electron.Protocol, scheme: string)
   if (!unregister.call(this, scheme)) {
     throw new Error(`Failed to unhandle protocol: ${scheme}`);
   }
+  getOrCreateProtocolHandlerChains(this).delete(scheme);
 };
 
 Protocol.prototype.isProtocolHandled = function (this: Electron.Protocol, scheme: string) {

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -14,7 +14,9 @@
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/converter.h"
 #include "gin/object_template_builder.h"
+#include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/common/gin_converters/callback_converter.h"
@@ -206,8 +208,10 @@ const char* const kBuiltinSchemes[] = {
 
 }  // namespace
 
-Protocol::Protocol(ProtocolRegistry* protocol_registry)
-    : protocol_registry_{protocol_registry} {}
+Protocol::Protocol(ElectronBrowserContext* browser_context,
+                   ProtocolRegistry* protocol_registry)
+    : browser_context_{browser_context},
+      protocol_registry_{protocol_registry} {}
 
 Protocol::~Protocol() = default;
 
@@ -264,6 +268,12 @@ bool Protocol::IsProtocolIntercepted(const std::string& scheme) {
   return protocol_registry_->FindIntercepted(scheme) != nullptr;
 }
 
+Session* Protocol::GetSession() {
+  if (auto* session = Session::FromBrowserContext(browser_context_))
+    return session->Get();
+  return nullptr;
+}
+
 v8::Local<v8::Promise> Protocol::IsProtocolHandled(v8::Isolate* const isolate,
                                                    const std::string& scheme) {
   util::EmitWarning(isolate,
@@ -300,9 +310,11 @@ void Protocol::HandleOptionalCallback(gin::Arguments* args, Error error) {
 
 // static
 Protocol* Protocol::Create(v8::Isolate* isolate,
+                           ElectronBrowserContext* browser_context,
                            ProtocolRegistry* protocol_registry) {
   return cppgc::MakeGarbageCollected<Protocol>(
-      isolate->GetCppHeap()->GetAllocationHandle(), protocol_registry);
+      isolate->GetCppHeap()->GetAllocationHandle(), browser_context,
+      protocol_registry);
 }
 
 // static
@@ -344,6 +356,7 @@ void Protocol::FillObjectTemplate(v8::Isolate* isolate,
                  &Protocol::InterceptProtocolFor<ProtocolType::kFree>)
       .SetMethod("uninterceptProtocol", &Protocol::UninterceptProtocol)
       .SetMethod("isProtocolIntercepted", &Protocol::IsProtocolIntercepted)
+      .SetProperty("session", &Protocol::GetSession)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -19,9 +19,12 @@ class Arguments;
 
 namespace electron {
 
+class ElectronBrowserContext;
 class ProtocolRegistry;
 
 namespace api {
+
+class Session;
 
 std::vector<std::string>& GetStandardSchemes();
 std::vector<std::string>& GetCodeCacheSchemes();
@@ -36,6 +39,7 @@ class Protocol final : public gin::Wrappable<Protocol>,
                        public gin_helper::Constructible<Protocol> {
  public:
   static Protocol* Create(v8::Isolate* isolate,
+                          ElectronBrowserContext* browser_context,
                           ProtocolRegistry* protocol_registry);
 
   // gin_helper::Constructible
@@ -49,7 +53,8 @@ class Protocol final : public gin::Wrappable<Protocol>,
   const gin::WrapperInfo* wrapper_info() const override;
   const char* GetHumanReadableName() const override;
 
-  explicit Protocol(ProtocolRegistry* protocol_registry);
+  Protocol(ElectronBrowserContext* browser_context,
+           ProtocolRegistry* protocol_registry);
   ~Protocol() override;
 
  private:
@@ -80,6 +85,7 @@ class Protocol final : public gin::Wrappable<Protocol>,
                           const ProtocolHandler& handler);
   bool UninterceptProtocol(const std::string& scheme, gin::Arguments* args);
   bool IsProtocolIntercepted(const std::string& scheme);
+  Session* GetSession();
 
   // Old async version of IsProtocolRegistered.
   v8::Local<v8::Promise> IsProtocolHandled(v8::Isolate* isolate,
@@ -105,6 +111,8 @@ class Protocol final : public gin::Wrappable<Protocol>,
 
   // Be compatible with old interface, which accepts optional callback.
   void HandleOptionalCallback(gin::Arguments* args, Error error);
+
+  raw_ptr<ElectronBrowserContext> browser_context_;
 
   // Weak pointer; the lifetime of the ProtocolRegistry is guaranteed to be
   // longer than the lifetime of this JS interface.

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -562,7 +562,8 @@ Session::Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
 
   SessionPreferences::CreateForBrowserContext(browser_context);
 
-  protocol_ = Protocol::Create(isolate, browser_context->protocol_registry());
+  protocol_ = Protocol::Create(isolate, browser_context,
+                               browser_context->protocol_registry());
 
   browser_context->SetUserData(
       kElectronApiSessionKey,

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -4,9 +4,14 @@ declare const BUILDFLAG: (flag: boolean) => boolean;
 
 declare namespace NodeJS {
   interface ModuleInternal extends NodeJS.Module {
-    new(id: string, parent?: NodeJS.Module | null): NodeJS.Module;
+    new (id: string, parent?: NodeJS.Module | null): NodeJS.Module;
     _load(request: string, parent?: NodeJS.Module | null, isMain?: boolean): any;
-    _resolveFilename(request: string, parent?: NodeJS.Module | null, isMain?: boolean, options?: { paths: string[] }): string;
+    _resolveFilename(
+      request: string,
+      parent?: NodeJS.Module | null,
+      isMain?: boolean,
+      options?: { paths: string[] }
+    ): string;
     _preloadModules(requests: string[]): void;
     _nodeModulePaths(from: string): string[];
     _extensions: Record<string, (module: NodeJS.Module, filename: string) => any>;
@@ -27,7 +32,7 @@ declare namespace NodeJS {
     send(internal: boolean, channel: string, args: any[]): void;
     sendSync(internal: boolean, channel: string, args: any[]): any;
     sendToHost(channel: string, args: any[]): void;
-    invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string, result: T }>;
+    invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string; result: T }>;
     postMessage(channel: string, message: any, transferables: MessagePort[]): void;
   }
 
@@ -45,15 +50,17 @@ declare namespace NodeJS {
   }
 
   type CrashReporterBinding = Omit<Electron.CrashReporter, 'start'> & {
-    start(submitUrl: string,
+    start(
+      submitUrl: string,
       uploadToServer: boolean,
       ignoreSystemCrashHandler: boolean,
       rateLimit: boolean,
       compress: boolean,
       globalExtra: Record<string, string>,
       extra: Record<string, string>,
-      isNodeProcess: boolean): void;
-  }
+      isNodeProcess: boolean
+    ): void;
+  };
 
   interface EnvironmentBinding {
     getVar(name: string): string | null;
@@ -68,14 +75,14 @@ declare namespace NodeJS {
     integrity?: {
       algorithm: 'SHA256';
       hash: string;
-    }
+    };
   };
 
   type AsarFileStat = {
     size: number;
     offset: number;
     type: number;
-  }
+  };
 
   interface AsarArchive {
     getFileInfo(path: string): AsarFileInfo | false;
@@ -87,14 +94,16 @@ declare namespace NodeJS {
   }
 
   interface AsarBinding {
-    Archive: { new(path: string): AsarArchive };
-    splitPath(path: string): {
-      isAsar: false;
-    } | {
-      isAsar: true;
-      asarPath: string;
-      filePath: string;
-    };
+    Archive: { new (path: string): AsarArchive };
+    splitPath(path: string):
+      | {
+          isAsar: false;
+        }
+      | {
+          isAsar: true;
+          asarPath: string;
+          filePath: string;
+        };
   }
 
   interface NetBinding {
@@ -134,13 +143,18 @@ declare namespace NodeJS {
   }
 
   interface SessionBinding {
-    fromPartition: typeof Electron.Session.fromPartition,
-    fromPath: typeof Electron.Session.fromPath,
-    Session: typeof Electron.Session
+    fromPartition: typeof Electron.Session.fromPartition;
+    fromPath: typeof Electron.Session.fromPath;
+    Session: typeof Electron.Session;
   }
 
   interface WebViewManagerBinding {
-    addGuest(guestInstanceId: number, embedder: Electron.WebContents, guest: Electron.WebContents, webPreferences: Electron.WebPreferences): void;
+    addGuest(
+      guestInstanceId: number,
+      embedder: Electron.WebContents,
+      guest: Electron.WebContents,
+      webPreferences: Electron.WebPreferences
+    ): void;
     removeGuest(embedder: Electron.WebContents, guestInstanceId: number): void;
   }
 
@@ -181,7 +195,7 @@ declare namespace NodeJS {
     extraHeaders?: Record<string, string>;
     useSessionCookies?: boolean;
     credentials?: 'include' | 'omit' | 'same-origin';
-    body: Uint8Array | BodyFunc;
+    body?: Uint8Array | BodyFunc;
     session?: Electron.Session;
     partition?: string;
     referrer?: string;
@@ -198,9 +212,10 @@ declare namespace NodeJS {
   type ResponseHead = {
     statusCode: number;
     statusMessage: string;
-    httpVersion: { major: number, minor: number };
-    rawHeaders: { key: string, value: string }[];
+    httpVersion: { major: number; minor: number };
+    rawHeaders: { key: string; value: string }[];
     headers: Record<string, string[]>;
+    mimeType: string;
   };
 
   type RedirectInfo = {
@@ -211,16 +226,29 @@ declare namespace NodeJS {
     newReferrer: string;
     insecureSchemeWasUpgraded: boolean;
     isSignedExchangeFallbackRedirect: boolean;
-  }
+  };
 
   interface URLLoader extends EventEmitter {
     cancel(): void;
     on(eventName: 'data', listener: (event: any, data: ArrayBuffer, resume: () => void) => void): this;
-    on(eventName: 'response-started', listener: (event: any, finalUrl: string, responseHead: ResponseHead) => void): this;
+    on(
+      eventName: 'response-started',
+      listener: (event: any, finalUrl: string, responseHead: ResponseHead) => void
+    ): this;
     on(eventName: 'complete', listener: (event: any) => void): this;
     on(eventName: 'error', listener: (event: any, netErrorString: string) => void): this;
-    on(eventName: 'login', listener: (event: any, authInfo: Electron.AuthInfo, callback: (username?: string, password?: string) => void) => void): this;
-    on(eventName: 'redirect', listener: (event: any, redirectInfo: RedirectInfo, headers: Record<string, string>) => void): this;
+    on(
+      eventName: 'login',
+      listener: (
+        event: any,
+        authInfo: Electron.AuthInfo,
+        callback: (username?: string, password?: string) => void
+      ) => void
+    ): this;
+    on(
+      eventName: 'redirect',
+      listener: (event: any, redirectInfo: RedirectInfo, headers: Record<string, string | string[]>) => void
+    ): this;
     on(eventName: 'upload-progress', listener: (event: any, position: number, total: number) => void): this;
     on(eventName: 'download-progress', listener: (event: any, current: number) => void): this;
   }
@@ -238,15 +266,20 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_common_net'): NetBinding;
     _linkedBinding(name: 'electron_common_shell'): Electron.Shell;
     _linkedBinding(name: 'electron_common_v8_util'): V8UtilBinding;
-    _linkedBinding(name: 'electron_browser_app'): { app: Electron.App, App: Function };
+    _linkedBinding(name: 'electron_browser_app'): { app: Electron.App; App: Function };
     _linkedBinding(name: 'electron_browser_auto_updater'): { autoUpdater: Electron.AutoUpdater };
     _linkedBinding(name: 'electron_browser_crash_reporter'): CrashReporterBinding;
-    _linkedBinding(name: 'electron_browser_desktop_capturer'): { createDesktopCapturer(): ElectronInternal.DesktopCapturer; isDisplayMediaSystemPickerAvailable(): boolean; };
-    _linkedBinding(name: 'electron_browser_event_emitter'): { setEventEmitterPrototype(prototype: Object): void; };
+    _linkedBinding(name: 'electron_browser_desktop_capturer'): {
+      createDesktopCapturer(): ElectronInternal.DesktopCapturer;
+      isDisplayMediaSystemPickerAvailable(): boolean;
+    };
+    _linkedBinding(name: 'electron_browser_event_emitter'): { setEventEmitterPrototype(prototype: Object): void };
     _linkedBinding(name: 'electron_browser_global_shortcut'): { createGlobalShortcut(): Electron.GlobalShortcut };
     _linkedBinding(name: 'electron_browser_image_view'): { ImageView: any };
     _linkedBinding(name: 'electron_browser_in_app_purchase'): { inAppPurchase: Electron.InAppPurchase };
-    _linkedBinding(name: 'electron_browser_message_port'): { createPair(): { port1: Electron.MessagePortMain, port2: Electron.MessagePortMain }; };
+    _linkedBinding(name: 'electron_browser_message_port'): {
+      createPair(): { port1: Electron.MessagePortMain; port2: Electron.MessagePortMain };
+    };
     _linkedBinding(name: 'electron_browser_native_theme'): { nativeTheme: Electron.NativeTheme };
     _linkedBinding(name: 'electron_browser_notification'): NotificationBinding;
     _linkedBinding(name: 'electron_browser_power_monitor'): PowerMonitorBinding;
@@ -305,19 +338,19 @@ declare interface Window {
   ELECTRON_DISABLE_SECURITY_WARNINGS?: boolean;
   ELECTRON_ENABLE_SECURITY_WARNINGS?: boolean;
   InspectorFrontendHost?: {
-    showContextMenuAtPoint: (x: number, y: number, items: ContextMenuItem[]) => void
+    showContextMenuAtPoint: (x: number, y: number, items: ContextMenuItem[]) => void;
   };
   DevToolsAPI?: {
     contextMenuItemSelected: (id: number) => void;
-    contextMenuCleared: () => void
+    contextMenuCleared: () => void;
   };
   UI?: {
-    createFileSelectorElement: (callback: () => void) => HTMLSpanElement
+    createFileSelectorElement: (callback: () => void) => HTMLSpanElement;
   };
   Persistence?: {
     FileSystemWorkspaceBinding: {
       completeURL: (project: string, path: string) => string;
-    }
+    };
   };
   WebView: typeof ElectronInternal.WebViewElement;
   trustedTypes: TrustedTypePolicyFactory;
@@ -356,7 +389,7 @@ interface TrustedTypePolicyOptions {
 // https://w3c.github.io/webappsec-trusted-types/dist/spec/#typedef-trustedtypepolicyfactory
 
 interface TrustedTypePolicyFactory {
-  createPolicy(policyName: string, policyOptions: TrustedTypePolicyOptions): TrustedTypePolicy
+  createPolicy(policyName: string, policyOptions: TrustedTypePolicyOptions): TrustedTypePolicy;
   isHTML(value: any): boolean;
   isScript(value: any): boolean;
   isScriptURL(value: any): boolean;


### PR DESCRIPTION
#### Description of Change

This adds middleware semantics `protocol.handle`. It also introduces a better continuation layer as the terminal handler for intercepted protocols. The middleware part was fairly trivial, but this PR also adds what I've been working on for a bit now: **_better continuation semantics for `protocol.handle`._**

I could write an entire essay on all the different approaches I considered, as well as the history of the code layers involved here, but I'll try to keep things (relatively) brief:

1. This issue here (https://github.com/electron/electron/issues/49358) was filed which alerted me to the ways `net.fetch(..., { bypassCustomProtocolHandlers: true })` failed to match browser semantics (especially around redirects) when used with `protocol.handle`. I started to investigate how to provide continuation semantics in `protocol.handle`.
2. My initial PR here (https://github.com/electron/electron/pull/49671) introduced a sentinel return as a way to provide continuation semantics. It would ignore changes to the JS `Request` object and did not surface a JS `Response`. It _was_ a good continuation, though. However the initial sentinel, (`null`) was deemed an API smell, and the replacement sentinel (`DeferredResponse`) didn't really fit any known Electron API pattern.
3. I open an information-gathering RFC here (https://github.com/electron/rfcs/pull/29) and continued to discuss this with the Electron team.
4. I come across this old comment here (https://github.com/electron/governance/pull/368#issuecomment-1338506658) from when `protocol.handle` was initially being discussed. I realize that the middleware-like usage suggested there never really came to fruition, and I decided, since it was already suggested, it was a good target for providing (a best approximation) of continuation semantics.

There is some slight awkwardness here mainly due to the fact that the `Request`->`Response` abstraction that `protocol.handle` uses is a fairly new abstraction that doesn't map cleanly onto any existing API's we could use to provide browser semantics. This implementation is a best attempt at molding usage of the `URLLoader` API into a `Request`->`Response` shape that retains browser semantics.

While I initially wanted a true continuation, I've discovered that's not particularly feasible in a way that also surfaces a JS `Response` object (as we need from the shape of `next()`). So this approach *does* re-dispatch a request, but the semantics should still match in most cases.

Finally, the continuation implementation necessitated the need to add a `session` property to the `protocol` object shape. Please see the code for more information on that.

#### Example

```js
protocol.handle('https', (req, next) => {
  if (shouldPassThrough(req)) return next(req);
  // otherwise synthesize a response
});
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: TBA.
