### PR TITLE
chore: cherry-pick 20 security fixes for 40-x-y

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,3 +1,6 @@
 optionally_validate_gl_max_uniform_blocks_at_compile_time.patch
 cherry-pick-cl-7708753.patch
 cherry-pick-6d8b704e2a.patch
+cherry-pick-7695232.patch
+cherry-pick-7712217.patch
+cherry-pick-7722080.patch

--- a/patches/angle/cherry-pick-7695232.patch
+++ b/patches/angle/cherry-pick-7695232.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Mon, 23 Mar 2026 17:32:05 -0400
+Subject: D3D11: Protect against overflows for texture staging buffers
+
+When TextureStorage11 needs to calculate sizes of intermediate buffers
+for data conversion, do the math in 64-bit using CheckedNumerics.
+Validate that the results fit into 32 bits.
+
+Bug: chromium:491760376
+Change-Id: Ie5942291fe7790c229cb1070fa9a2325fa40ac2f
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7695232
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+
+diff --git a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
+index 7ffc190cbc798161be6c5b801459e73c35253e68..93607bc7cbe495dfe14c6231218cc4d992ce0888 100644
+--- a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
++++ b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.cpp
+@@ -17,6 +17,7 @@
+ #include <tuple>
+ 
+ #include "common/MemoryBuffer.h"
++#include "common/base/anglebase/numerics/checked_math.h"
+ #include "common/utilities.h"
+ #include "image_util/loadimage.h"
+ #include "libANGLE/Context.h"
+@@ -902,22 +903,35 @@ angle::Result TextureStorage11::setData(const gl::Context *context,
+ 
+     const d3d11::Format &d3d11Format =
+         d3d11::Format::Get(image->getInternalFormat(), mRenderer->getRenderer11DeviceCaps());
+-    const d3d11::DXGIFormatSize &dxgiFormatInfo =
+-        d3d11::GetDXGIFormatSizeInfo(d3d11Format.texFormat);
+ 
+-    const size_t outputPixelSize = dxgiFormatInfo.pixelBytes;
+-
+-    UINT bufferRowPitch   = static_cast<unsigned int>(outputPixelSize) * width;
+-    UINT bufferDepthPitch = bufferRowPitch * height;
+-
+-    const size_t neededSize               = bufferDepthPitch * depth;
+     angle::MemoryBuffer *conversionBuffer = nullptr;
+     const uint8_t *data                   = nullptr;
++    UINT bufferRowPitch                   = 0;
++    UINT bufferDepthPitch                 = 0;
+ 
+     LoadImageFunctionInfo loadFunctionInfo = d3d11Format.getLoadFunctions()(type);
+     if (loadFunctionInfo.requiresConversion)
+     {
+-        ANGLE_TRY(mRenderer->getScratchMemoryBuffer(context11, neededSize, &conversionBuffer));
++        const d3d11::DXGIFormatSize &dxgiFormatInfo =
++            d3d11::GetDXGIFormatSizeInfo(d3d11Format.texFormat);
++
++        const size_t outputPixelSize = dxgiFormatInfo.pixelBytes;
++
++        angle::CheckedNumeric<uint64_t> checkedBufferRowPitch = outputPixelSize;
++        checkedBufferRowPitch *= static_cast<uint64_t>(width);
++
++        angle::CheckedNumeric<uint64_t> checkedBufferDepthPitch = checkedBufferRowPitch * height;
++        angle::CheckedNumeric<uint64_t> checkedNeededSize       = checkedBufferDepthPitch * depth;
++
++        ANGLE_CHECK_GL_MATH(context11, checkedNeededSize.IsValid<size_t>() &&
++                                           checkedBufferRowPitch.IsValid<UINT>() &&
++                                           checkedBufferDepthPitch.IsValid<UINT>());
++
++        bufferRowPitch   = checkedBufferRowPitch.ValueOrDie<UINT>();
++        bufferDepthPitch = checkedBufferDepthPitch.ValueOrDie<UINT>();
++
++        ANGLE_TRY(mRenderer->getScratchMemoryBuffer(
++            context11, checkedNeededSize.ValueOrDie<size_t>(), &conversionBuffer));
+         loadFunctionInfo.loadFunction(mRenderer->getDisplay()->getImageLoadContext(), width, height,
+                                       depth, pixelData + srcSkipBytes, srcRowPitch, srcDepthPitch,
+                                       conversionBuffer->data(), bufferRowPitch, bufferDepthPitch);
+diff --git a/src/tests/gl_tests/TextureTest.cpp b/src/tests/gl_tests/TextureTest.cpp
+index 890d4defd1838d8eff612e4e81f10850fb278292..502aa7bb759593996837d5653413e89d513c87e0 100644
+--- a/src/tests/gl_tests/TextureTest.cpp
++++ b/src/tests/gl_tests/TextureTest.cpp
+@@ -17340,6 +17340,23 @@ TEST_P(TextureBufferTestES31, TexBufferFormatMismatch)
+     }
+ }
+ 
++// Test that uploading a max size texture with large formats does not crash.
++TEST_P(Texture2DTestES3, LargeTextureOverflow)
++{
++    // Some backends generate internal errors for OOM. That's OK as long as they don't crash.
++    ScopedIgnorePlatformMessages ignore;
++
++    GLint maxTextureSize;
++    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
++
++    GLTexture texture;
++    glBindTexture(GL_TEXTURE_2D, texture);
++
++    // This may succeed or generate an error about overflows but it should not crash.
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB32F, maxTextureSize, maxTextureSize, 0, GL_RGB, GL_FLOAT,
++                 nullptr);
++}
++
+ // Create an integer format texture but specify a FLOAT sampler. OpenGL
+ // tolerates this but it causes a Vulkan validation error.
+ TEST_P(Texture2DTestES3, TexImageFormatMismatch)

--- a/patches/angle/cherry-pick-7712217.patch
+++ b/patches/angle/cherry-pick-7712217.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charlie Lao <cclao@google.com>
+Date: Mon, 30 Mar 2026 12:01:45 -0700
+Subject: Vulkan: Fix heap-buffer-overflow in convertVertexBufferCPU
+
+There was a bug in vulkan backend
+VertexArrayVk::convertVertexBufferCPU() that it streams more data than
+buffer it allocates. A test has been added to expose the
+heap-buffer-overflow bug. The bug is also fixed in the CL.
+
+Bug: b/496503799
+Change-Id: I79f8619699a9c82ea7d35e4849edfb91866c3623
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7712217
+Reviewed-by: Amirali Abdolrashidi <abdolrashidi@google.com>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Commit-Queue: Charlie Lao <cclao@google.com>
+
+diff --git a/src/libANGLE/renderer/vulkan/VertexArrayVk.cpp b/src/libANGLE/renderer/vulkan/VertexArrayVk.cpp
+index dc3b832ac0d4d0a2a530ca7fe28e1066648ccaf3..e96a7db8ee87a6d361c12e3439a98020f5a17d49 100644
+--- a/src/libANGLE/renderer/vulkan/VertexArrayVk.cpp
++++ b/src/libANGLE/renderer/vulkan/VertexArrayVk.cpp
+@@ -719,17 +719,21 @@ angle::Result VertexArrayVk::convertVertexBufferCPU(ContextVk *contextVk,
+                 continue;
+             }
+ 
++            // Use numVertices instead of maxNumVertices to calculate bytesToCopy to avoid buffer
++            // overrun.
+             uint32_t srcOffset, dstOffset, numVertices;
+             CalculateOffsetAndVertexCountForDirtyRange(srcBuffer, conversion, srcFormat, dstFormat,
+                                                        dirtyRange, &srcOffset, &dstOffset,
+                                                        &numVertices);
++            ASSERT(numVertices <= maxNumVertices);
+ 
+             if (numVertices > 0)
+             {
+                 const uint8_t *srcBytes = src + srcOffset;
+-                size_t bytesToCopy      = maxNumVertices * dstFormat.pixelBytes;
++
++                size_t bytesToCopy = numVertices * dstFormat.pixelBytes;
+                 ANGLE_TRY(StreamVertexData(contextVk, conversion->getBuffer(), srcBytes,
+-                                           bytesToCopy, dstOffset, maxNumVertices, srcStride,
++                                           bytesToCopy, dstOffset, numVertices, srcStride,
+                                            vertexLoadFunction));
+             }
+         }
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index 6659512c2e33e5296a8a814f426f0fc09a1f0cd0..f616328d5fe7a71aec5755653cf468b788b342a7 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -2152,6 +2152,8 @@
+ 
+ // WebGPU does not support BGRA
+ 42267264 WGPU : ClearTest.*BGRA* = SKIP
++// WebGPU error BufferOffset (5242862) is not a multiple of 4.
++496503799 WGPU : BufferDataTest.UnalignedVertexAttribPointer/* = SKIP
+ 
+ // Fails on Mac & OpenGL & NVIDIA
+ 406807990 MAC NVIDIA OPENGL : TextureUploadFormatTest_ES3.AllWithPBO/* = SKIP
+diff --git a/src/tests/gl_tests/BufferDataTest.cpp b/src/tests/gl_tests/BufferDataTest.cpp
+index f9960a42077b54557e7e4ad4de16d3d8bd9287b1..fc4e76c18c64b69bf6af2e556f092217a6e6e72e 100644
+--- a/src/tests/gl_tests/BufferDataTest.cpp
++++ b/src/tests/gl_tests/BufferDataTest.cpp
+@@ -1376,6 +1376,67 @@ void main()
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::cyan);
+ }
+ 
++// Tests unaligned vertex attribute pointer, which should get to convertVertexBufferCPU in vulkan
++// backend.
++TEST_P(BufferDataTest, UnalignedVertexAttribPointer)
++{
++    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), essl1_shaders::fs::UniformColor());
++    glUseProgram(program);
++
++    GLint positionLocation = glGetAttribLocation(program, essl1_shaders::PositionAttrib());
++    ASSERT_NE(positionLocation, -1);
++    glEnableVertexAttribArray(positionLocation);
++
++    GLint colorUniformLocation =
++        glGetUniformLocation(program, angle::essl1_shaders::ColorUniform());
++    ASSERT_NE(colorUniformLocation, -1);
++
++    // Allocate 8MB buffer to force non sub-allocation path
++    constexpr GLsizeiptr kBufferSize = 8 * 1024 * 1024;
++    std::vector<uint8_t> initialData(kBufferSize, 0);
++
++    GLBuffer positionBuffer;
++    glBindBuffer(GL_ARRAY_BUFFER, positionBuffer);
++    glBufferData(GL_ARRAY_BUFFER, kBufferSize, initialData.data(), GL_DYNAMIC_DRAW);
++
++    // Trigger CPU downgrade conversion with unaligned stride/offset
++    const GLsizei stride      = 13;
++    const GLintptr offset     = 1;
++    const GLint components    = 3;
++    const GLsizei typeSize    = sizeof(GLfloat);
++    const GLsizei elementSize = components * typeSize;  // 12
++
++    // Calculate vertexCount equivalent to Math.floor in JS
++    GLsizei vertexCount     = (kBufferSize - offset - elementSize) / stride + 1;
++    GLsizei quadVertexCount = (vertexCount / 6) * 6;
++    GLsizei firstVertex     = vertexCount - quadVertexCount;
++
++    glVertexAttribPointer(positionLocation, components, GL_FLOAT, GL_FALSE, stride,
++                          reinterpret_cast<const void *>(offset));
++
++    // First draw: establishes the conversion buffer
++    glDrawArrays(GL_TRIANGLES, firstVertex, quadVertexCount);
++    // CRITICAL: glFinish() forces GPU pipeline flush, preventing buffer reallocation
++    glFinish();
++
++    // SubData near the end - must be >= 12 bytes to break ANGLE's dirty-range short-circuit
++    const std::array<Vector3, 6> &quadVertices = GetQuadVertices();
++    std::vector<uint8_t> updateData(stride * 6);
++    for (int vertexIndex = 0; vertexIndex < 6; vertexIndex++)
++    {
++        memcpy(updateData.data() + stride * vertexIndex, quadVertices[vertexIndex].data(),
++               quadVertices[vertexIndex].size() * sizeof(float));
++    }
++    GLintptr lastQuadVertexStartPtr = offset + (vertexCount - 6) * stride;
++    glBufferSubData(GL_ARRAY_BUFFER, lastQuadVertexStartPtr, updateData.size(), updateData.data());
++
++    // Draw green quad. This should trigger partial update but should not access out of bounds
++    glClear(GL_COLOR_BUFFER_BIT);
++    glUniform4fv(colorUniformLocation, 1, &kFloatGreen.R);
++    glDrawArrays(GL_TRIANGLES, firstVertex, quadVertexCount);
++    EXPECT_PIXEL_RECT_EQ(0, 0, getWindowWidth(), getWindowHeight(), GLColor::green);
++}
++
+ // Verify that previous draws are not affected when a buffer is respecified with null data
+ // and updated by calling map.
+ TEST_P(BufferDataTestES3, BufferDataWithNullFollowedByMap)

--- a/patches/angle/cherry-pick-7722080.patch
+++ b/patches/angle/cherry-pick-7722080.patch
@@ -1,0 +1,105 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Geoff Lang <geofflang@chromium.org>
+Date: Wed, 1 Apr 2026 15:54:06 -0400
+Subject: Metal: Store LibraryCacheEntry in a shared_ptr
+
+This ensures that if an entry is removed from the cache while it is
+compiling, it is not deleted until it is fully unreferenced.
+
+If there were > kMaxCachedLibraries simultaneous compile requests, it
+was possible that the cache gets trimmed while threads are compiling and
+we can end up writing to removed cache entries.
+
+Bug: chromium:497724490
+Change-Id: Iba4281d5d12c6882de51fc1bf88d60157ffc7fb6
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7722080
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: dan sinclair <dsinclair@chromium.org>
+
+diff --git a/src/libANGLE/renderer/metal/mtl_library_cache.h b/src/libANGLE/renderer/metal/mtl_library_cache.h
+index d936e6a4aeec66c66ae9b4203c61c9480b68563b..93dfc15cad79e7963b53609eee889f705b201c8a 100644
+--- a/src/libANGLE/renderer/metal/mtl_library_cache.h
++++ b/src/libANGLE/renderer/metal/mtl_library_cache.h
+@@ -77,7 +77,7 @@ class LibraryCache : angle::NonCopyable
+         std::mutex lock;
+     };
+ 
+-    LibraryCacheEntry &getCacheEntry(LibraryKey &&key);
++    std::shared_ptr<LibraryCacheEntry> getCacheEntry(LibraryKey &&key);
+ 
+     static constexpr unsigned int kMaxCachedLibraries = 128;
+ 
+@@ -87,7 +87,8 @@ class LibraryCache : angle::NonCopyable
+     // Lock for searching and adding new entries to the cache
+     std::mutex mCacheLock;
+ 
+-    using CacheMap = angle::base::HashingMRUCache<LibraryKey, LibraryCacheEntry, LibraryKeyHasher>;
++    using CacheMap = angle::base::
++        HashingMRUCache<LibraryKey, std::shared_ptr<LibraryCacheEntry>, LibraryKeyHasher>;
+     CacheMap mCache;
+ };
+ 
+diff --git a/src/libANGLE/renderer/metal/mtl_library_cache.mm b/src/libANGLE/renderer/metal/mtl_library_cache.mm
+index 5fb63eaa41cd0520e1210c175ce1253c71ec7486..27512a19defd8f59903b645b0218eaf9468ba7e0 100644
+--- a/src/libANGLE/renderer/metal/mtl_library_cache.mm
++++ b/src/libANGLE/renderer/metal/mtl_library_cache.mm
+@@ -36,15 +36,15 @@
+                                                  bool usesInvariance)
+ {
+     ASSERT(source != nullptr);
+-    LibraryCache::LibraryCacheEntry &entry =
++    std::shared_ptr<LibraryCache::LibraryCacheEntry> entry =
+         getCacheEntry(LibraryKey(source, macros, disableFastMath, usesInvariance));
+ 
+     // Try to lock the entry and return the library if it exists. If we can't lock then it means
+     // another thread is currently compiling.
+-    std::unique_lock<std::mutex> entryLockGuard(entry.lock, std::try_to_lock);
++    std::unique_lock<std::mutex> entryLockGuard(entry->lock, std::try_to_lock);
+     if (entryLockGuard)
+     {
+-        return entry.library;
++        return entry->library;
+     }
+     else
+     {
+@@ -69,23 +69,23 @@
+     }
+ 
+     ASSERT(source != nullptr);
+-    LibraryCache::LibraryCacheEntry &entry =
++    std::shared_ptr<LibraryCache::LibraryCacheEntry> entry =
+         getCacheEntry(LibraryKey(source, macros, disableFastMath, usesInvariance));
+ 
+     // Lock this cache entry while compiling the shader. This causes other threads calling this
+     // function to wait and not duplicate the compilation.
+-    std::lock_guard<std::mutex> entryLockGuard(entry.lock);
+-    if (entry.library)
++    std::lock_guard<std::mutex> entryLockGuard(entry->lock);
++    if (entry->library)
+     {
+-        return entry.library;
++        return entry->library;
+     }
+ 
+-    entry.library = CreateShaderLibrary(metalDevice, *source, macros, disableFastMath,
+-                                        usesInvariance, errorOut);
+-    return entry.library;
++    entry->library = CreateShaderLibrary(metalDevice, *source, macros, disableFastMath,
++                                         usesInvariance, errorOut);
++    return entry->library;
+ }
+ 
+-LibraryCache::LibraryCacheEntry &LibraryCache::getCacheEntry(LibraryKey &&key)
++std::shared_ptr<LibraryCache::LibraryCacheEntry> LibraryCache::getCacheEntry(LibraryKey &&key)
+ {
+     // Lock while searching or adding new items to the cache.
+     std::lock_guard<std::mutex> cacheLockGuard(mCacheLock);
+@@ -98,7 +98,7 @@
+ 
+     angle::TrimCache(kMaxCachedLibraries, kGCLimit, "metal library", &mCache);
+ 
+-    iter = mCache.Put(std::move(key), LibraryCacheEntry());
++    iter = mCache.Put(std::move(key), std::make_shared<LibraryCacheEntry>());
+     return iter->second;
+ }
+ 

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -190,3 +190,17 @@ cherry-pick-d141d62357df.patch
 cherry-pick-848cf5567223.patch
 cherry-pick-cve-2026-6920.patch
 fix_make_macos_text_replacement_work_on_contenteditable.patch
+cherry-pick-7695218.patch
+cherry-pick-7695435.patch
+cherry-pick-7701234.patch
+cherry-pick-7718624.patch
+cherry-pick-7722343.patch
+cherry-pick-7722499.patch
+cherry-pick-7723101.patch
+cherry-pick-7726850.patch
+cherry-pick-7726886.patch
+cherry-pick-7727919.patch
+cherry-pick-7737952.patch
+cherry-pick-7779792.patch
+cherry-pick-7791302.patch
+cherry-pick-7800635.patch

--- a/patches/chromium/cherry-pick-7695218.patch
+++ b/patches/chromium/cherry-pick-7695218.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Cheng <dcheng@chromium.org>
+Date: Wed, 13 May 2026 13:42:33 -0700
+Subject: Avoid unsafe buffers in StringView(view, offset, length) constructor.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use the subspan() method which will perform these bounds checks
+under the covers before extracting a data() pointer.
+
+This is a simpler way to get part of the benefit of the CL at
+https://crrev.com/c/7667267 but without the performance impact
+of making all the other methods touched in that CL safe.
+
+-- Do the same for StringView::Set().
+
+Bug: 492350406
+Change-Id: If2741f7241204862d28f3b662d897f9cba3e0b1c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7695218
+Reviewed-by: Dominik Röttsches <drott@chromium.org>
+Commit-Queue: Daniel Cheng <dcheng@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1602363}
+
+diff --git a/third_party/blink/renderer/platform/wtf/text/string_view.h b/third_party/blink/renderer/platform/wtf/text/string_view.h
+index 66d1303b7b24c6baf30930f4de1ac8696d801d22..ce05aaaa797ca9265848477baa28aac67b9915a6 100644
+--- a/third_party/blink/renderer/platform/wtf/text/string_view.h
++++ b/third_party/blink/renderer/platform/wtf/text/string_view.h
+@@ -311,16 +311,11 @@ inline StringView::StringView(const StringView& view,
+                               unsigned offset,
+                               unsigned length)
+     : impl_(view.impl_), length_(length) {
+-  SECURITY_DCHECK(offset <= view.length());
+-  SECURITY_DCHECK(length <= view.length() - offset);
+-  // SAFETY: Invariants are checked last two line.
+-  UNSAFE_BUFFERS({
+-    if (Is8Bit()) {
+-      bytes_ = view.Span8().data() + offset;
+-    } else {
+-      bytes_ = view.Span16().data() + offset;
+-    }
+-  });
++  if (Is8Bit()) {
++    bytes_ = view.Span8().subspan(offset, length).data();
++  } else {
++    bytes_ = view.Span16().subspan(offset, length).data();
++  }
+ }
+ 
+ inline StringView::StringView(const StringImpl* impl) {
+@@ -362,18 +357,13 @@ inline void StringView::Clear() {
+ inline void StringView::Set(const StringImpl& impl,
+                             unsigned offset,
+                             unsigned length) {
+-  SECURITY_DCHECK(offset <= impl.length());
+-  SECURITY_DCHECK(length <= impl.length() - offset);
+   length_ = length;
+   impl_ = const_cast<StringImpl*>(&impl);
+-  // SAFETY: Invariants are checked at beginning of this method.
+-  UNSAFE_BUFFERS({
+-    if (impl.Is8Bit()) {
+-      bytes_ = impl.Characters8() + offset;
+-    } else {
+-      bytes_ = impl.Characters16() + offset;
+-    }
+-  });
++  if (impl.Is8Bit()) {
++    bytes_ = impl.Span8().subspan(offset, length).data();
++  } else {
++    bytes_ = impl.Span16().subspan(offset, length).data();
++  }
+ }
+ 
+ // Unicode aware case insensitive string matching. Non-ASCII characters might

--- a/patches/chromium/cherry-pick-7695435.patch
+++ b/patches/chromium/cherry-pick-7695435.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen Nusko <nuskos@chromium.org>
+Date: Sun, 29 Mar 2026 23:45:15 -0700
+Subject: [MiracleFix] Replace DCHECK with CHECK in media/base and media/mojo.
+
+These assertions are critical for maintaining invariants and should
+cause a crash in all build configurations if violated.
+
+This is a speculative hardening based on the linked bug.
+
+Bug: 495259842
+Change-Id: I44509ce9b18f994d748bc42255ffa85ca3496abc
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7695435
+Auto-Submit: Stephen Nusko <nuskos@chromium.org>
+Reviewed-by: Colin Blundell <blundell@chromium.org>
+Reviewed-by: Takashi Toyoshima <toyoshim@chromium.org>
+Commit-Queue: Stephen Nusko <nuskos@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1606907}
+
+diff --git a/media/base/decrypt_config.cc b/media/base/decrypt_config.cc
+index 2b889ba1b15dd515f2cba7d98220c03e3076769c..d5b560be082d05f2cb588c32f1e31f260c902f0b 100644
+--- a/media/base/decrypt_config.cc
++++ b/media/base/decrypt_config.cc
+@@ -47,12 +47,12 @@ DecryptConfig::DecryptConfig(
+       subsamples_(subsamples),
+       encryption_pattern_(std::move(encryption_pattern)) {
+   // Unencrypted blocks should not have a DecryptConfig.
+-  DCHECK_NE(encryption_scheme_, EncryptionScheme::kUnencrypted);
++  CHECK_NE(encryption_scheme_, EncryptionScheme::kUnencrypted);
+   CHECK_GT(key_id_.size(), 0u);
+   CHECK_EQ(iv_.size(), static_cast<size_t>(DecryptConfig::kDecryptionKeySize));
+ 
+   // Pattern not allowed for non-'cbcs' schemes.
+-  DCHECK(encryption_scheme_ == EncryptionScheme::kCbcs || !encryption_pattern_);
++  CHECK(encryption_scheme_ == EncryptionScheme::kCbcs || !encryption_pattern_);
+ }
+ 
+ DecryptConfig::~DecryptConfig() = default;
+diff --git a/media/mojo/common/media_type_converters.cc b/media/mojo/common/media_type_converters.cc
+index ea13051529d4a41ea0f659bd45d5465ab764ebf6..33cf43104e31a23c203e9038286928a53acf901f 100644
+--- a/media/mojo/common/media_type_converters.cc
++++ b/media/mojo/common/media_type_converters.cc
+@@ -43,6 +43,17 @@ std::unique_ptr<media::DecryptConfig>
+ TypeConverter<std::unique_ptr<media::DecryptConfig>,
+               media::mojom::DecryptConfigPtr>::
+     Convert(const media::mojom::DecryptConfigPtr& input) {
++  // Required invariants by the DecryptConfig constructor, to prevent a renderer
++  // from crashing the GPU we check them here as well and gracefully return
++  // nullptr instead.
++  if (input->encryption_scheme == media::EncryptionScheme::kUnencrypted) {
++    return nullptr;
++  }
++  // Pattern not allowed for non-'cbcs' schemes.
++  if (input->encryption_scheme != media::EncryptionScheme::kCbcs &&
++      input->encryption_pattern) {
++    return nullptr;
++  }
+   return std::make_unique<media::DecryptConfig>(
+       input->encryption_scheme, input->key_id, input->iv, input->subsamples,
+       input->encryption_pattern);
+@@ -203,8 +214,10 @@ TypeConverter<media::mojom::AudioBufferPtr, media::AudioBuffer>::Convert(
+     // `media::AudioBuffer`.
+     // `data_size()` refers to the amount of memory really used by the audio
+     // data. The rest is padding, which we don't need to copy.
+-    DCHECK_GT(input.data_size(), 0u);
+-    DCHECK_GE(input.data_size(), input.data_->span().size());
++    // Safe to CHECK here since this is into Mojo not From mojo (and thus not
++    // untrusted input).
++    CHECK_GT(input.data_size(), 0u);
++    CHECK_GE(input.data_size(), input.data_->span().size());
+     auto buffer_start = input.data_->span().begin();
+     auto buffer_end = buffer_start + input.data_size();
+     buffer->data.assign(buffer_start, buffer_end);
+@@ -252,7 +265,8 @@ TypeConverter<scoped_refptr<media::AudioBuffer>, media::mojom::AudioBufferPtr>::
+       base::CheckMul(input->frame_count,
+                      base::CheckMul(input->channel_count, bytes_per_channel))
+           .ValueOrDefault(0u);
+-  if (input->data.size() < min_data_size) {
++  if (input->data.size() < min_data_size ||
++      input->data.size() % input->channel_count != 0) {
+     DLOG(ERROR) << "Received invalid AudioBuffer, replace it with EOS.";
+     return media::AudioBuffer::CreateEOSBuffer();
+   }
+@@ -261,7 +275,6 @@ TypeConverter<scoped_refptr<media::AudioBuffer>, media::mojom::AudioBufferPtr>::
+   // one in the case of interleaved data.
+   std::vector<const uint8_t*> channel_ptrs(input->channel_count, nullptr);
+   const size_t size_per_channel = input->data.size() / input->channel_count;
+-  DCHECK_EQ(0u, input->data.size() % input->channel_count);
+   for (int i = 0; i < input->channel_count; ++i) {
+     channel_ptrs[i] = UNSAFE_TODO(input->data.data() + i * size_per_channel);
+   }

--- a/patches/chromium/cherry-pick-7701234.patch
+++ b/patches/chromium/cherry-pick-7701234.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Takashi Sakamoto <tasak@google.com>
+Date: Mon, 30 Mar 2026 19:03:37 -0700
+Subject: Block PrepareScript() while a document state is
+ preserving-atomic-move-in-progress.
+
+Bug: 496292089
+Change-Id: I1b357a0dc34874e5e3795ea54d9dd1da2b584ac7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7701234
+Reviewed-by: Dominic Farolino <dom@chromium.org>
+Commit-Queue: Takashi Sakamoto <tasak@google.com>
+Cr-Commit-Position: refs/heads/main@{#1607555}
+
+diff --git a/third_party/blink/renderer/core/html/html_script_element.cc b/third_party/blink/renderer/core/html/html_script_element.cc
+index 3c47f19e459b1ec15a5e66e1dffec3d857e3e4fe..769510b94651577490056fe4380761ca1073e78c 100644
+--- a/third_party/blink/renderer/core/html/html_script_element.cc
++++ b/third_party/blink/renderer/core/html/html_script_element.cc
+@@ -85,7 +85,10 @@ bool HTMLScriptElement::HasLegalLinkAttribute(const QualifiedName& name) const {
+ 
+ void HTMLScriptElement::ChildrenChanged(const ChildrenChange& change) {
+   HTMLElement::ChildrenChanged(change);
+-  loader_->ChildrenChanged(change);
++
++  if (!GetDocument().StatePreservingAtomicMoveInProgress()) {
++    loader_->ChildrenChanged(change);
++  }
+ 
+   // We'll record whether the script element children were ever changed by
+   // the API (as opposed to the parser).

--- a/patches/chromium/cherry-pick-7718624.patch
+++ b/patches/chromium/cherry-pick-7718624.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Francisco Ochoa <frankchavez@google.com>
+Date: Thu, 2 Apr 2026 04:43:30 -0700
+Subject: Fix potential integer overflow and add size check.
+
+Perform vertex addition in GetVerticesNeededForDraw within
+base::CheckedNumeric to catch overflows that wrap to negative values and
+bypass buffer bounds checks.
+
+Add size(count variable) check in RequestBuffersAccess.
+
+See (internal-only): go/code-terracotta-review-explainer
+
+This is a phase 1 quick fix.
+
+Bug: 497639714
+Change-Id: Iecb9fe274109013e7d7383e409609d13ea2c7003
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7718624
+Reviewed-by: Stephen Nusko <nuskos@chromium.org>
+Commit-Queue: Francisco Ochoa <frankchavez@google.com>
+Reviewed-by: Arthur Sonzogni <arthursonzogni@chromium.org>
+Reviewed-by: Colin Blundell <blundell@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609104}
+
+diff --git a/gpu/command_buffer/service/buffer_manager.cc b/gpu/command_buffer/service/buffer_manager.cc
+index 770368605215c9d329f87afa57c11a7e7d7f8d3d..9620813c928b306401903d1594e369dce9b81cc9 100644
+--- a/gpu/command_buffer/service/buffer_manager.cc
++++ b/gpu/command_buffer/service/buffer_manager.cc
+@@ -889,8 +889,9 @@ bool BufferManager::RequestBuffersAccess(
+     GLsizei count,
+     const char* func_name,
+     const char* message_tag) {
+-  DCHECK(error_state);
+-  DCHECK(bindings);
++  CHECK(error_state);
++  CHECK(bindings);
++  CHECK_GE(count, 0);
+ 
+   for (size_t ii = 0; ii < variable_sizes.size(); ++ii) {
+     if (variable_sizes[ii] == 0)
+diff --git a/gpu/command_buffer/service/transform_feedback_manager.cc b/gpu/command_buffer/service/transform_feedback_manager.cc
+index 8bc1ff2d7baec214d3664da1d1a9ab1b61dd4dcc..f2bd17ffc5a02a5a967a61403b9d5cc4905a740b 100644
+--- a/gpu/command_buffer/service/transform_feedback_manager.cc
++++ b/gpu/command_buffer/service/transform_feedback_manager.cc
+@@ -108,8 +108,8 @@ bool TransformFeedback::GetVerticesNeededForDraw(GLenum mode,
+   // Transform feedback only outputs complete primitives, so we need to round
+   // down to the nearest complete primitive before multiplying by the number of
+   // instances.
+-  base::CheckedNumeric<GLsizei> checked_vertices =
+-      vertices_drawn_ + pending_vertices_drawn;
++  base::CheckedNumeric<GLsizei> checked_vertices = vertices_drawn_;
++  checked_vertices += pending_vertices_drawn;
+   base::CheckedNumeric<GLsizei> checked_count = count;
+   base::CheckedNumeric<GLsizei> checked_primcount = primcount;
+   switch (mode) {

--- a/patches/chromium/cherry-pick-7722343.patch
+++ b/patches/chromium/cherry-pick-7722343.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Arthur Sonzogni <arthursonzogni@chromium.org>
+Date: Thu, 2 Apr 2026 18:28:34 -0700
+Subject: [Fullscreen] Guard against UAF during EnterFullscreenMode
+
+Entering fullscreen on Windows can spin a nested message loop via
+::SetWindowPos, allowing a pending task to destroy the tab. This adds
+WeakPtr guards to prevent UAF upon return, matching the existing fix
+for ExitFullscreenMode (crbug.com/1506535).
+
+I haven't added tests because testing the precise timing of this
+synchronous Windows-specific destruction is difficult to get right,
+especially from a Linux workstation.
+
+Fixed: 498752242
+Change-Id: I90c926214e9548208de1dbe54c0201a5393a512d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7722343
+Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+Auto-Submit: Arthur Sonzogni <arthursonzogni@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609608}
+
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 393808a7959d684fe4e46f86eff687ec15258fa9..ac4dae801611f22848705484fb744185f814b73e 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -8989,7 +8989,13 @@ void RenderFrameHostImpl::EnterFullscreen(
+   if (had_fullscreen_token && !GetView()->HasFocus()) {
+     GetView()->Focus();
+   }
++  // This may spin the message loop and destroy this object.
++  // See crbug.com/1506535, crbug.com/498752242.
++  base::WeakPtr<RenderFrameHostImpl> weak_ptr = GetWeakPtr();
+   delegate_->EnterFullscreenMode(this, *options);
++  if (!weak_ptr) {
++    return;
++  }
+   delegate_->FullscreenStateChanged(this, /*is_fullscreen=*/true,
+                                     std::move(options));
+ 
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index 6545ec2edfec6d2712f49abecafc3027b6045c3d..364c749aa7ef82f9050a9e94655712b6d8b36ede 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -4668,7 +4668,13 @@ void WebContentsImpl::EnterFullscreenMode(
+   }
+ 
+   if (delegate_) {
++    // This may spin the message loop and destroy this object.
++    // See crbug.com/1506535, crbug.com/498752242.
++    base::WeakPtr<WebContents> weak_ptr = GetWeakPtr();
+     delegate_->EnterFullscreenModeForTab(requesting_frame, options);
++    if (!weak_ptr) {
++      return;
++    }
+ 
+     if (keyboard_lock_widget_) {
+       delegate_->RequestKeyboardLock(this, esc_key_locked_);
+@@ -4696,8 +4702,9 @@ void WebContentsImpl::ExitFullscreenMode(bool will_cause_resize) {
+                          base::TimeTicks::Now());
+ 
+   if (delegate_) {
+-    // This may spin the message loop and destroy this object crbug.com/1506535
+-    base::WeakPtr<WebContentsImpl> weak_ptr = weak_factory_.GetWeakPtr();
++    // This may spin the message loop and destroy this object.
++    // See crbug.com/1506535, crbug.com/498752242.
++    base::WeakPtr<WebContents> weak_ptr = GetWeakPtr();
+     delegate_->ExitFullscreenModeForTab(this);
+     if (!weak_ptr) {
+       return;

--- a/patches/chromium/cherry-pick-7722499.patch
+++ b/patches/chromium/cherry-pick-7722499.patch
@@ -1,0 +1,120 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jacques Newman <janewman@microsoft.com>
+Date: Thu, 2 Apr 2026 08:57:32 -0700
+Subject: [a11y] Fix type confusion in get_hyperlink
+
+Replace unchecked static_cast with COM QueryInterface in
+get_hyperlink(). The old code cast an AXPlatformNode* from the
+process-wide UniqueIdMap directly to BrowserAccessibilityComWin*
+without verifying the type. If a stale unique ID was reassigned
+to a different node type, this produced an invalid pointer.
+
+QueryInterface for IAccessibleHyperlink returns E_NOINTERFACE
+for nodes that don't implement it, preventing the bad cast.
+
+Also invalidate the parent iframe's hypertext cache when a child
+frame's BrowserAccessibilityManager detaches. Without this, the
+parent retains stale unique IDs in its hyperlinks array.
+
+Fixed: 498401609
+Change-Id: I859b2aafa9383a6fbbce73d76226ef9f95fedca5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7722499
+Reviewed-by: Benjamin Beaudry <benjamin.beaudry@microsoft.com>
+Commit-Queue: Jacques Newman <janewman@microsoft.com>
+Cr-Commit-Position: refs/heads/main@{#1609259}
+
+diff --git a/ui/accessibility/platform/browser_accessibility_com_win.cc b/ui/accessibility/platform/browser_accessibility_com_win.cc
+index 880b148f6641308999264a8463303ba2582d5943..ad38a0716e10c8c3dde6582db6e32fd5251b8c38 100644
+--- a/ui/accessibility/platform/browser_accessibility_com_win.cc
++++ b/ui/accessibility/platform/browser_accessibility_com_win.cc
+@@ -563,11 +563,13 @@ IFACEMETHODIMP BrowserAccessibilityComWin::get_hyperlink(
+                << "\nroot=" << manager->GetRootManager()->GetRoot();
+     return E_FAIL;
+   }
+-  auto* link = static_cast<BrowserAccessibilityComWin*>(node);
+-  if (!link)
++  Microsoft::WRL::ComPtr<IAccessibleHyperlink> hyperlink_result;
++  if (FAILED(node->GetNativeViewAccessible()->QueryInterface(
++          IID_PPV_ARGS(&hyperlink_result)))) {
+     return E_FAIL;
++  }
+ 
+-  *hyperlink = static_cast<IAccessibleHyperlink*>(link->NewReference());
++  *hyperlink = hyperlink_result.Detach();
+   return S_OK;
+ }
+ 
+diff --git a/ui/accessibility/platform/browser_accessibility_manager.cc b/ui/accessibility/platform/browser_accessibility_manager.cc
+index ecb5de88fcd490881df98dcc265f45853d889673..82f3ffa9530d2ecc0142da04a07cd52d528fca23 100644
+--- a/ui/accessibility/platform/browser_accessibility_manager.cc
++++ b/ui/accessibility/platform/browser_accessibility_manager.cc
+@@ -1899,6 +1899,13 @@ BrowserAccessibility* BrowserAccessibilityManager::ApproximateHitTest(
+ }
+ 
+ void BrowserAccessibilityManager::DetachFromParentManager() {
++  // Notify the parent to invalidate its hypertext cache before disconnecting,
++  // otherwise stale hyperlink IDs can cause type confusion after reassignment.
++  if (connected_to_parent_tree_node_) {
++    if (AXNode* parent = GetParentNodeFromParentTree()) {
++      UpdateAttributesOnParent(parent);
++    }
++  }
+   connected_to_parent_tree_node_ = false;
+ }
+ 
+diff --git a/ui/accessibility/platform/browser_accessibility_win_unittest.cc b/ui/accessibility/platform/browser_accessibility_win_unittest.cc
+index 3f863afa8eee270c3caeda831f19e72dca000383..8f6753b750f6de0b9bc0dc2720e179e92f9c008d 100644
+--- a/ui/accessibility/platform/browser_accessibility_win_unittest.cc
++++ b/ui/accessibility/platform/browser_accessibility_win_unittest.cc
+@@ -3775,4 +3775,51 @@ TEST_F(BrowserAccessibilityWinTest, OnExtendedPropertiesUsedAfterDestruction) {
+   text_field_node->SetDelegateForTesting(pre_delegate);
+ }
+ 
++// Regression test for type confusion fix: verify get_hyperlink uses
++// QueryInterface and returns correct results for valid hyperlinks.
++TEST_F(BrowserAccessibilityWinTest, TestHyperlinkSafeTypeCheck) {
++  AXNodeData root;
++  root.id = 1;
++  root.role = ax::mojom::Role::kRootWebArea;
++  root.AddState(ax::mojom::State::kFocusable);
++
++  AXNodeData text;
++  text.id = 2;
++  text.role = ax::mojom::Role::kStaticText;
++  text.SetName("Hello ");
++
++  AXNodeData link;
++  link.id = 3;
++  link.role = ax::mojom::Role::kLink;
++  link.AddState(ax::mojom::State::kFocusable);
++  link.AddState(ax::mojom::State::kLinked);
++  link.SetName("world");
++  link.SetNameFrom(ax::mojom::NameFrom::kContents);
++
++  root.child_ids = {text.id, link.id};
++
++  std::unique_ptr<BrowserAccessibilityManager> manager(
++      BrowserAccessibilityManager::Create(
++          MakeAXTreeUpdateForTesting(root, text, link), node_id_delegate_,
++          test_browser_accessibility_delegate_.get()));
++
++  BrowserAccessibilityComWin* root_obj =
++      ToBrowserAccessibilityWin(manager->GetBrowserAccessibilityRoot())
++          ->GetCOM();
++
++  LONG hyperlink_count = -1;
++  EXPECT_EQ(S_OK, root_obj->get_nHyperlinks(&hyperlink_count));
++  EXPECT_EQ(1, hyperlink_count);
++
++  Microsoft::WRL::ComPtr<IAccessibleHyperlink> hyperlink;
++  EXPECT_EQ(S_OK, root_obj->get_hyperlink(0, &hyperlink));
++  EXPECT_NE(nullptr, hyperlink.Get());
++  hyperlink.Reset();
++
++  EXPECT_EQ(E_INVALIDARG, root_obj->get_hyperlink(1, &hyperlink));
++  EXPECT_EQ(E_INVALIDARG, root_obj->get_hyperlink(-1, &hyperlink));
++
++  manager.reset();
++}
++
+ }  // namespace ui

--- a/patches/chromium/cherry-pick-7723101.patch
+++ b/patches/chromium/cherry-pick-7723101.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shunya Shishido <sisidovski@chromium.org>
+Date: Thu, 2 Apr 2026 08:23:44 -0700
+Subject: Report bad message on reuse of
+ ForwardedRaceNetworkRequestURLLoaderFactory
+
+The ForwardedRaceNetworkRequestURLLoaderFactory is intended for a single
+use. If CreateLoaderAndStart is called after the data pipe has already
+been fused, it indicates an unexpected state, so report a bad message
+instead of falling back.
+
+Bug: 497437113
+Change-Id: I2867a9359a6764065fe95e0b1f7d68fc80cf0d05
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7723101
+Commit-Queue: Shunya Shishido <sisidovski@chromium.org>
+Reviewed-by: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609228}
+
+diff --git a/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc b/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
+index a64f9b5fe98dd925cbc5396cac5a0a8699d5d97b..cfd03bec7e2f13b934d87337344ebbcf755d8400 100644
+--- a/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
++++ b/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
+@@ -4,8 +4,16 @@
+ 
+ #include "content/common/service_worker/forwarded_race_network_request_url_loader_factory.h"
+ 
++#include "base/feature_list.h"
++
+ namespace content {
+ 
++namespace {
++// Kill switch for multiple CreateLoaderAndStart calls.
++BASE_FEATURE(kKillSwitchForRaceNetworkRequestMultipleCreateLoaderAndStartCalls,
++             base::FEATURE_ENABLED_BY_DEFAULT);
++}  // namespace
++
+ ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory::
+     ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory(
+         mojo::PendingReceiver<network::mojom::URLLoaderClient> client_receiver,
+@@ -34,10 +42,14 @@ void ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory::
+     CHECK(result) << resource_request.url;
+     is_data_pipe_fused_ = true;
+   } else {
+-    // If already fused, create a new URLLoader and start the new request.
+-    fallback_factory_->CreateLoaderAndStart(
+-        std::move(receiver), request_id, options, resource_request,
+-        std::move(client), traffic_annotation);
++    // A legitimate renderer will never hit this branch.
++    // If we are here, the renderer is compromised or severely buggy.
++    if (base::FeatureList::IsEnabled(
++            kKillSwitchForRaceNetworkRequestMultipleCreateLoaderAndStartCalls)) {
++      receiver_.ReportBadMessage(
++          "ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory: "
++          "CreateLoaderAndStart called multiple times.");
++    }
+   }
+ }
+ 

--- a/patches/chromium/cherry-pick-7726850.patch
+++ b/patches/chromium/cherry-pick-7726850.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Menke <mmenke@chromium.org>
+Date: Thu, 2 Apr 2026 13:03:05 -0700
+Subject: [Protected Audiences] Add some checks around request upload bodies.
+
+And methods as well.
+
+Fixed: 498720754
+Change-Id: I3339444bdc1da51f7b308e3e5e059106c2fb751f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7726850
+Reviewed-by: Maks Orlovich <morlovich@chromium.org>
+Commit-Queue: mmenke <mmenke@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609453}
+
+diff --git a/content/browser/interest_group/auction_url_loader_factory_proxy.cc b/content/browser/interest_group/auction_url_loader_factory_proxy.cc
+index 9eedf1306b801e81a625186f7830c8dbd5e47b35..93e4d2848df5858a86eb9cb0b0b9b366e18b11c2 100644
+--- a/content/browser/interest_group/auction_url_loader_factory_proxy.cc
++++ b/content/browser/interest_group/auction_url_loader_factory_proxy.cc
+@@ -38,7 +38,9 @@
+ #include "net/cookies/site_for_cookies.h"
+ #include "net/http/http_request_headers.h"
+ #include "net/traffic_annotation/network_traffic_annotation.h"
++#include "services/network/public/cpp/data_element.h"
+ #include "services/network/public/cpp/resource_request.h"
++#include "services/network/public/cpp/resource_request_body.h"
+ #include "services/network/public/mojom/cookie_manager.mojom-shared.h"
+ #include "services/network/public/mojom/url_loader_factory.mojom.h"
+ #include "third_party/blink/public/common/features.h"
+@@ -179,6 +181,26 @@ void AuctionURLLoaderFactoryProxy::CreateLoaderAndStart(
+     }
+   }
+ 
++  if (url_request.method != net::HttpRequestHeaders::kGetMethod) {
++    // If the request is not a GET and not a trusted signals POST, disallow the
++    // request.
++    if (url_request.method != net::HttpRequestHeaders::kPostMethod ||
++        !is_trusted_signals_request) {
++      is_request_allowed = false;
++    } else {
++      // For trusted signals POSTs only allow request bodies that contain a
++      // single byte element, since that's all the auction worklet code should
++      // produce. The most important thing here is to disallow attempts to
++      // upload files.
++      if (url_request.request_body &&
++          (url_request.request_body->elements()->size() != 1u ||
++           url_request.request_body->elements()->front().type() !=
++               network::DataElement::Tag::kBytes)) {
++        is_request_allowed = false;
++      }
++    }
++  }
++
+   if (!is_request_allowed) {
+     // Debugging for https://crbug.com/1448458
+     SCOPED_CRASH_KEY_STRING32("fledge", "req-accept", accept_header);
+@@ -218,6 +240,7 @@ void AuctionURLLoaderFactoryProxy::CreateLoaderAndStart(
+ 
+   if (url_request.method == net::HttpRequestHeaders::kPostMethod) {
+     new_request.method = std::move(url_request.method);
++    // Note that GET request bodies are ignored.
+     new_request.request_body = std::move(url_request.request_body);
+     std::optional<std::string> content_type =
+         url_request.headers.GetHeader(net::HttpRequestHeaders::kContentType);
+diff --git a/content/browser/interest_group/auction_url_loader_factory_proxy_unittest.cc b/content/browser/interest_group/auction_url_loader_factory_proxy_unittest.cc
+index 2117411b9f23e293b14c67b6c471888855b5c67d..576e74a0e03b97ea7fbce1b4c8e0a496a423e43a 100644
+--- a/content/browser/interest_group/auction_url_loader_factory_proxy_unittest.cc
++++ b/content/browser/interest_group/auction_url_loader_factory_proxy_unittest.cc
+@@ -8,6 +8,7 @@
+ 
+ #include <vector>
+ 
++#include "base/containers/span.h"
+ #include "base/functional/bind.h"
+ #include "base/functional/callback_helpers.h"
+ #include "base/memory/ref_counted.h"
+@@ -31,7 +32,9 @@
+ #include "net/http/http_request_headers.h"
+ #include "net/traffic_annotation/network_traffic_annotation.h"
+ #include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
++#include "services/network/public/cpp/data_element.h"
+ #include "services/network/public/cpp/resource_request.h"
++#include "services/network/public/cpp/resource_request_body.h"
+ #include "services/network/public/mojom/client_security_state.mojom.h"
+ #include "services/network/public/mojom/ip_address_space.mojom.h"
+ #include "services/network/public/mojom/url_loader_factory.mojom.h"
+@@ -350,7 +353,26 @@ class AuctionUrlLoaderFactoryProxyTest : public testing::TestWithParam<bool> {
+     // Check method, body and content-type for POST requests.
+     if (request.method == net::HttpRequestHeaders::kPostMethod) {
+       EXPECT_EQ(observed_request.method, net::HttpRequestHeaders::kPostMethod);
+-      EXPECT_EQ(request.request_body, observed_request.request_body);
++      ASSERT_EQ(!!request.request_body, !!observed_request.request_body);
++      // If there's a request body, both bodies should both have a single
++      // matching element of type kBytes.
++      if (request.request_body) {
++        const auto& request_elements = *request.request_body->elements();
++        const auto& observed_elements =
++            *observed_request.request_body->elements();
++        ASSERT_EQ(request_elements.size(), 1u);
++        ASSERT_EQ(observed_elements.size(), 1u);
++        ASSERT_EQ(request_elements.front().type(),
++                  network::DataElement::Tag::kBytes);
++        ASSERT_EQ(observed_elements.front().type(),
++                  network::DataElement::Tag::kBytes);
++        EXPECT_EQ(request_elements.front()
++                      .As<network::DataElementBytes>()
++                      .AsStringPiece(),
++                  observed_elements.front()
++                      .As<network::DataElementBytes>()
++                      .AsStringPiece());
++      }
+       if (request.headers.GetHeader(net::HttpRequestHeaders::kContentType)
+               .has_value()) {
+         EXPECT_EQ(
+@@ -573,6 +595,24 @@ TEST_P(AuctionUrlLoaderFactoryProxyTest, Basic) {
+                    ExpectedResponse::kReject);
+     TryMakeRequest("https://host.test/", std::nullopt,
+                    ExpectedResponse::kReject);
++
++    // Methods other than GET should be rejected for non-signals URLs. Method
++    // logic for signals URLs is checked further down.
++    network::ResourceRequest request;
++    request.url = GURL(kScriptUrl);
++    request.headers.SetHeader(net::HttpRequestHeaders::kAccept,
++                              kAcceptJavascript);
++    request.method = net::HttpRequestHeaders::kPostMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
++    request.method = net::HttpRequestHeaders::kHeadMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
++
++    request.url = GURL(kWasmUrl);
++    request.headers.SetHeader(net::HttpRequestHeaders::kAccept, kAcceptWasm);
++    request.method = net::HttpRequestHeaders::kPostMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
++    request.method = net::HttpRequestHeaders::kHeadMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
+   }
+ }
+ 
+@@ -747,9 +787,11 @@ TEST_P(AuctionUrlLoaderFactoryProxyTest, TrustedSignalsUrl) {
+         "https://host.test/trusted_signals?hostname=top.test&keys=%23%26%3D",
+         kAcceptJson, ExpectedResponse::kAllow);
+ 
+-    // Valid Trusted Signals KVv2 POST request
++    // Valid Trusted Signals KVv2 POST request.
+     network::ResourceRequest request;
+     request.method = net::HttpRequestHeaders::kPostMethod;
++    request.request_body = network::ResourceRequestBody::CreateFromCopyOfBytes(
++        base::as_byte_span("1234"));
+     request.url = GURL(kTrustedSignalsBaseUrl);
+     request.headers.SetHeader(net::HttpRequestHeaders::kAccept,
+                               kAcceptAdAuctionTrustedSignals);
+@@ -757,6 +799,35 @@ TEST_P(AuctionUrlLoaderFactoryProxyTest, TrustedSignalsUrl) {
+                               kAdAuctionTrustedSignalsContentType);
+     TryMakeRequest(request, ExpectedResponse::kAllow);
+ 
++    // Methods other than GET and POST are rejected.
++    request.method = net::HttpRequestHeaders::kPutMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
++    request.method = net::HttpRequestHeaders::kHeadMethod;
++    TryMakeRequest(request, ExpectedResponse::kReject);
++    // Restore method.
++    request.method = net::HttpRequestHeaders::kPostMethod;
++
++    // Uploads with multiple elements should be rejected. This isn't too
++    // important, but need to make sure they don't crash.
++    request.request_body->AppendCopyOfBytes(base::as_byte_span("5678"));
++    TryMakeRequest(request, ExpectedResponse::kReject);
++
++    // Empty uploads should be rejected. This case is mostly to make sure they
++    // don't result in crashes.
++    request.request_body = base::MakeRefCounted<network::ResourceRequestBody>();
++    TryMakeRequest(request, ExpectedResponse::kReject);
++
++    // Uploads of files should be rejected. There's no code wired up to actually
++    // read the file, so don't need a path to a real file.
++    request.request_body->AppendFileRange(
++        base::FilePath(), /*offset=*/0u, /*length=*/2u,
++        /*expected_modification_time=*/base::Time());
++    TryMakeRequest(request, ExpectedResponse::kReject);
++
++    // Restore the upload body.
++    request.request_body = network::ResourceRequestBody::CreateFromCopyOfBytes(
++        base::as_byte_span("1234"));
++
+     // Invalid Trusted Signals KVv2 POST request with mismatched base url.
+     request.url = GURL("https://host.test/trusted_signals?");
+     TryMakeRequest(request, ExpectedResponse::kReject);

--- a/patches/chromium/cherry-pick-7726886.patch
+++ b/patches/chromium/cherry-pick-7726886.patch
@@ -1,0 +1,160 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Paseltiner <apaseltiner@chromium.org>
+Date: Fri, 3 Apr 2026 13:21:20 -0700
+Subject: Fix iterator invalidation in aura::Window and Ash ID clash
+
+This CL addresses two related issues that could lead to memory safety
+vulnerabilities:
+
+1. Update aura::Window notification loops to use WindowTracker.
+   NotifyRemovingFromRootWindow, NotifyAddedToRootWindow, and
+   NotifyWindowHierarchyChangeDown now safely handle potential hierarchy
+   mutations during child iteration.
+
+2. Upgrade ID validation in MoveAllTransientChildrenToNewRoot.
+   Upgraded the ID validation from DCHECK_GE to CHECK_GE to ensure that
+   container_id is non-negative in all builds. This prevents incorrect
+   reparenting to the Wallpaper Window (which often has an ID of -1)
+   and subsequent iterator invalidation.
+
+Fixed: 498832921
+Change-Id: Ie38a4f864ffdc0baa6c59d83c3f4e59babbe2528
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7726886
+Reviewed-by: Mitsuru Oshima <oshima@chromium.org>
+Commit-Queue: Andrew Paseltiner <apaseltiner@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609938}
+
+diff --git a/ash/wm/window_state.cc b/ash/wm/window_state.cc
+index 086bebc6d52772a62b17f1ca0fff033dad996ece..451beb23bde2ae00b693e285ac744a5557e281f4 100644
+--- a/ash/wm/window_state.cc
++++ b/ash/wm/window_state.cc
+@@ -40,6 +40,7 @@
+ #include "ash/wm/wm_event.h"
+ #include "ash/wm/wm_metrics.h"
+ #include "base/check_is_test.h"
++#include "base/check_op.h"
+ #include "base/containers/adapters.h"
+ #include "base/containers/fixed_flat_map.h"
+ #include "base/debug/crash_logging.h"
+@@ -266,7 +267,7 @@ void MoveAllTransientChildrenToNewRoot(aura::Window* window) {
+     if (!transient_child->parent())
+       continue;
+     const int container_id = transient_child->parent()->GetId();
+-    DCHECK_GE(container_id, 0);
++    CHECK_GE(container_id, 0);
+     aura::Window* container = dst_root->GetChildById(container_id);
+     if (container->Contains(transient_child))
+       continue;
+diff --git a/ui/aura/window.cc b/ui/aura/window.cc
+index 2444fa5747d82bbb47cf9343d46f6a5ee87f13d9..e1f3485a478d407efd22e605f679e7bacec98914 100644
+--- a/ui/aura/window.cc
++++ b/ui/aura/window.cc
+@@ -1233,9 +1233,10 @@ void Window::NotifyRemovingFromRootWindow(Window* new_root) {
+     UnregisterFrameSinkId();
+   for (WindowObserver& observer : observers_)
+     observer.OnWindowRemovingFromRootWindow(this, new_root);
+-  for (Window::Windows::const_iterator it = children_.begin();
+-       it != children_.end(); ++it) {
+-    (*it)->NotifyRemovingFromRootWindow(new_root);
++
++  WindowTracker tracker(children_);
++  while (!tracker.windows().empty()) {
++    tracker.Pop()->NotifyRemovingFromRootWindow(new_root);
+   }
+ }
+ 
+@@ -1244,9 +1245,10 @@ void Window::NotifyAddedToRootWindow() {
+     RegisterFrameSinkId();
+   for (WindowObserver& observer : observers_)
+     observer.OnWindowAddedToRootWindow(this);
+-  for (Window::Windows::const_iterator it = children_.begin();
+-       it != children_.end(); ++it) {
+-    (*it)->NotifyAddedToRootWindow();
++
++  WindowTracker tracker(children_);
++  while (!tracker.windows().empty()) {
++    tracker.Pop()->NotifyAddedToRootWindow();
+   }
+ }
+ 
+@@ -1268,9 +1270,9 @@ void Window::NotifyWindowHierarchyChange(
+ void Window::NotifyWindowHierarchyChangeDown(
+     const WindowObserver::HierarchyChangeParams& params) {
+   NotifyWindowHierarchyChangeAtReceiver(params);
+-  for (Window::Windows::const_iterator it = children_.begin();
+-       it != children_.end(); ++it) {
+-    (*it)->NotifyWindowHierarchyChangeDown(params);
++  WindowTracker tracker(children_);
++  while (!tracker.windows().empty()) {
++    tracker.Pop()->NotifyWindowHierarchyChangeDown(params);
+   }
+ }
+ 
+diff --git a/ui/aura/window_unittest.cc b/ui/aura/window_unittest.cc
+index 8af5d68baff728b8787016d4c26eefcf6ced6145..4f67b0d34fb200cbf3902d1d34cca0ea91ebee30 100644
+--- a/ui/aura/window_unittest.cc
++++ b/ui/aura/window_unittest.cc
+@@ -13,6 +13,7 @@
+ 
+ #include "base/compiler_specific.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/scoped_observation.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/stringprintf.h"
+@@ -3592,6 +3593,55 @@ TEST_F(WindowTest, OnWindowHierarchyChange) {
+   }
+ }
+ 
++namespace {
++
++class HierarchyMutatingObserver : public WindowObserver {
++ public:
++  explicit HierarchyMutatingObserver(Window* window_to_remove)
++      : window_to_remove_(window_to_remove) {}
++
++  HierarchyMutatingObserver(const HierarchyMutatingObserver&) = delete;
++  HierarchyMutatingObserver& operator=(const HierarchyMutatingObserver&) =
++      delete;
++
++  void OnWindowAddedToRootWindow(Window* window) override {
++    if (window_to_remove_) {
++      window_to_remove_->parent()->RemoveChild(window_to_remove_);
++      window_to_remove_ = nullptr;
++    }
++  }
++
++ private:
++  raw_ptr<Window> window_to_remove_;
++};
++
++}  // namespace
++
++// Tests that modifying the hierarchy during NotifyAddedToRootWindow doesn't
++// cause a crash.
++TEST_F(WindowTest, MutateHierarchyDuringNotifyAddedToRootWindow) {
++  std::unique_ptr<Window> parent_window(CreateTestWindow({.window_id = 0}));
++  std::unique_ptr<Window> w1(CreateTestWindow({.window_id = 1}));
++  std::unique_ptr<Window> w2(CreateTestWindow({.window_id = 2}));
++  std::unique_ptr<Window> w3(CreateTestWindow({.window_id = 3}));
++
++  parent_window->AddChild(w1.get());
++  parent_window->AddChild(w2.get());
++  parent_window->AddChild(w3.get());
++
++  // Add an observer to w2 that removes w1.
++  // When parent_window is added to the root, it will notify its children: w1,
++  // w2, w3.
++  // 1. Notify w1.
++  // 2. Notify w2. w2's observer removes w1.
++  // 3. Notify w3.
++  HierarchyMutatingObserver observer(w1.get());
++  base::ScopedObservation<Window, WindowObserver> observation(&observer);
++  observation.Observe(w2.get());
++
++  root_window()->AddChild(parent_window.get());
++}
++
+ class TestLayerAnimationObserver : public ui::LayerAnimationObserver {
+  public:
+   TestLayerAnimationObserver()

--- a/patches/chromium/cherry-pick-7727919.patch
+++ b/patches/chromium/cherry-pick-7727919.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shunya Shishido <sisidovski@chromium.org>
+Date: Thu, 2 Apr 2026 22:18:24 -0700
+Subject: Restore `fallback_factory_` CreateLoaderAndStart call
+
+This was previously removed by crrev.com/c/7723101, but we would keep
+previous behavior with the killswitch.
+
+Bug: 497437113
+Change-Id: I409e66e0abc78c0aa5687bd8dc4378a5b0823b01
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7727919
+Reviewed-by: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Commit-Queue: Shunya Shishido <sisidovski@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1609669}
+
+diff --git a/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc b/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
+index cfd03bec7e2f13b934d87337344ebbcf755d8400..83073ad98ccaae7c926a24c1904e3d14142eab6c 100644
+--- a/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
++++ b/content/common/service_worker/forwarded_race_network_request_url_loader_factory.cc
+@@ -49,6 +49,12 @@ void ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory::
+       receiver_.ReportBadMessage(
+           "ServiceWorkerForwardedRaceNetworkRequestURLLoaderFactory: "
+           "CreateLoaderAndStart called multiple times.");
++    } else {
++      // If already fused, create a new URLLoader and start the new request.
++      // TODO(crbug.com/497437113): Remove this once the kill switch is removed.
++      fallback_factory_->CreateLoaderAndStart(
++          std::move(receiver), request_id, options, resource_request,
++          std::move(client), traffic_annotation);
+     }
+   }
+ }

--- a/patches/chromium/cherry-pick-7737952.patch
+++ b/patches/chromium/cherry-pick-7737952.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Thu, 9 Apr 2026 12:12:20 -0700
+Subject: views: Guard against UAF in DWTHP::OnActivationChanged
+
+HandleActivationChanged() notifications can cause the widget to be
+synchronously closed. On Linux/Ozone, this can result in the destruction
+of the DesktopWindowTreeHostPlatform instance.
+
+This change adds a base::WeakPtr guard around HandleActivationChanged()
+to ensure 'this' is still valid before calling ScheduleRelayout().
+This mirrors an analogous fix previously applied to the Windows
+implementation in hwnd_message_handler.cc.
+
+Fixed: 497543810
+Change-Id: I58fcddf8542bc1aa30d0ad5508d16849fd56e3ac
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7737952
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1612417}
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+index 4e54b0408c6af8c9bd9c8639c358dc67e546c597..211bb5a1927b7e7d333eef37d687824b1c8e6a50 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+@@ -1022,7 +1022,15 @@ void DesktopWindowTreeHostPlatform::OnActivationChanged(bool active) {
+   }
+   is_active_ = active;
+   aura::WindowTreeHostPlatform::OnActivationChanged(active);
++
++  // HandleActivationChanged() notifications can cause the widget to be
++  // synchronously closed.
++  auto weak_this = weak_factory_.GetWeakPtr();
+   desktop_native_widget_aura_->HandleActivationChanged(active);
++  if (!weak_this) {
++    return;
++  }
++
+   ScheduleRelayout();
+ }
+ 
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+index 2e4802edb4e2b9d59f269d0722bcbc4d94ed8db5..1a8605b9c13af3ccc849ee3253a79687a9353576 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+@@ -264,6 +264,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
+ 
+   base::WeakPtrFactory<DesktopWindowTreeHostPlatform> close_widget_factory_{
+       this};
++  base::WeakPtrFactory<DesktopWindowTreeHostPlatform> weak_factory_{this};
+ };
+ 
+ }  // namespace views
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+index 1236cb1e53736cf56f4257760312b97100bae86b..950938b5ed8362519e3cd154f18383b0010884cc 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+@@ -137,6 +137,22 @@ std::unique_ptr<Widget> CreateWidgetWithNativeWidget() {
+   return CreateWidgetWithNativeWidgetWithParams(std::move(params));
+ }
+ 
++class CloseOnActivationWidgetObserver : public WidgetObserver {
++ public:
++  explicit CloseOnActivationWidgetObserver(Widget* widget) {
++    observation_.Observe(widget);
++  }
++  ~CloseOnActivationWidgetObserver() override = default;
++
++  void OnWidgetActivationChanged(Widget* widget, bool active) override {
++    observation_.Reset();
++    widget->CloseNow();
++  }
++
++ private:
++  base::ScopedObservation<Widget, WidgetObserver> observation_{this};
++};
++
+ }  // namespace
+ 
+ class DesktopWindowTreeHostPlatformTest : public ViewsTestBase {
+@@ -606,6 +622,22 @@ TEST_F(DesktopWindowTreeHostPlatformTest, FocusParentWindowWillActivate) {
+   EXPECT_TRUE(host_platform->IsActive());
+ }
+ 
++TEST_F(DesktopWindowTreeHostPlatformTest,
++       OnActivationChangedSurvivesSynchronousClose) {
++  std::unique_ptr<Widget> widget = CreateWidgetWithNativeWidget();
++  widget->Show();
++
++  auto* host_platform = DesktopWindowTreeHostPlatform::GetHostForWidget(
++      widget->GetNativeWindow()->GetHost()->GetAcceleratedWidget());
++  ASSERT_TRUE(host_platform);
++
++  CloseOnActivationWidgetObserver observer(widget.get());
++
++  // This should not crash.
++  static_cast<ui::PlatformWindowDelegate*>(host_platform)
++      ->OnActivationChanged(false);
++}
++
+ #endif  // !BUILDFLAG(IS_FUCHSIA)
+ 
+ class VisibilityObserver : public aura::WindowObserver {

--- a/patches/chromium/cherry-pick-7779792.patch
+++ b/patches/chromium/cherry-pick-7779792.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jordan Bayles <jophba@chromium.org>
+Date: Tue, 28 Apr 2026 15:03:05 -0700
+Subject: [M146] Fix Use-After-Free in
+ WebContentsImpl::ForSecurityDropFullscreen
+
+Original change's description:
+> Fix Use-After-Free in WebContentsImpl::ForSecurityDropFullscreen
+>
+> When `ForSecurityDropFullscreen` drops the fullscreen state of upstream
+> openers, it iterates over a set of `raw_ptr<WebContentsImpl>` instances.
+> Calling `ExitFullscreen()` on these openers can spin a nested message
+> loop (e.g., when waiting for the OS window transition to finish).
+> During this nested message loop, other `WebContentsImpl` instances in
+> the iteration set can be destroyed via IPCs (such as `window.close()`).
+>
+> Previously, the loop continued to process the dangling `raw_ptr`s in
+> the local copy of the set, leading to a Use-After-Free when attempting
+> to query their fullscreen state via `is_fullscreen()`.
+>
+> This CL mitigates the UAF by first caching the target WebContentsImpl
+> instances as a `std::vector<base::WeakPtr<WebContentsImpl>>`. During the
+> actual iteration where `ExitFullscreen()` is called, the validity of
+> each `WeakPtr` is checked before dereferencing, ensuring that destroyed
+> WebContents are safely ignored even if reentrancy occurs.
+>
+> Bug: 497436531
+> Change-Id: I190490caeab24daa9508fa27caf8dace613e9172
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7747694
+> Reviewed-by: Avi Drissman <avi@chromium.org>
+> Commit-Queue: Jordan Bayles <jophba@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1613095}
+
+(cherry picked from commit 899e77f0d448f44b5c9065911721d6f608a675c9)
+
+Bug: 502439888,497436531
+Change-Id: I190490caeab24daa9508fa27caf8dace613e9172
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7779792
+Reviewed-by: Avi Drissman <avi@chromium.org>
+Commit-Queue: Jordan Bayles <jophba@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7680@{#4020}
+Cr-Branched-From: 76b7d80e5cda23fe6537eed26d68c92e995c7f39-refs/heads/main@{#1582197}
+
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index 364c749aa7ef82f9050a9e94655712b6d8b36ede..047426b5503113e46775bab9b7d4b796faec349e 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -7206,10 +7206,20 @@ base::ScopedClosureRunner WebContentsImpl::ForSecurityDropFullscreen(
+   // upstream contents. Drop that WebContents out of fullscreen if it does. This
+   // is theoretically quadratic-ish (fullscreen contentses x each one's opener
+   // length) but neither of those is expected to ever be a large number.
+-  auto fullscreen_set_copy = *FullscreenContentsSet(GetBrowserContext());
+-  for (WebContentsImpl* fullscreen_contents : fullscreen_set_copy) {
+-    if (is_fullscreen(fullscreen_contents, display_id)) {
+-      auto opener_contentses = GetAllOpeningWebContents(fullscreen_contents);
++  std::vector<base::WeakPtr<WebContentsImpl>> fullscreen_contents_list;
++  for (WebContentsImpl* fullscreen_contents :
++       *FullscreenContentsSet(GetBrowserContext())) {
++    fullscreen_contents_list.push_back(
++        fullscreen_contents->weak_factory_.GetWeakPtr());
++  }
++
++  for (auto& fullscreen_contents : fullscreen_contents_list) {
++    if (!fullscreen_contents) {
++      continue;
++    }
++    if (is_fullscreen(fullscreen_contents.get(), display_id)) {
++      auto opener_contentses =
++          GetAllOpeningWebContents(fullscreen_contents.get());
+       if (opener_contentses.count(this)) {
+         fullscreen_contents->ExitFullscreen(true);
+       }
+@@ -7223,29 +7233,41 @@ base::ScopedClosureRunner WebContentsImpl::ForSecurityDropFullscreen(
+   // any request to enter fullscreen will have the upstream of the WebContents
+   // checked. (See CanEnterFullscreenMode().)
+ 
+-  std::vector<base::WeakPtr<WebContentsImpl>> blocked_contentses;
++  std::vector<base::WeakPtr<WebContentsImpl>> blocked_contents_list;
++  std::vector<base::WeakPtr<WebContentsImpl>> openers;
++  for (WebContentsImpl* opener : GetAllOpeningWebContents(this)) {
++    openers.push_back(opener->weak_factory_.GetWeakPtr());
++  }
+ 
+-  for (auto* opener : GetAllOpeningWebContents(this)) {
+-    if (is_fullscreen(opener, display_id)) {
++  for (auto& opener : openers) {
++    if (!opener) {
++      continue;
++    }
++
++    if (is_fullscreen(opener.get(), display_id)) {
+       opener->ExitFullscreen(true);
+     }
+ 
++    if (!opener) {
++      continue;
++    }
++
+     // ...block the WebContents from entering fullscreen until further notice.
+     ++opener->fullscreen_blocker_count_;
+-    blocked_contentses.push_back(opener->weak_factory_.GetWeakPtr());
++    blocked_contents_list.push_back(opener);
+   }
+ 
+   return base::ScopedClosureRunner(base::BindOnce(
+-      [](std::vector<base::WeakPtr<WebContentsImpl>> blocked_contentses) {
++      [](std::vector<base::WeakPtr<WebContentsImpl>> blocked_contents_list) {
+         for (base::WeakPtr<WebContentsImpl>& web_contents :
+-             blocked_contentses) {
++             blocked_contents_list) {
+           if (web_contents) {
+             DCHECK_GT(web_contents->fullscreen_blocker_count_, 0);
+             --web_contents->fullscreen_blocker_count_;
+           }
+         }
+       },
+-      std::move(blocked_contentses)));
++      std::move(blocked_contents_list)));
+ }
+ 
+ void WebContentsImpl::ResumeLoadingCreatedWebContents() {

--- a/patches/chromium/cherry-pick-7791302.patch
+++ b/patches/chromium/cherry-pick-7791302.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kalvin Lee <kdlee@chromium.org>
+Date: Tue, 28 Apr 2026 03:47:30 -0700
+Subject: [M146] Terracotta-Phase-1: Copy vector in
+ `SVGElement::SynchronizeAttributeInShadowInstances()`
+
+Original change's description:
+> Terracotta-Phase-1: Copy vector in `SVGElement::SynchronizeAttributeInShadowInstances()`
+>
+> Speculative fix for potential issue (more context in the bug).
+>
+> Bug: 496284584
+> Change-Id: I4906a3269afe37aec524f36cd7aa64327327f9c5
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7703714
+> Commit-Queue: Kalvin Lee <kdlee@chromium.org>
+> Reviewed-by: Keishi Hattori <keishi@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1605966}
+
+(cherry picked from commit 122679a5ea41c567989005e90ae0bcd27d590b95)
+
+Bug: 505251912,496284584
+Change-Id: I4906a3269afe37aec524f36cd7aa64327327f9c5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7791302
+Reviewed-by: Rune Lillesveen <futhark@chromium.org>
+Reviewed-by: Kalvin Lee <kdlee@chromium.org>
+Commit-Queue: Kalvin Lee <kdlee@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7680@{#4017}
+Cr-Branched-From: 76b7d80e5cda23fe6537eed26d68c92e995c7f39-refs/heads/main@{#1582197}
+
+diff --git a/third_party/blink/renderer/core/svg/svg_element.cc b/third_party/blink/renderer/core/svg/svg_element.cc
+index edafb101a0cd4eb5fb1bede26b60ac0e10fd318e..6a5dff7622ae623fecc4c92f70c591dd254466d7 100644
+--- a/third_party/blink/renderer/core/svg/svg_element.cc
++++ b/third_party/blink/renderer/core/svg/svg_element.cc
+@@ -1211,8 +1211,8 @@ SMILTimeContainer* SVGElement::GetTimeContainer() const {
+ void SVGElement::SynchronizeAttributeInShadowInstances(
+     const QualifiedName& name,
+     const AtomicString& value) {
+-  const HeapHashSet<WeakMember<SVGElement>>& set = InstancesForElement();
+-  for (SVGElement* instance : set) {
++  HeapHashSet<WeakMember<SVGElement>> instances = InstancesForElement();
++  for (SVGElement* instance : instances) {
+     instance->SetAttributeWithoutValidation(name, value);
+   }
+ }

--- a/patches/chromium/cherry-pick-7800635.patch
+++ b/patches/chromium/cherry-pick-7800635.patch
@@ -1,0 +1,184 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "mark a. foltz" <mfoltz@chromium.org>
+Date: Tue, 28 Apr 2026 09:46:49 -0700
+Subject: [M146] [Presentation API] Fix Use-After-Free in
+ PresentationAvailability
+
+Original change's description:
+> [Presentation API] Fix Use-After-Free in PresentationAvailability
+>
+> This CL fixes a Use-After-Free/Use-After-Poison vulnerability caused by
+> re-entrant modifications of collections during promise resolution.
+>
+> 1. In PresentationAvailability, we now swap availability_resolvers_ to
+>    a local vector before iterating. This prevents re-entrant calls
+>    (e.g., from JS calling getAvailability()) from modifying the
+>    collection being iterated.
+>
+> 2. In PresentationAvailabilityState, we now copy the availabilities set
+>    to a local vector using strong Member references and null checks.
+>    This ensures objects stay alive during iteration and handles
+>    WeakMember references safely.
+>
+> A regression test is added to verify that re-entrant RequestAvailability
+> calls no longer trigger memory safety issues.
+>
+> Fixed: 456795077, 502249087
+> Change-Id: I34d722892b4d253b17d27612f0895c033dd46eaa
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7793737
+> Reviewed-by: Muyao Xu <muyaoxu@google.com>
+> Commit-Queue: Mark Foltz <mfoltz@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1620515}
+
+(cherry picked from commit 959627a8a6af4b0e26380aa129e0e40266003f93)
+
+Bug: 507046103,456795077,502249087
+Change-Id: I34d722892b4d253b17d27612f0895c033dd46eaa
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7800635
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7680@{#4018}
+Cr-Branched-From: 76b7d80e5cda23fe6537eed26d68c92e995c7f39-refs/heads/main@{#1582197}
+
+diff --git a/third_party/blink/renderer/modules/presentation/presentation_availability.cc b/third_party/blink/renderer/modules/presentation/presentation_availability.cc
+index 582bc7e5f416bef7d82bf947dc94bb80d6e38df4..13e5fb6359ce348dbcb0be8dba85ea942e96173d 100644
+--- a/third_party/blink/renderer/modules/presentation/presentation_availability.cc
++++ b/third_party/blink/renderer/modules/presentation/presentation_availability.cc
+@@ -129,18 +129,20 @@ void PresentationAvailability::AddResolver(
+ }
+ 
+ void PresentationAvailability::RejectPendingPromises() {
+-  for (auto& resolver : availability_resolvers_) {
++  HeapVector<Member<ScriptPromiseResolver<PresentationAvailability>>> resolvers;
++  resolvers.swap(availability_resolvers_);
++  for (auto& resolver : resolvers) {
+     resolver->RejectWithDOMException(DOMExceptionCode::kNotSupportedError,
+                                      kNotSupportedErrorInfo);
+   }
+-  availability_resolvers_.clear();
+ }
+ 
+ void PresentationAvailability::ResolvePendingPromises() {
+-  for (auto& resolver : availability_resolvers_) {
++  HeapVector<Member<ScriptPromiseResolver<PresentationAvailability>>> resolvers;
++  resolvers.swap(availability_resolvers_);
++  for (auto& resolver : resolvers) {
+     resolver->Resolve(this);
+   }
+-  availability_resolvers_.clear();
+ }
+ 
+ void PresentationAvailability::Trace(Visitor* visitor) const {
+diff --git a/third_party/blink/renderer/modules/presentation/presentation_availability_state.cc b/third_party/blink/renderer/modules/presentation/presentation_availability_state.cc
+index eadd9ea791f99387701a5614d2bab5552a1b77c4..9786f71ce7e1dc72c166c459022bef15409b1348 100644
+--- a/third_party/blink/renderer/modules/presentation/presentation_availability_state.cc
++++ b/third_party/blink/renderer/modules/presentation/presentation_availability_state.cc
+@@ -103,16 +103,23 @@ void PresentationAvailabilityState::UpdateAvailability(
+       observer->AvailabilityChanged(screen_availability);
+     }
+ 
++    HeapVector<Member<PresentationAvailability>> availabilities;
++    for (auto& availability_ptr : listener->availabilities) {
++      if (availability_ptr) {
++        availabilities.push_back(availability_ptr);
++      }
++    }
++    listener->availabilities.clear();
++
+     if (screen_availability == mojom::blink::ScreenAvailability::DISABLED) {
+-      for (auto& availability_ptr : listener->availabilities) {
++      for (auto& availability_ptr : availabilities) {
+         availability_ptr->RejectPendingPromises();
+       }
+     } else {
+-      for (auto& availability_ptr : listener->availabilities) {
++      for (auto& availability_ptr : availabilities) {
+         availability_ptr->ResolvePendingPromises();
+       }
+     }
+-    listener->availabilities.clear();
+ 
+     for (const auto& availability_url : listener->urls) {
+       MaybeStopListeningToURL(availability_url);
+diff --git a/third_party/blink/renderer/modules/presentation/presentation_availability_state_test.cc b/third_party/blink/renderer/modules/presentation/presentation_availability_state_test.cc
+index 14da3c758232c5455c1ea26a3204c9e968626abd..3718d5021082159c3a0f916307078949a5d54deb 100644
+--- a/third_party/blink/renderer/modules/presentation/presentation_availability_state_test.cc
++++ b/third_party/blink/renderer/modules/presentation/presentation_availability_state_test.cc
+@@ -38,6 +38,37 @@ class MockPresentationAvailabilityObserver
+   const Vector<KURL> urls_;
+ };
+ 
++// Helper class for ReentrantRequestAvailability test.
++class ReentrantResolver final
++    : public ThenCallable<PresentationAvailability, ReentrantResolver> {
++ public:
++  ReentrantResolver(PresentationAvailabilityState* state,
++                    PresentationAvailability* availability,
++                    base::OnceClosure callback)
++      : state_(state),
++        availability_(availability),
++        callback_(std::move(callback)) {}
++
++  void React(ScriptState*, PresentationAvailability*) {
++    // Simulate re-entrant RequestAvailability call.
++    state_->RequestAvailability(availability_);
++    if (callback_) {
++      std::move(callback_).Run();
++    }
++  }
++
++  void Trace(Visitor* visitor) const override {
++    visitor->Trace(state_);
++    visitor->Trace(availability_);
++    ThenCallable<PresentationAvailability, ReentrantResolver>::Trace(visitor);
++  }
++
++ private:
++  Member<PresentationAvailabilityState> state_;
++  Member<PresentationAvailability> availability_;
++  base::OnceClosure callback_;
++};
++
+ // Helper classes for WaitForPromise{Fulfillment,Rejection}(). Provides a
+ // function that invokes |callback| when a ScriptPromise is resolved/rejected.
+ class ClosureOnResolve final
+@@ -638,4 +669,38 @@ TEST_F(PresentationAvailabilityStateTest,
+   ChangeURLState(url2_, ScreenAvailability::SOURCE_NOT_SUPPORTED);
+ }
+ 
++TEST_F(PresentationAvailabilityStateTest, ReentrantRequestAvailability) {
++  PresentationAvailabilityStateTestingContext context;
++  EXPECT_CALL(mock_presentation_service_, ListenForScreenAvailability(url1_))
++      .Times(1);
++
++  auto* resolver =
++      MakeGarbageCollected<ScriptPromiseResolver<PresentationAvailability>>(
++          context.GetScriptState(), context.GetExceptionContext());
++  auto* availability = MakeGarbageCollected<PresentationAvailability>(
++      context.GetExecutionContext(), Vector<KURL>({url1_}), false);
++  availability->AddResolver(resolver);
++  state_->AddObserver(availability);
++  auto promise = resolver->Promise();
++
++  base::RunLoop run_loop;
++  promise.Then(context.GetScriptState(),
++               MakeGarbageCollected<ReentrantResolver>(state_, availability,
++                                                       run_loop.QuitClosure()));
++
++  TestRequestAvailability({ScreenAvailability::AVAILABLE}, availability);
++
++  // Execute pending microtasks to trigger the re-entrant call.
++  context.GetScriptState()
++      ->GetContext()
++      ->GetMicrotaskQueue()
++      ->PerformCheckpoint(context.GetScriptState()->GetIsolate());
++  run_loop.Run();
++
++  // The re-entrant RequestAvailability call added 'availability' back to
++  // listener->availabilities.
++  state_->UpdateAvailability(url1_, ScreenAvailability::AVAILABLE);
++  state_->RemoveObserver(availability);
++}
++
+ }  // namespace blink

--- a/patches/config.json
+++ b/patches/config.json
@@ -17,5 +17,6 @@
   { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia" },
   { "patch_dir": "src/electron/patches/angle", "repo": "src/third_party/angle/src" },
   { "patch_dir": "src/electron/patches/pdfium", "repo": "src/third_party/pdfium" },
-  { "patch_dir": "src/electron/patches/libaom", "repo": "src/third_party/libaom/source/libaom" }
+  { "patch_dir": "src/electron/patches/libaom", "repo": "src/third_party/libaom/source/libaom" },
+  { "patch_dir": "src/electron/patches/libwebm", "repo": "src/third_party/libwebm/source" }
 ]

--- a/patches/libwebm/.patches
+++ b/patches/libwebm/.patches
@@ -1,0 +1,1 @@
+cherry-pick-7783104.patch

--- a/patches/libwebm/cherry-pick-7783104.patch
+++ b/patches/libwebm/cherry-pick-7783104.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "vigneshv@google.com" <vigneshv@google.com>
+Date: Tue, 21 Apr 2026 09:35:31 -0700
+Subject: mkvmuxer: fix UAF and double-free in WriteFramesLessThan
+
+Failures in writing frames within `Segment::WriteFramesLessThan` failed
+to increment the `shift_left` compaction counter. This left deleted
+frame pointers in the array as dangling references, triggering
+heap-use-after-free or double-free on cleanup when subsequent
+frames are written or the segment is destroyed.
+
+This patch ensures the `shift_left` array shift bounds counter is
+incremented for each error handling failure path where deletion is
+triggered without immediate break from loop.
+
+Also add unit tests that will fail without this fix.
+
+Bug: 504660052
+Change-Id: I345c90b1ff10bfe82c7ede1f5ec5a4d5f8ee318a
+
+diff --git a/mkvmuxer/mkvmuxer.cc b/mkvmuxer/mkvmuxer.cc
+index 77520b7041547787656da42b5049b4ede420d49b..9ac09cbf434a1a5a2ec5d8136012eabc6d0d9acd 100644
+--- a/mkvmuxer/mkvmuxer.cc
++++ b/mkvmuxer/mkvmuxer.cc
+@@ -4152,12 +4152,14 @@ bool Segment::WriteFramesLessThan(uint64_t timestamp) {
+         doc_type_version_ = 4;
+       if (!cluster->AddFrame(frame_prev)) {
+         delete frame_prev;
++        ++shift_left;
+         continue;
+       }
+ 
+       if (new_cuepoint_ && cues_track_ == frame_prev->track_number()) {
+         if (!AddCuePoint(frame_prev->timestamp(), cues_track_)) {
+           delete frame_prev;
++          ++shift_left;
+           continue;
+         }
+       }
+diff --git a/testing/mkvmuxer_test.cc b/testing/mkvmuxer_test.cc
+index 0b92e73105a8bc8b10ccc6bde5fb47def01d63fc..5d6f2a2142582720920f3f03fc2af97e98f269b4 100644
+--- a/testing/mkvmuxer_test.cc
++++ b/testing/mkvmuxer_test.cc
+@@ -39,6 +39,87 @@ using mkvmuxer::VideoTrack;
+ 
+ namespace test {
+ 
++class FailingWriter : public mkvmuxer::IMkvWriter {
++ public:
++  mkvmuxer::int32 Write(const void* /*buf*/, mkvmuxer::uint32 len) override {
++    if (fail_ && len >= fail_min_len_) {
++      return -1;
++    }
++    pos_ += len;
++    return 0;
++  }
++  mkvmuxer::int64 Position() const override { return pos_; }
++  mkvmuxer::int32 Position(mkvmuxer::int64 position) override {
++    pos_ = position;
++    return 0;
++  }
++  bool Seekable() const override { return true; }
++  void ElementStartNotify(mkvmuxer::uint64, mkvmuxer::int64) override {}
++
++  void StartFailing(mkvmuxer::uint32 min_len) {
++    fail_ = true;
++    fail_min_len_ = min_len;
++  }
++
++ private:
++  mkvmuxer::int64 pos_ = 0;
++  bool fail_ = false;
++  mkvmuxer::uint32 fail_min_len_ = 0;
++};
++
++constexpr uint64_t kMs = 1000000ULL;  // 1 ms in ns (default timecode_scale).
++constexpr uint64_t kAudioFrameLen = 100;  // > all EBML metadata writes.
++constexpr uint64_t kVideoFrameLen = 8;
++
++// Test case from crbug.com/504660052.
++TEST(MkvmuxerUafTest, WriteFramesLessThanDanglingSlot_UseAfterFreeRead) {
++  FailingWriter writer;
++  mkvmuxer::Segment segment;
++  ASSERT_TRUE(segment.Init(&writer));
++
++  const uint64_t vtrack = segment.AddVideoTrack(320, 240, 1);
++  const uint64_t atrack = segment.AddAudioTrack(48000, 2, 2);
++  ASSERT_NE(vtrack, 0u);
++  ASSERT_NE(atrack, 0u);
++
++  uint8_t vdata[kVideoFrameLen] = {};
++  uint8_t adata[kAudioFrameLen] = {};
++
++  ASSERT_TRUE(segment.AddFrame(vdata, kVideoFrameLen, vtrack, 0 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 10 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 20 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 30 * kMs, true));
++
++  writer.StartFailing(/*min_len=*/50);
++
++  // It does not matter whether this succeeds or fails, it should not crash.
++  segment.AddFrame(vdata, kVideoFrameLen, vtrack, 40 * kMs, true);
++}
++
++// Test case from crbug.com/504660052.
++TEST(MkvmuxerUafTest, WriteFramesLessThanDanglingSlot_DoubleFree) {
++  FailingWriter writer;
++  mkvmuxer::Segment segment;
++  ASSERT_TRUE(segment.Init(&writer));
++
++  const uint64_t vtrack = segment.AddVideoTrack(320, 240, 1);
++  const uint64_t atrack = segment.AddAudioTrack(48000, 2, 2);
++  ASSERT_NE(vtrack, 0u);
++  ASSERT_NE(atrack, 0u);
++
++  uint8_t vdata[kVideoFrameLen] = {};
++  uint8_t adata[kAudioFrameLen] = {};
++
++  ASSERT_TRUE(segment.AddFrame(vdata, kVideoFrameLen, vtrack, 0 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 10 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 20 * kMs, true));
++  ASSERT_TRUE(segment.AddFrame(adata, kAudioFrameLen, atrack, 30 * kMs, true));
++
++  writer.StartFailing(/*min_len=*/0);
++
++  EXPECT_FALSE(segment.AddFrame(vdata, kVideoFrameLen, vtrack, 40 * kMs, true));
++}
++
+ // Base class containing boiler plate stuff.
+ class MuxerTest : public testing::Test {
+  public:

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -11,3 +11,5 @@ fix_reset_errno_before_strtol_in_builtin_hash_profile_parser.patch
 cherry-pick-cl-7698216.patch
 cherry-pick-cl-7709449.patch
 cherry-pick-cl-7702700.patch
+cherry-pick-7758773.patch
+cherry-pick-7766691.patch

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -13,3 +13,4 @@ cherry-pick-cl-7709449.patch
 cherry-pick-cl-7702700.patch
 cherry-pick-7758773.patch
 cherry-pick-7766691.patch
+cherry-pick-7789282.patch

--- a/patches/v8/cherry-pick-7758773.patch
+++ b/patches/v8/cherry-pick-7758773.patch
@@ -1,0 +1,135 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthias Liedtke <mliedtke@chromium.org>
+Date: Tue, 14 Apr 2026 16:31:35 +0200
+Subject: [wasm] 32 bit platforms: Fix int64 lowering for 'invalid' offsets
+
+The logic for the case !LoadOp::OffsetIsValid() was not correct.
+
+Fixed: 502030575
+Change-Id: I81692e2bb7cc15f85911c0110b84ae3a66189d53
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7758773
+Auto-Submit: Matthias Liedtke <mliedtke@chromium.org>
+Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
+Commit-Queue: Matthias Liedtke <mliedtke@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#106481}
+
+diff --git a/src/compiler/turboshaft/int64-lowering-reducer.h b/src/compiler/turboshaft/int64-lowering-reducer.h
+index 52c1c7c3077522499044dc8e86cb9c0039141608..e73258fbbf72376b64b103c8c53bfaa907b5e549 100644
+--- a/src/compiler/turboshaft/int64-lowering-reducer.h
++++ b/src/compiler/turboshaft/int64-lowering-reducer.h
+@@ -295,10 +295,10 @@ class Int64LoweringReducer : public Next {
+     FATAL("%s", str.str().c_str());
+   }
+ 
+-  std::pair<OptionalV<Word32>, int32_t> IncreaseOffset(OptionalV<Word32> index,
+-                                                       int32_t offset,
+-                                                       int32_t add_offset,
+-                                                       bool tagged_base) {
++  std::pair<OptionalV<Word32>, int32_t> IncreaseOffset(
++      OptionalV<Word32> index, int32_t offset, int32_t add_offset,
++      uint8_t element_size_log2, bool tagged_base) {
++    uint32_t element_size = 1 << element_size_log2;
+     // Note that the offset will just wrap around. Still, we need to always
+     // use an offset that is not std::numeric_limits<int32_t>::min() on tagged
+     // loads.
+@@ -308,13 +308,17 @@ class Int64LoweringReducer : public Next {
+         static_cast<uint32_t>(offset) + static_cast<uint32_t>(add_offset);
+     OptionalV<Word32> new_index = index;
+     if (!LoadOp::OffsetIsValid(new_offset, tagged_base)) {
+-      // We cannot encode the new offset so we use the old offset
+-      // instead and use the Index to represent the extra offset.
+-      new_offset = offset;
++      // We cannot encode the new offset because it has the one invalid value.
++      // We can choose any other value and the only requirement is that we end
++      // up at the same final location after calculating
++      // |  index * element_size + offset
++      // So we'll just subtract "one element" and increase the index by one.
++      // We could do this for almost any arbitrary value larger than 0.
++      new_offset -= element_size;
+       if (index.has_value()) {
+-        new_index = __ Word32Add(new_index.value(), add_offset);
++        new_index = __ Word32Add(new_index.value(), 1);
+       } else {
+-        new_index = __ Word32Constant(sizeof(int32_t));
++        new_index = __ Word32Constant(1);
+       }
+     }
+     return {new_index, new_offset};
+@@ -347,8 +351,8 @@ class Int64LoweringReducer : public Next {
+     }
+     if (loaded_rep == MemoryRepresentation::Int64() ||
+         loaded_rep == MemoryRepresentation::Uint64()) {
+-      auto [high_index, high_offset] =
+-          IncreaseOffset(index, offset, sizeof(int32_t), kind.tagged_base);
++      auto [high_index, high_offset] = IncreaseOffset(
++          index, offset, sizeof(int32_t), element_scale, kind.tagged_base);
+       return __ MakeTuple(
+           Next::ReduceLoad(base, index, kind, MemoryRepresentation::Int32(),
+                            RegisterRepresentation::Word32(), offset,
+@@ -388,8 +392,8 @@ class Int64LoweringReducer : public Next {
+                         maybe_initializing_or_transitioning,
+                         maybe_indirect_pointer_tag);
+       // high store
+-      auto [high_index, high_offset] =
+-          IncreaseOffset(index, offset, sizeof(int32_t), kind.tagged_base);
++      auto [high_index, high_offset] = IncreaseOffset(
++          index, offset, sizeof(int32_t), element_size_log2, kind.tagged_base);
+       Next::ReduceStore(
+           base, high_index, high, kind, MemoryRepresentation::Int32(),
+           write_barrier, high_offset, element_size_log2,
+diff --git a/test/mjsunit/regress/wasm/regress-502030575.js b/test/mjsunit/regress/wasm/regress-502030575.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..f0fd90b7e3ce96332243f2746c043d727b314376
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-502030575.js
+@@ -0,0 +1,50 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++d8.file.execute("test/mjsunit/wasm/wasm-module-builder.js");
++
++let builder = new WasmModuleBuilder();
++let array_type = builder.addArray(kWasmI64);
++
++// For 32 bit platforms:
++// Choose a big constant offset, so that when adding the constant wasm array
++// header offset and the extra offset for the 2nd i32 load we end up with a
++// value that exactly equals INT32_MIN (which is the singular value that
++// returns false for LoadOp::OffsetIsValid()).
++const BIG_CONST = 0xFFFFFFE;
++const WASM_ARRAY_HEADER = 12; // map + hash + array size (subject to change)
++const SECOND_LOAD_OFFSET = 4
++const INT32_MIN = 1 << 31;
++assertEquals(
++  (BIG_CONST * 8 + WASM_ARRAY_HEADER + SECOND_LOAD_OFFSET) | 0,
++  INT32_MIN);
++let testValue = 0x1234_5678_90ab_cdefn;
++
++builder.addFunction("test", makeSig([kWasmI32], [kWasmI64]))
++  .addLocals(wasmRefNullType(array_type), 1)
++  .addBody([
++    // Create an array with a single value
++    ...wasmI32Const(1),
++    kGCPrefix, kExprArrayNewDefault, array_type,
++    kExprLocalTee, 1,
++    // Write a value at offset 0.
++    kExprI32Const, 0,
++    ...wasmI64Const(testValue),
++    kGCPrefix, kExprArraySet, array_type,
++    // Read the value at offset 0 by having the index calculation
++    // (BIG_CONST - BIG_CONST). The i32.const in the code will be folded into
++    // the offset of the load.
++    kExprLocalGet, 1,
++    kExprLocalGet, 0,
++    ...wasmI32Const(BIG_CONST),
++    kExprI32Add,
++    kGCPrefix, kExprArrayGet, array_type,
++  ])
++  .exportFunc();
++
++let instance = builder.instantiate();
++let result = instance.exports.test(-BIG_CONST);
++assertEquals(testValue, result);

--- a/patches/v8/cherry-pick-7766691.patch
+++ b/patches/v8/cherry-pick-7766691.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marja=20H=C3=B6ltt=C3=A4?= <marja@chromium.org>
+Date: Thu, 16 Apr 2026 14:56:51 +0200
+Subject: [builtins] Fix Array.p.slice bailout threshold on arguments objects
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixed: 502830119
+Change-Id: Ia5b299cd9c33cabfe2a0647ff6a54e1942d6cd3f
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7766691
+Commit-Queue: Marja Hölttä <marja@chromium.org>
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#106550}
+
+diff --git a/src/builtins/array-slice.tq b/src/builtins/array-slice.tq
+index 067262a9362f6076bc736883a3c7faa3a4a27dd5..0557958bfd3eba30de860c6d8fd6256747b650a9 100644
+--- a/src/builtins/array-slice.tq
++++ b/src/builtins/array-slice.tq
+@@ -3,12 +3,21 @@
+ // found in the LICENSE file.
+ 
+ namespace array {
++
++const kJSArrayHeaderSizeSlots:
++    constexpr int31 generates 'JSArray::kHeaderSize / kTaggedSize';
++
+ macro HandleSimpleArgumentsSlice(
+     context: NativeContext, args: JSArgumentsObjectWithLength, start: Smi,
+     count: Smi): JSArray
+     labels Bailout {
+   // If the resulting array doesn't fit in new space, use the slow path.
+-  if (count >= kMaxNewSpaceFixedArrayElements) goto Bailout;
++  // We subtract the JSArray header size to ensure the JSArray and elements
++  // allocation can be safely folded together into a single object.
++  if (count >= kMaxNewSpaceFixedArrayElements - kJSArrayHeaderSizeSlots) {
++    goto Bailout;
++  }
++
+ 
+   const end: Smi = start + count;
+   const sourceElements: FixedArray =
+@@ -32,7 +41,11 @@ macro HandleFastAliasedSloppyArgumentsSlice(
+     count: Smi): JSArray
+     labels Bailout {
+   // If the resulting array doesn't fit in new space, use the slow path.
+-  if (count >= kMaxNewSpaceFixedArrayElements) goto Bailout;
++  // We subtract the JSArray header size to ensure the JSArray and elements
++  // allocation can be safely folded together into a single object.
++  if (count >= kMaxNewSpaceFixedArrayElements - kJSArrayHeaderSizeSlots) {
++    goto Bailout;
++  }
+ 
+   const sloppyElements: SloppyArgumentsElements =
+       Cast<SloppyArgumentsElements>(args.elements) otherwise Bailout;

--- a/patches/v8/cherry-pick-7789282.patch
+++ b/patches/v8/cherry-pick-7789282.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakob Kummerow <jkummerow@chromium.org>
+Date: Thu, 23 Apr 2026 15:49:16 +0200
+Subject: [wasm][turboshaft] Fix Phi handling in Wasm Load Elimination
+
+When a Phi is later found to not have all-identical inputs after
+all, we must unset its replacement.
+
+Fixed: 505481948
+Change-Id: Ic9d405db231f30859f4e0f8831b2db5c76bdd622
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7789282
+Auto-Submit: Jakob Kummerow <jkummerow@chromium.org>
+Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
+Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#106779}
+
+diff --git a/src/compiler/turboshaft/wasm-load-elimination-reducer.h b/src/compiler/turboshaft/wasm-load-elimination-reducer.h
+index e15a7d6cd9392674f875f93446c23c10360086fb..e1b415f5d87dc48baf82eda5da6912d514e4eca9 100644
+--- a/src/compiler/turboshaft/wasm-load-elimination-reducer.h
++++ b/src/compiler/turboshaft/wasm-load-elimination-reducer.h
+@@ -987,6 +987,8 @@ void WasmLoadEliminationAnalyzer::ProcessPhi(OpIndex op_idx, const PhiOp& phi) {
+     }
+     if (same_inputs) {
+       replacements_[op_idx] = first;
++    } else {
++      replacements_[op_idx] = OpIndex::Invalid();
+     }
+   }
+ }
+diff --git a/test/mjsunit/regress/wasm/regress-505481948.js b/test/mjsunit/regress/wasm/regress-505481948.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..50acc24c5b140ce6690f02c394ad9f24b94736ec
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-505481948.js
+@@ -0,0 +1,108 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --nowasm-loop-unrolling --nowasm-loop-peeling
++
++d8.file.execute("test/mjsunit/wasm/wasm-module-builder.js")
++
++const builder = new WasmModuleBuilder();
++
++const arr = builder.addArray(kWasmI32, { final: true });
++const holder = builder.addStruct([makeField(wasmRefType(arr), true)]);
++
++const bigLen = 8;
++const smallLen = 1;
++const victimInit = 0x12345678;
++const expandedVictimLen = 0x40;
++
++const gVictim = builder.addGlobal(wasmRefNullType(arr), true);
++const gHolder = builder.addGlobal(wasmRefNullType(holder), true);
++
++builder.addFunction('expand_victim_length', makeSig([], []))
++  .addLocals(wasmRefType(holder), 1)
++  .addLocals(wasmRefType(arr), 3)
++  .addLocals(kWasmI32, 1)
++  .addBody([
++    kExprI32Const, bigLen,
++    kGCPrefix, kExprArrayNewDefault, arr,
++    kExprLocalSet, 1,
++
++    kExprI32Const, smallLen,
++    kGCPrefix, kExprArrayNewDefault, arr,
++    kExprLocalSet, 2,
++
++    kExprI32Const, smallLen,
++    kGCPrefix, kExprArrayNewDefault, arr,
++    kExprLocalSet, 3,
++
++    kExprLocalGet, 3,
++    kExprI32Const, 0,
++    ...wasmI32Const(victimInit),
++    kGCPrefix, kExprArraySet, arr,
++
++    kExprLocalGet, 1,
++    kGCPrefix, kExprStructNew, holder,
++    kExprLocalSet, 0,
++
++    kExprLocalGet, 3,
++    kExprGlobalSet, gVictim.index,
++    kExprLocalGet, 0,
++    kExprGlobalSet, gHolder.index,
++
++    kExprI32Const, 2,
++    kExprLocalSet, 4,
++
++    kExprLoop, kWasmVoid,
++    kExprLocalGet, 4,
++    kExprI32Const, 2,
++    kExprI32Eq,
++    kExprIf, kWasmRef, arr,
++    kExprLocalGet, 1,
++    kExprElse,
++    kExprLocalGet, 0,
++    kGCPrefix, kExprStructGet, holder, 0,
++    kExprEnd,
++    kExprI32Const, 3,
++    kExprI32Const, expandedVictimLen,
++    kGCPrefix, kExprArraySet, arr,
++
++    kExprLocalGet, 0,
++    kExprLocalGet, 2,
++    kGCPrefix, kExprStructSet, holder, 0,
++
++    kExprLocalGet, 4,
++    kExprI32Const, 1,
++    kExprI32Sub,
++    kExprLocalTee, 4,
++    kExprBrIf, 0,
++    kExprEnd,
++  ])
++  .exportFunc();
++
++builder.addFunction('victim_write', kSig_v_ii)
++  .addBody([
++    kExprGlobalGet, gVictim.index,
++    kExprLocalGet, 0,
++    kExprLocalGet, 1,
++    kGCPrefix, kExprArraySet, arr,
++  ])
++  .exportFunc();
++
++builder.addFunction('get_holder', kSig_r_v)
++  .addBody([
++    kExprGlobalGet, gHolder.index,
++    kGCPrefix, kExprStructGet, holder, 0,
++    kGCPrefix, kExprExternConvertAny,
++  ])
++  .exportFunc();
++
++const instance = builder.instantiate({});
++const wasm = instance.exports;
++
++assertTraps(kTrapArrayOutOfBounds, () => {
++  wasm.expand_victim_length()
++  let addr = 0x10000001;
++  wasm.victim_write(3, addr);
++  wasm.get_holder();
++});


### PR DESCRIPTION
## Summary

Backports **20 High-severity** security fixes from the Chrome 148 stable release (May 2026) to 40-x-y (Chromium M144).

**Chromium** (14 patches):
* [`7695218`](https://chromium-review.googlesource.com/c/chromium/src/+/7695218) — Bounds check in StringView constructor ([492350406](https://crbug.com/492350406))
* [`7695435`](https://chromium-review.googlesource.com/c/chromium/src/+/7695435) — DCHECK→CHECK in media/base and media/mojo ([495259842](https://crbug.com/495259842))
* [`7701234`](https://chromium-review.googlesource.com/c/chromium/src/+/7701234) — Block PrepareScript during atomic-move ([496292089](https://crbug.com/496292089))
* [`7718624`](https://chromium-review.googlesource.com/c/chromium/src/+/7718624) — Integer overflow in GPU buffer/transform feedback ([497639714](https://crbug.com/497639714))
* [`7722343`](https://chromium-review.googlesource.com/c/chromium/src/+/7722343) — UAF during EnterFullscreenMode ([498752242](https://crbug.com/498752242))
* [`7722499`](https://chromium-review.googlesource.com/c/chromium/src/+/7722499) — Type confusion in accessibility get_hyperlink ([498401609](https://crbug.com/498401609))
* [`7723101`](https://chromium-review.googlesource.com/c/chromium/src/+/7723101) — Bad message on race loader reuse ([497437113](https://crbug.com/497437113))
* [`7726850`](https://chromium-review.googlesource.com/c/chromium/src/+/7726850) — Check request upload bodies in InterestGroups ([498720754](https://crbug.com/498720754))
* [`7726886`](https://chromium-review.googlesource.com/c/chromium/src/+/7726886) — Iterator invalidation in aura::Window ([498832921](https://crbug.com/498832921))
* [`7727919`](https://chromium-review.googlesource.com/c/chromium/src/+/7727919) — Restore fallback_factory_ CreateLoaderAndStart ([497437113](https://crbug.com/497437113))
* [`7737952`](https://chromium-review.googlesource.com/c/chromium/src/+/7737952) — UAF in DWTHP::OnActivationChanged ([497543810](https://crbug.com/497543810))
* [`7779792`](https://chromium-review.googlesource.com/c/chromium/src/+/7779792) — [M146] UAF in ForSecurityDropFullscreen ([497436531](https://crbug.com/497436531))
* [`7791302`](https://chromium-review.googlesource.com/c/chromium/src/+/7791302) — [M146] Copy vector in SVGElement::Synchronize ([496284584](https://crbug.com/496284584))
* [`7800635`](https://chromium-review.googlesource.com/c/chromium/src/+/7800635) — [M146] UAF in PresentationAvailability ([502830119](https://crbug.com/502830119))

**ANGLE** (3 patches):
* [`7695232`](https://chromium-review.googlesource.com/c/angle/angle/+/7695232) — Overflow in D3D11 texture staging buffers ([491760376](https://crbug.com/491760376))
* [`7712217`](https://chromium-review.googlesource.com/c/angle/angle/+/7712217) — Heap-buffer-overflow in convertVertexBufferCPU ([496503799](https://crbug.com/496503799))
* [`7722080`](https://chromium-review.googlesource.com/c/angle/angle/+/7722080) — Store LibraryCacheEntry in shared_ptr ([497724490](https://crbug.com/497724490))

**V8** (2 patches):
* [`7758773`](https://chromium-review.googlesource.com/c/v8/v8/+/7758773) — Fix int64 lowering for invalid offsets ([502030575](https://crbug.com/502030575))
* [`7766691`](https://chromium-review.googlesource.com/c/v8/v8/+/7766691) — Fix Array.p.slice bailout threshold ([502830119](https://crbug.com/502830119))

**libwebm** (1 patch):
* [`7783104`](https://chromium-review.googlesource.com/c/webm/libwebm/+/7783104) — UAF and double-free in WriteFramesLessThan ([504660052](https://crbug.com/504660052))

## Test plan
- [ ] Patches apply cleanly via `e sync --3` ✅ (verified locally)
- [ ] `lint --patches` passes ✅ (verified locally)
- [ ] CI Apply Patches passes
- [ ] CI build passes

Notes: Security: backported 20 High-severity fixes from Chrome 148 stable release.
