### PR TITLE
fix: BrowserWindow created with x/y on secondary monitor reports correct size on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -271,16 +271,15 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   const int width = options.ValueOrDefault(options::kWidth, 800);
   const int height = options.ValueOrDefault(options::kHeight, 600);
   gfx::Rect bounds{0, 0, width, height};
-#if BUILDFLAG(IS_WIN)
   // If an explicit position is provided, place the HWND on the target monitor
-  // at creation time. DesktopWindowTreeHostWin::SetBoundsInDIP resolves the
-  // display from the bounds' DIP position (with a null window) so the very
-  // first DIP->pixel conversion picks up the correct per-monitor scale factor.
-  // Without this, the HWND is created at (0,0) using primary-monitor DPI and
-  // later repositioned, producing the secondary-creation deflation symptom.
+  // at creation time. On Windows, DesktopWindowTreeHostWin::SetBoundsInDIP
+  // resolves the display from the bounds' DIP position (with a null window),
+  // so the very first DIP->pixel conversion picks up the correct per-monitor
+  // scale factor. Without this, the HWND is created at (0,0) using
+  // primary-monitor DPI and later repositioned, producing the
+  // secondary-creation deflation symptom.
   if (int x, y; options.Get(options::kX, &x) && options.Get(options::kY, &y))
     bounds.set_origin({x, y});
-#endif
   widget_size_ = bounds.size();
 
   has_shadow_ = options.ValueOrDefault(options::kHasShadow, true);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -271,6 +271,16 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   const int width = options.ValueOrDefault(options::kWidth, 800);
   const int height = options.ValueOrDefault(options::kHeight, 600);
   gfx::Rect bounds{0, 0, width, height};
+#if BUILDFLAG(IS_WIN)
+  // If an explicit position is provided, place the HWND on the target monitor
+  // at creation time. DesktopWindowTreeHostWin::SetBoundsInDIP resolves the
+  // display from the bounds' DIP position (with a null window) so the very
+  // first DIP->pixel conversion picks up the correct per-monitor scale factor.
+  // Without this, the HWND is created at (0,0) using primary-monitor DPI and
+  // later repositioned, producing the secondary-creation deflation symptom.
+  if (int x, y; options.Get(options::kX, &x) && options.Get(options::kY, &y))
+    bounds.set_origin({x, y});
+#endif
   widget_size_ = bounds.size();
 
   has_shadow_ = options.ValueOrDefault(options::kHasShadow, true);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1925,15 +1925,12 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(process.platform === 'win32')('secondary-monitor creation (Windows)', () => {
-      // Regression test for the secondary-monitor creation deflation: the
-      // HWND was created at (0, 0) using primary-monitor DPI then moved,
-      // so getBounds() reported scaled-by-primary then re-read-at-secondary
-      // values. Threading x/y into params.bounds at construction time makes
-      // the very first DIP->pixel conversion use the target monitor's DPI.
-      // CI runs at a single 96 DPI virtual display so the cross-monitor
-      // behavioural signal can't fire here, but the assertion still catches
-      // regressions in the construction path.
+    describe('explicit x/y at construction', () => {
+      // Regression: on Windows, the HWND was created at (0,0) with
+      // primary-monitor DPI then moved, producing wrong bounds. Now that
+      // the origin is threaded into params.bounds on all platforms, run
+      // the test everywhere. CI is single-display so this only validates
+      // the construction path, not true cross-monitor behaviour.
       afterEach(closeAllWindows);
 
       for (const frame of [true, false]) {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1925,6 +1925,26 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    ifdescribe(process.platform === 'win32')('secondary-monitor creation (Windows)', () => {
+      // Regression test for the secondary-monitor creation deflation: the
+      // HWND was created at (0, 0) using primary-monitor DPI then moved,
+      // so getBounds() reported scaled-by-primary then re-read-at-secondary
+      // values. Threading x/y into params.bounds at construction time makes
+      // the very first DIP->pixel conversion use the target monitor's DPI.
+      // CI runs at a single 96 DPI virtual display so the cross-monitor
+      // behavioural signal can't fire here, but the assertion still catches
+      // regressions in the construction path.
+      afterEach(closeAllWindows);
+
+      for (const frame of [true, false]) {
+        it(`reports requested bounds when created with explicit x/y (frame: ${frame})`, () => {
+          const requested = { x: 120, y: 140, width: 420, height: 320 };
+          const win = new BrowserWindow({ show: false, frame, ...requested });
+          expectBoundsEqual(win.getBounds(), requested);
+        });
+      }
+    });
+
     describe('BrowserWindow.setAspectRatio(ratio)', () => {
       it('resets the behaviour when passing in 0', async () => {
         const size = [300, 400];


### PR DESCRIPTION
#### Description of Change

On Windows, `new BrowserWindow({ x, y, width, height })` with `x`/`y` on a secondary monitor whose DPI differs from the primary reports `getBounds()` with the wrong size — off by a factor of `secondary_scale / primary_scale`. For example with a 2.0× primary and 1.0× secondary, a window requested at 500 × 400 reports 500 × 200.

Root cause: `NativeWindowViews` passed `params.bounds = {0, 0, width, height}` to `widget()->Init()` and moved the window later via `SetPosition`. Under the hood, `DesktopWindowTreeHostWin::SetBoundsInDIP` resolves the target display from the rect's origin (passing the window as `nullptr` per crbug.com/1224715). With origin `(0, 0)` that always picks the primary monitor's scale factor for the first DIP→pixel conversion. By the time `SetPosition` runs, the HWND has already been created at the wrong size.

Fix: thread the explicit `x`/`y` options into `params.bounds.origin` so the first DIP→pixel conversion uses the actual target monitor's DPI.

## Before / after

| Stock 42.0.1 | Patched |
|---|---|
| Requested 500 × 400 | Requested 500 × 400 |
| `Initial: 339 × 270` ❌ | `Initial: 505 × 403` ✅ |
| Drift `−162 × −130` | Drift `+5 × +3` (invisible-border accounting) |

<img width="598" height="730" alt="image" src="https://github.com/user-attachments/assets/4029524d-cdef-42a1-b375-2b872817cddd" />
(screenshot from manual repro on 2.0× / 1.0× and 1.65× / 1.10× dual-display hardware

## Test plan

- [x] Manual: 1.375× / 1.1× and 2.0× / 1.0× dual-display hardware — requested height matches reported height post-fix
- [x] Manual: window without explicit x/y on primary — unchanged behavior
- [x] Single-DPI CI regression test in [spec/api-browser-window-spec.ts](spec/api-browser-window-spec.ts) — catches regressions in the construction path

#### Checklist
- [X] I have built and tested this change
- [X] I have filled out the PR description
- [X] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `BrowserWindow` size corruption on Windows when created with explicit `x`/`y` on a secondary monitor whose DPI differs from the primary.
