### PR TITLE
chore: remove dialog showHiddenFiles support on Linux

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -40,7 +40,7 @@ added:
     * `openFile` - Allow files to be selected.
     * `openDirectory` - Allow directories to be selected.
     * `multiSelections` - Allow multiple paths to be selected.
-    * `showHiddenFiles` _macOS_ _Windows_ _Deprecated_ - Show hidden files in dialog. Deprecated on Linux.
+    * `showHiddenFiles` _macOS_ _Windows_ - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
       in the dialog does not exist. This does not actually create the file at
@@ -124,7 +124,7 @@ changes:
     * `openFile` - Allow files to be selected.
     * `openDirectory` - Allow directories to be selected.
     * `multiSelections` - Allow multiple paths to be selected.
-    * `showHiddenFiles` _macOS_ _Windows_ _Deprecated_ - Show hidden files in dialog. Deprecated on Linux.
+    * `showHiddenFiles` _macOS_ _Windows_ - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `promptToCreate` _Windows_ - Prompt for creation if the file path entered
       in the dialog does not exist. This does not actually create the file at
@@ -216,7 +216,7 @@ added:
   * `showsTagField` boolean (optional) _macOS_ - Show the tags input box,
     defaults to `true`.
   * `properties` string[]&#32;(optional)
-    * `showHiddenFiles` _macOS_ _Windows_ _Deprecated_ - Show hidden files in dialog. Deprecated on Linux.
+    * `showHiddenFiles` _macOS_ _Windows_ - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
@@ -257,7 +257,7 @@ changes:
     displayed in front of the filename text field.
   * `showsTagField` boolean (optional) _macOS_ - Show the tags input box, defaults to `true`.
   * `properties` string[]&#32;(optional)
-    * `showHiddenFiles` _macOS_ _Windows_ _Deprecated_ - Show hidden files in dialog. Deprecated on Linux.
+    * `showHiddenFiles` _macOS_ _Windows_ - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -187,6 +187,12 @@ When a cookie is deleted, the change cause remains `explicit`.
 When the cookie being set is identical to an existing one (same name, domain, path, and value, with no actual changes), the change cause is `inserted-no-change-overwrite`.
 When the value of the cookie being set remains unchanged but some of its attributes are updated, such as the expiration attribute, the change cause will be `inserted-no-value-change-overwrite`.
 
+### Deprecated: `showHiddenFiles` in Dialogs on Linux
+
+This property will still be honored on macOS and Windows, but support on Linux
+will be removed in a future version of Electron. GTK intends for this to be a user choice rather
+than an app choice and has removed the API to do this programmatically.
+
 ## Planned Breaking API Changes (40.0)
 
 ### Deprecated: `clipboard` API access from renderer processes

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -84,6 +84,13 @@ if (!result.canceled && result.filePaths.length > 0) {
 }
 ```
 
+### Removed: `showHiddenFiles` in Dialogs on Linux
+
+The `showHiddenFiles` property is no longer supported on Linux.
+It continues to work on macOS and Windows. GTK intends for this feature
+to be a user choice rather than an app choice, and has removed the API
+to do this programmatically.
+
 ## Planned Breaking API Changes (42.0)
 
 ### Behavior Changed: macOS notifications now use `UNNotification` API
@@ -179,12 +186,6 @@ When a new cookie is set, the change cause is `inserted`.
 When a cookie is deleted, the change cause remains `explicit`.
 When the cookie being set is identical to an existing one (same name, domain, path, and value, with no actual changes), the change cause is `inserted-no-change-overwrite`.
 When the value of the cookie being set remains unchanged but some of its attributes are updated, such as the expiration attribute, the change cause will be `inserted-no-value-change-overwrite`.
-
-### Deprecated: `showHiddenFiles` in Dialogs on Linux
-
-This property will still be honored on macOS and Windows, but support on Linux
-will be removed in a future version of Electron. GTK intends for this to be a user choice rather
-than an app choice and has removed the API to do this programmatically.
 
 ## Planned Breaking API Changes (40.0)
 

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -204,10 +204,6 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
         settings.properties & SAVE_DIALOG_SHOW_OVERWRITE_CONFIRMATION);
     dialog_->SetMultipleSelectionsAllowed(settings.properties &
                                           OPEN_DIALOG_MULTI_SELECTIONS);
-    int hidden_flag = type_ == DialogType::SAVE
-                          ? static_cast<int>(SAVE_DIALOG_SHOW_HIDDEN_FILES)
-                          : static_cast<int>(OPEN_DIALOG_SHOW_HIDDEN_FILES);
-    dialog_->SetHiddenShown(settings.properties & hidden_flag);
   }
 
   DialogType type_;


### PR DESCRIPTION
#### Description of Change

Fixes #46817.

Remove `showHiddenFiles` support from the `dialog` API on Linux.

This was deprecated in b9a09ac / #46926 for 42-x-y. This PR removes it.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Removed `showHiddenFiles` support from the `dialog` API on Linux.