### PR TITLE
refactor: remove `FramelessView::Init()` (#51008)

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1923,23 +1923,15 @@ views::ClientView* NativeWindowViews::CreateClientView(views::Widget* widget) {
 std::unique_ptr<views::FrameView> NativeWindowViews::CreateFrameView(
     views::Widget* widget) {
 #if BUILDFLAG(IS_WIN)
-  auto frame_view = std::make_unique<WinFrameView>();
-  frame_view->Init(this, widget);
-  return frame_view;
+  return std::make_unique<WinFrameView>(this, widget);
 #else
-  if (has_frame() && !has_client_frame()) {
-    return std::make_unique<NativeFrameView>(this, widget);
-  } else {
-    if (has_frame() && has_client_frame()) {
-      auto frame_view = std::make_unique<ClientFrameViewLinux>();
-      frame_view->Init(this, widget);
-      return frame_view;
-    } else {
-      auto frame_view = std::make_unique<OpaqueFrameView>();
-      frame_view->Init(this, widget);
-      return frame_view;
-    }
-  }
+  if (!has_frame())
+    return std::make_unique<OpaqueFrameView>(this, widget);
+
+  if (has_client_frame())
+    return std::make_unique<ClientFrameViewLinux>(this, widget);
+
+  return std::make_unique<NativeFrameView>(this, widget);
 #endif
 }
 

--- a/shell/browser/ui/views/client_frame_view_linux.cc
+++ b/shell/browser/ui/views/client_frame_view_linux.cc
@@ -58,8 +58,10 @@ ui::NavButtonProvider::ButtonState ButtonStateToNavButtonProviderState(
 
 }  // namespace
 
-ClientFrameViewLinux::ClientFrameViewLinux()
-    : theme_(ui::NativeTheme::GetInstanceForNativeUi()),
+ClientFrameViewLinux::ClientFrameViewLinux(NativeWindowViews* window,
+                                           views::Widget* frame)
+    : FramelessView{window, frame},
+      theme_{ui::NativeTheme::GetInstanceForNativeUi()},
       nav_button_provider_(
           ui::LinuxUiTheme::GetForProfile(nullptr)->CreateNavButtonProvider()),
       nav_buttons_{
@@ -101,23 +103,12 @@ ClientFrameViewLinux::ClientFrameViewLinux()
     ui->AddWindowButtonOrderObserver(this);
     OnWindowButtonOrderingChange();
   }
-}
-
-ClientFrameViewLinux::~ClientFrameViewLinux() {
-  if (auto* ui = ui::LinuxUi::instance())
-    ui->RemoveWindowButtonOrderObserver(this);
-  theme_->RemoveObserver(this);
-}
-
-void ClientFrameViewLinux::Init(NativeWindowViews* window,
-                                views::Widget* frame) {
-  FramelessView::Init(window, frame);
   linux_frame_layout_ = std::make_unique<LinuxCSDNativeFrameLayout>(window);
 
   // Unretained() is safe because the subscription is saved into an instance
   // member and thus will be cancelled upon the instance's destruction.
   paint_as_active_changed_subscription_ =
-      frame_->RegisterPaintAsActiveChangedCallback(base::BindRepeating(
+      frame->RegisterPaintAsActiveChangedCallback(base::BindRepeating(
           &ClientFrameViewLinux::PaintAsActiveChanged, base::Unretained(this)));
 
   UpdateWindowTitle();
@@ -132,6 +123,12 @@ void ClientFrameViewLinux::Init(NativeWindowViews* window,
   }
 
   UpdateThemeValues();
+}
+
+ClientFrameViewLinux::~ClientFrameViewLinux() {
+  if (auto* ui = ui::LinuxUi::instance())
+    ui->RemoveWindowButtonOrderObserver(this);
+  theme_->RemoveObserver(this);
 }
 
 gfx::Insets ClientFrameViewLinux::RestoredFrameBorderInsets() const {

--- a/shell/browser/ui/views/client_frame_view_linux.h
+++ b/shell/browser/ui/views/client_frame_view_linux.h
@@ -36,10 +36,8 @@ class ClientFrameViewLinux : public FramelessView,
   METADATA_HEADER(ClientFrameViewLinux, FramelessView)
 
  public:
-  ClientFrameViewLinux();
+  ClientFrameViewLinux(NativeWindowViews* window, views::Widget* frame);
   ~ClientFrameViewLinux() override;
-
-  void Init(NativeWindowViews* window, views::Widget* frame) override;
 
   // FramelessView:
   gfx::Insets RestoredFrameBorderInsets() const override;

--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -21,14 +21,10 @@ const int kResizeAreaCornerSize = 16;
 
 }  // namespace
 
-FramelessView::FramelessView() = default;
+FramelessView::FramelessView(NativeWindowViews* window, views::Widget* frame)
+    : window_{window}, frame_{frame} {}
 
 FramelessView::~FramelessView() = default;
-
-void FramelessView::Init(NativeWindowViews* window, views::Widget* frame) {
-  window_ = window;
-  frame_ = frame;
-}
 
 gfx::Insets FramelessView::RestoredFrameBorderInsets() const {
   return gfx::Insets();

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -26,14 +26,12 @@ class FramelessView : public views::FrameView {
   METADATA_HEADER(FramelessView, views::FrameView)
 
  public:
-  FramelessView();
+  FramelessView(NativeWindowViews* window, views::Widget* frame);
   ~FramelessView() override;
 
   // disable copy
   FramelessView(const FramelessView&) = delete;
   FramelessView& operator=(const FramelessView&) = delete;
-
-  virtual void Init(NativeWindowViews* window, views::Widget* frame);
 
   // Returns whether the |point| is on frameless window's resizing border.
   virtual int ResizingBorderHitTest(const gfx::Point& point);
@@ -80,10 +78,8 @@ class FramelessView : public views::FrameView {
   gfx::Size GetMaximumSize() const override;
 
   // Not owned.
-  raw_ptr<NativeWindowViews> window_ = nullptr;
-  raw_ptr<views::Widget> frame_ = nullptr;
-
-  friend class NativeWindowsViews;
+  const raw_ptr<NativeWindowViews> window_;
+  const raw_ptr<views::Widget> frame_;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -57,12 +57,10 @@ const int kCaptionButtonBottomPadding = 3;
 // The content edge images have a shadow built into them.
 const int OpaqueFrameView::kContentEdgeShadowThickness = 2;
 
-OpaqueFrameView::OpaqueFrameView()
-    : frame_background_(std::make_unique<views::FrameBackground>()) {}
-OpaqueFrameView::~OpaqueFrameView() = default;
-
-void OpaqueFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
-  FramelessView::Init(window, frame);
+OpaqueFrameView::OpaqueFrameView(NativeWindowViews* window,
+                                 views::Widget* frame)
+    : FramelessView{window, frame},
+      frame_background_{std::make_unique<views::FrameBackground>()} {
   linux_frame_layout_ = LinuxFrameLayout::Create(
       window, window->HasShadow(), LinuxFrameLayout::CSDStyle::kCustom);
 
@@ -100,6 +98,7 @@ void OpaqueFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
                           base::Unretained(frame),
                           views::Widget::ClosedReason::kCloseButtonClicked));
 }
+OpaqueFrameView::~OpaqueFrameView() = default;
 
 int OpaqueFrameView::ResizingBorderHitTest(const gfx::Point& point) {
   return ResizingBorderHitTestImpl(

--- a/shell/browser/ui/views/opaque_frame_view.h
+++ b/shell/browser/ui/views/opaque_frame_view.h
@@ -37,11 +37,10 @@ class OpaqueFrameView : public FramelessView {
 
   static constexpr int kNonClientExtraTopThickness = 1;
 
-  OpaqueFrameView();
+  OpaqueFrameView(NativeWindowViews* window, views::Widget* frame);
   ~OpaqueFrameView() override;
 
   // FramelessView:
-  void Init(NativeWindowViews* window, views::Widget* frame) override;
   int ResizingBorderHitTest(const gfx::Point& point) override;
   void InvalidateCaptionButtons() override;
   gfx::Insets RestoredFrameBorderInsets() const override;

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -25,19 +25,15 @@
 
 namespace electron {
 
-WinFrameView::WinFrameView() = default;
-
-WinFrameView::~WinFrameView() = default;
-
-void WinFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
-  window_ = window;
-  frame_ = frame;
-
+WinFrameView::WinFrameView(NativeWindowViews* window, views::Widget* frame)
+    : FramelessView{window, frame} {
   if (window->IsWindowControlsOverlayEnabled()) {
     caption_button_container_ =
         AddChildView(std::make_unique<WinCaptionButtonContainer>(this));
   }
 }
+
+WinFrameView::~WinFrameView() = default;
 
 void WinFrameView::InvalidateCaptionButtons() {
   if (!caption_button_container_)
@@ -261,7 +257,7 @@ void WinFrameView::LayoutWindowControlsOverlay() {
   window()->NotifyLayoutWindowControlsOverlay();
 }
 
-bool WinFrameView::GetShouldPaintAsActive() {
+bool WinFrameView::GetShouldPaintAsActive() const {
   return ShouldPaintAsActive();
 }
 

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -23,10 +23,9 @@ class WinFrameView : public FramelessView {
   METADATA_HEADER(WinFrameView, FramelessView)
 
  public:
-  WinFrameView();
+  WinFrameView(NativeWindowViews* window, views::Widget* frame);
   ~WinFrameView() override;
 
-  void Init(NativeWindowViews* window, views::Widget* frame) override;
   void InvalidateCaptionButtons() override;
 
   SkColor GetReadableFeatureColor(SkColor background_color);
@@ -52,7 +51,7 @@ class WinFrameView : public FramelessView {
   int TitlebarMaximizedVisualHeight() const;
 
   // Returns true if the frame should be painted as active.
-  bool GetShouldPaintAsActive();
+  [[nodiscard]] bool GetShouldPaintAsActive() const;
 
  protected:
   // views::View:


### PR DESCRIPTION
Manual backport of #51008. See that PR for details. 

Notes: none