### PR TITLE
ci: run builds with -quiet flag by default

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -82,10 +82,12 @@ runs:
 
         export NINJA_SUMMARIZE_BUILD=1
         export NO_COLOR=1
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+
         if [ "${{ inputs.is-release }}" = "true" ]; then
           e build --target electron:release_build
         else
-          e build --target electron:testing_build
+          e build --target electron:testing_build $QUIET_FLAG
         fi
         cp out/Default/.ninja_log out/electron_ninja_log
         node electron/script/check-symlinks.js
@@ -111,10 +113,11 @@ runs:
 
         $env:NINJA_SUMMARIZE_BUILD = 1
         $env:NO_COLOR = 1
+        $quietFlag = if ($env:ACTIONS_STEP_DEBUG -eq "true" -or "${{ inputs.is-release }}" -eq "true") { @() } else { @("-quiet") }
         if ("${{ inputs.is-release }}" -eq "true") {          
           e build --target electron:release_build
         } else {
-          e build --target electron:testing_build
+          e build --target electron:testing_build $quietFlag
         }
         if ($LASTEXITCODE -ne 0) {
           Write-Host "e build failed with exit code $LASTEXITCODE"
@@ -198,8 +201,8 @@ runs:
       shell: bash
       run: |
         cd src
-        e build --target electron:electron_chromedriver_zip
-
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+        e build --target electron:electron_chromedriver_zip $QUIET_FLAG
         if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
           if [ "${{ inputs.artifact-platform }}" = "mas" ]; then
@@ -252,7 +255,8 @@ runs:
           MAC_SDK_ARG=$(sed -n 's|^\(mac_sdk_path = "//out/\)Default/|\1ffmpeg/|p' out/Default/args.gn)
         fi
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $MAC_SDK_ARG $GN_EXTRA_ARGS"
-        e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+        e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg $QUIET_FLAG
     - name: Remove Clang problem matcher
       shell: bash
       run: echo "::remove-matcher owner=clang::"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Without the `-quiet` flag, builds will output multiple log lines for every compilation step, leading to log files that are close to 30 MB and difficult to work with on GitHub. With the `-quiet` flag they're under 2 MB and can be viewed in the GitHub UI without stalling the page.

This is wired up to not use the `-quiet` flag for release builds so that we get all the output by default, and is also set up to drop the `-quiet` flag if we rerun a job with GitHub's debug logging enabled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
