### PR TITLE
ci: set no color output during build

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -80,10 +80,12 @@ runs:
           sudo launchctl limit maxfiles 65536 200000
         fi
 
+        export NINJA_SUMMARIZE_BUILD=1
+        export NO_COLOR=1
         if [ "${{ inputs.is-release }}" = "true" ]; then
-          NINJA_SUMMARIZE_BUILD=1 e build --target electron:release_build
+          e build --target electron:release_build
         else
-          NINJA_SUMMARIZE_BUILD=1 e build --target electron:testing_build
+          e build --target electron:testing_build
         fi
         cp out/Default/.ninja_log out/electron_ninja_log
         node electron/script/check-symlinks.js
@@ -108,6 +110,7 @@ runs:
         cd ..
 
         $env:NINJA_SUMMARIZE_BUILD = 1
+        $env:NO_COLOR = 1
         if ("${{ inputs.is-release }}" -eq "true") {          
           e build --target electron:release_build
         } else {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

At some point in the past week something changed (either Chromium roll or GitHub Actions change) and now macOS and Linux are defaulting to color output from clang during the build. This breaks the problem matcher we have for clang output since now there are ANSI escape characters in the raw output. Fix is to just disable color output explicitly during the build.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
