### PR TITLE
fix: reset hover state when disabling mouse event forwarding on Windows

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -677,6 +677,14 @@ void NativeWindowViews::SetForwardMouseMessages(bool forward) {
 
     RemoveWindowSubclass(legacy_window_, SubclassProc, 1);
 
+    // Re-arm mouse tracking so Windows delivers WM_MOUSELEAVE if the
+    // cursor is already outside the client area (fixes stale :hover).
+    TRACKMOUSEEVENT tme = {};
+    tme.cbSize = sizeof(tme);
+    tme.dwFlags = TME_LEAVE;
+    tme.hwndTrack = legacy_window_;
+    TrackMouseEvent(&tme);
+
     if (forwarding_windows_->empty()) {
       // If UnhookWindowsHookEx fails, the hook is still installed in the
       // system. Leave |mouse_hook_| pointing at the existing hook so that a


### PR DESCRIPTION
#### Description of Change

Fixes #51521
Supersedes #51539

> **Note:** This is a resubmission of #51539, which was closed as part of a batch `ai-pr` sweep by @jkleinsc. During the review of that PR, @ckerr provided valuable feedback, suggesting the cleaner `TrackMouseEvent` approach to resolve the issue without relying on synthetic messages, and also advised removing the unhelpful unit tests. This resubmission implements those exact suggestions and is rebased on the latest `main`. CC @ckerr @jkleinsc for review.

**Motivation:**

When `setIgnoreMouseEvents(true, { forward: true })` is active on Windows, the `SubclassProc` in `native_window_views_win.cc` intentionally swallows `WM_MOUSELEAVE` messages to prevent flickering caused by rapidly entering and leaving forwarding mode. However, when `setIgnoreMouseEvents(false)` is later called to re-enable mouse events, the previously swallowed `WM_MOUSELEAVE` is never re-sent. 

This leaves Chromium's internal hover tracking in a stale state, causing the `<body>` element's `:hover` CSS selector to remain permanently active even after the cursor has physically left the window.

**Implementation:**

Following @ckerr's suggestion in #51539, this fix re-arms Windows native mouse tracking instead of trying to manually calculate bounds and post synthetic messages.

- When `SetForwardMouseMessages(false)` is called and the `SubclassProc` is removed, we immediately call `TrackMouseEvent(TME_LEAVE)`.
- If the cursor is already outside the client area when this happens, Windows natively detects this and immediately posts a `WM_MOUSELEAVE` message.
- This correctly resets Chromium's hover state without reintroducing the flickering that the original message swallow was designed to prevent.
- Removed the previous spec tests as they were not accurately testing the regression condition, per maintainer feedback.

**Changes:**

| File | Change |
|------|--------|
| `shell/browser/native_window_views_win.cc` | Re-arm mouse tracking via `TrackMouseEvent(TME_LEAVE)` when disabling mouse event forwarding |

**Previous Review Context:**
- **@ckerr** — Reviewed the initial synthetic message approach in #51539, provided the `TrackMouseEvent` code snippet as a cleaner alternative, and requested the removal of the regression tests since they weren't effectively validating the specific bug.
- **@jkleinsc** — Added the `ai-pr` label, leading to the previous PR's automated closure.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a bug on Windows where `setIgnoreMouseEvents(true, { forward: true })` caused the `<body>` element's `:hover` state to remain permanently active after the cursor left the window.
