### PR TITLE
feat: add BaseWindow.getCursorPoint() API

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -979,6 +979,16 @@ Returns `Integer[]` - Contains the window's current position.
 > [!NOTE]
 > On Wayland, this method will return `[0, 0]` as introspecting or programmatically changing the global window coordinates is prohibited.
 
+#### `win.getCursorPoint()`
+
+Returns `Point | null` - The current position of the mouse cursor relative
+to this window, where `(0, 0)` represents the top-left corner of the window
+frame. Returns `null` if the cursor is outside the window's bounds.
+
+> [!NOTE]
+> The returned coordinates are relative to the window frame, not the web
+> content area. For framed windows, this includes the title bar.
+
 #### `win.setTitle(title)`
 
 * `title` string

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1097,6 +1097,16 @@ Returns `Integer[]` - Contains the window's current position.
 > [!NOTE]
 > On Wayland, this method will return `[0, 0]` as introspecting or programmatically changing the global window coordinates is prohibited.
 
+#### `win.getCursorPoint()`
+
+Returns `Point | null` - The current position of the mouse cursor relative
+to this window, where `(0, 0)` represents the top-left corner of the window
+frame. Returns `null` if the cursor is outside the window's bounds.
+
+> [!NOTE]
+> The returned coordinates are relative to the window frame, not the web
+> content area. For framed windows, this includes the title bar.
+
 #### `win.setTitle(title)`
 
 * `title` string

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -33,6 +33,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/node_util.h"
 #include "shell/common/options_switches.h"
+#include "ui/display/screen.h"
 
 #if defined(TOOLKIT_VIEWS)
 #include "shell/browser/native_window_views.h"
@@ -596,6 +597,20 @@ void BaseWindow::SetPosition(const int x,
 std::array<int, 2U> BaseWindow::GetPosition() const {
   return ToArray(window_->GetPosition());
 }
+
+std::optional<gfx::Point> BaseWindow::GetCursorPoint() const {
+  if (auto* screen = display::Screen::Get()) {
+    const gfx::Point cursor_point = screen->GetCursorScreenPoint();
+    // Ignore positions outside the logical window surface.
+    if (const auto window_bounds = window_->GetBounds();
+        window_bounds.Contains(cursor_point)) {
+      // Return window-local coordinates.
+      return cursor_point - window_bounds.OffsetFromOrigin();
+    }
+  }
+  return {};
+}
+
 void BaseWindow::MoveAbove(const std::string& sourceId,
                            gin::Arguments* const args) {
   if (!window_->MoveAbove(sourceId))
@@ -1219,6 +1234,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("center", &BaseWindow::Center)
       .SetMethod("setPosition", &BaseWindow::SetPosition)
       .SetMethod("getPosition", &BaseWindow::GetPosition)
+      .SetMethod("getCursorPoint", &BaseWindow::GetCursorPoint)
       .SetMethod("setTitle", &BaseWindow::SetTitle)
       .SetMethod("getTitle", &BaseWindow::GetTitle)
       .SetProperty("accessibleTitle", &BaseWindow::GetAccessibleTitle,

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -156,6 +156,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void Center();
   void SetPosition(int x, int y, gin::Arguments* args);
   std::array<int, 2U> GetPosition() const;
+  std::optional<gfx::Point> GetCursorPoint() const;
   void SetTitle(const std::string& title);
   std::string GetTitle() const;
   void SetAccessibleTitle(const std::string& title);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1902,6 +1902,18 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    describe('BrowserWindow.getCursorPoint()', () => {
+      it('returns a point object with x and y or null', () => {
+        const point = w.getCursorPoint();
+        if (point !== null) {
+          expect(point).to.have.property('x');
+          expect(point).to.have.property('y');
+          expect(point.x).to.be.a('number');
+          expect(point.y).to.be.a('number');
+        }
+      });
+    });
+
     describe('BrowserWindow.setContentSize(width, height)', () => {
       it('sets the content size', async () => {
         // NB. The CI server has a very small screen. Attempting to size the window


### PR DESCRIPTION
#### Description of Change

Fixes #51325
Refs #51153
Supersedes #51338

> **Note:** This is a resubmission of #51338, which was closed as part of a batch `ai-pr` sweep by @jkleinsc. That PR had received `semver/minor`, `enhancement`, `wayland`, and `api-review/requested` labels. @ckerr approved the API with "API LGTM", @mitchchn approved the final implementation, and @iamEvanYT provided valuable feedback on out-of-bounds behavior. This resubmission is rebased on latest `main` with the same changes. CC @ckerr @mitchchn @iamEvanYT @deepak1556 for review.

Adds a new `BaseWindow.getCursorPoint()` instance method that returns the position of the mouse cursor relative to the window frame as a `Point` object, where `(0, 0)` represents the top-left corner of the window. Returns `null` if the cursor is outside the window's bounds.

**Motivation:**

After #50092 landed, `screen.getCursorScreenPoint()` became a no-op on Wayland (returning `{}`), leaving no built-in way to obtain cursor position on that platform. Maintainers in #51153 and #51325 proposed a `BaseWindow.getCursorPoint()` API as the proper solution.

Unlike `screen.getCursorScreenPoint()`, this method:
- Returns coordinates **relative to the window**, not the screen
- Works on **all platforms**, including Wayland
- Is more useful for apps with multiple `WebContentsView`s (where renderer-side `mousemove` events require complex calculations)

**Implementation:**

- Uses `display::Screen::GetCursorScreenPoint()` at the Chromium C++ level, then converts to window-relative coordinates by offsetting against `window_->GetBounds()`
- Returns `null` when the cursor is outside the logical window bounds (negative values or exceeding width/height)
- On Wayland, this works correctly because Chromium's screen API returns window-relative coordinates natively, and the window origin is `(0, 0)`

**Wayland out-of-bounds behavior** (as discussed with @iamEvanYT in #51338):
On Wayland, the compositor stops sending pointer position updates once the cursor leaves the window surface. `getCursorPoint()` will return the last known position at the window edge, which may still be technically "in bounds". On X11/macOS/Windows, the coordinates update normally and `null` is returned when outside.

**Changes:**

| File | Change |
|------|--------|
| `electron_api_base_window.h` | Declaration of `GetCursorPoint()` |
| `electron_api_base_window.cc` | Implementation + JS binding via `SetMethod` |
| `docs/api/base-window.md` | API documentation with Wayland note |
| `docs/api/browser-window.md` | Inherited API documentation |
| `spec/api-browser-window-spec.ts` | Test validating return type |

**After Fix:**

<img width="1920" height="1080" alt="issue51325" src="https://github.com/user-attachments/assets/0522d7d8-2bdd-4d1c-9eb9-6dd9b36f9140" />

> **Note:** The mouse cursor itself was not captured in the screen recording software, but you can see the coordinates updating dynamically as the invisible cursor moves across the web content, title bar, and outside the window bounds.

**Previous Review Context:**
- **@ckerr** — "API LGTM", added `semver/minor`, `enhancement`, `wayland` labels
- **@mitchchn** — Approved the final implementation after doc fixes
- **@iamEvanYT** — Raised out-of-bounds question on Wayland, discussed returning `null` vs last-known position

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `BaseWindow.getCursorPoint()` API that returns the cursor position relative to the window frame, providing cross-platform support including Wayland.
