### PR TITLE
refactor: SafeStorage never emits, so do not inherit from EventEmitter (#51057)

### DIFF
--- a/shell/browser/api/electron_api_safe_storage.h
+++ b/shell/browser/api/electron_api_safe_storage.h
@@ -11,7 +11,6 @@
 #include "build/build_config.h"
 #include "components/os_crypt/async/common/encryptor.h"
 #include "shell/browser/browser_observer.h"
-#include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/wrappable.h"
@@ -37,7 +36,6 @@ class Handle;
 namespace electron::api {
 
 class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
-                          public gin_helper::EventEmitterMixin<SafeStorage>,
                           private BrowserObserver {
  public:
   static gin_helper::Handle<SafeStorage> Create(v8::Isolate* isolate);


### PR DESCRIPTION
Manual backport of #51057. See that PR for details.

Notes: None.