### PR TITLE
Pr/test

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -677,6 +677,14 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
 
     RemoveWindowSubclass(legacy_window_, SubclassProc, 1);
 
+    // Re-arm mouse tracking so Windows delivers WM_MOUSELEAVE if the
+    // cursor is already outside the client area (fixes stale :hover).
+    TRACKMOUSEEVENT tme = {};
+    tme.cbSize = sizeof(tme);
+    tme.dwFlags = TME_LEAVE;
+    tme.hwndTrack = legacy_window_;
+    TrackMouseEvent(&tme);
+
     if (forwarding_windows_->empty()) {
       // If UnhookWindowsHookEx fails, the hook is still installed in the
       // system. Leave |mouse_hook_| pointing at the existing hook so that a


### PR DESCRIPTION
#### Description of Change

Test build for the hover state fix on Windows. When `setIgnoreMouseEvents(true, { forward: true })` is active, `SubclassProc` swallows `WM_MOUSELEAVE`. After calling `setIgnoreMouseEvents(false)`, the stale hover state causes `:hover` CSS to remain permanently active. This fix re-arms mouse tracking via `TrackMouseEvent(TME_LEAVE)` after removing the subclass.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug on Windows where disabling mouse event forwarding left the `:hover` CSS state permanently active.
