### PR TITLE
fix: macOS dialog.showOpenDialog LSTypeIsPackage filter in 36.2.0+

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -135,8 +135,19 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
           [content_types_set addObject:utt];
         }
       } else {
-        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
+        // First try to get a UTType conforming to the package type, which is
+        // necessary for custom macOS package types like .rtfd to be recognized
+        // properly in file dialogs. If that fails, fall back to the regular
+        // method.
+        UTType* packageType = [UTType typeWithIdentifier:@"com.apple.package"];
+        UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())
+                                       conformingToType:packageType];
+        if (!utt) {
+          utt = [UTType typeWithFilenameExtension:@(ext.c_str())];
+        }
+        if (utt) {
           [content_types_set addObject:utt];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes an issue where custom macOS package types (like .rtfd) were not properly recognized in file dialogs when filtering by extension in Electron 36.2.0+. The regression was introduced when migrating to the non-deprecated allowedContentTypes API (PR #46623).

The UTType creation did not specify package conformance, causing the system to not recognize these files as valid packages. The fix attempts to create UTTypes with com.apple.package conformance first, then falls back to the regular method if that fails.

**Repro steps** (from issue #48191):
1. Create a .rtf file using Text Edit (macOS)
2. Use dialog.showOpenDialog with filters: [{ name: 'rich text files', extensions: ['rtf', 'rtfd'] }]
3. On Electron 36.2.0+, no files are selectable; on 35.7.5 it works

Fixes: https://github.com/electron/electron/issues/48191