### PR TITLE
build: restore CHROMIUM_BUILDTOOLS_PATH in devcontainer config

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -54,6 +54,7 @@ if [ ! -f $buildtools/configs/evm.testing.json ]; then
                 \"out\": \"Testing\"
             },
             \"env\": {
+                \"CHROMIUM_BUILDTOOLS_PATH\": \"/workspaces/gclient/src/buildtools\",
                 \"GIT_CACHE_PATH\": \"/workspaces/gclient/.git-cache\"
             },
             \"\$schema\": \"file:///home/builduser/.electron_build_tools/evm-config.schema.json\",


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Follow-up to #51558 to fix the failing codespaces prebuilds. This is an edge case because we hand roll a config here, and `build-tools` is still including `CHROMIUM_BUILDTOOLS_PATH` in configs and just ignoring it if the conditions are met. The condition check can't work without `CHROMIUM_BUILDTOOLS_PATH` in the config IF there's also no sync'd checkout (to create `.gclient`).

We'll remove this from the hand rolled config in the future when `build-tools` drops the conditional check for upstream `depot_tools` support. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
