### PR TITLE
chore: cherry-pick 8 changes from chromium, skia, angle (41-x-y)

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -2,3 +2,4 @@ cherry-pick-b149a5c62d76.patch
 cherry-pick-7695232.patch
 cherry-pick-7712217.patch
 cherry-pick-7722080.patch
+cherry-pick-d8ffa7447da0.patch

--- a/patches/angle/cherry-pick-d8ffa7447da0.patch
+++ b/patches/angle/cherry-pick-d8ffa7447da0.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 20 Apr 2026 11:37:22 -0400
+Subject: Translator: Avoid setting initializer for too-large variable
+
+Test credit kbr@chromium.org / gemini.
+
+Fixed: chromium:498400132
+Change-Id: I4b5379de712c22fcfcdbabbaf9c3f92bae209922
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7778457
+Auto-Submit: Shahbaz Youssefi <syoussefi@chromium.org>
+Reviewed-by: Kenneth Russell <kbr@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+
+diff --git a/src/compiler/translator/ParseContext.cpp b/src/compiler/translator/ParseContext.cpp
+index 59df57bde5bf185a900b238a30fada9974bd3250..462cef8228d0b9102c96d1a8c4a99eb9aaba364b 100644
+--- a/src/compiler/translator/ParseContext.cpp
++++ b/src/compiler/translator/ParseContext.cpp
+@@ -1676,7 +1676,7 @@ void TParseContext::checkDeclarationIsValidArraySize(const TSourceLoc &line,
+     }
+ }
+ 
+-void TParseContext::checkVariableSize(const TSourceLoc &line,
++bool TParseContext::checkVariableSize(const TSourceLoc &line,
+                                       const ImmutableString &identifier,
+                                       const TType *type)
+ {
+@@ -1694,7 +1694,7 @@ void TParseContext::checkVariableSize(const TSourceLoc &line,
+     if (!mCompileOptions.rejectWebglShadersWithLargeVariables || numErrors() > 0 ||
+         (mShaderType != GL_VERTEX_SHADER && mShaderType != GL_FRAGMENT_SHADER))
+     {
+-        return;
++        return true;
+     }
+ 
+     // Note: the only allowed interface block in webgl shaders is UBOs in std140 mode, so the size
+@@ -1707,7 +1707,7 @@ void TParseContext::checkVariableSize(const TSourceLoc &line,
+     if (variableSize > kWebGLMaxVariableSizeInBytes)
+     {
+         error(line, "Size of declared variable exceeds implementation-defined limit", identifier);
+-        return;
++        return false;
+     }
+ 
+     switch (type->getQualifier())
+@@ -1753,13 +1753,14 @@ void TParseContext::checkVariableSize(const TSourceLoc &line,
+                 error(line,
+                       "Size of declared private variable exceeds implementation-defined limit",
+                       identifier);
+-                return;
++                return false;
+             }
+             mTotalPrivateVariablesSize += variableSize;
+             break;
+         default:
+             break;
+     }
++    return true;
+ }
+ 
+ void TParseContext::checkVaryingLocations(const TSourceLoc &line, const TVariable *variable)
+@@ -2102,7 +2103,10 @@ bool TParseContext::declareVariable(const TSourceLoc &line,
+     if (!checkIsNonVoid(line, identifier, type->getBasicType()))
+         return false;
+ 
+-    checkVariableSize(line, identifier, type);
++    if (!checkVariableSize(line, identifier, type))
++    {
++        return false;
++    }
+     checkVariableLocations(line, *variable);
+ 
+     // Declare the variable in IR
+diff --git a/src/compiler/translator/ParseContext.h b/src/compiler/translator/ParseContext.h
+index cc43abe747084af1b979bc0e7f78f4ce021d6410..4009a08999518695c1028ad519d85a528a675c79 100644
+--- a/src/compiler/translator/ParseContext.h
++++ b/src/compiler/translator/ParseContext.h
+@@ -753,7 +753,7 @@ class TParseContext : angle::NonCopyable
+     bool parseTessControlShaderOutputLayoutQualifier(const TTypeQualifier &typeQualifier);
+     bool parseTessEvaluationShaderInputLayoutQualifier(const TTypeQualifier &typeQualifier);
+ 
+-    void checkVariableSize(const TSourceLoc &line,
++    bool checkVariableSize(const TSourceLoc &line,
+                            const ImmutableString &identifier,
+                            const TType *type);
+     void checkVaryingLocations(const TSourceLoc &line, const TVariable *variable);

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -189,3 +189,9 @@ cherry-pick-7737952.patch
 cherry-pick-7779792.patch
 cherry-pick-7791302.patch
 cherry-pick-7800635.patch
+cherry-pick-411ebd37c1e0.patch
+cherry-pick-788e99004847.patch
+cherry-pick-bd0b5614e7e5.patch
+cherry-pick-cc6431e78e7b.patch
+cherry-pick-743a681ba8c9.patch
+cherry-pick-9674640f1813.patch

--- a/patches/chromium/cherry-pick-411ebd37c1e0.patch
+++ b/patches/chromium/cherry-pick-411ebd37c1e0.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tommy Steimel <steimel@chromium.org>
+Date: Tue, 24 Mar 2026 11:57:15 -0700
+Subject: [SMTC] Use weak ptr in SystemMediaControlsWin callback
+
+We currently capture a raw `this` pointer in a SystemMediaControlsWin
+callback for writing image data. This could be problematic as it's
+possible the SystemMediaControlsWin doesn't outlive the operation.
+This CL updates the callback to capture and use a weak pointer instead.
+
+Bug: 495108488
+Change-Id: I8698af5cf5d828ee5064793d35a6c33b6072ce53
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7694234
+Commit-Queue: Tommy Steimel <steimel@chromium.org>
+Reviewed-by: Frank Liberato <liberato@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1604285}
+
+diff --git a/components/system_media_controls/win/system_media_controls_win.cc b/components/system_media_controls/win/system_media_controls_win.cc
+index 052f0397e0c328c7ea0718ff823f0471960f23e9..0bbfd11ae575387643a31a581d41a7c792bd0cf7 100644
+--- a/components/system_media_controls/win/system_media_controls_win.cc
++++ b/components/system_media_controls/win/system_media_controls_win.cc
+@@ -308,10 +308,16 @@ void SystemMediaControlsWin::SetThumbnail(const SkBitmap& bitmap) {
+ 
+   // Make a callback that gives the icon to the SMTC once the bits make it into
+   // |icon_stream_|
++  auto weak_ptr = weak_factory_.GetWeakPtr();
+   auto store_async_callback = Microsoft::WRL::Callback<
+       ABI::Windows::Foundation::IAsyncOperationCompletedHandler<unsigned int>>(
+-      [this](ABI::Windows::Foundation::IAsyncOperation<unsigned int>* async_op,
+-             ABI::Windows::Foundation::AsyncStatus status) mutable {
++      [weak_ptr](
++          ABI::Windows::Foundation::IAsyncOperation<unsigned int>* async_op,
++          ABI::Windows::Foundation::AsyncStatus status) mutable {
++        if (!weak_ptr) {
++          return S_OK;
++        }
++
+         // Check the async operation completed successfully.
+         ABI::Windows::Foundation::IAsyncInfo* async_info;
+         HRESULT hr = async_op->QueryInterface(
+@@ -328,15 +334,15 @@ void SystemMediaControlsWin::SetThumbnail(const SkBitmap& bitmap) {
+               &reference_statics);
+           DCHECK(SUCCEEDED(result));
+ 
+-          result = reference_statics->CreateFromStream(icon_stream_.Get(),
+-                                                       &icon_stream_reference_);
++          result = reference_statics->CreateFromStream(
++              weak_ptr->icon_stream_.Get(), &weak_ptr->icon_stream_reference_);
+           DCHECK(SUCCEEDED(result));
+ 
+-          result =
+-              display_updater_->put_Thumbnail(icon_stream_reference_.Get());
++          result = weak_ptr->display_updater_->put_Thumbnail(
++              weak_ptr->icon_stream_reference_.Get());
+           DCHECK(SUCCEEDED(result));
+ 
+-          result = display_updater_->Update();
++          result = weak_ptr->display_updater_->Update();
+           DCHECK(SUCCEEDED(result));
+         }
+         return hr;

--- a/patches/chromium/cherry-pick-743a681ba8c9.patch
+++ b/patches/chromium/cherry-pick-743a681ba8c9.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mikt <mikt@google.com>
+Date: Wed, 25 Mar 2026 22:08:44 -0700
+Subject: Add AMSC macro to PendingHidTransfer
+
+Bug: 495999127
+Change-Id: Ice2c459c94064181328c03a4beb86963c8ab96f4
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699518
+Commit-Queue: Mikihito Matsuura <mikt@google.com>
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1605269}
+
+diff --git a/services/device/hid/hid_connection_win.cc b/services/device/hid/hid_connection_win.cc
+index 45ca01537ff9533592e050d6ebd0afe6e0de844b..ba1a0262deac20d99d6d9c30951317a6c1dec33f 100644
+--- a/services/device/hid/hid_connection_win.cc
++++ b/services/device/hid/hid_connection_win.cc
+@@ -12,6 +12,7 @@
+ #include "base/feature_list.h"
+ #include "base/files/file.h"
+ #include "base/functional/bind.h"
++#include "base/memory/advanced_memory_safety_checks.h"
+ #include "base/memory/ref_counted_memory.h"
+ #include "base/numerics/safe_conversions.h"
+ #include "base/win/object_watcher.h"
+@@ -50,6 +51,9 @@ HidConnectionWin::HidDeviceEntry::HidDeviceEntry(
+ HidConnectionWin::HidDeviceEntry::~HidDeviceEntry() = default;
+ 
+ class PendingHidTransfer : public base::win::ObjectWatcher::Delegate {
++  // TODO(https://crbug.com/495999127): Remove this macro.
++  ADVANCED_MEMORY_SAFETY_CHECKS();
++
+  public:
+   typedef base::OnceCallback<void(PendingHidTransfer*, bool)> Callback;
+ 

--- a/patches/chromium/cherry-pick-788e99004847.patch
+++ b/patches/chromium/cherry-pick-788e99004847.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mikt <mikt@google.com>
+Date: Tue, 24 Mar 2026 21:08:00 -0700
+Subject: Add AMSC macro to FilePathWatcherFSEvents
+
+As a band aid fix for potential memory issue.
+
+Bug: 495782021
+Change-Id: I2e53ef61ba9a0cbcff71b22148f800b3c59e0bb3
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699084
+Reviewed-by: Mingyu Lei <leimy@chromium.org>
+Commit-Queue: Mikihito Matsuura <mikt@google.com>
+Cr-Commit-Position: refs/heads/main@{#1604590}
+
+diff --git a/content/browser/file_system_access/file_path_watcher/file_path_watcher_fsevents.h b/content/browser/file_system_access/file_path_watcher/file_path_watcher_fsevents.h
+index dfe4d30fc71d8ee713e598c2ea92cfa2c2a95ba2..d2a20930389d6aba6762fcb7c34b2d75fa99de85 100644
+--- a/content/browser/file_system_access/file_path_watcher/file_path_watcher_fsevents.h
++++ b/content/browser/file_system_access/file_path_watcher/file_path_watcher_fsevents.h
+@@ -14,6 +14,7 @@
+ 
+ #include "base/apple/scoped_dispatch_object.h"
+ #include "base/files/file_path.h"
++#include "base/memory/safety_checks.h"
+ #include "base/memory/weak_ptr.h"
+ #include "content/browser/file_system_access/file_path_watcher/file_path_watcher.h"
+ #include "content/browser/file_system_access/file_path_watcher/file_path_watcher_fsevents_change_tracker.h"
+@@ -28,6 +29,9 @@ namespace content {
+ // directory. See file_path_watcher_mac.cc for the code that decides when to
+ // use which one.
+ class FilePathWatcherFSEvents : public FilePathWatcher::PlatformDelegate {
++  // TODO(https://crbug.com/495782021): Remove this macro.
++  ADVANCED_MEMORY_SAFETY_CHECKS();
++
+  public:
+   using ChangeEvent = FilePathWatcherFSEventsChangeTracker::ChangeEvent;
+ 

--- a/patches/chromium/cherry-pick-9674640f1813.patch
+++ b/patches/chromium/cherry-pick-9674640f1813.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keishi Hattori <keishi@google.com>
+Date: Thu, 2 Apr 2026 19:17:37 -0700
+Subject: Fix realloc while iterating in HTMLSlotElement::DetachLayoutTree
+
+Bug: 497830330
+Change-Id: Id29714983245bcb58f3f3c2174f4b098c963d948
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7718078
+Commit-Queue: Keishi Hattori <keishi@chromium.org>
+Reviewed-by: Takashi Sakamoto <tasak@google.com>
+Cr-Commit-Position: refs/heads/main@{#1609626}
+
+diff --git a/third_party/blink/renderer/core/html/html_slot_element.cc b/third_party/blink/renderer/core/html/html_slot_element.cc
+index 6633ea6f52bd9f159859854b0903db48c7ff058d..cb6bc168a7837c1edf2384d8c32f7f6faae07245 100644
+--- a/third_party/blink/renderer/core/html/html_slot_element.cc
++++ b/third_party/blink/renderer/core/html/html_slot_element.cc
+@@ -365,7 +365,8 @@ void HTMLSlotElement::AttachLayoutTreeForSlotChildren(AttachContext& context) {
+ void HTMLSlotElement::DetachLayoutTree(bool performing_reattach) {
+   if (SupportsAssignment()) {
+     auto* host = OwnerShadowHost();
+-    const HeapVector<Member<Node>>& flat_tree_children = assigned_nodes_;
++    // Defensive copy to prevent UAF from sync recalc. See crbug.com/497830330.
++    const HeapVector<Member<Node>> flat_tree_children = assigned_nodes_;
+     for (auto& node : flat_tree_children) {
+       // Don't detach the assigned node if the node is no longer a child of the
+       // host.

--- a/patches/chromium/cherry-pick-bd0b5614e7e5.patch
+++ b/patches/chromium/cherry-pick-bd0b5614e7e5.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Takashi Sakamoto <tasak@google.com>
+Date: Wed, 8 Apr 2026 23:47:27 -0700
+Subject: Make PassthroughTouchEventQueue weakable to see whether `this` is
+ destroyed or not inside AckCompletedEvents.
+
+PassthroughTouchEventQueue::AckCompletedEvents() synchronously invokes
+nested message loop and the message loop may invoke some method which
+destroys the PassthroughTouchEventQueue instance. This is
+heap-use-after-free.
+
+Bug: 495939973
+Change-Id: I66bebcbce76b2638fdbb38b774cc163396aea509
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7735834
+Owners-Override: Keishi Hattori <keishi@chromium.org>
+Commit-Queue: Takashi Sakamoto <tasak@google.com>
+Reviewed-by: Keishi Hattori <keishi@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1611993}
+
+diff --git a/components/input/passthrough_touch_event_queue.cc b/components/input/passthrough_touch_event_queue.cc
+index c4aed0bf4c49730ec929713ec647a7af04ed7de1..8b8567aef274e0e33709a458c6eb13f83a1a6e7b 100644
+--- a/components/input/passthrough_touch_event_queue.cc
++++ b/components/input/passthrough_touch_event_queue.cc
+@@ -285,6 +285,8 @@ void PassthroughTouchEventQueue::AckCompletedEvents() {
+     return;
+   }
+   base::AutoReset<bool> process_acks(&processing_acks_, true);
++  base::WeakPtr<PassthroughTouchEventQueue> weak_this =
++      weak_ptr_factory_.GetWeakPtr();
+   while (!outstanding_touches_.empty()) {
+     auto iter = outstanding_touches_.begin();
+     if (iter->ack_state() == blink::mojom::InputEventResultState::kUnknown) {
+@@ -294,6 +296,9 @@ void PassthroughTouchEventQueue::AckCompletedEvents() {
+     TouchEventWithLatencyInfoAndAckState event = *iter;
+     outstanding_touches_.erase(iter);
+     AckTouchEventToClient(event, event.ack_source(), event.ack_state());
++    if (!weak_this) {
++      return;
++    }
+   }
+ }
+ 
+diff --git a/components/input/passthrough_touch_event_queue.h b/components/input/passthrough_touch_event_queue.h
+index 7e4d09edc3cf60478432ca0e65d483ad5810ad80..943fd7da708ba355cce2da17bd7404001cc614c8 100644
+--- a/components/input/passthrough_touch_event_queue.h
++++ b/components/input/passthrough_touch_event_queue.h
+@@ -13,6 +13,7 @@
+ #include "base/feature_list.h"
+ #include "base/gtest_prod_util.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "base/metrics/field_trial_params.h"
+ #include "base/time/time.h"
+ #include "components/input/dispatch_to_renderer_callback.h"
+@@ -298,6 +299,8 @@ class COMPONENT_EXPORT(INPUT) PassthroughTouchEventQueue {
+   // What events types are allowed to bypass the filter.
+   const std::string events_to_always_forward_;
+   static const base::FeatureParam<std::string> kSkipTouchEventFilterType;
++
++  base::WeakPtrFactory<PassthroughTouchEventQueue> weak_ptr_factory_{this};
+ };
+ 
+ }  // namespace input

--- a/patches/chromium/cherry-pick-cc6431e78e7b.patch
+++ b/patches/chromium/cherry-pick-cc6431e78e7b.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Keishi Hattori <keishi@google.com>
+Date: Sun, 29 Mar 2026 21:49:40 -0700
+Subject: [aura] Mitigate Use-After-Free in
+ WindowTreeHostPlatform::OnStateUpdate
+
+WindowTreeHostPlatform::OnStateUpdate calls OnBoundsChanged, which can
+trigger observer notifications that synchronously destroy the host.
+While OnBoundsChanged safely handles this internally, it returns control
+to OnStateUpdate, which continues executing with a dangling `this` pointer. Past report is crbug.com/1185482.
+
+Bug: 495948109
+Change-Id: Ic0eac7b9d91005f0275035b8393f67af43a19d32
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699933
+Commit-Queue: Keishi Hattori <keishi@chromium.org>
+Reviewed-by: Mitsuru Oshima <oshima@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1606889}
+
+diff --git a/ui/aura/window_tree_host_platform.cc b/ui/aura/window_tree_host_platform.cc
+index 3ac3eaccb9d0eeaf75a7e00ed165d410e3ebd42b..122e8b50e2dda3c082460af9adaa9e72560aa6f1 100644
+--- a/ui/aura/window_tree_host_platform.cc
++++ b/ui/aura/window_tree_host_platform.cc
+@@ -375,7 +375,12 @@ int64_t WindowTreeHostPlatform::OnStateUpdate(
+   if (old.bounds_dip != latest.bounds_dip || old.size_px != latest.size_px ||
+       old.window_scale != latest.window_scale) {
+     bool origin_changed = old.bounds_dip.origin() != latest.bounds_dip.origin();
++    auto weak_ref = GetWeakPtr();
+     OnBoundsChanged({origin_changed});
++    // Notifying observers of the bounds change may delete this.
++    if (!weak_ref) {
++      return -1;
++    }
+   }
+ 
+   bool needs_frame = latest.WillProduceFrameOnUpdateFrom(old);
+diff --git a/ui/aura/window_tree_host_platform_unittest.cc b/ui/aura/window_tree_host_platform_unittest.cc
+index a4eddc7d6b455a7339b6da613469cd59e3e43ca6..1a9802348c8060062c7b75091eb2c37da21f2f82 100644
+--- a/ui/aura/window_tree_host_platform_unittest.cc
++++ b/ui/aura/window_tree_host_platform_unittest.cc
+@@ -49,6 +49,12 @@ class TestWindowTreeHost : public WindowTreeHostPlatform {
+   ui::PlatformWindow* platform_window() {
+     return WindowTreeHostPlatform::platform_window();
+   }
++
++  int64_t OnStateUpdate(
++      const ui::PlatformWindowDelegate::State& old,
++      const ui::PlatformWindowDelegate::State& latest) override {
++    return WindowTreeHostPlatform::OnStateUpdate(old, latest);
++  }
+ };
+ 
+ // WindowTreeHostObserver that tracks calls to
+@@ -155,5 +161,21 @@ TEST_F(WindowTreeHostPlatformTest, DeleteHostFromOnHostMovedInPixels) {
+   EXPECT_EQ(nullptr, observer.host());
+ }
+ 
++// Verifies WindowTreeHostPlatform can be safely deleted during OnStateUpdate.
++TEST_F(WindowTreeHostPlatformTest, DeleteHostFromOnStateUpdate) {
++  std::unique_ptr<TestWindowTreeHost> host =
++      std::make_unique<TestWindowTreeHost>();
++  TestWindowTreeHost* host_ptr = host.get();
++  DeleteHostWindowTreeHostObserver observer(std::move(host));
++
++  ui::PlatformWindowDelegate::State old_state;
++  ui::PlatformWindowDelegate::State new_state;
++  new_state.bounds_dip = gfx::Rect(1, 2, 3, 4);
++
++  // This should not crash.
++  EXPECT_EQ(-1, host_ptr->OnStateUpdate(old_state, new_state));
++  EXPECT_EQ(nullptr, observer.host());
++}
++
+ }  // namespace
+ }  // namespace aura

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,2 +1,3 @@
 cherry-pick-3f9969421ad5.patch
 cherry-pick-8c705ac86366.patch
+cherry-pick-3150bddf3edd.patch

--- a/patches/skia/cherry-pick-3150bddf3edd.patch
+++ b/patches/skia/cherry-pick-3150bddf3edd.patch
@@ -1,0 +1,184 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Ludwig <michaelludwig@google.com>
+Date: Tue, 21 Apr 2026 13:49:08 -0400
+Subject: [sksl] Check allowSkSL for SkRuntimeImageFilter::CreateProc
+
+Since SkRuntimeImageFilter doesn't create its runtime shaders until
+actually evaluating the image filter, SkRuntimeShader's CreateProc
+was not being reached; it must be responsible for validating allowSkSL.
+
+Updates the unit test to confirm that all sources of runtime effects
+in drawables are detected when allowSkSl is false.
+
+Bug: b/502636904
+Change-Id: I391ba2608010431429ac3e3c03e106f380304edb
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1214636
+Reviewed-by: Kaylee Lubick <kjlubick@google.com>
+Reviewed-by: Jorge Betancourt <jmbetancourt@google.com>
+Commit-Queue: Michael Ludwig <michaelludwig@google.com>
+
+diff --git a/src/effects/imagefilters/SkRuntimeImageFilter.cpp b/src/effects/imagefilters/SkRuntimeImageFilter.cpp
+index 96757809d0252ad28dc674ee4ff9a283fe0becc2..5665f8357ddb4226b3c933f52640f4ba0928ffc7 100644
+--- a/src/effects/imagefilters/SkRuntimeImageFilter.cpp
++++ b/src/effects/imagefilters/SkRuntimeImageFilter.cpp
+@@ -156,7 +156,11 @@ sk_sp<SkFlattenable> SkRuntimeImageFilter::CreateProc(SkReadBuffer& buffer) {
+         return nullptr;
+     }
+ 
+-    // Read the SkSL string and convert it into a runtime effect
++    // Read the SkSL string and convert it into a runtime effect (if allowed)
++    if (!buffer.validate(buffer.allowSkSL())) {
++        return nullptr;
++    }
++
+     SkString sksl;
+     buffer.readString(&sksl);
+     auto effect = SkMakeCachedRuntimeEffect(SkRuntimeEffect::MakeForShader, std::move(sksl));
+diff --git a/tests/SkGlyphTest.cpp b/tests/SkGlyphTest.cpp
+index 444e761a33607f107908166ff8014140d0cb3069..015a998b78674c6b908ee21324cf8810490c8a54 100644
+--- a/tests/SkGlyphTest.cpp
++++ b/tests/SkGlyphTest.cpp
+@@ -17,6 +17,7 @@
+ #include "include/core/SkRefCnt.h"
+ #include "include/core/SkString.h"
+ #include "include/core/SkTypes.h"
++#include "include/effects/SkImageFilters.h"
+ #include "include/effects/SkRuntimeEffect.h"
+ #include "src/base/SkArenaAlloc.h"
+ #include "src/core/SkCanvasPriv.h"
+@@ -373,20 +374,68 @@ DEF_TEST(SkPictureBackedGlyphDrawable_Basic, reporter) {
+     REPORTER_ASSERT(reporter, !badReadBuffer.isValid());
+ }
+ 
+-static sk_sp<SkDrawable> make_sksl_drawable() {
++namespace {
++
++// There is currently on SkMaskFilter that directly creates runtime effects
++enum class SkSLSource {
++    kShader, kColorFilter, kBlender, kImageFilter
++};
++
++} // anonymous namespace
++
++static sk_sp<SkDrawable> make_sksl_drawable(SkSLSource source) {
+     SkRect rect = SkRect::MakeWH(50, 50);
+ 
+     SkPictureRecorder recorder;
+     SkCanvas* canvas = recorder.beginRecording(rect);
+ 
+-    const sk_sp<SkRuntimeEffect> effect =
+-            SkRuntimeEffect::MakeForShader(
++    SkPaint paint;
++
++    switch (source) {
++        case SkSLSource::kShader: {
++            const sk_sp<SkRuntimeEffect> effect = SkRuntimeEffect::MakeForShader(
+                     SkString("half4 main(float2 xy) { return half4(0, 1, 0, 1); }"))
+                     .effect;
+-    SkASSERT(effect);
++            SkASSERT(effect);
++
++            paint.setShader(effect->makeShader(/*uniforms=*/nullptr, /*children=*/{}));
++            break;
++        }
++
++        case SkSLSource::kColorFilter: {
++            const sk_sp<SkRuntimeEffect> effect = SkRuntimeEffect::MakeForColorFilter(
++                    SkString("half4 main(half4 color) { return 0.5 * color; }"))
++                    .effect;
++            SkASSERT(effect);
++
++            paint.setColorFilter(effect->makeColorFilter(/*uniforms=*/nullptr, /*children=*/{}));
++            break;
++        }
++
++        case SkSLSource::kBlender: {
++            const sk_sp<SkRuntimeEffect> effect = SkRuntimeEffect::MakeForBlender(
++                    SkString("half4 main(half4 src, half4 dst) { return src + dst; }"))
++                    .effect;
++            SkASSERT(effect);
++
++            paint.setBlender(effect->makeBlender(/*uniforms=*/nullptr, /*children=*/{}));
++            break;
++        }
++
++        case SkSLSource::kImageFilter: {
++            const sk_sp<SkRuntimeEffect> effect =
++                    SkRuntimeEffect::MakeForShader(
++                            SkString("uniform shader child;"
++                                     "half4 main(float2 xy) { return 0.5 * child.eval(xy); }"))
++                            .effect;
++            SkASSERT(effect);
++
++            SkRuntimeEffectBuilder builder{std::move(effect)};
++            paint.setImageFilter(SkImageFilters::RuntimeShader(builder, "child", nullptr));
++            break;
++        }
++    }
+ 
+-    SkPaint paint;
+-    paint.setShader(effect->makeShader(/*uniforms=*/nullptr, /*children=*/{}));
+     // See note in make_nested_sksl_drawable: We include enough ops that this drawable will be
+     // preserved as a sub-picture when we wrap it in a second layer.
+     for (int i = 0; i < kMaxPictureOpsToUnrollInsteadOfRef + 1; ++i) {
+@@ -396,13 +445,13 @@ static sk_sp<SkDrawable> make_sksl_drawable() {
+     return recorder.finishRecordingAsDrawable();
+ }
+ 
+-static sk_sp<SkDrawable> make_nested_sksl_drawable() {
++static sk_sp<SkDrawable> make_nested_sksl_drawable(SkSLSource source) {
+     SkRect rect = SkRect::MakeWH(50, 50);
+ 
+     SkPictureRecorder recorder;
+     SkCanvas* canvas = recorder.beginRecording(rect);
+ 
+-    auto sksl_drawable = make_sksl_drawable();
++    auto sksl_drawable = make_sksl_drawable(source);
+     sk_sp<SkPicture> sksl_picture = sksl_drawable->makePictureSnapshot();
+ 
+     // We need to ensure that the op count of our picture is larger than this threshold, so we
+@@ -414,23 +463,32 @@ static sk_sp<SkDrawable> make_nested_sksl_drawable() {
+ }
+ 
+ DEF_TEST(SkPictureBackedGlyphDrawable_SkSL, reporter) {
+-    for (const sk_sp<SkDrawable>& drawable : {make_sksl_drawable(), make_nested_sksl_drawable()}) {
+-        for (bool allowSkSL : {true, false}) {
+-            REPORTER_ASSERT(reporter, drawable);
++    for (SkSLSource source : {SkSLSource::kShader,
++                              SkSLSource::kColorFilter,
++                              SkSLSource::kBlender,
++                              SkSLSource::kImageFilter}) {
++        for (const sk_sp<SkDrawable>& drawable : {make_sksl_drawable(source),
++                                                  make_nested_sksl_drawable(source)}) {
++            for (bool allowSkSL : {true, false}) {
++                skiatest::ReporterContext ctx{reporter,
++                        SkStringPrintf("source: %d, allow sksl: %d", (int) source, allowSkSL)};
++
++                REPORTER_ASSERT(reporter, drawable);
+ 
+-            SkBinaryWriteBuffer writeBuffer({});
+-            SkPictureBackedGlyphDrawable::FlattenDrawable(writeBuffer, drawable.get());
++                SkBinaryWriteBuffer writeBuffer({});
++                SkPictureBackedGlyphDrawable::FlattenDrawable(writeBuffer, drawable.get());
+ 
+-            sk_sp<SkData> data = writeBuffer.snapshotAsData();
++                sk_sp<SkData> data = writeBuffer.snapshotAsData();
+ 
+-            SkReadBuffer readBuffer{data->data(), data->size()};
+-            readBuffer.setAllowSkSL(allowSkSL);
++                SkReadBuffer readBuffer{data->data(), data->size()};
++                readBuffer.setAllowSkSL(allowSkSL);
+ 
+-            sk_sp<SkPictureBackedGlyphDrawable> dstDrawable =
+-                    SkPictureBackedGlyphDrawable::MakeFromBuffer(readBuffer);
++                sk_sp<SkPictureBackedGlyphDrawable> dstDrawable =
++                        SkPictureBackedGlyphDrawable::MakeFromBuffer(readBuffer);
+ 
+-            REPORTER_ASSERT(reporter, readBuffer.isValid() == allowSkSL);
+-            REPORTER_ASSERT(reporter, !!dstDrawable == allowSkSL);
++                REPORTER_ASSERT(reporter, readBuffer.isValid() == allowSkSL);
++                REPORTER_ASSERT(reporter, !!dstDrawable == allowSkSL);
++            }
+         }
+     }
+ }


### PR DESCRIPTION
<details>
<summary>cherry-pick 411ebd37c1e0 from chromium</summary>

[SMTC] Use weak ptr in SystemMediaControlsWin callback

We currently capture a raw `this` pointer in a SystemMediaControlsWin
callback for writing image data. This could be problematic as it's
possible the SystemMediaControlsWin doesn't outlive the operation.
This CL updates the callback to capture and use a weak pointer instead.

Bug: 495108488
Change-Id: I8698af5cf5d828ee5064793d35a6c33b6072ce53
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7694234
Commit-Queue: Tommy Steimel <steimel@chromium.org>
Reviewed-by: Frank Liberato <liberato@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1604285}

</details>

<details>
<summary>cherry-pick 788e99004847 from chromium</summary>

Add AMSC macro to FilePathWatcherFSEvents

As a band aid fix for potential memory issue.

Bug: 495782021
Change-Id: I2e53ef61ba9a0cbcff71b22148f800b3c59e0bb3
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699084
Reviewed-by: Mingyu Lei <leimy@chromium.org>
Commit-Queue: Mikihito Matsuura <mikt@google.com>
Cr-Commit-Position: refs/heads/main@{#1604590}

</details>

<details>
<summary>cherry-pick bd0b5614e7e5 from chromium</summary>

Make PassthroughTouchEventQueue weakable to see whether `this` is
 destroyed or not inside AckCompletedEvents.

PassthroughTouchEventQueue::AckCompletedEvents() synchronously invokes
nested message loop and the message loop may invoke some method which
destroys the PassthroughTouchEventQueue instance. This is
heap-use-after-free.

Bug: 495939973
Change-Id: I66bebcbce76b2638fdbb38b774cc163396aea509
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7735834
Owners-Override: Keishi Hattori <keishi@chromium.org>
Commit-Queue: Takashi Sakamoto <tasak@google.com>
Reviewed-by: Keishi Hattori <keishi@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1611993}

</details>

<details>
<summary>cherry-pick cc6431e78e7b from chromium</summary>

[aura] Mitigate Use-After-Free in
 WindowTreeHostPlatform::OnStateUpdate

WindowTreeHostPlatform::OnStateUpdate calls OnBoundsChanged, which can
trigger observer notifications that synchronously destroy the host.
While OnBoundsChanged safely handles this internally, it returns control
to OnStateUpdate, which continues executing with a dangling `this` pointer. Past report is crbug.com/1185482.

Bug: 495948109
Change-Id: Ic0eac7b9d91005f0275035b8393f67af43a19d32
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699933
Commit-Queue: Keishi Hattori <keishi@chromium.org>
Reviewed-by: Mitsuru Oshima <oshima@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1606889}

</details>

<details>
<summary>cherry-pick 743a681ba8c9 from chromium</summary>

Add AMSC macro to PendingHidTransfer

Bug: 495999127
Change-Id: Ice2c459c94064181328c03a4beb86963c8ab96f4
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7699518
Commit-Queue: Mikihito Matsuura <mikt@google.com>
Reviewed-by: Daniel Cheng <dcheng@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1605269}

</details>

<details>
<summary>cherry-pick 9674640f1813 from chromium</summary>

Fix realloc while iterating in HTMLSlotElement::DetachLayoutTree

Bug: 497830330
Change-Id: Id29714983245bcb58f3f3c2174f4b098c963d948
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7718078
Commit-Queue: Keishi Hattori <keishi@chromium.org>
Reviewed-by: Takashi Sakamoto <tasak@google.com>
Cr-Commit-Position: refs/heads/main@{#1609626}

</details>

<details>
<summary>cherry-pick 3150bddf3edd from skia</summary>

[sksl] Check allowSkSL for SkRuntimeImageFilter::CreateProc

Since SkRuntimeImageFilter doesn't create its runtime shaders until
actually evaluating the image filter, SkRuntimeShader's CreateProc
was not being reached; it must be responsible for validating allowSkSL.

Updates the unit test to confirm that all sources of runtime effects
in drawables are detected when allowSkSl is false.

Bug: b/502636904
Change-Id: I391ba2608010431429ac3e3c03e106f380304edb
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1214636
Reviewed-by: Kaylee Lubick <kjlubick@google.com>
Reviewed-by: Jorge Betancourt <jmbetancourt@google.com>
Commit-Queue: Michael Ludwig <michaelludwig@google.com>

</details>

<details>
<summary>cherry-pick d8ffa7447da0 from angle</summary>

Translator: Avoid setting initializer for too-large variable

Test credit kbr@chromium.org / gemini.

Fixed: chromium:498400132
Change-Id: I4b5379de712c22fcfcdbabbaf9c3f92bae209922
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7778457
Auto-Submit: Shahbaz Youssefi <syoussefi@chromium.org>
Reviewed-by: Kenneth Russell <kbr@chromium.org>
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>

</details>

Notes: Backported fixes for several use-after-free and object-lifetime issues in input, UI, Aura, HID and file-system teardown paths, a runtime-effect validation gap in Skia, and an integer overflow in the GLSL translator.
