### PR TITLE
test: wait for navigation to settle in loadURL tests

### DIFF
--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -545,24 +545,21 @@ describe('webContents module', () => {
       }
     });
 
-    it('fails if loadURL is called inside did-start-loading', (done) => {
-      w.webContents.once('did-fail-load', (_event, _errorCode, _errorDescription, validatedURL) => {
-        expect(validatedURL).to.contain('blank.html');
-        done();
-      });
+    it('fails if loadURL is called inside did-start-loading', async () => {
+      const result = Promise.all([once(w.webContents, 'did-fail-load'), once(w.webContents, 'did-stop-loading')]);
 
       w.webContents.once('did-start-loading', () => {
         w.loadURL(`file://${fixturesPath}/pages/blank.html`);
       });
 
       w.loadURL('data:text/html,<h1>HELLO</h1>');
+
+      const [[, , , validatedURL]] = await result;
+      expect(validatedURL).to.contain('blank.html');
     });
 
-    it('fails if loadurl is called after the navigation is ready to commit', (done) => {
-      w.webContents.once('did-fail-load', (_event, _errorCode, _errorDescription, validatedURL) => {
-        expect(validatedURL).to.contain('blank.html');
-        done();
-      });
+    it('fails if loadurl is called after the navigation is ready to commit', async () => {
+      const result = Promise.all([once(w.webContents, 'did-fail-load'), once(w.webContents, 'did-stop-loading')]);
 
       // @ts-expect-error internal-only event.
       w.webContents.once('-ready-to-commit-navigation', () => {
@@ -570,9 +567,12 @@ describe('webContents module', () => {
       });
 
       w.loadURL('data:text/html,<h1>HELLO</h1>');
+
+      const [[, , , validatedURL]] = await result;
+      expect(validatedURL).to.contain('blank.html');
     });
 
-    it('fails if loadURL is called inside did-redirect-navigation', (done) => {
+    it('fails if loadURL is called inside did-redirect-navigation', async () => {
       const server = http.createServer((req, res) => {
         if (req.url === '/302') {
           res.statusCode = 302;
@@ -585,23 +585,18 @@ describe('webContents module', () => {
         }
       });
 
-      w.webContents.once('did-fail-load', (_event, _errorCode, _errorDescription, validatedURL) => {
-        expect(validatedURL).to.contain('blank.html');
-        server.close();
-        done();
-      });
+      const { url } = await listen(server);
 
-      listen(server)
-        .then(({ url }) => {
-          w.webContents.once('did-redirect-navigation', () => {
-            w.loadURL(`file://${fixturesPath}/pages/blank.html`);
-          });
-          w.loadURL(`${url}/302`);
-        })
-        .catch((e) => {
-          server.close();
-          done(e);
-        });
+      const result = Promise.all([once(w.webContents, 'did-fail-load'), once(w.webContents, 'did-stop-loading')]);
+
+      w.webContents.once('did-redirect-navigation', () => {
+        w.loadURL(`file://${fixturesPath}/pages/blank.html`);
+      });
+      w.loadURL(`${url}/302`);
+
+      const [[, , , validatedURL]] = await result;
+      server.close();
+      expect(validatedURL).to.contain('blank.html');
     });
 
     it('sets appropriate error information on rejection', async () => {


### PR DESCRIPTION
#### Description of Change

Followup to #51315, which was a partial fix but missed another way for these tests to break.

The three `loadURL()` tests could call `done()` while the primary navigation was still in-flight. When the second `loadURL()` call is rejected by the guard in `WebContents::LoadURL()`, it emits `did-fail-load` synchronously. If the test exits on `did-fail-load` alone, the `afterEach()` call to `closeAllWindows()` can destroy the window while that primary navigation still has in-flight events.

Fix by using `Promise.all()` to wait for both `did-fail-load` and `did-stop-loading` before the test exits, ensuring the primary navigation has fully settled. 

Sample log of this failure, seen in a downstream CI run for `v41.5.1` :

```
ok 415 webContents module loadURL() promise API fails if loadurl is called after the navigation is ready to commit
Unhandled exception in main spec runner: TypeError: Object has been destroyed
    at BrowserWindow.__webpack_modules__../lib/browser/api/browser-window.ts.BrowserWindow.loadURL (node:electron/js2c/browser_init:1069:17)
    at WebContents.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts:557:11)
    at Object.onceWrapper (node:events:634:26)
    at WebContents.emit (node:events:519:28)
ok 412 webContents module loadURL() promise API rejects when navigation is cancelled due to a bad scheme
ok 413 webContents module loadURL() promise API does not crash when loading a new URL with emulation settings set
ok 414 webContents module loadURL() promise API fails if loadURL is called inside did-start-loading
ok 415 webContents module loadURL() promise API fails if loadurl is called after the navigation is ready to commit
not ok 416 webContents module loadURL() promise API "after each" hook: closeAllWindows in "loadURL() promise API"
  done() called multiple times in hook <webContents module loadURL() promise API "after each" hook: closeAllWindows in "loadURL() promise API"> of file D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts; in addition, done() received error: TypeError: Object has been destroyed
      at BrowserWindow.__webpack_modules__../lib/browser/api/browser-window.ts.BrowserWindow.loadURL (node:electron/js2c/browser_init:1069:17)
      at WebContents.<anonymous> (D:\a\_work\1\b\src\electron\spec\api-web-contents-spec.ts:557:11)
      at Object.onceWrapper (node:events:634:26)
      at WebContents.emit (node:events:519:28) {
    uncaught: true
  }
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none