### PR TITLE
perf: reduce per-call overhead in gin_helper hot paths

### DIFF
--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -55,8 +55,10 @@ struct Converter<char16_t> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      char16_t* out) {
-    std::u16string code = base::UTF8ToUTF16(gin::V8ToString(isolate, val));
-    if (code.length() != 1)
+    // V8 strings are UTF-16; read directly rather than via UTF-8.
+    std::u16string code;
+    if (!gin::Converter<std::u16string>::FromV8(isolate, val, &code) ||
+        code.length() != 1)
       return false;
     *out = code[0];
     return true;

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -45,13 +45,28 @@ class Dictionary : public gin::Dictionary {
     v8::Isolate* const iso = isolate();
     v8::Local<v8::Object> handle = GetHandle();
     v8::Local<v8::Context> context = iso->GetCurrentContext();
-    v8::Local<v8::Value> v8_key = gin::ConvertToV8(iso, key);
     v8::Local<v8::Value> value;
-    // Check for existence before getting, otherwise this method will always
-    // returns true when T == v8::Local<v8::Value>.
-    return handle->Has(context, v8_key).FromMaybe(false) &&
-           handle->Get(context, v8_key).ToLocal(&value) &&
-           gin::ConvertFromV8(iso, value, out);
+    if constexpr (std::is_convertible_v<const K&, std::string_view>) {
+      // GetRealNamedProperty() distinguishes "missing" (empty MaybeLocal)
+      // from "present with undefined value" in one V8 call, replacing the
+      // Has()+Get() pair. It skips C++ named-property interceptors
+      // (process.env, etc.), so detect those and fall back.
+      v8::Local<v8::String> v8_key = MakeKey(key);
+      if (V8_LIKELY(!handle->HasNamedLookupInterceptor())) {
+        if (!handle->GetRealNamedProperty(context, v8_key).ToLocal(&value))
+          return false;
+        return gin::ConvertFromV8(iso, value, out);
+      }
+      return handle->Has(context, v8_key).FromMaybe(false) &&
+             handle->Get(context, v8_key).ToLocal(&value) &&
+             gin::ConvertFromV8(iso, value, out);
+    } else {
+      // GetRealNamedProperty() requires a v8::Name.
+      v8::Local<v8::Value> v8_key = gin::ConvertToV8(iso, key);
+      return handle->Has(context, v8_key).FromMaybe(false) &&
+             handle->Get(context, v8_key).ToLocal(&value) &&
+             gin::ConvertFromV8(iso, value, out);
+    }
   }
 
   // Differences from the Set method in gin::Dictionary:
@@ -61,9 +76,8 @@ class Dictionary : public gin::Dictionary {
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(isolate(), val, &v8_value))
       return false;
-    v8::Maybe<bool> result =
-        GetHandle()->Set(isolate()->GetCurrentContext(),
-                         gin::ConvertToV8(isolate(), key), v8_value);
+    v8::Maybe<bool> result = GetHandle()->Set(isolate()->GetCurrentContext(),
+                                              MakeAnyKey(key), v8_value);
     return result.FromMaybe(false);
   }
 
@@ -211,9 +225,19 @@ class Dictionary : public gin::Dictionary {
  private:
   // DO NOT ADD ANY DATA MEMBER.
 
+  // Internalized so V8 can compare keys by pointer identity in property
+  // lookups, instead of hashing a fresh kNormal string per call.
   [[nodiscard]] v8::Local<v8::String> MakeKey(
       const std::string_view key) const {
-    return gin::StringToV8(isolate(), key);
+    return gin::StringToSymbol(isolate(), key);
+  }
+
+  template <typename K>
+  [[nodiscard]] v8::Local<v8::Value> MakeAnyKey(const K& key) const {
+    if constexpr (std::is_convertible_v<const K&, std::string_view>)
+      return MakeKey(key);
+    else
+      return gin::ConvertToV8(isolate(), key);
   }
 
   [[nodiscard]] v8::Local<v8::Private> MakeHiddenKey(

--- a/shell/common/gin_helper/event_emitter_caller.cc
+++ b/shell/common/gin_helper/event_emitter_caller.cc
@@ -9,18 +9,18 @@
 namespace gin_helper::internal {
 
 v8::Local<v8::Value> CallMethodWithArgs(
+    v8::EscapableHandleScope& scope,
     v8::Isolate* isolate,
     v8::Local<v8::Object> obj,
     const std::string_view method,
     const base::span<v8::Local<v8::Value>> args) {
-  v8::EscapableHandleScope handle_scope{isolate};
-
   // CallbackScope and MakeCallback both require an active node::Environment
   if (!node::Environment::GetCurrent(isolate))
-    return handle_scope.Escape(v8::False(isolate));
+    return scope.Escape(v8::False(isolate));
 
-  node::CallbackScope callback_scope{isolate, v8::Object::New(isolate),
-                                     node::async_context{0, 0}};
+  // |obj| is reused as the async resource; with async_context{0,0} no async
+  // hooks fire, so the resource is unobserved.
+  node::CallbackScope callback_scope{isolate, obj, node::async_context{0, 0}};
 
   // Perform microtask checkpoint after running JavaScript.
   v8::MicrotasksScope microtasks_scope(obj->GetCreationContextChecked(isolate),
@@ -28,7 +28,7 @@ v8::Local<v8::Value> CallMethodWithArgs(
 
   // node::MakeCallback will also run pending tasks in Node.js.
   v8::MaybeLocal<v8::Value> ret =
-      node::MakeCallback(isolate, obj, gin::StringToV8(isolate, method),
+      node::MakeCallback(isolate, obj, gin::StringToSymbol(isolate, method),
                          args.size(), args.data(), {0, 0});
 
   // If the JS function throws an exception (doesn't return a value) the result
@@ -36,9 +36,9 @@ v8::Local<v8::Value> CallMethodWithArgs(
   // case we need to return "false" as that indicates that the event emitter did
   // not handle the event
   if (v8::Local<v8::Value> localRet; ret.ToLocal(&localRet))
-    return handle_scope.Escape(localRet);
+    return scope.Escape(localRet);
 
-  return handle_scope.Escape(v8::False(isolate));
+  return scope.Escape(v8::False(isolate));
 }
 
 }  // namespace gin_helper::internal

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -19,7 +19,11 @@ namespace gin_helper {
 
 namespace internal {
 
-v8::Local<v8::Value> CallMethodWithArgs(v8::Isolate* isolate,
+// Allocates handles in (and escapes the result through) the caller's |scope|,
+// so a caller that forgets to open one is a compile error rather than a slow
+// per-call handle leak.
+v8::Local<v8::Value> CallMethodWithArgs(v8::EscapableHandleScope& scope,
+                                        v8::Isolate* isolate,
                                         v8::Local<v8::Object> obj,
                                         std::string_view method,
                                         base::span<v8::Local<v8::Value>> args);
@@ -35,11 +39,11 @@ v8::Local<v8::Value> EmitEvent(v8::Isolate* isolate,
                                Args&&... args) {
   v8::EscapableHandleScope scope{isolate};
   std::array<v8::Local<v8::Value>, 1U + sizeof...(args)> converted_args = {
-      gin::StringToV8(isolate, name),
+      gin::StringToSymbol(isolate, name),
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
-  return scope.Escape(
-      internal::CallMethodWithArgs(isolate, obj, "emit", converted_args));
+  return internal::CallMethodWithArgs(scope, isolate, obj, "emit",
+                                      converted_args);
 }
 
 // obj.custom_emit(args...)
@@ -52,8 +56,8 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
   std::array<v8::Local<v8::Value>, sizeof...(args)> converted_args = {
       gin::ConvertToV8(isolate, std::forward<Args>(args))...,
   };
-  return scope.Escape(internal::CallMethodWithArgs(isolate, object, custom_emit,
-                                                   converted_args));
+  return internal::CallMethodWithArgs(scope, isolate, object, custom_emit,
+                                      converted_args);
 }
 
 template <typename T, typename... Args>

--- a/shell/common/gin_helper/locker.cc
+++ b/shell/common/gin_helper/locker.cc
@@ -5,13 +5,13 @@
 #include "shell/common/gin_helper/locker.h"
 
 #include "shell/common/process_util.h"
-#include "v8/include/v8-locker.h"
 
 namespace gin_helper {
 
-Locker::Locker(v8::Isolate* isolate)
-    : locker_{electron::IsBrowserProcess() ? new v8::Locker{isolate}
-                                           : nullptr} {}
+Locker::Locker(v8::Isolate* isolate) {
+  if (electron::IsBrowserProcess())
+    locker_.emplace(isolate);
+}
 
 Locker::~Locker() = default;
 

--- a/shell/common/gin_helper/locker.h
+++ b/shell/common/gin_helper/locker.h
@@ -5,11 +5,12 @@
 #ifndef ELECTRON_SHELL_COMMON_GIN_HELPER_LOCKER_H_
 #define ELECTRON_SHELL_COMMON_GIN_HELPER_LOCKER_H_
 
-#include <memory>
+#include <optional>
+
+#include "v8/include/v8-locker.h"
 
 namespace v8 {
 class Isolate;
-class Locker;
 }  // namespace v8
 
 namespace gin_helper {
@@ -29,7 +30,8 @@ class Locker {
   void operator delete(void*, size_t) = delete;
 
  private:
-  const std::unique_ptr<v8::Locker> locker_;
+  // Inline storage — avoids a heap allocation per C++ -> JS callback.
+  std::optional<v8::Locker> locker_;
 };
 
 }  // namespace gin_helper


### PR DESCRIPTION
### Description of Change

Removes a handful of avoidable per-call costs from `gin_helper` paths that run on every native event emit, IPC message, option-dictionary parse, and C++ → JS callback.

- **`EmitEvent` / `CallMethodWithArgs`** — internalize the event name and `"emit"` (`gin::StringToSymbol`); reuse the emitter as the `node::CallbackScope` resource instead of allocating a throwaway `v8::Object`; drop the redundant inner `EscapableHandleScope`.
- **`gin_helper::Dictionary`** — internalize property keys; replace `Has()` + `Get()` in `Get()` with a single `GetRealNamedProperty()` (one V8 boundary crossing instead of two), guarded by a zero-cost `HasNamedLookupInterceptor()` flag check that routes native-interceptor objects (`process.env`, etc.) to the original path.
- **`gin_helper::Locker`** — store `v8::Locker` inline in `std::optional` instead of heap-allocating per construction.
- **`Converter<char16_t>::FromV8`** — read the UTF-16 code unit directly instead of round-tripping through UTF-8.

### Benchmarks

Linux x86-64 testing build, microbenchmark medians:

| hot path | before | after | Δ |
|---|---:|---:|---:|
| `EmitEvent` (1 listener) | 2806 ns | 1816 ns | **−35%** |
| `EmitEvent` (no listeners) | 2788 ns | 1800 ns | **−35%** |
| `Dictionary::Get` (per key, all hit) | 82.2 ns | 26.9 ns | **−67%** |
| `Dictionary::Get` (per key, all miss) | 55.6 ns | 18.5 ns | **−67%** |
| `Dictionary::Set` (per key) | 121 ns | 82.6 ns | **−32%** |
| `gin_helper::Locker` ctor/dtor | 94.3 ns | 9.85 ns | **−90%** |
| C++ → JS callback (`base::RepeatingClosure`) | 463 ns | 301 ns | **−35%** |

### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR title follows [semantic commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#release-notes) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/electron/blob/main/docs/development/style-guide.md#release-notes)

### Release Notes

Notes: Improved performance of native event emission, IPC dispatch, and option-dictionary parsing.
