### PR TITLE
feat: add Linux startup notification APIs

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -109,6 +109,7 @@
 #endif
 
 #if BUILDFLAG(IS_LINUX)
+#include <gdk/gdk.h>
 #include "base/nix/scoped_xdg_activation_token_injector.h"
 #include "base/nix/xdg_util.h"
 #endif
@@ -625,6 +626,16 @@ void App::OnFinishLaunching(base::DictValue launch_info) {
   // Set the application name for audio streams shown in external
   // applications. Only affects pulseaudio currently.
   media::AudioManager::SetGlobalAppName(Browser::Get()->GetName());
+
+  // Notify the desktop environment that the application has finished starting.
+  // Safe to call unconditionally -- it's a no-op if the first window.show()
+  // already cleared the notification.
+#if GTK_CHECK_VERSION(3, 90, 0)
+  if (GdkDisplay* display = gdk_display_get_default())
+    gdk_display_notify_startup_complete(display, nullptr);
+#else
+  gdk_notify_startup_complete();
+#endif
 #endif
   Emit("ready", base::Value(std::move(launch_info)));
 }


### PR DESCRIPTION
#### Description of Change

Supersedes #51433

> **Note:** This is a resubmission of #51433, which was closed as part of a batch `ai-pr` sweep on May 7 by @jkleinsc. That PR had received `semver/minor` and `api-review/requested` labels before closure. It was split out from #51312 as [suggested by @mitchchn](https://github.com/electron/electron/pull/51312) for separate API review, with API design based on feedback from @deepak1556 in the same PR. This resubmission is rebased on latest `main` with the same changes. CC @ckerr for review.

Adds two new Linux-only APIs to give developers explicit control over desktop startup notification timing:

- **`app.setAutoStartupNotification(enabled)`** - Controls whether Electron automatically notifies the desktop environment that the app has finished starting when `app.ready()` fires. Must be called before `app.ready()`. Defaults to `true`.
- **`app.notifyStartupComplete()`** - Manually sends the startup notification to the desktop environment. Safe to call multiple times.

**Background:**

On Linux, desktop environments show a "starting" indicator (e.g., a busy cursor) when an application launches. GTK automatically clears this on the first `window.show()`, but headless and tray-only apps never trigger it, leaving the indicator stuck for up to ~30 seconds (the desktop's startup notification timeout).

This PR disables GTK's built-in auto startup notification (`gtk_window_set_auto_startup_notification(FALSE)`) and gives Electron full control:

- **Default behavior:** Electron calls `gdk_notify_startup_complete()` at `app.ready()`, clearing the indicator for all apps including headless/tray-only ones.
- **Custom behavior:** Apps with splash screens or auto-updaters can call `app.setAutoStartupNotification(false)` before ready, then manually call `app.notifyStartupComplete()` when truly ready.

> **Note:** On Wayland, `gdk_notify_startup_complete()` may be a no-op. These APIs primarily affect X11 desktop environments.

**Changes:**

| File | Change |
|---|---|
| `shell/browser/api/electron_api_app.h` | Method declarations + `auto_startup_notification_` member |
| `shell/browser/api/electron_api_app.cc` | Implementation: GTK disable in constructor, auto-notify at ready, method bodies, JS bindings |
| `docs/api/app.md` | API documentation with code examples |
| `spec/api-app-spec.ts` | 4 Linux-specific tests |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `app.setAutoStartupNotification(enabled)` and `app.notifyStartupComplete()` APIs on Linux to give developers control over desktop startup notification timing.
