### PR TITLE
fix: macOS dialog.showOpenDialog LSTypeIsPackage filter in 36.2.0+

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -135,8 +135,19 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
           [content_types_set addObject:utt];
         }
       } else {
-        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
+        // First try to get a UTType conforming to the package type, which is
+        // necessary for custom macOS package types like .rtfd to be recognized
+        // properly in file dialogs. If that fails, fall back to the regular
+        // method.
+        UTType* packageType = [UTType typeWithIdentifier:@"com.apple.package"];
+        UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())
+                                       conformingToType:packageType];
+        if (!utt) {
+          utt = [UTType typeWithFilenameExtension:@(ext.c_str())];
+        }
+        if (utt) {
           [content_types_set addObject:utt];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/48191

Root cause: PR #46623 migration to allowedContentTypes API did not specify package conformance for UTType creation. Custom macOS packages (.rtfd, etc with LSTypeIsPackage=true) were not recognized.

Fix: attempt UTTypes with com.apple.package conforming type first, fall back to regular.