### PR TITLE
perf: use GIO for Browser::IsDefaultProtocolClient() on Linux (#51316)

### DIFF
--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -4,20 +4,15 @@
 
 #include "shell/browser/browser.h"
 
-#include <fcntl.h>
-#include <stdlib.h>
-#include <string_view>
 #if BUILDFLAG(IS_LINUX)
+#include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 #endif
 
-#include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
-#include "base/process/launch.h"
-#include "base/strings/strcat.h"
 #include "base/strings/utf_string_conversions.h"
 #include "electron/electron_version.h"
 #include "shell/browser/javascript_environment.h"
@@ -45,64 +40,26 @@ namespace electron {
 
 namespace {
 
-const char kXdgSettings[] = "xdg-settings";
-const char kXdgSettingsDefaultSchemeHandler[] = "default-url-scheme-handler";
-
-// The use of the ForTesting flavors is a hack workaround to avoid having to
-// patch these as friends into the associated guard classes.
-class [[maybe_unused, nodiscard]] LaunchXdgUtilityScopedAllowBaseSyncPrimitives
-    : public base::ScopedAllowBaseSyncPrimitivesForTesting {};
-
-bool LaunchXdgUtility(const std::vector<std::string>& argv, int* exit_code) {
-  *exit_code = EXIT_FAILURE;
-  int devnull = open("/dev/null", O_RDONLY);
-  if (devnull < 0)
-    return false;
-
-  base::LaunchOptions options;
-  options.fds_to_remap.emplace_back(devnull, STDIN_FILENO);
-
-  base::Process process = base::LaunchProcess(argv, options);
-  close(devnull);
-
-  if (!process.IsValid())
-    return false;
-  LaunchXdgUtilityScopedAllowBaseSyncPrimitives allow_base_sync_primitives;
-  return process.WaitForExit(exit_code);
-}
-
-std::optional<std::string> GetXdgAppOutput(
-    const std::vector<std::string>& argv) {
-  std::string reply;
-  int success_code;
-  ScopedAllowBlockingForElectron allow_blocking;
-  bool ran_ok = base::GetAppOutputWithExitCode(base::CommandLine(argv), &reply,
-                                               &success_code);
-
-  if (!ran_ok || success_code != EXIT_SUCCESS)
-    return {};
-
-  return reply;
-}
-
 bool SetDefaultWebClient(const std::string& protocol) {
-  auto env = base::Environment::Create();
-
-  std::vector<std::string> argv = {kXdgSettings, "set"};
-  if (!protocol.empty()) {
-    argv.emplace_back(kXdgSettingsDefaultSchemeHandler);
-    argv.emplace_back(protocol);
-  }
-
-  if (std::optional<std::string> desktop_name = env->GetVar("CHROME_DESKTOP")) {
-    argv.emplace_back(desktop_name.value());
-  } else {
+  const auto env = base::Environment::Create();
+  const std::optional<std::string> desktop_name = env->GetVar("CHROME_DESKTOP");
+  if (!desktop_name)
     return false;
-  }
 
-  int exit_code;
-  bool ran_ok = LaunchXdgUtility(argv, &exit_code);
-  return ran_ok && exit_code == EXIT_SUCCESS;
+  GDesktopAppInfo* const app_info =
+      g_desktop_app_info_new(desktop_name->c_str());
+  if (!app_info)
+    return false;
+
+  const std::string content_type = "x-scheme-handler/" + protocol;
+  GError* error = nullptr;
+  const bool success = g_app_info_set_as_default_for_type(
+      G_APP_INFO(app_info), content_type.c_str(), &error);
+  if (error != nullptr)
+    LOG(ERROR) << error->message;
+  g_clear_error(&error);
+  g_object_unref(app_info);
+  return success;
 }
 
 [[nodiscard]] ScopedGObject<GAppInfo> GetAppInfoForProtocol(const GURL& url) {
@@ -223,18 +180,19 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
   if (!IsValidProtocolScheme(protocol))
     return false;
 
-  auto env = base::Environment::Create();
-
-  std::vector<std::string> argv = {kXdgSettings, "check",
-                                   kXdgSettingsDefaultSchemeHandler, protocol};
-  if (std::optional<std::string> desktop_name = env->GetVar("CHROME_DESKTOP")) {
-    argv.emplace_back(desktop_name.value());
-  } else {
+  const auto env = base::Environment::Create();
+  const std::optional<std::string> desktop_name = env->GetVar("CHROME_DESKTOP");
+  if (!desktop_name)
     return false;
-  }
-  // Allow any reply that starts with "yes".
-  const std::optional<std::string> output = GetXdgAppOutput(argv);
-  return output && output->starts_with("yes");
+
+  GAppInfo* app_info = g_app_info_get_default_for_uri_scheme(protocol.c_str());
+  if (!app_info)
+    return false;
+
+  const char* const app_id = g_app_info_get_id(app_info);
+  const bool is_default = app_id && app_id == desktop_name.value();
+  g_object_unref(app_info);
+  return is_default;
 }
 
 // Todo implement

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as net from 'node:net';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { setTimeout } from 'node:timers/promises';

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1653,92 +1653,70 @@ describe('app module', () => {
     });
   });
 
-  ifdescribe(process.platform === 'linux')('default protocol client APIs with mocked XDG settings', () => {
+  ifdescribe(process.platform === 'linux')('default protocol client APIs', () => {
     const protocol = 'electron-test-linux';
     const desktopFileId = 'electron-test.desktop';
     const protocolMimeType = `x-scheme-handler/${protocol}`;
 
-    let xdgDir: string;
-    let xdgDataHome: string;
-    let xdgConfigHome: string;
-    let xdgBinDir: string;
-    let oldEnv: Record<string, string | undefined>;
-
-    const getRegisteredHandler = () => {
-      for (const list of [
-        path.join(xdgConfigHome, 'mimeapps.list'),
-        path.join(xdgDataHome, 'applications', 'mimeapps.list'),
-        path.join(xdgDataHome, 'applications', 'defaults.list')
-      ]) {
-        if (!fs.existsSync(list)) continue;
-
-        const match = fs
-          .readFileSync(list, 'utf8')
-          .split('\n')
-          .find((line) => line.startsWith(`${protocolMimeType}=`));
-
-        // foo=bar.desktop; --> bar.desktop
-        if (match) return match.split('=', 2)[1].split(';', 1)[0];
-      }
-
-      return '';
-    };
+    // GIO caches XDG directory paths at process startup, so we must
+    // operate on the directories it is actually monitoring rather than
+    // creating isolated temp dirs.
+    const gioDataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+    const gioConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+    const desktopFileDst = path.join(gioDataHome, 'applications', desktopFileId);
+    const mimeappsListPath = path.join(gioConfigHome, 'mimeapps.list');
 
     beforeEach(() => {
-      ({ xdgDir, xdgDataHome, xdgConfigHome, xdgBinDir } = makeXdgMockDirectories('electron-xdg-default-client-'));
+      const oldDesktopName = process.env.CHROME_DESKTOP;
 
-      oldEnv = {
-        PATH: process.env.PATH,
-        CHROME_DESKTOP: process.env.CHROME_DESKTOP,
-        XDG_DATA_HOME: process.env.XDG_DATA_HOME,
-        XDG_DATA_DIRS: process.env.XDG_DATA_DIRS,
-        XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME
-      };
+      // Install the test .desktop file where GIO can discover it.
+      fs.mkdirSync(path.dirname(desktopFileDst), { recursive: true });
+      fs.copyFileSync(
+        path.join(fixturesPath, 'api', 'xdg-mock', 'data', 'applications', desktopFileId),
+        desktopFileDst
+      );
+
+      app.setDesktopName(desktopFileId);
 
       defer(() => {
-        for (const [key, value] of Object.entries(oldEnv)) {
-          if (value === undefined) {
-            delete process.env[key];
-          } else {
-            process.env[key] = value;
-          }
+        // Restore CHROME_DESKTOP.
+        if (oldDesktopName !== undefined) {
+          process.env.CHROME_DESKTOP = oldDesktopName;
+        } else {
+          delete process.env.CHROME_DESKTOP;
         }
 
-        fs.rmSync(xdgDir, { recursive: true, force: true });
+        // Remove the test .desktop file.
+        try {
+          fs.unlinkSync(desktopFileDst);
+        } catch {}
+
+        // Remove any association for the test protocol from mimeapps.list.
+        if (fs.existsSync(mimeappsListPath)) {
+          const content = fs.readFileSync(mimeappsListPath, 'utf8');
+          const cleaned = content
+            .split('\n')
+            .filter((line) => !line.includes(protocolMimeType))
+            .join('\n');
+          if (cleaned !== content) {
+            fs.writeFileSync(mimeappsListPath, cleaned);
+          }
+        }
       });
-
-      process.env.PATH = [xdgBinDir, oldEnv.PATH].filter(Boolean).join(':');
-      process.env.XDG_DATA_HOME = xdgDataHome;
-      process.env.XDG_DATA_DIRS = [xdgDataHome, oldEnv.XDG_DATA_DIRS].filter(Boolean).join(':');
-      process.env.XDG_CONFIG_HOME = xdgConfigHome;
-      app.setDesktopName(desktopFileId);
     });
 
-    it('writes the default handler to the XDG association files', async () => {
-      expect(getRegisteredHandler()).to.equal('');
-
-      expect(app.setAsDefaultProtocolClient(protocol)).to.equal(true);
-
-      await waitUntil(() => getRegisteredHandler() === desktopFileId);
-      expect(getRegisteredHandler()).to.equal(desktopFileId);
-    });
-
-    it('detects whether the app is the default protocol client', async () => {
+    it('sets and queries the default protocol client', async () => {
       expect(app.isDefaultProtocolClient(protocol)).to.equal(false);
 
-      fs.writeFileSync(
-        path.join(xdgConfigHome, 'mimeapps.list'),
-        ['[Default Applications]', `${protocolMimeType}=other.desktop`].join('\n')
-      );
-      expect(app.isDefaultProtocolClient(protocol)).to.equal(false);
-
-      fs.writeFileSync(
-        path.join(xdgConfigHome, 'mimeapps.list'),
-        ['[Default Applications]', `${protocolMimeType}=${desktopFileId}`].join('\n')
-      );
+      // GIO needs to discover the newly installed .desktop file via inotify.
+      await waitUntil(() => app.setAsDefaultProtocolClient(protocol));
 
       await waitUntil(() => app.isDefaultProtocolClient(protocol));
       expect(app.isDefaultProtocolClient(protocol)).to.equal(true);
+
+      // Changing identity should make the check return false.
+      app.setDesktopName('other-app.desktop');
+      expect(app.isDefaultProtocolClient(protocol)).to.equal(false);
     });
   });
 


### PR DESCRIPTION
Manually backport #51316 to 42-x-y. See that PR for details.

Notes: Improved performance of `app.isDefaultProtocolClient()` and `app.setAsDefaultProtocolClient()` on Linux.