### PR TITLE
ci: add faraday trust configuration

### DIFF
--- a/.github/faraday.yml
+++ b/.github/faraday.yml
@@ -1,0 +1,12 @@
+# faraday trust configuration for electron/electron.
+# A bot listed here is "trusted": its pull requests need 1 maintainer
+# approval instead of 2, provided every commit is verifiably the bot's own.
+# See: https://github.com/electron/faraday
+
+trusted-bots:
+  # Backport PRs to release branches.
+  - login: trop[bot]
+    id: 37223003
+  # Chromium / Node.js roll PRs.
+  - login: electron-roller[bot]
+    id: 84116207


### PR DESCRIPTION
Adds the `.github/faraday.yml` trust configuration for [faraday](https://github.com/electron/faraday), the GitHub App that enforces a two-person rule on pull requests across the `electron` org starting Monday.

A bot listed in `trusted-bots` has its pull requests treated as trusted (1 maintainer approval instead of 2), provided every commit is verifiably authored, committed, and signed by the bot. A bot listed under `approvers` may stand in for a human review on PRs authored by the bot it is paired with — and only that bot.

See the [faraday README](https://github.com/electron/faraday#trusted-bots) for the full policy.

Notes: none