### PR TITLE
chore: cherry-pick 5 changes from chromium, angle (42-x-y)

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,1 +1,2 @@
 cherry-pick-d8ffa7447da0.patch
+cherry-pick-6c71c70ec7e8.patch

--- a/patches/angle/cherry-pick-6c71c70ec7e8.patch
+++ b/patches/angle/cherry-pick-6c71c70ec7e8.patch
@@ -1,0 +1,217 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shrek Shao <shrekshao@google.com>
+Date: Thu, 2 Apr 2026 13:05:19 -0700
+Subject: [M148] GL: Fix heap-buffer-overflow in streamAttributes
+
+When the shiftInstancedArrayDataWithOffset workaround is
+enabled (primarily for Intel drivers on macOS), the number
+of vertices to stream is increased to account for the first
+parameter in drawArraysInstanced.
+
+However, computeStreamingAttributeSizes was not aware of this
+workaround, leading to an under-allocation of the streaming
+buffer. Additionally, the copy loop in streamAttributes used
+the increased vertex count to read from the source client
+memory.
+This resulted in a heap-buffer-overflow because the source
+buffer might only contain enough data for the original instance
+count, and the destination buffer was also too small for the
+shifted layout.
+
+This CL:
+1. Updates computeStreamingAttributeSizes to accept an
+applyExtraOffsetWorkaroundForInstancedAttributes flag and
+correctly calculate the required buffer size when the
+workaround is active.
+2. Updates streamAttributes to only copy the original number
+of vertices from the source memory in both fast and slow paths.
+3. Ensures the destination buffer layout still respects the
+increased vertex count for correct attribute spacing as required
+by the workaround.
+4. Adds a regression test
+ShiftInstancedArrayDataWithOffsetSlowPath in
+VertexAttributeTest.cpp that triggers the workaround
+and the slow path copy loop.
+
+Bug: b/497928952
+Fixed: b/500613386
+Change-Id: I4b59ceec7cf9fc301eacb5b22faa4a3b2c2c863d
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7728161
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Shrek Shao <shrekshao@google.com>
+Auto-Submit: Shrek Shao <shrekshao@google.com>
+(cherry picked from commit c0c3b52cec94593157bea7a5ecd9e1ab7b2ce802)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7817770
+
+diff --git a/src/libANGLE/renderer/gl/VertexArrayGL.cpp b/src/libANGLE/renderer/gl/VertexArrayGL.cpp
+index 489cbffbce58773ea2d497cc6f5086660b2f0e6b..f4774a5b9622f79756d8db9c139cb7940e6000c7 100644
+--- a/src/libANGLE/renderer/gl/VertexArrayGL.cpp
++++ b/src/libANGLE/renderer/gl/VertexArrayGL.cpp
+@@ -367,11 +367,13 @@ angle::Result VertexArrayGL::syncIndexData(const gl::Context *context,
+     return angle::Result::Continue;
+ }
+ 
+-void VertexArrayGL::computeStreamingAttributeSizes(const gl::AttributesMask &attribsToStream,
+-                                                   GLsizei instanceCount,
+-                                                   const gl::IndexRange &indexRange,
+-                                                   size_t *outStreamingDataSize,
+-                                                   size_t *outMaxAttributeDataSize) const
++void VertexArrayGL::computeStreamingAttributeSizes(
++    const gl::AttributesMask &attribsToStream,
++    GLsizei instanceCount,
++    const gl::IndexRange &indexRange,
++    size_t *outStreamingDataSize,
++    size_t *outMaxAttributeDataSize,
++    bool applyExtraOffsetWorkaroundForInstancedAttributes) const
+ {
+     *outStreamingDataSize    = 0;
+     *outMaxAttributeDataSize = 0;
+@@ -391,9 +393,14 @@ void VertexArrayGL::computeStreamingAttributeSizes(const gl::AttributesMask &att
+         // the attribute with the largest data size.
+         size_t typeSize        = ComputeVertexAttributeTypeSize(attrib);
+         GLuint adjustedDivisor = GetAdjustedDivisor(mAppliedNumViews, binding.getDivisor());
+-        *outStreamingDataSize +=
+-            typeSize * ComputeVertexBindingElementCount(adjustedDivisor, indexRange.vertexCount(),
+-                                                        instanceCount);
++        size_t streamedVertexCount = ComputeVertexBindingElementCount(
++            adjustedDivisor, indexRange.vertexCount(), instanceCount);
++        if (applyExtraOffsetWorkaroundForInstancedAttributes && adjustedDivisor > 0)
++        {
++            streamedVertexCount =
++                (instanceCount + indexRange.start() + adjustedDivisor - 1u) / adjustedDivisor;
++        }
++        *outStreamingDataSize += typeSize * streamedVertexCount;
+         *outMaxAttributeDataSize = std::max(*outMaxAttributeDataSize, typeSize);
+     }
+ }
+@@ -413,7 +420,8 @@ angle::Result VertexArrayGL::streamAttributes(
+     size_t maxAttributeDataSize = 0;
+ 
+     computeStreamingAttributeSizes(attribsToStream, instanceCount, indexRange, &streamingDataSize,
+-                                   &maxAttributeDataSize);
++                                   &maxAttributeDataSize,
++                                   applyExtraOffsetWorkaroundForInstancedAttributes);
+ 
+     if (streamingDataSize == 0)
+     {
+@@ -468,6 +476,7 @@ angle::Result VertexArrayGL::streamAttributes(
+             // shiftInstancedArrayDataWithOffset workaround, otherwise it's const
+             size_t streamedVertexCount = ComputeVertexBindingElementCount(
+                 adjustedDivisor, indexRange.vertexCount(), instanceCount);
++            const size_t originalStreamedVertexCount = streamedVertexCount;
+ 
+             const size_t sourceStride = ComputeVertexAttributeStride(attrib, binding);
+             const size_t destStride   = ComputeVertexAttributeTypeSize(attrib);
+@@ -491,7 +500,6 @@ angle::Result VertexArrayGL::streamAttributes(
+ 
+             if (applyExtraOffsetWorkaroundForInstancedAttributes && adjustedDivisor > 0)
+             {
+-                const size_t originalStreamedVertexCount = streamedVertexCount;
+                 streamedVertexCount =
+                     (instanceCount + indexRange.start() + adjustedDivisor - 1u) / adjustedDivisor;
+ 
+@@ -545,7 +553,7 @@ angle::Result VertexArrayGL::streamAttributes(
+             }
+             else
+             {
+-                for (size_t vertexIdx = 0; vertexIdx < streamedVertexCount; vertexIdx++)
++                for (size_t vertexIdx = 0; vertexIdx < originalStreamedVertexCount; vertexIdx++)
+                 {
+                     uint8_t *out = bufferPointer + curBufferOffset + (destStride * vertexIdx);
+                     const uint8_t *in =
+diff --git a/src/libANGLE/renderer/gl/VertexArrayGL.h b/src/libANGLE/renderer/gl/VertexArrayGL.h
+index 2b08576bbef1e6ecc92ee3bceb0f35fc29763f87..b018e80e48170664d973391bad7b52ee741f82d6 100644
+--- a/src/libANGLE/renderer/gl/VertexArrayGL.h
++++ b/src/libANGLE/renderer/gl/VertexArrayGL.h
+@@ -91,11 +91,13 @@ class VertexArrayGL : public VertexArrayImpl
+ 
+     // Returns the amount of space needed to stream all attributes that need streaming
+     // and the data size of the largest attribute
+-    void computeStreamingAttributeSizes(const gl::AttributesMask &attribsToStream,
+-                                        GLsizei instanceCount,
+-                                        const gl::IndexRange &indexRange,
+-                                        size_t *outStreamingDataSize,
+-                                        size_t *outMaxAttributeDataSize) const;
++    void computeStreamingAttributeSizes(
++        const gl::AttributesMask &attribsToStream,
++        GLsizei instanceCount,
++        const gl::IndexRange &indexRange,
++        size_t *outStreamingDataSize,
++        size_t *outMaxAttributeDataSize,
++        bool applyExtraOffsetWorkaroundForInstancedAttributes) const;
+ 
+     // Stream attributes that have client data
+     angle::Result streamAttributes(const gl::Context *context,
+diff --git a/src/tests/gl_tests/VertexAttributeTest.cpp b/src/tests/gl_tests/VertexAttributeTest.cpp
+index a47e11e6edb31ce955eedd4478620208b3778a2f..efb1b6a0a941c59f39509c2b1b5b88574c0efc05 100644
+--- a/src/tests/gl_tests/VertexAttributeTest.cpp
++++ b/src/tests/gl_tests/VertexAttributeTest.cpp
+@@ -5865,6 +5865,68 @@ ANGLE_INSTANTIATE_TEST_ES3_AND(VertexAttributeUint8Test,
+                                ES3_VULKAN().disable(Feature::SupportsIndexTypeUint8),
+                                ES3_VULKAN_SWIFTSHADER().disable(Feature::SupportsIndexTypeUint8));
+ 
++class VertexAttributeShiftInstancedArrayDataWithOffsetTest : public VertexAttributeTest
++{};
++
++// Regression test (crbug.com/497928952) for heap-buffer-overflow in streamAttributes() when
++// shiftInstancedArrayDataWithOffset workaround is enabled.
++TEST_P(VertexAttributeShiftInstancedArrayDataWithOffsetTest,
++       ShiftInstancedArrayDataWithOffsetSlowPath)
++{
++    // The workaround is specifically for Mac Intel, but we can enable it for this test.
++    // It is only triggered for drawArraysInstanced with first > 0.
++    // The slow path is triggered when sourceStride != destStride.
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_ANGLE_instanced_arrays") &&
++                       getClientMajorVersion() < 3);
++
++    constexpr char kVS[] = R"(attribute vec4 position;
++attribute vec4 instance;
++varying vec4 color;
++void main() {
++    gl_Position = position + instance * 0.001;
++    color = vec4(1, 0, 0, 1);
++})";
++    constexpr char kFS[] = R"(varying lowp vec4 color;
++void main() {
++    gl_FragColor = color;
++})";
++
++    ANGLE_GL_PROGRAM(program, kVS, kFS);
++    glUseProgram(program);
++    GLint posLoc  = glGetAttribLocation(program, "position");
++    GLint instLoc = glGetAttribLocation(program, "instance");
++
++    auto quadVertices = GetQuadVertices();
++    GLBuffer posBuf;
++    glBindBuffer(GL_ARRAY_BUFFER, posBuf);
++    glBufferData(GL_ARRAY_BUFFER, quadVertices.size() * sizeof(Vector3), quadVertices.data(),
++                 GL_STATIC_DRAW);
++    glEnableVertexAttribArray(posLoc);
++    glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
++
++    const int instanceCount = 1024;
++    const int srcStride     = 20;  // 20 bytes stride for vec4 (16 bytes) forces slow path
++    std::vector<uint8_t> instData(instanceCount * srcStride, 0);
++    GLBuffer instBuf;
++    glBindBuffer(GL_ARRAY_BUFFER, instBuf);
++    glBufferData(GL_ARRAY_BUFFER, instData.size(), instData.data(), GL_STATIC_DRAW);
++    glEnableVertexAttribArray(instLoc);
++    glVertexAttribPointer(instLoc, 4, GL_FLOAT, GL_FALSE, srcStride, nullptr);
++    glVertexAttribDivisorANGLE(instLoc, 1);
++
++    const int first = 100;
++    // This will trigger the workaround and the overflow if the fix is not present.
++    glDrawArraysInstancedANGLE(GL_TRIANGLES, first, 6, instanceCount);
++    EXPECT_GL_NO_ERROR();
++}
++
++ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(
++    VertexAttributeShiftInstancedArrayDataWithOffsetTest,
++    ES2_OPENGL().enable(Feature::ShiftInstancedArrayDataWithOffset),
++    ES2_OPENGLES().enable(Feature::ShiftInstancedArrayDataWithOffset),
++    ES3_OPENGL().enable(Feature::ShiftInstancedArrayDataWithOffset),
++    ES3_OPENGLES().enable(Feature::ShiftInstancedArrayDataWithOffset));
++
+ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(
+     VertexAttributeTest,
+     ES2_VULKAN().enable(Feature::ForceFallbackFormat),

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,7 @@ fix_use_fresh_lazynow_for_onendworkitemimpl_after_didruntask.patch
 fix_make_macos_text_replacement_work_on_contenteditable.patch
 fix_constrain_allowuniversalaccessfromfileurls_to_file_origins_in.patch
 cherry-pick-bd0b5614e7e5.patch
+cherry-pick-c4653f71b7b1.patch
+cherry-pick-e7eeef31113d.patch
+cherry-pick-70c1db1e1b72.patch
+cherry-pick-66e1a4951c0c.patch

--- a/patches/chromium/cherry-pick-66e1a4951c0c.patch
+++ b/patches/chromium/cherry-pick-66e1a4951c0c.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kent Tamura <tkent@chromium.org>
+Date: Fri, 8 May 2026 10:53:43 -0700
+Subject: [M148] Workaround of a ubidi_getLogicalRun() issue
+
+Original change's description:
+> Workaround of a ubidi_getLogicalRun() issue
+>
+> A crash can occur within ICU's `ubidi_getLogicalRun()` function when
+> processing strings where `text.length() * N` exceeds the maximum value
+> of `int32_t`, where `N` represents the size of an internal ICU struct
+> (approximately 12 bytes, derived from `sizeof(int32_t) * 3`).
+>
+> This CL adds `CHECK_LE` assertions in `BidiParagraph::SetParagraph` and
+> `BiDiLineIterator::Open` to limit the input string length. This ensures
+> that the string length, when multiplied by the ICU internal factor, does
+> not cause an integer overflow.
+>
+> This is a temporary workaround until the underlying issue in ICU is
+> fixed and the updated library is rolled out.
+>
+> No dedicated tests are included in this CL, as reproducing the overflow
+> requires constructing extremely large strings, which is impractical for
+> standard unit tests.
+>
+> Fixed: 504629701
+> Change-Id: Ica350078f0f3809012e957afb37c5985d9765d5c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7781344
+> Reviewed-by: Nico Weber <thakis@chromium.org>
+> Auto-Submit: Kent Tamura <tkent@chromium.org>
+> Commit-Queue: Kent Tamura <tkent@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1618626}
+
+(cherry picked from commit e5e65102447845af6d246f9bca83b1a57277897f)
+
+Fuchsia-Binary-Size: Size increase is unavoidable.
+Bug: 506779184,504629701
+Change-Id: Ica350078f0f3809012e957afb37c5985d9765d5c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7824420
+Reviewed-by: Nico Weber <thakis@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Kent Tamura <tkent@chromium.org>
+Reviewed-by: Mitsuru Oshima <oshima@chromium.org>
+Commit-Queue: David Yeung <dayeung@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#2542}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/platform/text/bidi_paragraph.cc b/third_party/blink/renderer/platform/text/bidi_paragraph.cc
+index 93b1e0a3d0c00875d86f2f90cdcf30f7e624a335..8f7e8dc293e34592fff5024a058c2b45bfb0a705 100644
+--- a/third_party/blink/renderer/platform/text/bidi_paragraph.cc
++++ b/third_party/blink/renderer/platform/text/bidi_paragraph.cc
+@@ -13,6 +13,12 @@ namespace blink {
+ 
+ bool BidiParagraph::SetParagraph(const String& text,
+                                  std::optional<TextDirection> base_direction) {
++  // A workaround for integer overflow in ICU. See crbug.com/504629701.
++  // We can remove this after fixing the ICU issue, and rolling out the ICU
++  // update.
++  constexpr size_t kIcuRunSize = sizeof(int32_t) * 3;
++  CHECK_LE(text.length(), std::numeric_limits<int32_t>::max() / kIcuRunSize);
++
+   DCHECK(!text.IsNull());
+   if (!ubidi_) {
+     ubidi_ = UBidiPtr(ubidi_open());
+diff --git a/ui/gfx/bidi_line_iterator.cc b/ui/gfx/bidi_line_iterator.cc
+index 2fc1f285aa907bd979ccd3a90e4ddbe5f513474f..fc0b0a2d78829448d30496b412e01d67134cd2fd 100644
+--- a/ui/gfx/bidi_line_iterator.cc
++++ b/ui/gfx/bidi_line_iterator.cc
+@@ -5,6 +5,7 @@
+ #include "ui/gfx/bidi_line_iterator.h"
+ 
+ #include "base/check.h"
++#include "base/check_op.h"
+ #include "base/notreached.h"
+ 
+ namespace ui {
+@@ -32,6 +33,12 @@ BiDiLineIterator::~BiDiLineIterator() = default;
+ 
+ bool BiDiLineIterator::Open(std::u16string_view text,
+                             base::i18n::TextDirection direction) {
++  // A workaround for integer overflow in ICU. See crbug.com/504629701.
++  // We can remove this after fixing the ICU issue, and rolling out the ICU
++  // update.
++  constexpr size_t kIcuRunSize = sizeof(int32_t) * 3;
++  CHECK_LE(text.length(), std::numeric_limits<int32_t>::max() / kIcuRunSize);
++
+   DCHECK(!bidi_);
+   UErrorCode error = U_ZERO_ERROR;
+   bidi_.reset(ubidi_openSized(static_cast<int>(text.length()), 0, &error));

--- a/patches/chromium/cherry-pick-70c1db1e1b72.patch
+++ b/patches/chromium/cherry-pick-70c1db1e1b72.patch
@@ -1,0 +1,115 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Addison Luh <aluh@chromium.org>
+Date: Thu, 30 Apr 2026 13:01:42 -0700
+Subject: [M148] Reland "Prevent invalid tree state in
+ AutomationTreeManagerOwner"
+
+Original change's description:
+> Reland "Prevent invalid tree state in AutomationTreeManagerOwner"
+>
+> This is a reland of commit d2ab7831eecf3a1c192ae64b05c2c6a797b556e9
+>
+> Fixed tree id in the test.
+>
+> Original change's description:
+> > Prevent invalid tree state in AutomationTreeManagerOwner
+> >
+> > If an AXTree fails to fully unserialize in the automation tree manager
+> > owner, drop and destroy the corrupted client wrapper and its nested
+> > static caches immediately. This prevents the tree manager from
+> > referencing the corrupted, dangling pointers subsequently.
+> >
+> > Bug: b:502978647
+> > Test: out/Default/accessibility_unittests --gtest_filter=AutomationTreeManagerOwnerTest.UnserializeFailureClearsCachedTree
+> > Change-Id: Idbcbdab0e7b7a46d8d094a38f3ba4a32cf301ce7
+> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7793837
+> > Reviewed-by: David Tseng <dtseng@chromium.org>
+> > Auto-Submit: Addison Luh <aluh@chromium.org>
+> > Commit-Queue: David Tseng <dtseng@chromium.org>
+> > Cr-Commit-Position: refs/heads/main@{#1621369}
+>
+> Cq-Include-Trybots: luci.chrome.try:linux-chromeos-chrome
+> Bug: b:502978647
+> Change-Id: I720b30a6baa76570ea54b072e1e9bc0ad6c50f0a
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7802331
+> Auto-Submit: Addison Luh <aluh@chromium.org>
+> Reviewed-by: David Tseng <dtseng@chromium.org>
+> Commit-Queue: Addison Luh <aluh@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1622148}
+
+(cherry picked from commit a72c80884d88cb68fba22a552ec795f3b552f1a1)
+
+Bug: 507877803,b:502978647
+Change-Id: I720b30a6baa76570ea54b072e1e9bc0ad6c50f0a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7807647
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#2026}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/accessibility/platform/automation/automation_tree_manager_owner.cc b/ui/accessibility/platform/automation/automation_tree_manager_owner.cc
+index d6a36fcede4864d1647995136a3743782cf83799..17f0803ff07598b54263e1ffa306b06d01c556a9 100644
+--- a/ui/accessibility/platform/automation/automation_tree_manager_owner.cc
++++ b/ui/accessibility/platform/automation/automation_tree_manager_owner.cc
+@@ -1075,6 +1075,7 @@ void AutomationTreeManagerOwner::DispatchAccessibilityEvents(
+                                            mouse_location)) {
+     DLOG(ERROR) << tree_wrapper->ax_tree()->error();
+     GetAutomationV8Bindings()->SendTreeSerializationError(tree_id);
++    DestroyAccessibilityTree(tree_id);
+     return;
+   }
+ 
+diff --git a/ui/accessibility/platform/automation/automation_tree_manager_owner_unittest.cc b/ui/accessibility/platform/automation/automation_tree_manager_owner_unittest.cc
+index a16a96d7be7efff92d4717921f256c59dfa95471..693b5e5fb89e86469ab05eab81fdb9d4fd1a648f 100644
+--- a/ui/accessibility/platform/automation/automation_tree_manager_owner_unittest.cc
++++ b/ui/accessibility/platform/automation/automation_tree_manager_owner_unittest.cc
+@@ -1000,4 +1000,48 @@ TEST_F(AutomationTreeManagerOwnerTest, FireEventsWithListeners) {
+   EXPECT_TRUE(tree_destroyed);
+ }
+ 
++TEST_F(AutomationTreeManagerOwnerTest, UnserializeFailureClearsCachedTree) {
++  EXPECT_TRUE(GetTreeIDToTreeMap().empty());
++
++  const AXTreeID tree_id = AXTreeID::CreateNewAXTreeID();
++  const int valid_node_id = 1;
++  const int invalid_node_id = 2;
++
++  std::vector<AXTreeUpdate> updates;
++  updates.emplace_back();
++  auto& tree_update = updates.back();
++  auto& tree_data = tree_update.tree_data;
++  tree_data.tree_id = tree_id;
++  tree_update.has_tree_data = true;
++  tree_update.root_id = valid_node_id;
++  tree_update.nodes.emplace_back();
++  auto& node_data = tree_update.nodes.back();
++  node_data.role = ax::mojom::Role::kDesktop;
++  node_data.id = valid_node_id;
++  std::vector<AXEvent> events;
++  SendAccessibilityEvents(tree_id, updates, gfx::Point(), events);
++
++  ASSERT_EQ(1U, GetTreeIDToTreeMap().size());
++
++  updates.clear();
++  updates.emplace_back();
++  auto& bad_update = updates.back();
++  bad_update.has_tree_data = true;
++  bad_update.tree_data.tree_id = tree_id;
++  bad_update.root_id = valid_node_id;
++  bad_update.nodes.emplace_back();
++  auto& bad_node_data = bad_update.nodes.back();
++  bad_node_data.id = valid_node_id;
++  // Adds a non-existent node id.
++  bad_node_data.child_ids.push_back(invalid_node_id);
++
++#if AX_FAIL_FAST_BUILD()
++  EXPECT_DEATH_IF_SUPPORTED(
++      SendAccessibilityEvents(tree_id, updates, gfx::Point(), events), "");
++#else
++  SendAccessibilityEvents(tree_id, updates, gfx::Point(), events);
++  EXPECT_TRUE(GetTreeIDToTreeMap().empty());
++#endif
++}
++
+ }  // namespace ui

--- a/patches/chromium/cherry-pick-c4653f71b7b1.patch
+++ b/patches/chromium/cherry-pick-c4653f71b7b1.patch
@@ -1,0 +1,117 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Wilson <mjwilson@chromium.org>
+Date: Fri, 1 May 2026 15:25:51 -0700
+Subject: [M148] Disable denormals before isolate creation for AudioWorklet
+ threads
+
+Original change's description:
+> Disable denormals before isolate creation for AudioWorklet threads
+>
+> This is to ensure consistency in the denormal flag state between the
+> isolate and the global scope.
+>
+> Bug: 499565267
+> Change-Id: Iec7735bd6bc543da2ad08aea2f7bc716265dc54d
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7744866
+> Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
+> Commit-Queue: Michael Wilson <mjwilson@chromium.org>
+> Reviewed-by: Hongchan Choi <hongchan@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1615043}
+
+(cherry picked from commit 5c37ebf855147997e7cbc84d8ef67ab142cc78b4)
+
+Bug: 504873416,499565267
+Change-Id: Iec7735bd6bc543da2ad08aea2f7bc716265dc54d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7808785
+Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
+Commit-Queue: Michael Wilson <mjwilson@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Michael Wilson <mjwilson@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#2094}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/core/workers/worker_backing_thread.cc b/third_party/blink/renderer/core/workers/worker_backing_thread.cc
+index 38d221a6ca9b996bb3134669b0dbf73a6b94650a..5997bed33ccb8d9382cc0771c892a633081b7f14 100644
+--- a/third_party/blink/renderer/core/workers/worker_backing_thread.cc
++++ b/third_party/blink/renderer/core/workers/worker_backing_thread.cc
+@@ -18,6 +18,7 @@
+ #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"
+ #include "third_party/blink/renderer/core/inspector/worker_thread_debugger.h"
+ #include "third_party/blink/renderer/core/workers/worker_backing_thread_startup_data.h"
++#include "third_party/blink/renderer/platform/audio/denormal_disabler.h"
+ #include "third_party/blink/renderer/platform/heap/thread_state.h"
+ #include "third_party/blink/renderer/platform/runtime_enabled_features.h"
+ #include "third_party/blink/renderer/platform/scheduler/public/main_thread.h"
+@@ -91,6 +92,14 @@ void RemoveForegroundedWorkerIsolate(v8::Isolate* isolate) {
+   ForegroundedIsolates().erase(isolate);
+ }
+ 
++bool IsDenormalDisabledThreadType(ThreadType type) {
++  // Disable denormals on WebAudio threads for performance reasons.  See:
++  // https://esdiscuss.org/topic/float-denormal-issue-in-javascript-processor-node-in-web-audio-api
++  return type == ThreadType::kOfflineAudioWorkletThread ||
++         type == ThreadType::kRealtimeAudioWorkletThread ||
++         type == ThreadType::kSemiRealtimeAudioWorkletThread;
++}
++
+ }  // namespace
+ 
+ // Wrapper functions defined in third_party/blink/public/web/blink.h
+@@ -119,7 +128,9 @@ void SetMemorySaverModeForWorkerThreadIsolates(bool memory_saver_mode_enabled);
+ 
+ WorkerBackingThread::WorkerBackingThread(const ThreadCreationParams& params)
+     : backing_thread_(blink::NonMainThread::CreateThread(
+-          ThreadCreationParams(params).SetSupportsGC(true))) {}
++          ThreadCreationParams(params).SetSupportsGC(true))),
++      is_denormal_disabled_thread_(
++          IsDenormalDisabledThreadType(params.thread_type)) {}
+ 
+ WorkerBackingThread::~WorkerBackingThread() = default;
+ 
+@@ -127,6 +138,12 @@ void WorkerBackingThread::InitializeOnBackingThread(
+     const WorkerBackingThreadStartupData& startup_data) {
+   DCHECK(backing_thread_->IsCurrentThread());
+ 
++  // Denormals must be disabled before the V8 isolate is initialized so that the
++  // isolate's internal state and generated code respect the flag.
++  if (is_denormal_disabled_thread_) {
++    DenormalModifier::DisableDenormals();
++  }
++
+   DCHECK(!isolate_);
+   ThreadScheduler* scheduler = BackingThread().Scheduler();
+   isolate_ = V8PerIsolateData::Initialize(
+diff --git a/third_party/blink/renderer/core/workers/worker_backing_thread.h b/third_party/blink/renderer/core/workers/worker_backing_thread.h
+index 445aad71b09ba7cd35a9269d73a57edc7d567079..4c5f3cc73c08fc241f1323dd4eeee6033ee80bd4 100644
+--- a/third_party/blink/renderer/core/workers/worker_backing_thread.h
++++ b/third_party/blink/renderer/core/workers/worker_backing_thread.h
+@@ -56,6 +56,7 @@ class CORE_EXPORT WorkerBackingThread final {
+  private:
+   std::unique_ptr<blink::NonMainThread> backing_thread_;
+   v8::Isolate* isolate_ = nullptr;
++  const bool is_denormal_disabled_thread_;
+ };
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_worklet_global_scope.cc b/third_party/blink/renderer/modules/webaudio/audio_worklet_global_scope.cc
+index b258751aa6efce1111861943c9b0b8f1fc00abb3..e3c9d55a5b63baf7c94bbd1b4bfe3dadd30f94cc 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_worklet_global_scope.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_worklet_global_scope.cc
+@@ -23,7 +23,6 @@
+ #include "third_party/blink/renderer/modules/webaudio/audio_worklet_processor.h"
+ #include "third_party/blink/renderer/modules/webaudio/audio_worklet_processor_definition.h"
+ #include "third_party/blink/renderer/modules/webaudio/cross_thread_audio_worklet_processor_info.h"
+-#include "third_party/blink/renderer/platform/audio/denormal_disabler.h"
+ #include "third_party/blink/renderer/platform/bindings/callback_method_retriever.h"
+ #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+ #include "third_party/blink/renderer/platform/wtf/text/strcat.h"
+@@ -36,9 +35,6 @@ AudioWorkletGlobalScope::AudioWorkletGlobalScope(
+     : WorkletGlobalScope(std::move(creation_params),
+                          thread->GetWorkerReportingProxy(),
+                          thread) {
+-  // Disable denormals for performance.
+-  DenormalModifier::DisableDenormals();
+-
+   // Audio is prone to jank introduced by e.g. the garbage collector. Workers
+   // are generally put in a background mode (as they are non-visible). Audio is
+   // an exception here, requiring low-latency behavior similar to any visible

--- a/patches/chromium/cherry-pick-e7eeef31113d.patch
+++ b/patches/chromium/cherry-pick-e7eeef31113d.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Mon, 11 May 2026 15:56:37 -0700
+Subject: [M148] gtk: Fix Use-After-Free in
+ GtkUiPlatformWayland::OnHandleSetTransient
+
+Original change's description:
+> gtk: Fix Use-After-Free in GtkUiPlatformWayland::OnHandleSetTransient
+>
+> GtkUiPlatformWayland::SetGtkWidgetTransientFor binds a raw GtkWidget*
+> to an asynchronous Wayland callback. If the dialog is closed before
+> the callback executes, the GtkWidget is destroyed, leading to a
+> Use-After-Free when the callback dereferences it.
+>
+> This CL fixes the issue by using ScopedGObject to hold a strong
+> reference to the GtkWidget in the callback. This ensures the widget's
+> memory remains valid until the callback completes, even if it has
+> been destroyed/disposed by GTK.
+>
+> R=thestig
+>
+> Change-Id: I402b18c246c9192038418f1348ff9066089917eb
+> Fixed: 500033878
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7737624
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Commit-Queue: Lei Zhang <thestig@chromium.org>
+> Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1611064}
+
+(cherry picked from commit eed57ee58f276d40af4c842d7d900f68482cc5f1)
+
+Bug: 500597110,500033878
+Change-Id: I402b18c246c9192038418f1348ff9066089917eb
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7807594
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#2781}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/gtk/wayland/gtk_ui_platform_wayland.cc b/ui/gtk/wayland/gtk_ui_platform_wayland.cc
+index 1702e2d54ab73743d8cf27afa72c1f9c6fc3388d..60049a3cd66beb36e35201d3843281e769430486 100644
+--- a/ui/gtk/wayland/gtk_ui_platform_wayland.cc
++++ b/ui/gtk/wayland/gtk_ui_platform_wayland.cc
+@@ -45,7 +45,7 @@ void GtkUiPlatformWayland::SetGtkWidgetTransientFor(
+     gfx::AcceleratedWidget parent) {
+   ui::LinuxUiDelegate::GetInstance()->ExportWindowHandle(
+       parent, base::BindOnce(&GtkUiPlatformWayland::OnHandleSetTransient,
+-                             weak_factory_.GetWeakPtr(), widget));
++                             weak_factory_.GetWeakPtr(), WrapGObject(widget)));
+ }
+ 
+ void GtkUiPlatformWayland::ClearTransientFor(gfx::AcceleratedWidget parent) {
+@@ -58,8 +58,10 @@ void GtkUiPlatformWayland::ShowGtkWindow(GtkWindow* window) {
+   gtk_window_present(window);
+ }
+ 
+-void GtkUiPlatformWayland::OnHandleSetTransient(GtkWidget* widget,
+-                                                std::string handle) {
++void GtkUiPlatformWayland::OnHandleSetTransient(
++    ScopedGObject<GtkWidget> widget_ref,
++    std::string handle) {
++  GtkWidget* widget = widget_ref.get();
+   auto handle_no_prefix = base::RemovePrefix(handle, "wayland:");
+   if (!handle_no_prefix || handle_no_prefix->empty()) {
+     return;
+diff --git a/ui/gtk/wayland/gtk_ui_platform_wayland.h b/ui/gtk/wayland/gtk_ui_platform_wayland.h
+index 296245efb607be1d58dda3cb00ce7a5ee22579ed..d8453ac54500b129ad8c832f176336998c5c3389 100644
+--- a/ui/gtk/wayland/gtk_ui_platform_wayland.h
++++ b/ui/gtk/wayland/gtk_ui_platform_wayland.h
+@@ -10,6 +10,7 @@
+ #include "base/functional/callback_forward.h"
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/weak_ptr.h"
++#include "ui/base/glib/scoped_gobject.h"
+ #include "ui/gtk/gtk_ui_platform.h"
+ 
+ namespace gtk {
+@@ -36,7 +37,8 @@ class GtkUiPlatformWayland : public GtkUiPlatform {
+  private:
+   // Called when xdg-foreign exports a parent window passed in
+   // SetGtkWidgetTransientFor.
+-  void OnHandleSetTransient(GtkWidget* widget, std::string handle);
++  void OnHandleSetTransient(ScopedGObject<GtkWidget> widget_ref,
++                            std::string handle);
+ 
+   base::WeakPtrFactory<GtkUiPlatformWayland> weak_factory_{this};
+ };


### PR DESCRIPTION
<details>
<summary>cherry-pick c4653f71b7b1 from chromium</summary>

[M148] Disable denormals before isolate creation for AudioWorklet
 threads

Original change's description:
> Disable denormals before isolate creation for AudioWorklet threads
>
> This is to ensure consistency in the denormal flag state between the
> isolate and the global scope.
>
> Bug: 499565267
> Change-Id: Iec7735bd6bc543da2ad08aea2f7bc716265dc54d
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7744866
> Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
> Commit-Queue: Michael Wilson <mjwilson@chromium.org>
> Reviewed-by: Hongchan Choi <hongchan@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1615043}

(cherry picked from commit 5c37ebf855147997e7cbc84d8ef67ab142cc78b4)

Bug: 504873416,499565267
Change-Id: Iec7735bd6bc543da2ad08aea2f7bc716265dc54d
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7808785
Reviewed-by: Hiroshige Hayashizaki <hiroshige@chromium.org>
Commit-Queue: Michael Wilson <mjwilson@chromium.org>
Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
Reviewed-by: Michael Wilson <mjwilson@chromium.org>
Cr-Commit-Position: refs/branch-heads/7778@{#2094}
Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}

</details>

<details>
<summary>cherry-pick e7eeef31113d from chromium</summary>

[M148] gtk: Fix Use-After-Free in
 GtkUiPlatformWayland::OnHandleSetTransient

Original change's description:
> gtk: Fix Use-After-Free in GtkUiPlatformWayland::OnHandleSetTransient
>
> GtkUiPlatformWayland::SetGtkWidgetTransientFor binds a raw GtkWidget*
> to an asynchronous Wayland callback. If the dialog is closed before
> the callback executes, the GtkWidget is destroyed, leading to a
> Use-After-Free when the callback dereferences it.
>
> This CL fixes the issue by using ScopedGObject to hold a strong
> reference to the GtkWidget in the callback. This ensures the widget's
> memory remains valid until the callback completes, even if it has
> been destroyed/disposed by GTK.
>
> R=thestig
>
> Change-Id: I402b18c246c9192038418f1348ff9066089917eb
> Fixed: 500033878
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7737624
> Reviewed-by: Lei Zhang <thestig@chromium.org>
> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
> Commit-Queue: Lei Zhang <thestig@chromium.org>
> Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1611064}

(cherry picked from commit eed57ee58f276d40af4c842d7d900f68482cc5f1)

Bug: 500597110,500033878
Change-Id: I402b18c246c9192038418f1348ff9066089917eb
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7807594
Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
Reviewed-by: Lei Zhang <thestig@chromium.org>
Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
Cr-Commit-Position: refs/branch-heads/7778@{#2781}
Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}

</details>

<details>
<summary>cherry-pick 70c1db1e1b72 from chromium</summary>

[M148] Reland "Prevent invalid tree state in
 AutomationTreeManagerOwner"

Original change's description:
> Reland "Prevent invalid tree state in AutomationTreeManagerOwner"
>
> This is a reland of commit d2ab7831eecf3a1c192ae64b05c2c6a797b556e9
>
> Fixed tree id in the test.
>
> Original change's description:
> > Prevent invalid tree state in AutomationTreeManagerOwner
> >
> > If an AXTree fails to fully unserialize in the automation tree manager
> > owner, drop and destroy the corrupted client wrapper and its nested
> > static caches immediately. This prevents the tree manager from
> > referencing the corrupted, dangling pointers subsequently.
> >
> > Bug: b:502978647
> > Test: out/Default/accessibility_unittests --gtest_filter=AutomationTreeManagerOwnerTest.UnserializeFailureClearsCachedTree
> > Change-Id: Idbcbdab0e7b7a46d8d094a38f3ba4a32cf301ce7
> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7793837
> > Reviewed-by: David Tseng <dtseng@chromium.org>
> > Auto-Submit: Addison Luh <aluh@chromium.org>
> > Commit-Queue: David Tseng <dtseng@chromium.org>
> > Cr-Commit-Position: refs/heads/main@{#1621369}
>
> Cq-Include-Trybots: luci.chrome.try:linux-chromeos-chrome
> Bug: b:502978647
> Change-Id: I720b30a6baa76570ea54b072e1e9bc0ad6c50f0a
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7802331
> Auto-Submit: Addison Luh <aluh@chromium.org>
> Reviewed-by: David Tseng <dtseng@chromium.org>
> Commit-Queue: Addison Luh <aluh@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1622148}

(cherry picked from commit a72c80884d88cb68fba22a552ec795f3b552f1a1)

Bug: 507877803,b:502978647
Change-Id: I720b30a6baa76570ea54b072e1e9bc0ad6c50f0a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7807647
Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
Cr-Commit-Position: refs/branch-heads/7778@{#2026}
Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}

</details>

<details>
<summary>cherry-pick 66e1a4951c0c from chromium</summary>

[M148] Workaround of a ubidi_getLogicalRun() issue

Original change's description:
> Workaround of a ubidi_getLogicalRun() issue
>
> A crash can occur within ICU's `ubidi_getLogicalRun()` function when
> processing strings where `text.length() * N` exceeds the maximum value
> of `int32_t`, where `N` represents the size of an internal ICU struct
> (approximately 12 bytes, derived from `sizeof(int32_t) * 3`).
>
> This CL adds `CHECK_LE` assertions in `BidiParagraph::SetParagraph` and
> `BiDiLineIterator::Open` to limit the input string length. This ensures
> that the string length, when multiplied by the ICU internal factor, does
> not cause an integer overflow.
>
> This is a temporary workaround until the underlying issue in ICU is
> fixed and the updated library is rolled out.
>
> No dedicated tests are included in this CL, as reproducing the overflow
> requires constructing extremely large strings, which is impractical for
> standard unit tests.
>
> Fixed: 504629701
> Change-Id: Ica350078f0f3809012e957afb37c5985d9765d5c
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7781344
> Reviewed-by: Nico Weber <thakis@chromium.org>
> Auto-Submit: Kent Tamura <tkent@chromium.org>
> Commit-Queue: Kent Tamura <tkent@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#1618626}

(cherry picked from commit e5e65102447845af6d246f9bca83b1a57277897f)

Fuchsia-Binary-Size: Size increase is unavoidable.
Bug: 506779184,504629701
Change-Id: Ica350078f0f3809012e957afb37c5985d9765d5c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7824420
Reviewed-by: Nico Weber <thakis@chromium.org>
Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
Reviewed-by: Kent Tamura <tkent@chromium.org>
Reviewed-by: Mitsuru Oshima <oshima@chromium.org>
Commit-Queue: David Yeung <dayeung@chromium.org>
Cr-Commit-Position: refs/branch-heads/7778@{#2542}
Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}

</details>

<details>
<summary>cherry-pick 6c71c70ec7e8 from angle</summary>

[M148] GL: Fix heap-buffer-overflow in streamAttributes

When the shiftInstancedArrayDataWithOffset workaround is
enabled (primarily for Intel drivers on macOS), the number
of vertices to stream is increased to account for the first
parameter in drawArraysInstanced.

However, computeStreamingAttributeSizes was not aware of this
workaround, leading to an under-allocation of the streaming
buffer. Additionally, the copy loop in streamAttributes used
the increased vertex count to read from the source client
memory.
This resulted in a heap-buffer-overflow because the source
buffer might only contain enough data for the original instance
count, and the destination buffer was also too small for the
shifted layout.

This CL:
1. Updates computeStreamingAttributeSizes to accept an
applyExtraOffsetWorkaroundForInstancedAttributes flag and
correctly calculate the required buffer size when the
workaround is active.
2. Updates streamAttributes to only copy the original number
of vertices from the source memory in both fast and slow paths.
3. Ensures the destination buffer layout still respects the
increased vertex count for correct attribute spacing as required
by the workaround.
4. Adds a regression test
ShiftInstancedArrayDataWithOffsetSlowPath in
VertexAttributeTest.cpp that triggers the workaround
and the slow path copy loop.

Bug: b/497928952
Fixed: b/500613386
Change-Id: I4b59ceec7cf9fc301eacb5b22faa4a3b2c2c863d
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7728161
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Commit-Queue: Shrek Shao <shrekshao@google.com>
Auto-Submit: Shrek Shao <shrekshao@google.com>
(cherry picked from commit c0c3b52cec94593157bea7a5ecd9e1ab7b2ce802)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7817770

</details>

Notes: Backported fixes for an out-of-bounds write in WebAudio worklet setup, a heap overflow in the ANGLE GL backend, a use-after-free in the GTK Wayland platform, an accessibility tree-state validation issue, and an integer overflow in text bidi handling.
