### PR TITLE
fix: allow macOS file packages in dialog filters

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -99,6 +99,20 @@ DialogSettings::~DialogSettings() = default;
 
 namespace {
 
+UTType* TypeForFilenameExtension(const std::string& ext) {
+  NSString* extension = @(ext.c_str());
+  UTType* super_type = [UTType typeWithIdentifier:@"com.apple.package"];
+  UTType* package_type = [UTType typeWithFilenameExtension:extension
+                                          conformingToType:super_type];
+
+  // Asking for package conformance can synthesize a dynamic type for ordinary
+  // files like .txt. Only prefer package types that Launch Services knows.
+  if (package_type && ![package_type isDynamic])
+    return package_type;
+
+  return [UTType typeWithFilenameExtension:extension];
+}
+
 void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   NSMutableArray* file_types_list = [NSMutableArray array];
   NSMutableArray* filter_names = [NSMutableArray array];
@@ -122,20 +136,8 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       if (ext == "*") {
         [content_types_set addObject:[UTType typeWithFilenameExtension:@"*"]];
         break;
-      } else if (ext == "app") {
-        // This handles a bug on macOS where the "app" extension by default
-        // maps to "com.apple.application-file", which is for an Application
-        // file (older single-file carbon based apps), and not modern
-        // Application Bundles (multi file packages as you'd see for all modern
-        // applications).
-        UTType* superType =
-            [UTType typeWithIdentifier:@"com.apple.application-bundle"];
-        if (UTType* utt = [UTType typeWithFilenameExtension:@"app"
-                                           conformingToType:superType]) {
-          [content_types_set addObject:utt];
-        }
       } else {
-        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
+        if (UTType* utt = TypeForFilenameExtension(ext))
           [content_types_set addObject:utt];
       }
     }


### PR DESCRIPTION
Backport of #49444

#### Description of Change

Fixes #48191.

On macOS, file packages such as `.rtfd` are directories presented as files. When `dialog.showOpenDialog()` uses extension filters, `NSOpenPanel` receives `allowedContentTypes`, so package extensions need to be resolved as package-conforming `UTType`s.

This updates the macOS file dialog filter conversion to prefer a Launch Services-known package type when one exists. The fallback remains the normal filename-extension lookup, because asking for package conformance can synthesize dynamic package types for ordinary extensions like `.txt` and `.rtf`.

The existing `.app` bundle behavior is preserved by the same helper because `app` resolves to `com.apple.application-bundle` when looked up as a package type.

Local validation:

```sh
python3 script/run-clang-format.py -r -c shell/browser/ui/file_dialog_mac.mm
git diff --check
swift -e 'import UniformTypeIdentifiers; for ext in ["rtfd","app","txt","rtf"] { let pkg = UTType(filenameExtension: ext, conformingTo: .package); let normal = UTType(filenameExtension: ext); print("\(ext): package=\(pkg?.identifier ?? "nil") dynamic=\(pkg?.isDynamic ?? false) normal=\(normal?.identifier ?? "nil") normalDynamic=\(normal?.isDynamic ?? false)") }'
```

Observed UTType behavior:

```text
rtfd: package=com.apple.rtfd dynamic=false normal=dyn... normalDynamic=true
app: package=com.apple.application-bundle dynamic=false normal=com.apple.application-file normalDynamic=false
txt: package=dyn... dynamic=true normal=public.plain-text normalDynamic=false
rtf: package=dyn... dynamic=true normal=public.rtf normalDynamic=false
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Fixed macOS file dialogs allowing known file packages when extension filters were used.
