### PR TITLE
fix: resolve 30s delay in parentless showMessageBox on Linux

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -397,6 +397,14 @@ Shows a message box.
 
 The `window` argument allows the dialog to attach itself to a parent window, making it modal.
 
+> [!NOTE]
+> On Linux, when no parent `window` is provided **and** no `BrowserWindow`
+> instances are open, `dialog.showMessageBox()` will block the main process
+> until the dialog is dismissed (behaving like `dialog.showMessageBoxSync()`).
+> This is a workaround for a GTK event-dispatch limitation in this scenario
+> and is not a breaking change — the previous behavior in this edge case was
+> buggy (promise resolution delayed by ~30 seconds).
+
 ### `dialog.showErrorBox(title, content)`
 
 * `title` string - The title to display in the error box.

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -18,6 +18,7 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/browser/native_window_views.h"
+#include "shell/browser/window_list.h"
 #include "shell/browser/ui/gtk_util.h"
 #include "ui/base/glib/scoped_gsignal.h"
 #include "ui/gfx/image/image_skia.h"
@@ -181,6 +182,18 @@ class GtkMessageBox : private NativeWindowObserver {
 
   void RunAsynchronous(MessageBoxCallback callback) {
     callback_ = std::move(callback);
+
+    // When there is no parent window and no BrowserWindow exists,
+    // Chromium's MessagePumpGlib may not be actively iterating the GLib
+    // main context, causing GTK's "response" signal to sit undelivered
+    // for up to ~30 seconds. Use gtk_dialog_run() which spins its own
+    // nested GLib main loop to ensure events are dispatched immediately.
+    // See: https://github.com/electron/electron/issues/51049
+    if (!parent_ && WindowList::IsEmpty()) {
+      Show();
+      OnResponseDialog(dialog_, gtk_dialog_run(GTK_DIALOG(dialog_)));
+      return;
+    }
 
     signals_.emplace_back(dialog_, "delete-event",
                           base::BindRepeating(gtk_widget_hide_on_delete));


### PR DESCRIPTION
#### Description of Change

Fixes #51049
Supersedes #51242, #51312

> **Note:** This is a resubmission of #51312, which was closed as part of a batch `ai-pr` sweep by @jkleinsc. That PR had been through multiple rounds of review — @deepak1556 suggested targeting the startup phase specifically (addressed via `WindowList::IsEmpty()`), @mitchchn approved the final approach, and it was awaiting final sign-off from @ckerr and @deepak1556. This resubmission is rebased on latest `main` with the same changes.

When `dialog.showMessageBox()` is called **before any `BrowserWindow` exists** on Linux, the returned promise takes ~30 seconds to resolve after the user clicks a button. This happens because Chromium's message loop is not actively pumping GLib events when no `BrowserWindow` is driving it, causing GTK's `"response"` signal to sit undelivered until an internal timeout forces a GLib iteration.

**Root Cause:**
The async path in `GtkMessageBox::RunAsynchronous()` connects to GTK's `"response"` signal and relies on Chromium's `MessagePumpGlib` to dispatch it. However, when no `BrowserWindow` has been created yet, the message pump is not actively iterating the GLib main context, resulting in the signal being delayed by ~30 seconds.

**Fix:**
For **parentless dialogs** when `WindowList::IsEmpty()`, this PR switches the async path to use `gtk_dialog_run()`, which creates its own **nested GLib main loop** that properly dispatches all GTK events. The callback fires immediately when the user clicks a button.

When a parent `BrowserWindow` **is** present, the original signal-based async path is used unchanged.

**Before & After:**

> As requested by @codebytere and @ckerr in #51242, a demonstration is attached below.

| | Delay |
|---|---|
| **Before** (upstream `main`) | `dialog: 30.104s` |
| **After** (this PR) | `dialog: 2.783s` *(~2.7s is the user's reaction time to click OK)* |

**Before Fix:**
<img width="1920" height="1080" alt="before-fix" src="https://github.com/user-attachments/assets/29a24d25-afa9-48fc-8e4a-5b96d70616ca" />

**After Fix:**
<img width="1920" height="1080" alt="after-fix" src="https://github.com/user-attachments/assets/d3d107ed-97e0-4aa7-906f-519fa476b7ff" />

**Test app used** (from [original issue gist](https://gist.github.com/Harrison-M/4c6fe09e54d3ec83ef6b79324785314e)):

```js
const { app, dialog } = require('electron');
app.whenReady().then(async () => {
  console.log("App started");
  console.time("dialog");
  await dialog.showMessageBox({
    type: "info",
    message: "Test the Dialog",
    buttons: ["OK"]
  });
  console.timeEnd("dialog");
  app.quit();
});
```

**Previous Review Context:**
- **@deepak1556** requested targeting the startup phase specifically, not just `!parent_`. Addressed via `WindowList::IsEmpty()`.
- **@mitchchn** approved the final approach: *"I think this has ended up with the most practical approach overall."*
- **@codebytere** and **@ckerr** requested before/after GIFs — attached above.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a ~30 second delay in `dialog.showMessageBox()` promise resolution on Linux when called before any BrowserWindow is created.
