### PR TITLE
perf: reduce per-call overhead in gin converters

### DIFF
--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -226,6 +226,7 @@ namespace {
 
 std::vector<std::string_view> ModifiersToArray(int modifiers) {
   std::vector<std::string_view> modifier_strings;
+  modifier_strings.reserve(Modifiers.size());
 
   for (const auto& [name, mask] : Modifiers)
     if (mask & modifiers)
@@ -362,15 +363,16 @@ v8::Local<v8::Value> Converter<blink::WebKeyboardEvent>::ToV8(
                        static_cast<ui::DomCode>(in.dom_code)));
 
   using Modifiers = blink::WebInputEvent::Modifiers;
-  dict.Set("isAutoRepeat", (in.GetModifiers() & Modifiers::kIsAutoRepeat) != 0);
-  dict.Set("isComposing", (in.GetModifiers() & Modifiers::kIsComposing) != 0);
-  dict.Set("shift", (in.GetModifiers() & Modifiers::kShiftKey) != 0);
-  dict.Set("control", (in.GetModifiers() & Modifiers::kControlKey) != 0);
-  dict.Set("alt", (in.GetModifiers() & Modifiers::kAltKey) != 0);
-  dict.Set("meta", (in.GetModifiers() & Modifiers::kMetaKey) != 0);
+  const int mods = in.GetModifiers();
+  dict.Set("isAutoRepeat", (mods & Modifiers::kIsAutoRepeat) != 0);
+  dict.Set("isComposing", (mods & Modifiers::kIsComposing) != 0);
+  dict.Set("shift", (mods & Modifiers::kShiftKey) != 0);
+  dict.Set("control", (mods & Modifiers::kControlKey) != 0);
+  dict.Set("alt", (mods & Modifiers::kAltKey) != 0);
+  dict.Set("meta", (mods & Modifiers::kMetaKey) != 0);
   dict.Set("location", GetKeyLocationCode(in));
-  dict.Set("_modifiers", in.GetModifiers());
-  dict.Set("modifiers", ModifiersToArray(in.GetModifiers()));
+  dict.Set("_modifiers", mods);
+  dict.Set("modifiers", ModifiersToArray(mods));
 
   return dict.GetHandle();
 }

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -12,6 +12,7 @@
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/permission_result.h"
 #include "content/public/browser/web_contents.h"
+#include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/web_contents_permission_helper.h"
 #include "shell/common/gin_converters/blink_converter.h"
@@ -305,10 +306,10 @@ bool Converter<content::WebContents*>::FromV8(v8::Isolate* isolate,
 v8::Local<v8::Value> Converter<content::Referrer>::ToV8(
     v8::Isolate* isolate,
     const content::Referrer& val) {
-  auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
-  dict.Set("url", ConvertToV8(isolate, val.url));
-  dict.Set("policy", ConvertToV8(isolate, val.policy));
-  return gin::ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("url", ConvertToV8(isolate, val.url))
+      .Set("policy", ConvertToV8(isolate, val.policy))
+      .Build();
 }
 
 // static

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -241,7 +241,7 @@ v8::Local<v8::Value> Converter<gfx::ColorSpace>::ToV8(
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
 
   // Convert primaries to string
-  std::string primaries;
+  std::string_view primaries;
   switch (val.GetPrimaryID()) {
     case gfx::ColorSpace::PrimaryID::BT709:
       primaries = "bt709";
@@ -297,7 +297,7 @@ v8::Local<v8::Value> Converter<gfx::ColorSpace>::ToV8(
   }
 
   // Convert transfer function to string
-  std::string transfer;
+  std::string_view transfer;
   switch (val.GetTransferID()) {
     case gfx::ColorSpace::TransferID::BT709:
       transfer = "bt709";
@@ -377,7 +377,7 @@ v8::Local<v8::Value> Converter<gfx::ColorSpace>::ToV8(
   }
 
   // Convert matrix to string
-  std::string matrix;
+  std::string_view matrix;
   switch (val.GetMatrixID()) {
     case gfx::ColorSpace::MatrixID::RGB:
       matrix = "rgb";
@@ -415,7 +415,7 @@ v8::Local<v8::Value> Converter<gfx::ColorSpace>::ToV8(
   }
 
   // Convert range to string
-  std::string range;
+  std::string_view range;
   switch (val.GetRangeID()) {
     case gfx::ColorSpace::RangeID::LIMITED:
       range = "limited";

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -55,7 +55,8 @@ struct Converter<base::Uuid> {
     return true;
   }
 
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const base::Uuid& val) {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::Uuid& val) {
     return gin::ConvertToV8(isolate, val.AsLowercaseString());
   }
 };

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -47,17 +47,16 @@ struct Converter<base::Uuid> {
     if (!gin::ConvertFromV8(isolate, val, &guid))
       return false;
 
-    base::Uuid parsed = base::Uuid::ParseLowercase(base::ToLowerASCII(guid));
+    base::Uuid parsed = base::Uuid::ParseCaseInsensitive(guid);
     if (!parsed.is_valid())
       return false;
 
-    *out = parsed;
+    *out = std::move(parsed);
     return true;
   }
 
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, base::Uuid val) {
-    const std::string guid = val.AsLowercaseString();
-    return gin::ConvertToV8(isolate, guid);
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const base::Uuid& val) {
+    return gin::ConvertToV8(isolate, val.AsLowercaseString());
   }
 };
 

--- a/shell/common/gin_converters/login_item_settings_converter.cc
+++ b/shell/common/gin_converters/login_item_settings_converter.cc
@@ -31,7 +31,7 @@ bool Converter<electron::LaunchItem>::FromV8(v8::Isolate* isolate,
 
 v8::Local<v8::Value> Converter<electron::LaunchItem>::ToV8(
     v8::Isolate* isolate,
-    electron::LaunchItem val) {
+    const electron::LaunchItem& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
   dict.Set("name", val.name);
   dict.Set("path", val.path);
@@ -66,7 +66,7 @@ bool Converter<electron::LoginItemSettings>::FromV8(
 
 v8::Local<v8::Value> Converter<electron::LoginItemSettings>::ToV8(
     v8::Isolate* isolate,
-    electron::LoginItemSettings val) {
+    const electron::LoginItemSettings& val) {
   auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
 #if BUILDFLAG(IS_WIN)
   dict.Set("launchItems", val.launch_items);

--- a/shell/common/gin_converters/login_item_settings_converter.h
+++ b/shell/common/gin_converters/login_item_settings_converter.h
@@ -18,7 +18,7 @@ namespace gin {
 template <>
 struct Converter<electron::LaunchItem> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   electron::LaunchItem val);
+                                   const electron::LaunchItem& val);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::LaunchItem* out);
@@ -28,7 +28,7 @@ struct Converter<electron::LaunchItem> {
 template <>
 struct Converter<electron::LoginItemSettings> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   electron::LoginItemSettings val);
+                                   const electron::LoginItemSettings& val);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::LoginItemSettings* out);

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -15,6 +15,7 @@
 #include "base/strings/string_util.h"
 #include "base/values.h"
 #include "gin/converter.h"
+#include "gin/data_object_builder.h"
 #include "gin/dictionary.h"
 #include "gin/object_template_builder.h"
 #include "net/cert/x509_certificate.h"
@@ -67,32 +68,32 @@ bool CertFromData(const std::string& data,
 v8::Local<v8::Value> Converter<net::AuthChallengeInfo>::ToV8(
     v8::Isolate* isolate,
     const net::AuthChallengeInfo& val) {
-  auto dict = gin::Dictionary::CreateEmpty(isolate);
-  dict.Set("isProxy", val.is_proxy);
-  dict.Set("scheme", val.scheme);
-  dict.Set("host", val.challenger.host());
-  dict.Set("port", static_cast<uint32_t>(val.challenger.port()));
-  dict.Set("realm", val.realm);
-  return gin::ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("isProxy", val.is_proxy)
+      .Set("scheme", val.scheme)
+      .Set("host", val.challenger.host())
+      .Set("port", static_cast<uint32_t>(val.challenger.port()))
+      .Set("realm", val.realm)
+      .Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
     v8::Isolate* isolate,
     const scoped_refptr<net::X509Certificate>& val) {
-  gin::Dictionary dict(isolate, v8::Object::New(isolate));
   std::string encoded_data;
   net::X509Certificate::GetPEMEncoded(val->cert_buffer(), &encoded_data);
 
-  dict.Set("data", encoded_data);
-  dict.Set("issuer", val->issuer());
-  dict.Set("issuerName", val->issuer().GetDisplayName());
-  dict.Set("subject", val->subject());
-  dict.Set("subjectName", val->subject().GetDisplayName());
-  dict.Set("serialNumber", base::HexEncode(val->serial_number()));
-  dict.Set("validStart", val->valid_start().InSecondsFSinceUnixEpoch());
-  dict.Set("validExpiry", val->valid_expiry().InSecondsFSinceUnixEpoch());
-  dict.Set("fingerprint",
+  gin::DataObjectBuilder builder(isolate);
+  builder.Set("data", encoded_data)
+      .Set("issuer", val->issuer())
+      .Set("issuerName", val->issuer().GetDisplayName())
+      .Set("subject", val->subject())
+      .Set("subjectName", val->subject().GetDisplayName())
+      .Set("serialNumber", base::HexEncode(val->serial_number()))
+      .Set("validStart", val->valid_start().InSecondsFSinceUnixEpoch())
+      .Set("validExpiry", val->valid_expiry().InSecondsFSinceUnixEpoch())
+      .Set("fingerprint",
            net::HashValue(val->CalculateFingerprint256(val->cert_buffer()))
                .ToString());
 
@@ -108,10 +109,10 @@ v8::Local<v8::Value> Converter<scoped_refptr<net::X509Certificate>>::ToV8(
         net::X509Certificate::CreateFromBuffer(
             bssl::UpRef(intermediate_buffers[0].get()),
             std::move(issuer_intermediates));
-    dict.Set("issuerCert", issuer_cert);
+    builder.Set("issuerCert", issuer_cert);
   }
 
-  return ConvertToV8(isolate, dict);
+  return builder.Build();
 }
 
 bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
@@ -149,25 +150,21 @@ bool Converter<scoped_refptr<net::X509Certificate>>::FromV8(
 v8::Local<v8::Value> Converter<net::CertPrincipal>::ToV8(
     v8::Isolate* isolate,
     const net::CertPrincipal& val) {
-  gin::Dictionary dict(isolate, v8::Object::New(isolate));
-
-  dict.Set("commonName", val.common_name);
-  dict.Set("organizations", val.organization_names);
-  dict.Set("organizationUnits", val.organization_unit_names);
-  dict.Set("locality", val.locality_name);
-  dict.Set("state", val.state_or_province_name);
-  dict.Set("country", val.country_name);
-
-  return ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("commonName", val.common_name)
+      .Set("organizations", val.organization_names)
+      .Set("organizationUnits", val.organization_unit_names)
+      .Set("locality", val.locality_name)
+      .Set("state", val.state_or_province_name)
+      .Set("country", val.country_name)
+      .Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<net::HttpResponseHeaders*>::ToV8(
     v8::Isolate* isolate,
     net::HttpResponseHeaders* headers) {
-  // Build the {name: [value, ...]} object directly rather than round-tripping
-  // through an intermediate base::DictValue and content::V8ValueConverter.
-  // std::map preserves the alphabetically-sorted key order the previous
+  // std::map preserves the sorted key order the previous base::DictValue
   // implementation produced.
   std::map<std::string, std::vector<std::string>> grouped;
   if (headers) {
@@ -252,23 +249,43 @@ v8::Local<v8::Value> Converter<net::HttpRequestHeaders>::ToV8(
     v8::Isolate* isolate,
     const net::HttpRequestHeaders& val) {
   gin::Dictionary headers(isolate, v8::Object::New(isolate));
+  gin::DataObjectBuilder builder(isolate);
   for (net::HttpRequestHeaders::Iterator it(val); it.GetNext();)
-    headers.Set(it.name(), it.value());
-  return ConvertToV8(isolate, headers);
+    builder.Set(it.name(), it.value());
+  return builder.Build();
 }
 
 // static
 bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
                                                 v8::Local<v8::Value> val,
                                                 net::HttpRequestHeaders* out) {
-  base::DictValue dict;
-  if (!ConvertFromV8(isolate, val, &dict))
+  if (!val->IsObject() || val->IsArray() || val->IsFunction())
     return false;
-  for (const auto it : dict) {
-    if (it.second.is_string() && net::HttpUtil::IsValidHeaderName(it.first) &&
-        net::HttpUtil::IsValidHeaderValue(it.second.GetString())) {
-      out->SetHeader(it.first, std::move(it.second).TakeString());
-    }
+  auto context = isolate->GetCurrentContext();
+  auto obj = val.As<v8::Object>();
+  v8::Local<v8::Array> keys;
+  if (!obj->GetOwnPropertyNames(context,
+                                static_cast<v8::PropertyFilter>(
+                                    v8::ONLY_ENUMERABLE | v8::SKIP_SYMBOLS),
+                                v8::KeyConversionMode::kConvertToString)
+           .ToLocal(&keys))
+    return false;
+  const uint32_t length = keys->Length();
+  std::string key, value;
+  for (uint32_t i = 0; i < length; ++i) {
+    v8::Local<v8::Value> v8key;
+    if (!keys->Get(context, i).ToLocal(&v8key))
+      return false;
+    v8::TryCatch try_catch{isolate};
+    v8::Local<v8::Value> v8value;
+    if (!obj->Get(context, v8key).ToLocal(&v8value) || !v8value->IsString())
+      continue;
+    if (!gin::ConvertFromV8(isolate, v8key, &key) ||
+        !gin::ConvertFromV8(isolate, v8value, &value))
+      return false;
+    if (net::HttpUtil::IsValidHeaderName(key) &&
+        net::HttpUtil::IsValidHeaderValue(value))
+      out->SetHeader(key, std::move(value));
   }
   return true;
 }
@@ -642,79 +659,76 @@ bool Converter<scoped_refptr<network::ResourceRequestBody>>::FromV8(
 v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
     v8::Isolate* isolate,
     const network::ResourceRequest& val) {
-  auto dict = gin::Dictionary::CreateEmpty(isolate);
-  dict.Set("method", val.method);
-  dict.Set("url", val.url.spec());
-  dict.Set("referrer", val.referrer.spec());
-  dict.Set("headers", val.headers);
+  gin::DataObjectBuilder builder(isolate);
+  builder.Set("method", val.method)
+      .Set("url", val.url.spec())
+      .Set("referrer", val.referrer.spec())
+      .Set("headers", val.headers);
   if (val.request_body)
-    dict.Set("uploadData", ConvertToV8(isolate, *val.request_body));
-  return ConvertToV8(isolate, dict);
+    builder.Set("uploadData", ConvertToV8(isolate, *val.request_body));
+  return builder.Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<electron::VerifyRequestParams>::ToV8(
     v8::Isolate* isolate,
     const electron::VerifyRequestParams& val) {
-  auto dict = gin::Dictionary::CreateEmpty(isolate);
-  dict.Set("hostname", val.hostname);
-  dict.Set("certificate", val.certificate);
-  dict.Set("validatedCertificate", val.validated_certificate);
-  dict.Set("isIssuedByKnownRoot", val.is_issued_by_known_root);
-  dict.Set("verificationResult", val.default_result);
-  dict.Set("errorCode", val.error_code);
-  return ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("hostname", val.hostname)
+      .Set("certificate", val.certificate)
+      .Set("validatedCertificate", val.validated_certificate)
+      .Set("isIssuedByKnownRoot", val.is_issued_by_known_root)
+      .Set("verificationResult", val.default_result)
+      .Set("errorCode", val.error_code)
+      .Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<net::HttpVersion>::ToV8(
     v8::Isolate* isolate,
     const net::HttpVersion& val) {
-  auto dict = gin::Dictionary::CreateEmpty(isolate);
-  dict.Set("major", static_cast<uint32_t>(val.major_value()));
-  dict.Set("minor", static_cast<uint32_t>(val.minor_value()));
-  return ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("major", static_cast<uint32_t>(val.major_value()))
+      .Set("minor", static_cast<uint32_t>(val.minor_value()))
+      .Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<net::RedirectInfo>::ToV8(
     v8::Isolate* isolate,
     const net::RedirectInfo& val) {
-  auto dict = gin::Dictionary::CreateEmpty(isolate);
-
-  dict.Set("statusCode", val.status_code);
-  dict.Set("newMethod", val.new_method);
-  dict.Set("newUrl", val.new_url);
-  dict.Set("newSiteForCookies", val.new_site_for_cookies.RepresentativeUrl());
-  dict.Set("newReferrer", val.new_referrer);
-  dict.Set("insecureSchemeWasUpgraded", val.insecure_scheme_was_upgraded);
-  dict.Set("isSignedExchangeFallbackRedirect",
-           val.is_signed_exchange_fallback_redirect);
-
-  return ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("statusCode", val.status_code)
+      .Set("newMethod", val.new_method)
+      .Set("newUrl", val.new_url)
+      .Set("newSiteForCookies", val.new_site_for_cookies.RepresentativeUrl())
+      .Set("newReferrer", val.new_referrer)
+      .Set("insecureSchemeWasUpgraded", val.insecure_scheme_was_upgraded)
+      .Set("isSignedExchangeFallbackRedirect",
+           val.is_signed_exchange_fallback_redirect)
+      .Build();
 }
 
 // static
 v8::Local<v8::Value> Converter<net::IPEndPoint>::ToV8(
     v8::Isolate* isolate,
     const net::IPEndPoint& val) {
-  gin::Dictionary dict(isolate, v8::Object::New(isolate));
-  dict.Set("address", val.ToStringWithoutPort());
+  std::string_view family;
   switch (val.GetFamily()) {
-    case net::ADDRESS_FAMILY_IPV4: {
-      dict.Set("family", "ipv4");
+    case net::ADDRESS_FAMILY_IPV4:
+      family = "ipv4";
       break;
-    }
-    case net::ADDRESS_FAMILY_IPV6: {
-      dict.Set("family", "ipv6");
+    case net::ADDRESS_FAMILY_IPV6:
+      family = "ipv6";
       break;
-    }
-    case net::ADDRESS_FAMILY_UNSPECIFIED: {
-      dict.Set("family", "unspec");
+    case net::ADDRESS_FAMILY_UNSPECIFIED:
+      family = "unspec";
       break;
-    }
   }
-  return ConvertToV8(isolate, dict);
+  return gin::DataObjectBuilder(isolate)
+      .Set("address", val.ToStringWithoutPort())
+      .Set("family", family)
+      .Build();
 }
 
 // static

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -4,6 +4,7 @@
 
 #include "shell/common/gin_converters/net_converter.h"
 
+#include <map>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -164,20 +165,31 @@ v8::Local<v8::Value> Converter<net::CertPrincipal>::ToV8(
 v8::Local<v8::Value> Converter<net::HttpResponseHeaders*>::ToV8(
     v8::Isolate* isolate,
     net::HttpResponseHeaders* headers) {
-  base::DictValue response_headers;
+  // Build the {name: [value, ...]} object directly rather than round-tripping
+  // through an intermediate base::DictValue and content::V8ValueConverter.
+  // std::map preserves the alphabetically-sorted key order the previous
+  // implementation produced.
+  std::map<std::string, std::vector<std::string>> grouped;
   if (headers) {
     size_t iter = 0;
     std::string key;
     std::string value;
-    while (headers->EnumerateHeaderLines(&iter, &key, &value)) {
-      key = base::ToLowerASCII(key);
-      base::ListValue* values = response_headers.FindList(key);
-      if (!values)
-        values = &response_headers.Set(key, base::ListValue())->GetList();
-      values->Append(value);
-    }
+    while (headers->EnumerateHeaderLines(&iter, &key, &value))
+      grouped[base::ToLowerASCII(key)].push_back(std::move(value));
   }
-  return ConvertToV8(isolate, response_headers);
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  for (const auto& [key, values] : grouped) {
+    v8::Local<v8::Array> arr =
+        v8::Array::New(isolate, static_cast<int>(values.size()));
+    for (uint32_t i = 0; i < values.size(); ++i)
+      arr->CreateDataProperty(context, i, StringToV8(isolate, values[i]))
+          .Check();
+    result->CreateDataProperty(context, StringToSymbol(isolate, key), arr)
+        .Check();
+  }
+  return result;
 }
 
 bool Converter<net::HttpResponseHeaders*>::FromV8(
@@ -513,6 +525,7 @@ v8::Local<v8::Value> Converter<network::ResourceRequestBody>::ToV8(
     v8::Isolate* isolate,
     const network::ResourceRequestBody& val) {
   const auto& elements = *val.elements();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Array> arr = v8::Array::New(isolate, elements.size());
   for (size_t i = 0; i < elements.size(); ++i) {
     const auto& element = elements[i];
@@ -569,8 +582,8 @@ v8::Local<v8::Value> Converter<network::ResourceRequestBody>::ToV8(
       default:
         NOTREACHED() << "Found unsupported data element";
     }
-    arr->Set(isolate->GetCurrentContext(), static_cast<uint32_t>(i),
-             ConvertToV8(isolate, upload_data))
+    arr->CreateDataProperty(context, static_cast<uint32_t>(i),
+                            ConvertToV8(isolate, upload_data))
         .Check();
   }
   return arr;
@@ -642,7 +655,7 @@ v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
 // static
 v8::Local<v8::Value> Converter<electron::VerifyRequestParams>::ToV8(
     v8::Isolate* isolate,
-    electron::VerifyRequestParams val) {
+    const electron::VerifyRequestParams& val) {
   auto dict = gin::Dictionary::CreateEmpty(isolate);
   dict.Set("hostname", val.hostname);
   dict.Set("certificate", val.certificate);

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -94,7 +94,7 @@ struct Converter<network::ResourceRequest> {
 template <>
 struct Converter<electron::VerifyRequestParams> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   electron::VerifyRequestParams val);
+                                   const electron::VerifyRequestParams& val);
 };
 
 template <>
@@ -161,7 +161,9 @@ struct Converter<std::vector<std::pair<K, V>>> {
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
     v8::Local<v8::Object> obj = value.As<v8::Object>();
     v8::Local<v8::Array> keys = obj->GetPropertyNames(context).ToLocalChecked();
-    for (uint32_t i = 0; i < keys->Length(); ++i) {
+    const uint32_t length = keys->Length();
+    out->reserve(length);
+    for (uint32_t i = 0; i < length; ++i) {
       v8::Local<v8::Value> v8key;
       if (!keys->Get(context, i).ToLocal(&v8key))
         return false;
@@ -173,7 +175,7 @@ struct Converter<std::vector<std::pair<K, V>>> {
       if (!ConvertFromV8(isolate, v8key, &key) ||
           !ConvertFromV8(isolate, v8value, &out_value))
         return false;
-      (*out).emplace_back(std::move(key), std::move(out_value));
+      out->emplace_back(std::move(key), std::move(out_value));
     }
     return true;
   }

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -131,7 +131,8 @@ struct Converter<std::set<T>> {
     auto context = isolate->GetCurrentContext();
     uint32_t i = 0;
     for (const T& item : val) {
-      result->CreateDataProperty(context, i++, Converter<T>::ToV8(isolate, item))
+      result
+          ->CreateDataProperty(context, i++, Converter<T>::ToV8(isolate, item))
           .Check();
     }
     return result;

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -34,7 +34,7 @@ template <typename T>
 struct Converter<std::span<T>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const std::span<const T>& span) {
-    int idx = 0;
+    uint32_t idx = 0;
     auto context = isolate->GetCurrentContext();
     auto result = v8::Array::New(isolate, static_cast<int>(span.size()));
     for (const auto& val : span) {
@@ -42,7 +42,7 @@ struct Converter<std::span<T>> {
       v8::Local<v8::Value> element;
       if (!maybe.ToLocal(&element))
         return {};
-      if (!result->Set(context, idx++, element).FromMaybe(false))
+      if (!result->CreateDataProperty(context, idx++, element).FromMaybe(false))
         NOTREACHED() << "CreateDataProperty should always succeed here.";
     }
     return result;
@@ -129,10 +129,11 @@ struct Converter<std::set<T>> {
     v8::Local<v8::Array> result(
         v8::Array::New(isolate, static_cast<int>(val.size())));
     auto context = isolate->GetCurrentContext();
-    typename std::set<T>::const_iterator it;
-    int i;
-    for (i = 0, it = val.begin(); it != val.end(); ++it, ++i)
-      result->Set(context, i, Converter<T>::ToV8(isolate, *it)).Check();
+    uint32_t i = 0;
+    for (const T& item : val) {
+      result->CreateDataProperty(context, i++, Converter<T>::ToV8(isolate, item))
+          .Check();
+    }
     return result;
   }
   static bool FromV8(v8::Isolate* isolate,
@@ -150,7 +151,7 @@ struct Converter<std::set<T>> {
       if (!Converter<T>::FromV8(isolate,
                                 array->Get(context, i).ToLocalChecked(), &item))
         return false;
-      result.insert(item);
+      result.insert(std::move(item));
     }
 
     out->swap(result);
@@ -169,7 +170,8 @@ struct Converter<std::map<K, V>> {
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
     v8::Local<v8::Object> obj = value.As<v8::Object>();
     v8::Local<v8::Array> keys = obj->GetPropertyNames(context).ToLocalChecked();
-    for (uint32_t i = 0; i < keys->Length(); ++i) {
+    const uint32_t length = keys->Length();
+    for (uint32_t i = 0; i < length; ++i) {
       v8::MaybeLocal<v8::Value> maybe_v8key = keys->Get(context, i);
       if (maybe_v8key.IsEmpty())
         return false;
@@ -182,7 +184,7 @@ struct Converter<std::map<K, V>> {
       if (!ConvertFromV8(isolate, v8key, &key) ||
           !ConvertFromV8(isolate, maybe_v8value.ToLocalChecked(), &out_value))
         return false;
-      (*out)[key] = std::move(out_value);
+      (*out)[std::move(key)] = std::move(out_value);
     }
     return true;
   }

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -101,7 +101,7 @@ class Dictionary : public gin::Dictionary {
   }
 
   template <typename T>
-  bool SetHidden(std::string_view key, T val) {
+  bool SetHidden(std::string_view key, const T& val) {
     v8::Isolate* const iso = isolate();
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(iso, val, &v8_value))
@@ -146,9 +146,9 @@ class Dictionary : public gin::Dictionary {
                                       &acc_value))
                 return;
 
-              V val = acc_value.Value;
               v8::Local<v8::Value> v8_value;
-              if (gin::TryConvertToV8(info.GetIsolate(), val, &v8_value))
+              if (gin::TryConvertToV8(info.GetIsolate(), acc_value.Value,
+                                      &v8_value))
                 info.GetReturnValue().Set(v8_value);
             },
             nullptr, v8_value_accessor, attribute)
@@ -168,7 +168,7 @@ class Dictionary : public gin::Dictionary {
   // Note: If we plan to add more Set methods, consider adding an option instead
   // of copying code.
   template <typename T>
-  bool SetReadOnlyNonConfigurable(std::string_view key, T val) {
+  bool SetReadOnlyNonConfigurable(std::string_view key, const T& val) {
     v8::Local<v8::Value> v8_value;
     if (!gin::TryConvertToV8(isolate(), val, &v8_value))
       return false;


### PR DESCRIPTION
### Description of Change

Removes a handful of avoidable allocations, copies, and V8 boundary crossings from the gin converters and `gin_helper` paths used by `webRequest`, `sendInputEvent`, certificate/auth events, and a number of options-dictionary parsers.

- **`net_converter.{h,cc}`, `content_converter.cc`** — switch the plain-data `ToV8` converters (`AuthChallengeInfo`, `X509Certificate`, `CertPrincipal`, `HttpRequestHeaders`, `HttpVersion`, `RedirectInfo`, `IPEndPoint`, `ResourceRequest`, `VerifyRequestParams`, `Referrer`) from `gin::Dictionary` + N×`Set()` to `gin::DataObjectBuilder`, which internalizes property keys and uses `CreateDataProperty()`. `HttpResponseHeaders::ToV8` and `HttpRequestHeaders::FromV8` build from / read the V8 object directly instead of round-tripping through `base::DictValue` + `content::V8ValueConverter`.
- **`std_converter.h`** — `set`/`map` `FromV8` move the converted element/key into the container; `set`/`span` `ToV8` use `CreateDataProperty()`; hoist `keys->Length()` out of loops.
- **`net_converter.h`** — `vector<pair<K,V>>::FromV8` hoists `Length()` and `reserve()`s.
- **`blink_converter.cc`** — `WebKeyboardEvent::ToV8` caches `GetModifiers()` once; `ModifiersToArray` `reserve()`s.
- **`gfx_converter.cc`** — `ColorSpace::ToV8` uses `string_view` for the enum-name literals.
- **`guid_converter.h`** — `Uuid::FromV8` uses `ParseCaseInsensitive()`; `Uuid::ToV8` takes by `const&` and passes `AsLowercaseString()` through directly (drops two heap-allocated string copies).
- **`login_item_settings_converter.{h,cc}`** — `LaunchItem`/`LoginItemSettings` `ToV8` take by `const&`.
- **`gin_helper/dictionary.h`** — `SetHidden`/`SetReadOnlyNonConfigurable` take `T` by `const&`; `SetGetter` accessor avoids copying the value.

A behavior-equivalence fuzz across 31 input shapes (plain objects, getters, throwing getters, non-string values, numeric/symbol keys, frozen/null-proto, proxies, arrays, functions, primitives, unicode, invalid header names/values) confirms the touched converters produce byte-identical output for the same inputs, with one deliberate change: `webRequest`'s `requestHeaders` are now applied in the JS object's insertion order rather than alphabetically (the previous order was an artifact of `base::DictValue` being a sorted map).

### Benchmarks

Linux x86-64 testing build, microbenchmark medians:

| path | before | after | Δ |
|---|---:|---:|---:|
| `Converter<base::Uuid>::ToV8` | 320 ns | 92 ns | **−71%** |
| `Converter<net::AuthChallengeInfo>::ToV8` | 5974 ns | 2228 ns | **−63%** |
| `Converter<net::HttpRequestHeaders>::ToV8` (10 headers) | 12557 ns | 4885 ns | **−61%** |
| `Converter<net::CertPrincipal>::ToV8` | 9009 ns | 4090 ns | **−55%** |
| `Converter<net::HttpRequestHeaders>::FromV8` (10 headers) | 17255 ns | 8511 ns | **−51%** |
| `Converter<net::HttpResponseHeaders*>::ToV8` (16 lines) | 31539 ns | 18938 ns | **−40%** |
| `Converter<base::Uuid>::FromV8` | 561 ns | 425 ns | **−24%** |
| `Converter<std::set<string>>::FromV8` (long strings) | 7422 ns | 6056 ns | **−18%** |
| `Dictionary::SetHidden`/`SetReadOnlyNonConfigurable` | 3147 ns | 2627 ns | **−17%** |
| `Converter<std::span<int>>::ToV8` | 12027 ns | 10311 ns | **−14%** |
| `Converter<std::map<string,string>>::FromV8` (long strings) | 13050 ns | 11621 ns | **−11%** |
| `Converter<std::set<string>>::ToV8` | 3857 ns | 3485 ns | **−10%** |
| `Converter<blink::WebKeyboardEvent>::ToV8` | 15883 ns | 15428 ns | **−3%** |

### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR title follows [semantic commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#release-notes) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/electron/blob/main/docs/development/style-guide.md#release-notes)

### Release Notes

Notes: Improved performance of `webRequest` header conversions and several other gin converter hot paths.
