### PR TITLE
build: remove vestigial shell:true from spec yarn install spawn

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -420,8 +420,7 @@ async function installSpecModules(dir) {
   const { status } = childProcess.spawnSync(process.execPath, yarnArgs, {
     env,
     cwd: dir,
-    stdio: 'inherit',
-    shell: process.platform === 'win32'
+    stdio: 'inherit'
   });
   if (status !== 0 && !process.env.IGNORE_YARN_INSTALL_ERROR) {
     console.log(`${fail} Failed to yarn install in '${dir}'`);


### PR DESCRIPTION
#### Description of Change

- Removes the leftover `shell: process.platform === 'win32'` from the `installSpecModules()` spawn in `script/spec-runner.js`.
- That option was originally needed when this code invoked `npx.cmd` directly (`.cmd` files require `shell: true` to avoid EINVAL — see #41893). #48243 (*build: update to yarn v4*) replaced the `npx.cmd` invocation with a direct `process.execPath` spawn of the bundled `yarn-4.11.0.cjs`, but the `shell` option was carried over unchanged from the previous block.
- For `node.exe` (a real `.exe`) `shell: true` is unnecessary, and on Windows it actively breaks the install: `cmd.exe` word-splits `process.execPath` on whitespace, so installs fail whenever Node is installed under a path with spaces — including the default MSI location `C:\Program Files\nodejs\`.

## Test plan

- [x] Reproduced the failure on two Windows machines with Node at `C:\Program Files\nodejs\node.exe`.
- [x] After the patch, `node script/spec-runner.js --runners=main` runs `yarn install` cleanly inside `spec/`.
- [ ] CI: Windows test job confirms no regression on the install step.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] I have built and tested this change
- [X] I have filled out the PR description
- [X] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:  none
