### PR TITLE
fix: skip current instance's child processes in Windows orphan killer

### DIFF
--- a/spec/index.js
+++ b/spec/index.js
@@ -95,20 +95,45 @@ async function killOrphanedElectronProcesses(suiteName) {
   let killed = 0;
   try {
     if (process.platform === 'win32') {
-      // Enumerate by executable path, filter current PID, force-kill each survivor
+      // Enumerate by executable path, also fetching ParentProcessId so we can
+      // skip the current instance's own child processes (GPU, network service,
+      // renderer helpers) which all run as the same electron.exe binary.
       const escapedPath = process.execPath.replace(/\\/g, '\\\\');
       const result = childProcess.spawnSync(
         'wmic',
-        ['process', 'where', `ExecutablePath='${escapedPath}'`, 'get', 'ProcessId', '/format:value'],
+        ['process', 'where', `ExecutablePath='${escapedPath}'`, 'get', 'ProcessId,ParentProcessId', '/format:value'],
         { encoding: 'utf8' }
       );
-      const pids = (result.stdout || '')
-        .split(/\r?\n/)
-        .map((line) => line.match(/^ProcessId=(\d+)/)?.[1])
-        .filter(Boolean)
-        .map(Number)
-        .filter((pid) => pid !== process.pid);
-      for (const pid of pids) {
+      // wmic /format:value outputs blank-line-separated records, each with
+      // Key=Value lines.  Build a pid→ppid map from the output.
+      const pidToParent = new Map();
+      for (const record of (result.stdout || '').split(/(?:\r?\n){2,}/)) {
+        let pid = null;
+        let ppid = null;
+        for (const line of record.split(/\r?\n/)) {
+          const pidMatch = line.match(/^ProcessId=(\d+)/);
+          const ppidMatch = line.match(/^ParentProcessId=(\d+)/);
+          if (pidMatch) pid = Number(pidMatch[1]);
+          if (ppidMatch) ppid = Number(ppidMatch[1]);
+        }
+        if (pid !== null && ppid !== null) pidToParent.set(pid, ppid);
+      }
+      // Walk the parent chain to check whether a pid is descended from us.
+      // Mirrors the Linux isDescendantOfCurrentProcess logic but uses the
+      // pre-built map instead of /proc.
+      const isDescendant = (pid) => {
+        let current = pid;
+        while (current > 1) {
+          const parent = pidToParent.get(current);
+          if (parent === undefined) return false;
+          if (parent === process.pid) return true;
+          if (parent === current) return false; // cycle guard
+          current = parent;
+        }
+        return false;
+      };
+      for (const [pid] of pidToParent) {
+        if (pid === process.pid || isDescendant(pid)) continue;
         try {
           childProcess.spawnSync('taskkill', ['/F', '/PID', String(pid), '/T']);
           killed++;


### PR DESCRIPTION
#### Description of Change

Fixup for f9635f7 / #51476, which updated the test suite to ensure that no orphan Electron processes from a previous test were still running before starting a new test.

That is a good change, but it had a bug that identified some persistent GPU/network/renderer helpers as orphans, causing some tests to fail. In particular, I'm seeing GPU-specific tests fail on Windows arm64 CI.

This PR was co-written with Claude and the fix was tested in downstream CI.

Sample CI failure:

```
2026-05-11T11:46:04.7994313Z [10888:0511/114604.798:ERROR:gpu\ipc\service\gpu_channel_manager.cc:919] ContextResult::kFatalFailure: Failed to create shared context for virtualization.
2026-05-11T11:46:04.8012489Z [9756:0511/114604.800:WARNING:content\browser\gpu\gpu_process_host.cc:1018] Reinitialized the GPU process after a crash. The reported initialization time was 0 ms
2026-05-11T11:46:05.1287091Z Killed 2 orphaned Electron processes before suite: TouchBar module
2026-05-11T11:46:05.1320393Z [9756:0511/114605.130:ERROR:content\browser\gpu\gpu_process_host.cc:996] GPU process exited unexpectedly: exit_code=1
2026-05-11T11:46:05.1323633Z [9756:0511/114605.130:WARNING:content\browser\gpu\gpu_process_host.cc:1438] The GPU process has crashed 6 time(s)
2026-05-11T11:46:05.4410996Z [9756:0511/114605.130:FATAL:content\browser\gpu\gpu_data_manager_impl_private.cc:417] GPU process isn't usable. Goodbye.
2026-05-11T11:46:05.4414420Z  electron!uv_os_getpid [0x7ff61a9989e4+9e14]
2026-05-11T11:46:05.4438836Z  electron!v8_inspector::V8StackTraceId::IsInvalid [0x7ff626e3307c+54d40c]
2026-05-11T11:46:05.4457079Z  electron!uv_fs_get_type [0x7ff61ffe747c+41e43c]
2026-05-11T11:46:05.4490995Z  electron!v8::api_internal::FromJustIsNothing [0x7ff625fca994+9824]
2026-05-11T11:46:05.4494047Z  electron!v8_inspector::V8StackTraceId::IsInvalid [0x7ff626a4f410+1697a0]
2026-05-11T11:46:05.4526503Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61eda8ef8+e96f68]
2026-05-11T11:46:05.4529877Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61edab31c+e9938c]
2026-05-11T11:46:05.4537294Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61eda8004+e96074]
2026-05-11T11:46:05.4562965Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61edb28d0+ea0940]
2026-05-11T11:46:05.4566248Z  electron!v8_inspector::V8StackTraceId::IsInvalid [0x7ff626a4fe90+16a220]
2026-05-11T11:46:05.4579702Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61eb77d60+c65dd0]
2026-05-11T11:46:05.4599326Z  electron!v8::ResourceConstraints::ResourceConstraints [0x7ff61aa244fc+34b7c]
2026-05-11T11:46:05.4615314Z  electron!IsSandboxedProcess [0x7ff6204e3434+456684]
2026-05-11T11:46:05.4648778Z  electron!v8::FunctionTemplate::SetCallHandler [0x7ff61b0c8db8+c58]
2026-05-11T11:46:05.4682355Z  electron!v8::Number::New [0x7ff61a421ee0+e3d0]
2026-05-11T11:46:05.4708931Z  electron!IsSandboxedProcess [0x7ff6200a7a34+1ac84]
2026-05-11T11:46:05.4710762Z  electron!IsSandboxedProcess [0x7ff6204db47c+44e6cc]
2026-05-11T11:46:05.4733904Z  electron!v8::ResourceConstraints::ResourceConstraints [0x7ff61aa2593c+35fbc]
2026-05-11T11:46:05.4758340Z  electron!Cr_z_crc32_z [0x7ff625457550+1b560]
2026-05-11T11:46:05.4761277Z  electron!cppgc::internal::StrongPersistentPolicy::GetPersistentRegion [0x7ff6252f3878+288]
2026-05-11T11:46:05.4789874Z  electron!cppgc::internal::GCInfoTable::RegisterNewGCInfo [0x7ff61a352dbc+a8c]
2026-05-11T11:46:05.4792653Z  electron!IsSandboxedProcess [0x7ff6200b5ef0+29140]
2026-05-11T11:46:05.4822778Z  electron!v8::Number::New [0x7ff61a421ee0+e3d0]
2026-05-11T11:46:05.4838282Z  electron!(No symbol) [0x7ff61a2d2b74]
2026-05-11T11:46:05.4841809Z  electron!cppgc::internal::WriteBarrier::DijkstraMarkingBarrierSlow [0x7ff61a3448bc+dcfc]
2026-05-11T11:46:05.4863818Z  electron!cppgc::internal::WeakPersistentPolicy::GetPersistentRegion [0x7ff62536df1c+c8fc]
2026-05-11T11:46:05.4893116Z  electron!uv_fs_get_type [0x7ff61ff422e8+3792a8]
2026-05-11T11:46:05.4908144Z  electron!uv_fs_get_type [0x7ff61ff41358+378318]
2026-05-11T11:46:05.4968087Z  electron!uv_fs_get_type [0x7ff61ff986c4+3cf684]
2026-05-11T11:46:05.4978298Z  electron!v8::ObjectTemplate::NewInstance [0x7ff61b2ca680+1b90]
2026-05-11T11:46:05.4980206Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61eb85b1c+c73b8c]
2026-05-11T11:46:05.4983440Z  electron!v8::internal::compiler::CompilationDependencies::IsFieldRepresentationDependencyOnMap [0x7ff61eb8798c+c759fc]
2026-05-11T11:46:05.4986251Z  electron!v8::HeapStatistics::external_memory [0x7ff61b17d360+82f0]
2026-05-11T11:46:05.4990979Z  electron!std::__Cr::vector<v8::CpuProfileDeoptFrame,std::__Cr::allocator<v8::CpuProfileDeoptFrame> >::resize [0x7ff61be34f6c+a32fc]
2026-05-11T11:46:05.4993178Z  electron!std::__Cr::vector<v8::CpuProfileDeoptFrame,std::__Cr::allocator<v8::CpuProfileDeoptFrame> >::resize [0x7ff61be37348+a56d8]
2026-05-11T11:46:05.4996240Z  electron!std::__Cr::vector<v8::CpuProfileDeoptFrame,std::__Cr::allocator<v8::CpuProfileDeoptFrame> >::resize [0x7ff61be37098+a5428]
2026-05-11T11:46:05.5004820Z  electron!v8::CpuProfilingOptions::max_samples [0x7ff61af223e0+6ee0]
2026-05-11T11:46:05.5006532Z  electron!v8::CpuProfilingOptions::max_samples [0x7ff61af21c7c+677c]
2026-05-11T11:46:05.5008215Z  electron!v8::CpuProfileDeoptInfo::CpuProfileDeoptInfo [0x7ff61b6f13d0+5f9a0]
2026-05-11T11:46:05.5009850Z  electron!v8::TryCatch::IsVerbose [0x7ff625f600cc+6b921c]
2026-05-11T11:46:05.5012831Z  electron!v8::TryCatch::IsVerbose [0x7ff625f60174+6b92c4]
2026-05-11T11:46:05.5014355Z  KERNEL32!BaseThreadInitThunk [0x7ffe284d76f0+40]
```

CC @mlaurencin, @jkleinsc 

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.