### PR TITLE
ci: fix capturing fatal errors in clang problem matcher

### DIFF
--- a/.github/problem-matchers/clang.json
+++ b/.github/problem-matchers/clang.json
@@ -5,7 +5,7 @@
       "fromPath": "src/out/Default/args.gn",
       "pattern": [
         {
-          "regexp": "^(.+)[(:](\\d+)[:,](\\d+)\\)?:\\s+(warning|fatal error|error):\\s+(.*)$",
+          "regexp": "^(.+)[(:](\\d+)[:,](\\d+)\\)?:\\s+(?:fatal )?(warning|error):\\s+(.*)$",
           "file": 1,
           "line": 2,
           "column": 3,


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Follow-up to #50984. That approach was incomplete because the value captured by the 4th capture group is what GitHub uses as the annotation level, and "fatal error" was being captured and not recognized by GitHub. So swap things around a bit so that only "error" is captured as the level.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
