### PR TITLE
fix: Crash for Notification close

### DIFF
--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -273,15 +273,19 @@ void Notification::NotificationClosed(const std::string& reason) {
 }
 
 void Notification::Close() {
-  if (notification_) {
-    if (notification_->is_dismissed()) {
-      notification_->Remove();
-    } else {
-      notification_->Dismiss();
-    }
-    notification_->set_delegate(nullptr);
-    notification_.reset();
+  auto notification = notification_;
+  notification_.reset();
+
+  if (!notification) {
+    return;
   }
+
+  if (notification->is_dismissed()) {
+    notification->Remove();
+  } else {
+    notification->Dismiss();
+  }
+  notification->set_delegate(nullptr);
 }
 
 // Showing notifications

--- a/spec/fixtures/crash-cases/notification-close/index.js
+++ b/spec/fixtures/crash-cases/notification-close/index.js
@@ -1,0 +1,47 @@
+// main.js
+const { app, Notification } = require('electron');
+
+function die(err) {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+}
+
+process.on('uncaughtException', die);
+process.on('unhandledRejection', die);
+
+app
+  .whenReady()
+  .then(() => {
+    if (process.platform !== 'darwin') {
+      console.log('skip: only repro on darwin');
+      app.exit(0);
+      return;
+    }
+
+    if (!Notification.isSupported()) {
+      console.log('skip: Notification not supported');
+      app.exit(0);
+      return;
+    }
+
+    const n = new Notification({
+      title: 'repro',
+      body: 'reentrant close'
+    });
+
+    // Key point: Close again within the close event to create reentrancy.
+    n.once('close', () => {
+      console.log('[js] close event fired, closing again...');
+      n.close();
+    });
+
+    app.on('before-quit', () => {
+      console.log('[js] before-quit, closing notification...');
+      n.close();
+    });
+
+    n.show();
+
+    setImmediate(() => app.quit());
+  })
+  .catch(die);


### PR DESCRIPTION
On the macOS platform, calling the `close` function again in the `close` event of a Notification will cause a crash. The specific reason is as follows: When the `close` function of a Notification is called, the `dismiss` logic dispatches a "close" event. If the `close` function is called again in the `close` event, it will reset |notification_|, causing the weakptr to become invalid. The first `close` function will continue to use this invalid weakptr directly, thus triggering a crash.

#### Description of Change
```
(lldb) bt
warning: Electron Framework was compiled with optimization - stepping may behave oddly; variables may not be available.
* thread #1, name = 'CrBrowserMain', queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x10d33e824)
  * frame #0: 0x000000010d33e824 Electron Framework`base::ImmediateCrash() at immediate_crash.h:186:3 [opt] [inlined]
    frame #1: 0x000000010d33e824 Electron Framework`logging::CheckFailure() at check.h:258:3 [opt] [inlined]
    frame #2: 0x000000010d33e824 Electron Framework`base::WeakPtr<electron::Notification>::operator->(this=<unavailable>) const at weak_ptr.h:249:5 [opt] [inlined]
    frame #3: 0x000000010d33e824 Electron Framework`electron::api::Notification::Close(this=0x0000012400186f60) at [electron_api_notification.cc:172](http://electron_api_notification.cc:172/):5 [opt]
    frame #4: 0x000000010d340864 Electron Framework`base::RepeatingCallback<void (electron::api::Notification*)>::Run(this=0x000000016fdfb5f8, args=0x000000016fdfb5d0) const & at callback.h:344:12 [opt] [inlined]
    frame #5: 0x000000010d340834 Electron Framework`gin::internal::Invoker<std::__Cr::integer_sequence<unsigned long, 0ul>, electron::api::Notification*>::DispatchToCallback(this=<unavailable>, callback=RepeatingCallback<void (electron::api::Notification *)> @ 0x000000016fdfb5f8) at function_template.h:232:14 [opt] [inlined]
    frame #6: 0x000000010d340834 Electron Framework`gin::internal::Dispatcher<void (electron::api::Notification*)>::DispatchToCallbackImpl(args=0x000000016fdfb648) at function_template.h:264:15 [opt]
    frame #7: 0x000000010d34066c Electron Framework`gin::internal::Dispatcher<void (electron::api::Notification*)>::DispatchToCallback(info=<unavailable>) at function_template.h:270:5 [opt]
    frame #8: 0x0000000157e0f6f8
    frame #9: 0x0000000157e0d710
    frame #10: 0x0000000150012acc
    frame #11: 0x0000000157e0b288
    frame #12: 0x0000000157e0aed4
```
The crash stack is as shown above.The specific reason is:
```
void Notification::Close() {
  if (notification_) {
    if (notification_->is_dismissed()) {
      notification_->Remove();
    } else {
      notification_->Dismiss(); ==> It will dispatch "close" event. If call notification.close in "close" event againt,
                                              ==> it run |notification_.reset()| in another close function.
    }
    notification_->set_delegate(nullptr);  ==> notification_ is invaild now. And crash.
    notification_.reset();
  }
}
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix crash for Notification close
