### PR TITLE
refactor: use `std::optional<>` to aggregate optional fields

### DIFF
--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -145,23 +145,16 @@ void ServiceWorkerMain::Send(v8::Isolate* isolate,
 }
 
 void ServiceWorkerMain::InvalidateVersionInfo() {
-  if (version_info_ != nullptr) {
-    version_info_.reset();
-  }
+  version_info_.reset();
 
   if (version_destroyed_)
     return;
 
-  auto version_info = GetLiveVersionInfo(service_worker_context_, version_id_);
-  if (version_info) {
-    version_info_ =
-        std::make_unique<content::ServiceWorkerVersionBaseInfo>(*version_info);
-  } else {
-    // When ServiceWorkerContextCore::RemoveLiveVersion is called, it posts a
-    // task to notify that the service worker has stopped. At this point, the
-    // live version will no longer exist.
+  version_info_ = GetLiveVersionInfo(service_worker_context_, version_id_);
+
+  // if there's no version info, mark the version as destroyed
+  if (!version_info_)
     Destroy();
-  }
 }
 
 void ServiceWorkerMain::OnRunningStatusChanged(

--- a/shell/browser/api/electron_api_service_worker_main.h
+++ b/shell/browser/api/electron_api_service_worker_main.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_API_ELECTRON_API_SERVICE_WORKER_MAIN_H_
 
 #include <compare>
+#include <optional>
 #include <string>
 
 #include "base/memory/raw_ptr.h"
@@ -115,7 +116,7 @@ class ServiceWorkerMain final
 
   void InvalidateVersionInfo();
   const content::ServiceWorkerVersionBaseInfo* version_info() const {
-    return version_info_.get();
+    return version_info_ ? &*version_info_ : nullptr;
   }
 
   bool IsDestroyed() const;
@@ -138,7 +139,7 @@ class ServiceWorkerMain final
   bool redundant_ = false;
 
   // Store copy of version info so it's accessible when not running.
-  std::unique_ptr<content::ServiceWorkerVersionBaseInfo> version_info_;
+  std::optional<content::ServiceWorkerVersionBaseInfo> version_info_;
 
   raw_ptr<content::ServiceWorkerContext> service_worker_context_;
   mojo::AssociatedRemote<mojom::ElectronRenderer> remote_;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2211,7 +2211,7 @@ void WebContents::DraggableRegionsChanged(
     return;
   }
 
-  draggable_region_ = DraggableRegionsToSkRegion(regions);
+  draggable_region_.emplace(DraggableRegionsToSkRegion(regions));
 }
 
 #if BUILDFLAG(ENABLE_PRINTING)
@@ -2228,7 +2228,9 @@ void WebContents::PrintCrossProcessSubframe(
 #endif
 
 SkRegion* WebContents::draggable_region() {
-  return g_disable_draggable_regions ? nullptr : draggable_region_.get();
+  return g_disable_draggable_regions || !draggable_region_
+             ? nullptr
+             : &*draggable_region_;
 }
 
 void WebContents::DidStartNavigation(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -42,6 +42,7 @@
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/wrappable.h"
+#include "third_party/skia/include/core/SkRegion.h"
 #include "ui/base/models/image_model.h"
 #include "v8/include/cppgc/persistent.h"
 
@@ -95,7 +96,6 @@ class Cursor;
 }
 
 class DevToolsEyeDropper;
-class SkRegion;
 
 namespace electron {
 
@@ -895,7 +895,7 @@ class WebContents final : public ExclusiveAccessContext,
   // Stores the frame that's currently in fullscreen, nullptr if there is none.
   raw_ptr<content::RenderFrameHost> fullscreen_frame_ = nullptr;
 
-  std::unique_ptr<SkRegion> draggable_region_;
+  std::optional<SkRegion> draggable_region_;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
 };

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -64,7 +64,7 @@ JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop,
     : isolate_holder_{CreateIsolateHolder(
           Initialize(event_loop, setup_wasm_streaming),
           &max_young_generation_size_)},
-      locker_{std::make_unique<v8::Locker>(isolate())} {
+      locker_{std::in_place, isolate()} {
   v8::Isolate* const isolate = this->isolate();
   isolate->Enter();
 

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -6,8 +6,10 @@
 #define ELECTRON_SHELL_BROWSER_JAVASCRIPT_ENVIRONMENT_H_
 
 #include <memory>
+#include <optional>
 
 #include "uv.h"  // NOLINT(build/include_directory)
+#include "v8/include/v8-locker.h"
 
 namespace gin {
 class IsolateHolder;
@@ -20,7 +22,6 @@ class MultiIsolatePlatform;
 
 namespace v8 {
 class Isolate;
-class Locker;
 }  // namespace v8
 
 namespace electron {
@@ -57,7 +58,7 @@ class JavascriptEnvironment {
   std::unique_ptr<gin::IsolateHolder> isolate_holder_;
 
   // depends-on: isolate_holder_'s isolate
-  std::unique_ptr<v8::Locker> locker_;
+  std::optional<v8::Locker> locker_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;
 };

--- a/shell/browser/ui/drag_util.cc
+++ b/shell/browser/ui/drag_util.cc
@@ -10,11 +10,11 @@
 namespace electron {
 
 // Convert draggable regions in raw format to SkRegion format.
-std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
+SkRegion DraggableRegionsToSkRegion(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions) {
-  auto sk_region = std::make_unique<SkRegion>();
+  SkRegion sk_region;
   for (const auto& region : regions) {
-    sk_region->op(
+    sk_region.op(
         SkIRect::MakeLTRB(region->bounds.x(), region->bounds.y(),
                           region->bounds.right(), region->bounds.bottom()),
         region->draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);

--- a/shell/browser/ui/drag_util.h
+++ b/shell/browser/ui/drag_util.h
@@ -5,7 +5,6 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_DRAG_UTIL_H_
 #define ELECTRON_SHELL_BROWSER_UI_DRAG_UTIL_H_
 
-#include <memory>
 #include <vector>
 
 #include "third_party/blink/public/mojom/page/draggable_region.mojom-forward.h"
@@ -28,7 +27,7 @@ void DragFileItems(const std::vector<base::FilePath>& files,
                    gfx::NativeView view);
 
 // Convert draggable regions in raw format to SkRegion format.
-std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
+[[nodiscard]] SkRegion DraggableRegionsToSkRegion(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions);
 
 }  // namespace electron

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -98,8 +98,8 @@ bool WebContentsZoomController::SetZoomLevel(double level) {
       content::HostZoomMap::GetForWebContents(web_contents());
   DCHECK(zoom_map);
   DCHECK(!event_data_);
-  event_data_ = std::make_unique<ZoomChangedEventData>(
-      web_contents(), GetZoomLevel(), level, false /* temporary */, zoom_mode_);
+  event_data_.emplace(web_contents(), GetZoomLevel(), level,
+                      false /* temporary */, zoom_mode_);
 
   content::GlobalRenderFrameHostId rfh_id =
       web_contents()->GetPrimaryMainFrame()->GetGlobalId();
@@ -170,9 +170,8 @@ void WebContentsZoomController::SetZoomMode(ZoomMode new_mode) {
   double original_zoom_level = GetZoomLevel();
 
   DCHECK(!event_data_);
-  event_data_ = std::make_unique<ZoomChangedEventData>(
-      web_contents(), original_zoom_level, original_zoom_level,
-      false /* temporary */, new_mode);
+  event_data_.emplace(web_contents(), original_zoom_level, original_zoom_level,
+                      false /* temporary */, new_mode);
 
   switch (new_mode) {
     case ZOOM_MODE_DEFAULT: {
@@ -274,8 +273,8 @@ void WebContentsZoomController::ResetZoomModeOnNavigationIfNeeded(
   double new_zoom_level = zoom_map->GetZoomLevelForHostAndScheme(
       url.GetScheme(), net::GetHostOrSpecFromURL(url));
 
-  event_data_ = std::make_unique<ZoomChangedEventData>(
-      web_contents(), old_zoom_level, new_zoom_level, false, ZOOM_MODE_DEFAULT);
+  event_data_.emplace(web_contents(), old_zoom_level, new_zoom_level, false,
+                      ZOOM_MODE_DEFAULT);
 
   // The call to ClearTemporaryZoomLevel() doesn't generate any events from
   // HostZoomMap, but the call to UpdateState() at the end of

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -5,6 +5,8 @@
 #ifndef ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 #define ELECTRON_SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 
+#include <optional>
+
 #include "base/callback_list.h"
 #include "base/memory/raw_ptr.h"
 #include "base/observer_list.h"
@@ -160,7 +162,7 @@ class WebContentsZoomController
   int old_process_id_ = -1;
   int old_view_id_ = -1;
 
-  std::unique_ptr<ZoomChangedEventData> event_data_;
+  std::optional<ZoomChangedEventData> event_data_;
 
   raw_ptr<WebContentsZoomController> embedder_zoom_controller_ = nullptr;
 

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -136,7 +136,7 @@ void NodeService::Initialize(
   }
 #endif
 
-  js_env_ = std::make_unique<JavascriptEnvironment>(node_bindings_->uv_loop());
+  js_env_.emplace(node_bindings_->uv_loop());
 
   v8::Isolate* const isolate = js_env_->isolate();
   v8::HandleScope scope{isolate};

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_SERVICES_NODE_NODE_SERVICE_H_
 
 #include <memory>
+#include <optional>
 
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
@@ -15,6 +16,7 @@
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/mojom/host_resolver.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom-forward.h"
+#include "shell/browser/javascript_environment.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
 
 namespace node {
@@ -26,7 +28,6 @@ class Environment;
 namespace electron {
 
 class ElectronBindings;
-class JavascriptEnvironment;
 class NodeBindings;
 
 class URLLoaderBundle {
@@ -83,7 +84,7 @@ class NodeService : public node::mojom::NodeService {
   const std::unique_ptr<ElectronBindings> electron_bindings_;
 
   // depends-on: node_bindings_'s uv_loop
-  std::unique_ptr<JavascriptEnvironment> js_env_;
+  std::optional<JavascriptEnvironment> js_env_;
 
   // depends-on: js_env_'s isolate
   std::shared_ptr<node::Environment> node_env_;


### PR DESCRIPTION
#### Description of Change

When a class aggregates an optional field Foo, do so with `std::optional<Foo>` rather than `std::unique_ptr<Foo>`.

Inspiration from https://github.com/electron/electron/pull/51596, which did this on a `gin_helper::Locker` hot path.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.