### PR TITLE
refactor: simplify content_view_ hit-test transparency on macOS

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -92,7 +92,6 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   // Note that |GetContentsView|, confusingly, does not refer to the same thing
   // as |BaseWindow::GetContentView|.
   window()->GetContentsView()->AddChildViewAt(web_contents_view->view(), 0);
-  window()->set_content_view_hit_test_transparent(true);
   window()->GetContentsView()->DeprecatedLayoutImmediately();
 
   // Init window after everything has been setup.

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -375,12 +375,6 @@ class NativeWindow : public views::WidgetDelegate {
 
   views::Widget* widget() const { return widget_.get(); }
   views::View* content_view() const { return content_view_; }
-  bool content_view_hit_test_transparent() const {
-    return content_view_hit_test_transparent_;
-  }
-  void set_content_view_hit_test_transparent(bool transparent) {
-    content_view_hit_test_transparent_ = transparent;
-  }
 
   enum class TitleBarStyle : uint8_t {
     kNormal,
@@ -482,12 +476,6 @@ class NativeWindow : public views::WidgetDelegate {
   // constraints because converting between them will cause rounding errors
   // on HiDPI displays on some environments.
   std::optional<extensions::SizeConstraints> content_size_constraints_;
-
-  // BrowserWindow installs a sibling WebContentsView behind content_view().
-  // When enabled on macOS, hit-testing can treat content_view() as transparent
-  // if it has no interactive child at the target point and continue searching
-  // siblings behind it.
-  bool content_view_hit_test_transparent_ = false;
 
   base::queue<bool> pending_transitions_;
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "base/apple/scoped_cftyperef.h"
-#include "base/containers/adapters.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
 #include "components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
@@ -43,10 +42,10 @@
 #include "third_party/webrtc/modules/desktop_capture/mac/window_list_utils.h"
 #include "ui/base/hit_test.h"
 #include "ui/display/screen.h"
+#include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gl/gpu_switching_manager.h"
 #include "ui/views/background.h"
 #include "ui/views/cocoa/native_widget_mac_ns_window_host.h"
-#include "ui/views/rect_based_targeting_utils.h"
 #include "ui/views/view_targeter.h"
 #include "ui/views/view_targeter_delegate.h"
 #include "ui/views/widget/widget.h"
@@ -118,58 +117,43 @@ struct Converter<electron::NativeWindowMac::VisualEffectState> {
 
 namespace {
 
-// A ViewTargeterDelegate installed on RootViewMac to make BrowserWindow's
-// content_view_ act like a transparent overlay when it has no interactive child
-// at the target point.
+// A ViewTargeterDelegate installed on content_view_ that makes it
+// hit-test-transparent except where one of its descendants covers the
+// target rect.
 //
-// In BrowserWindow, the WebContentsView is added as a sibling of content_view_
-// at a lower Z-order (behind it) so that user-added child views paint above
-// the web content. However, views::ViewTargeterDelegate::TargetForRect
-// iterates children front-to-back and returns the first child whose
-// HitTestRect() is true. content_view_ covers the full window area, so the
-// WebContentsView (and its NativeViewHost) is never reached.
+// In BrowserWindow, the WebContentsView is added as a sibling of
+// content_view_ at a lower z-order so that user-added child views paint
+// above web content. content_view_ itself covers the full window, so the
+// default DoesIntersectRect (a bounds check) would always return true and
+// the parent targeter would stop there, never reaching the WebContentsView
+// behind it. By only intersecting where a child actually does, the parent's
+// default TargetForRect loop skips content_view_ and falls through to the
+// sibling, ultimately resolving to the WebContentsView's NativeViewHost so
+// BridgedContentView::hitTest: routes the event to RenderWidgetHostViewCocoa.
 //
-// Keep sibling traversal in the parent targeter so content_view_ can act
-// transparently here while hit-testing continues to the views behind it.
-class RootViewMacTargeterDelegate : public views::ViewTargeterDelegate {
+// This must never affect TargetForRect's contract — it only narrows
+// HitTestRect, which the default loop already handles by skipping the child.
+// Returning nullptr from TargetForRect (the previous approach) violated the
+// contract and crashed RootView::UpdateCursor (see #51576).
+class ContentViewTargeterDelegate : public views::ViewTargeterDelegate {
  public:
-  explicit RootViewMacTargeterDelegate(electron::NativeWindowMac* window)
-      : window_(window) {}
-
-  views::View* TargetForRect(views::View* root,
-                             const gfx::Rect& rect) override {
-    if (!window_->content_view_hit_test_transparent() ||
-        !window_->content_view() || !views::UsePointBasedTargeting(rect)) {
-      return views::ViewTargeterDelegate::TargetForRect(root, rect);
+  bool DoesIntersectRect(const views::View* target,
+                         const gfx::Rect& rect) const override {
+    if (!views::ViewTargeterDelegate::DoesIntersectRect(target, rect)) {
+      return false;
     }
-
-    views::View* skipped_content_view = nullptr;
-    views::View::Views children = root->GetChildrenInZOrder();
-    for (views::View* child : base::Reversed(children)) {
-      if (!child->GetCanProcessEventsWithinSubtree() || !child->GetVisible()) {
+    for (const views::View* child : target->children()) {
+      if (!child->GetVisible() || !child->GetCanProcessEventsWithinSubtree()) {
         continue;
       }
-
-      gfx::Rect rect_in_child_coords =
-          views::View::ConvertRectToTarget(root, child, rect);
-      if (!child->HitTestRect(rect_in_child_coords)) {
-        continue;
+      gfx::RectF rect_in_child(rect);
+      views::View::ConvertRectToTarget(target, child, &rect_in_child);
+      if (child->HitTestRect(gfx::ToEnclosingRect(rect_in_child))) {
+        return true;
       }
-
-      views::View* target = child->GetEventHandlerForRect(rect_in_child_coords);
-      if (child == window_->content_view() && target == child) {
-        skipped_content_view = child;
-        continue;
-      }
-
-      return target;
     }
-
-    return skipped_content_view ? skipped_content_view : root;
+    return false;
   }
-
- private:
-  raw_ptr<electron::NativeWindowMac> window_;
 };
 
 }  // namespace
@@ -185,8 +169,6 @@ NativeWindowMac::NativeWindowMac(const int32_t base_window_id,
       root_view_(new RootViewMac(this)) {
   ui::NativeTheme::GetInstanceForNativeUi()->AddObserver(this);
   display::Screen::Get()->AddObserver(this);
-  root_view_->SetEventTargeter(std::make_unique<views::ViewTargeter>(
-      std::make_unique<RootViewMacTargeterDelegate>(this)));
 
   int width = options.ValueOrDefault(options::kWidth, 800);
   int height = options.ValueOrDefault(options::kHeight, 600);
@@ -393,6 +375,11 @@ void NativeWindowMac::SetContentView(views::View* view) {
     root_view->RemoveChildView(content_view());
 
   set_content_view(view);
+
+  // Make content_view_ hit-test-transparent where it has no covering child
+  // so events fall through to the sibling WebContentsView in BrowserWindow.
+  view->SetEventTargeter(std::make_unique<views::ViewTargeter>(
+      std::make_unique<ContentViewTargeterDelegate>()));
 
   root_view->AddChildViewRaw(content_view());
 


### PR DESCRIPTION
#### Description of Change

Replaces the fix for #51576 that landed in #51586 with a more scoped one. Same crash fix, much smaller surface.

##### Background

For `BrowserWindow` on macOS, the `WebContentsView` is added as a *sibling* of `content_view_` at lower z-order so that user-added child views paint above web content. But `content_view_` covers the whole window, so the default `views` hit-test always stops at `content_view_` before reaching the `WebContentsView`. After Chromium [CL:6574464](https://chromium-review.googlesource.com/c/chromium/src/+/6574464) (M139) changed `BridgedContentView::hitTest:` to use `GetHitTestResult()`, any non-`NativeViewHost` hit result causes `BridgedContentView` to swallow the event — so all `loadURL` page interaction broke. #50330 worked around this by making `ContentViewTargeterDelegate::TargetForRect` return `nullptr` when no descendant of `content_view_` covered the hit rect, so the result would propagate up as null → `kOther` → `[super hitTest:]` finds `RenderWidgetHostViewCocoa`.

Returning `nullptr` from `ViewTargeterDelegate::TargetForRect` violates its contract — for any in-bounds point it must resolve to a descendant or the root, never null (`ui/views/view_targeter_delegate.h`, `ui/views/view.h`). `RootView::UpdateCursor` and `RootView::HandleMouseEnteredOrMoved` both call `GetEventHandlerForPoint()` and dereference the result without a null check (`ui/views/widget/root_view.cc:851-853`, `:864-871`). When a right-click in a `-webkit-app-region: drag` region temporarily disables draggable regions ([`electron_ns_window.mm`](https://github.com/electron/electron/blob/main/shell/browser/ui/cocoa/electron_ns_window.mm#L224-L242)), the `HTCAPTION` early-exit no longer fires, the views path runs, and the `nullptr` SEGVs (#51576).

##### Why #51586 wasn't the right shape

#51586 fixed the crash, but did so by moving the transparency logic to a new targeter on `RootViewMac` that **re-implements `views::ViewTargeterDelegate::TargetForRect`'s child-walk loop** so it can skip `content_view_` and pick a sibling. That has several problems:

1. **It duplicates ~25 lines of upstream logic** that is exactly the part of `views` most likely to change (mirroring, layer transforms, visibility semantics, rounding mode). Any upstream change to that loop now needs to be ported by hand or the two will silently diverge.
2. **It already has one divergence baked in.** It uses `View::ConvertRectToTarget(root, child, rect)` (the `gfx::Rect` overload, which rounds inward via `ToEnclosedRectIgnoringError`), while the upstream loop converts to a `gfx::RectF` and rounds **outward** via `ToEnclosingRect`. For a 1×1 hit rect on a fractional-DPI display, those can disagree.
3. **It only special-cases point-based targeting** (`UsePointBasedTargeting(rect)`), so rect-based/touch targeting still falls through to the default — which returns `content_view_` → `kRootView` — i.e. the original `loadURL`-interaction bug is still live for the non-point path. #50330 covered both.
4. **It leaks a macOS-only quirk into the platform-neutral surface.** `native_window.h` (the cross-platform base) grew a `content_view_hit_test_transparent_` flag + getter + setter that only `native_window_mac.mm` reads, and `BrowserWindow`'s constructor (also platform-neutral) grew a `set_content_view_hit_test_transparent(true)` that does nothing on Windows/Linux.
5. **Latent footgun:** the `return skipped_content_view ? skipped_content_view : root;` fallback returns `content_view_` → `kRootView` → swallowed — the exact behavior #50330 was fixing. It's unreachable today only because `WebContentsView` always covers the window; if the view structure changes, this re-introduces the bug.
6. **It conflates two responsibilities.** "I am a transparent overlay" is a property of `content_view_`, not something its parent's targeter should have special knowledge of.

##### What this PR does instead

The `views` hit-test machinery already has a hook for "is this view opaque to events at this rect?" — `ViewTargeterDelegate::DoesIntersectRect`, which `View::HitTestRect` consults. The parent's *default* `TargetForRect` loop already checks `child->HitTestRect()` and skips children that say no ([`view_targeter_delegate.cc:61-63`](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/view_targeter_delegate.cc;l=61-63)). So we can fix #50330 in place: keep the targeter on `content_view_`, keep the same install site in `SetContentView`, and override `DoesIntersectRect` to return `false` when no visible, processable child of `content_view_` covers the rect. The parent's default loop then falls through to the `WebContentsView` sibling and resolves to its `NativeViewHost` — `kSubView` → routes to `RenderWidgetHostViewCocoa` — without ever returning `nullptr` from `TargetForRect` or duplicating the upstream walk.

This reverts the `NativeWindow` flag, the `BrowserWindow` constructor change, and `RootViewMacTargeterDelegate`. The net change vs the buggy #50330 state is a single method-body swap inside `native_window_mac.mm`.

##### Verification

Verified on macOS 26.4 (25E246), arm64, driving input with real OS-level `CGEventPost` events so the `NSWindow` → `BridgedContentView::hitTest:` → `RootView::UpdateCursor` → targeter path is actually exercised:

- **`loadURL` interaction** (the #50330 regression check): button click, input focus + typing, hover → `pointingHand` cursor, link click — all work.
- **Right-click in `-webkit-app-region: drag`** (the #51576 crash check): right-click bar, mouse-move over bar, drag (window moved), Ctrl+click, right/left-click content — no SIGSEGV on any step.
- **Child `WebContentsView` over web content**: clicking a `WebContentsView` overlaid on `content_view_` and clicking the background page both route correctly; `DoesIntersectRect` returns true over the overlay child and false outside it.
- `api-browser-window-spec.ts -g "BrowserView|contentView|setContentView"`: 4/4. `api-web-contents-view-spec.ts`: 29/29. `drag-region-spec.ts`: 6/6 (8 skip, non-macOS).

##### Backports

- `41-x-y` is **not affected** — #50330 was never backported there; the original Chromium revert patch is still in place. (#51611 was correctly closed unmerged.)
- `42-x-y` / `43-x-y`: the open #51586 backports (#51605, #51606) should be replaced with backports of this PR once it lands.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
