### PR TITLE
fix: resolve 30s delay in parentless showMessageBox on Linux

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -397,6 +397,15 @@ Shows a message box.
 
 The `window` argument allows the dialog to attach itself to a parent window, making it modal.
 
+> [!NOTE]
+> On Linux, when no parent `window` is provided **and** no `BrowserWindow`
+> instances are open, `dialog.showMessageBox()` will block the main process
+> until the dialog is dismissed (behaving like `dialog.showMessageBoxSync()`).
+> This is because Chromium's GLib event loop is not actively iterating without
+> an open window, which would otherwise cause a ~30-second delay in promise
+> resolution. When `BrowserWindow` instances exist, the normal async path is
+> used even without a parent `window`.
+
 ### `dialog.showErrorBox(title, content)`
 
 * `title` string - The title to display in the error box.

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -18,6 +18,7 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/browser/native_window_views.h"
+#include "shell/browser/window_list.h"
 #include "shell/browser/ui/gtk_util.h"
 #include "ui/base/glib/scoped_gsignal.h"
 #include "ui/gfx/image/image_skia.h"
@@ -181,6 +182,27 @@ class GtkMessageBox : private NativeWindowObserver {
 
   void RunAsynchronous(MessageBoxCallback callback) {
     callback_ = std::move(callback);
+
+    // When there is no parent window and no BrowserWindow exists,
+    // Chromium's MessagePumpGlib may not be actively iterating the GLib
+    // main context, causing GTK's "response" signal to sit undelivered
+    // for up to ~30 seconds. Use gtk_dialog_run() which spins its own
+    // nested GLib main loop to ensure events are dispatched immediately.
+    // See: https://github.com/electron/electron/issues/51049
+    if (!parent_ && WindowList::IsEmpty()) {
+      Show();
+      int response = gtk_dialog_run(GTK_DIALOG(dialog_));
+      if (id_)
+        GetDialogsMap().erase(*id_);
+      gtk_widget_hide(dialog_);
+
+      if (response < 0)
+        std::move(callback_).Run(cancel_id_, checkbox_checked_);
+      else
+        std::move(callback_).Run(response, checkbox_checked_);
+      delete this;
+      return;
+    }
 
     signals_.emplace_back(dialog_, "delete-event",
                           base::BindRepeating(gtk_widget_hide_on_delete));


### PR DESCRIPTION
## Description of Change

Fixes #51049
Supersedes #51242, #51312

> **Note:** This is a resubmission of #51312, which was closed as part of a batch `ai-pr` sweep on May 7 by @jkleinsc. That PR had been through multiple rounds of review @deepak1556 suggested targeting the startup phase specifically (addressed via `WindowList::IsEmpty()`), @mitchchn approved the final approach, and it was awaiting final sign-off from @ckerr and @deepak1556. This resubmission is rebased on latest `main` with the same changes.

When `dialog.showMessageBox()` is called before any `BrowserWindow` exists on Linux, the returned promise takes ~30 seconds to resolve after the user clicks a button. This happens because Chromium's `MessagePumpGlib` is not actively iterating the GLib main context when no `BrowserWindow` is driving it, causing GTK's `"response"` signal to sit undelivered until an internal timeout forces a GLib iteration.

**Root Cause:** The async path in `GtkMessageBox::RunAsynchronous()` connects to GTK's `"response"` signal and relies on Chromium's `MessagePumpGlib` to dispatch it. When no `BrowserWindow` has been created yet, the message pump is not actively iterating the GLib main context.

**Fix:** For parentless dialogs when `WindowList::IsEmpty()`, switch the async path to use `gtk_dialog_run()` which creates its own nested GLib main loop that properly dispatches all GTK events. The callback fires immediately when the user clicks a button. When a parent `BrowserWindow` is present, the original signal-based async path is used unchanged.

### Review History (from #51312)
- @deepak1556 Requested better targeting of startup phase rather than just checking `!parent_`. Addressed by adding `WindowList::IsEmpty()` check.
- @mitchchn Reviewed docs and code, approved the final approach: *"I think this has ended up with the most practical approach overall, especially with the documentation for the async edge case."*
- @ckerr Assigned as reviewer, awaiting final review at time of closure.

### Checklist
- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] relevant API documentation updated

### Release Notes

Notes: Fixed a ~30 second delay in `dialog.showMessageBox()` promise resolution on Linux when called before any BrowserWindow is created.
