### PR TITLE
chore: move skill-specific model instructions into skill files

### DIFF
--- a/.claude/skills/patches/SKILL.md
+++ b/.claude/skills/patches/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: patches
 description: "Electron patch system for upstream dependencies (Chromium, Node.js, V8, etc.). Activate when creating, modifying, fixing, or debugging patches."
+applyTo: "patches/**"
 ---
 
 # Electron Patches

--- a/.claude/skills/patches/SKILL.md
+++ b/.claude/skills/patches/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: patches
 description: "Electron patch system for upstream dependencies (Chromium, Node.js, V8, etc.). Activate when creating, modifying, fixing, or debugging patches."
-applyTo: "patches/**"
 ---
 
 # Electron Patches

--- a/.claude/skills/patches/SKILL.md
+++ b/.claude/skills/patches/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: "Electron patch system for upstream dependencies (Chromium, Node.js, V8, etc.). Activate when creating, modifying, fixing, or debugging patches."
+---
+
+# Electron Patches
+
+## Overview
+
+Electron patches upstream dependencies (Chromium, Node.js, V8, etc.) to add features or modify behavior.
+
+```text
+patches/{target}/*.patch  →  [e sync --3]  →  target repo commits
+                          ←  [e patches]   ←
+```
+
+**Patch configuration:** `patches/config.json` maps patch directories to target repos.
+
+## Key Rules
+
+- Fix existing patches 99% of the time rather than creating new ones
+- Preserve original authorship in TODO comments
+- Never change TODO assignees (`TODO(name)` must retain original name)
+- Each patch file includes commit message explaining its purpose
+
+## Creating/Modifying Patches
+
+1. Make changes in the target repo (e.g., `../` for Chromium)
+2. Create a git commit
+3. Run `e patches <target>` to export
+
+### Patch Commands
+
+| Command | Purpose |
+|---------|---------|
+| `e patches <target>` | Export patches for a target (chromium, node, v8, etc.) |
+| `e patches all` | Export all patches from all targets |
+| `e patches --list-targets` | List available patch targets |
+
+## Fixing Patch Conflicts on an Existing PR
+
+If asked to fix a patch conflict on a branch that already has an open PR, check the PR's failed **Apply Patches** CI run for an `update-patches` artifact before running `e sync` locally. CI has already performed the 3-way merge and exported the resolved patch diff — applying it is much faster than a full local sync.
+
+```bash
+# Find the failed Apply Patches run for the PR and download the artifact
+gh run list --repo electron/electron --branch <pr-branch> --workflow "Apply Patches" --limit 1
+gh run download <run-id> --repo electron/electron --name update-patches
+
+# Apply the CI-generated fix, then push
+git am update-patches.patch
+git push
+```
+
+If no artifact exists (e.g. the 3-way merge itself failed), fall back to `e sync --3` and resolve manually.
+
+## Useful Commands
+
+```bash
+# Find which patch affects a file
+grep -l "filename.cc" patches/chromium/*.patch
+```
+
+## Common Issues
+
+**Patch conflict during sync:**
+
+- Use `e sync --3` for 3-way merge
+- Check if file was renamed/moved upstream
+- Verify patch is still needed
+
+**Build error in patched file:**
+
+- Find the patch: `grep -l "filename" patches/chromium/*.patch`
+- Match existing patch style (#if 0 guards, BUILDFLAG conditionals, etc.)

--- a/.claude/skills/pr-labeling/SKILL.md
+++ b/.claude/skills/pr-labeling/SKILL.md
@@ -1,0 +1,26 @@
+---
+description: "Semver and backport target labeling rules for Electron PRs. Load when creating or labeling a pull request on electron/electron."
+---
+
+# PR Labeling (write-access only)
+
+When the user has write access to `electron/electron`, add these labels when creating PRs:
+
+**Semver label** — one of:
+
+- `semver/none` — build changes, refactors, CI, or anything with no end-user impact
+- `semver/patch` — backwards-compatible bug fixes
+- `semver/minor` — backwards-compatible new functionality
+- `semver/major` — incompatible API changes
+
+**Backport target labels** — add `target/{N}-x-y` for each supported release branch the change should land on. Default policy:
+
+- **Bug fixes** — backport to all active release lines _except the oldest_
+- **Security fixes** — backport to all active release lines _including the oldest_
+- **Features (semver/minor) and breaking changes (semver/major)** — no backport labels; main-only by default
+
+To find which release branches are active, check label colors — active `target/*` labels use color `#ad244f`, older/EOL ones use `#ededed`:
+
+```bash
+gh label list --repo electron/electron --search target/ --json name,color --jq '.[] | select(.color == "ad244f") | .name'
+```

--- a/.claude/skills/pr-labeling/SKILL.md
+++ b/.claude/skills/pr-labeling/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: "Semver and backport target labeling rules for Electron PRs. Load when creating or labeling a pull request on electron/electron."
+name: pr-labeling
+description: "Semver and backport target labeling rules for Electron PRs. Load when doing any work on a pull request: creating, labeling, reviewing, updating, or merging."
 ---
 
 # PR Labeling (write-access only)

--- a/.github/skills
+++ b/.github/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,6 @@ npm i -g @electron/build-tools
 | `e test` | Run the test suite |
 | `e debug` | Run Electron in debugger (lldb on macOS, gdb on Linux) |
 
-### Patch Management
-
-| Command | Purpose |
-|---------|---------|
-| `e patches <target>` | Export patches for a target (chromium, node, v8, etc.) |
-| `e patches all` | Export all patches from all targets |
-| `e patches --list-targets` | List available patch targets |
-
 ## Typical Development Workflow
 
 ```bash
@@ -102,55 +94,12 @@ e build
 e start
 e test
 
-# 6. If you modified patched files in Chromium:
-cd ..  # Go to Chromium repo
-git add <files>
-git commit -m "description of change"
-cd electron
-e patches chromium  # Export the patch
+# 6. If you modified patched files, activate the "Patches" skill
 ```
 
 ## Patches System
 
-Electron patches upstream dependencies (Chromium, Node.js, V8, etc.) to add features or modify behavior.
-
-**How patches work:**
-
-```text
-patches/{target}/*.patch  →  [e sync --3]  →  target repo commits
-                          ←  [e patches]   ←
-```
-
-**Patch configuration:** `patches/config.json` maps patch directories to target repos.
-
-**Key rules:**
-
-- Fix existing patches 99% of the time rather than creating new ones
-- Preserve original authorship in TODO comments
-- Never change TODO assignees (`TODO(name)` must retain original name)
-- Each patch file includes commit message explaining its purpose
-
-**Creating/modifying patches:**
-
-1. Make changes in the target repo (e.g., `../` for Chromium)
-2. Create a git commit
-3. Run `e patches <target>` to export
-
-**Fixing patch conflicts on an existing PR:**
-
-If asked to fix a patch conflict on a branch that already has an open PR, check the PR's failed **Apply Patches** CI run for an `update-patches` artifact before running `e sync` locally. CI has already performed the 3-way merge and exported the resolved patch diff — applying it is much faster than a full local sync.
-
-```bash
-# Find the failed Apply Patches run for the PR and download the artifact
-gh run list --repo electron/electron --branch <pr-branch> --workflow "Apply Patches" --limit 1
-gh run download <run-id> --repo electron/electron --name update-patches
-
-# Apply the CI-generated fix, then push
-git am update-patches.patch
-git push
-```
-
-If no artifact exists (e.g. the 3-way merge itself failed), fall back to `e sync --3` and resolve manually.
+When working with patches (creating, modifying, fixing conflicts), activate the "Patches" skill.
 
 ## Testing
 
@@ -231,9 +180,6 @@ git blame -L {start},{end} -- {file}
 
 # Look for Chromium CL reference in commit
 git log -1 {commit_sha}  # Find "Reviewed-on:" line
-
-# Find which patch affects a file
-grep -l "filename.cc" patches/chromium/*.patch
 ```
 
 ## CI/CD
@@ -245,17 +191,6 @@ GitHub Actions workflows in `.github/workflows/`:
 - `pipeline-segment-electron-test.yml` - Testing
 
 ## Common Issues
-
-**Patch conflict during sync:**
-
-- Use `e sync --3` for 3-way merge
-- Check if file was renamed/moved upstream
-- Verify patch is still needed
-
-**Build error in patched file:**
-
-- Find the patch: `grep -l "filename" patches/chromium/*.patch`
-- Match existing patch style (#if 0 guards, BUILDFLAG conditionals, etc.)
 
 **Remote build issues:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,28 +188,7 @@ When working on the `roller/node/main` branch to upgrade Node.js activate the "E
 
 PR bodies must always include a `Notes:` section as the **last line** of the body. This is a consumer-facing release note for Electron app developers — describe the user-visible fix or change, not internal implementation details. Use `Notes: none` if there is no user-facing change.
 
-### PR Labeling (write-access only)
-
-When the user has write access to `electron/electron`, add these labels when creating PRs:
-
-**Semver label** — one of:
-
-- `semver/none` — build changes, refactors, CI, or anything with no end-user impact
-- `semver/patch` — backwards-compatible bug fixes
-- `semver/minor` — backwards-compatible new functionality
-- `semver/major` — incompatible API changes
-
-**Backport target labels** — add `target/{N}-x-y` for each supported release branch the change should land on. Default policy:
-
-- **Bug fixes** — backport to all active release lines _except the oldest_
-- **Security fixes** — backport to all active release lines _including the oldest_
-- **Features (semver/minor) and breaking changes (semver/major)** — no backport labels; main-only by default
-
-To find which release branches are active, check label colors — active `target/*` labels use color `#ad244f`, older/EOL ones use `#ededed`:
-
-```bash
-gh label list --repo electron/electron --search target/ --json name,color --jq '.[] | select(.color == "ad244f") | .name'
-```
+When creating PRs, activate the "PR Labeling" skill.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,14 @@
 # Electron Development Guide
 
+## Required Reading by Task
+
+| When you are… | You MUST first read… |
+|---|---|
+| Working with patches | `.claude/skills/patches/SKILL.md` |
+| Working with any PR | `.claude/skills/pr-labeling/SKILL.md` |
+| Upgrading Chromium | `.claude/skills/electron-chromium-upgrade/SKILL.md` |
+| Upgrading Node.js | `.claude/skills/electron-node-upgrade/SKILL.md` |
+
 ## Running node_modules binaries
 
 **Never use `npx`.** It is considered dangerous because it can silently fetch and execute arbitrary packages from the registry. Always run binaries through one of these safer mechanisms instead:
@@ -93,13 +102,11 @@ e build
 # 5. Test your changes (Leave the user to do this, don't run these commands unless asked)
 e start
 e test
-
-# 6. If you modified patched files, activate the "Patches" skill
 ```
 
 ## Patches System
 
-When working with patches (creating, modifying, fixing conflicts), activate the "Patches" skill.
+When working with patches (creating, modifying, fixing conflicts), you MUST read `.claude/skills/patches/SKILL.md`.
 
 ## Testing
 
@@ -137,7 +144,7 @@ When working on the `roller/node/main` branch to upgrade Node.js activate the "E
 
 PR bodies must always include a `Notes:` section as the **last line** of the body. This is a consumer-facing release note for Electron app developers — describe the user-visible fix or change, not internal implementation details. Use `Notes: none` if there is no user-facing change.
 
-When creating PRs, activate the "PR Labeling" skill.
+> **Required:** Read `.claude/skills/pr-labeling/SKILL.md` before doing any work on a PR.
 
 ## Code Style
 

--- a/script/lint.js
+++ b/script/lint.js
@@ -303,10 +303,11 @@ const LINTERS = [
     ignoreRoots: [
       '.claude',
       '.git',
+      '.github/skills',
       '.github/workflows/node_modules',
       'node_modules',
-      'spec/node_modules',
-      'spec/fixtures/native-addon'
+      'spec/fixtures/native-addon',
+      'spec/node_modules'
     ],
     test: (filename) => filename.endsWith('.md'),
     run: async (opts, filenames) => {


### PR DESCRIPTION
#### Description of Change

Small refactor to `CLAUDE.md` that moves task-specific info into skills so they're not loaded in every session:

- Move patch-specific pieces to a skill that's read when working on patches
- Move the PR labeling section to a skill  that's read when creating PRs
- Add a symlink from `.claude/skills/` to `.github/skills` so that skills are usable by copilot CLI

Note: I've marked this as `no-backport` because there's pre-existing drift in `CLAUDE.md` across branches and IDK if that's by accident or by design. Does @electron/wg-infra have a preference on this?

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.