### PR TITLE
ci: adjust clang-tidy macOS runner size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
     needs: checkout-macos
     with:
       build-runs-on: macos-15-xlarge
-      clang-tidy-runs-on: macos-15-large
+      clang-tidy-runs-on: macos-15-xlarge
       test-runs-on: macos-15
       target-platform: macos
       target-arch: arm64

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -133,6 +133,7 @@ jobs:
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Run Clang-Tidy
       env:
+        # macOS runners have fewer CPU cores, so use fewer jobs for better results
         CLANG_TIDY_JOBS: ${{ case(inputs.target-platform == 'macos', 5, 8) }}
       run: |
         e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH} --remote-build none

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -133,7 +133,7 @@ jobs:
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Run Clang-Tidy
       env:
-        CLANG_TIDY_JOBS: ${{ case(inputs.target-platform == 'macos', 4, 8) }}
+        CLANG_TIDY_JOBS: ${{ case(inputs.target-platform == 'macos', 5, 8) }}
       run: |
         e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH} --remote-build none
 

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -132,6 +132,8 @@ jobs:
       shell: bash
       run: echo "::add-matcher::src/electron/.github/problem-matchers/clang.json"
     - name: Run Clang-Tidy
+      env:
+        CLANG_TIDY_JOBS: ${{ case(inputs.target-platform == 'macos', 4, 8) }}
       run: |
         e init -f --root=$(pwd) --out=${ELECTRON_OUT_DIR} testing --target-cpu ${TARGET_ARCH} --remote-build none
 
@@ -162,7 +164,7 @@ jobs:
         fi
 
         cd src/electron
-        node script/yarn.js lint:clang-tidy --jobs 8 --out-dir ../out/${ELECTRON_OUT_DIR}
+        node script/yarn.js lint:clang-tidy --jobs ${CLANG_TIDY_JOBS} --out-dir ../out/${ELECTRON_OUT_DIR}
     - name: Remove Clang problem matcher
       shell: bash
       run: echo "::remove-matcher owner=clang::"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Turns out `macos-15-large` is Intel, which was not the intention (it's a sub-job of `macos-arm64`). Switching this to one of the Apple Silicon runners.

This also tweaks the number of jobs as macOS runners have fewer CPUs and less memory and seem to be bogging down under the load. These combined tweaks cut the time for this job from 50m+ to 22m.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
