### PR TITLE
build: add --check option to script/gen-filenames.ts and extend CI check

### DIFF
--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -129,7 +129,7 @@ jobs:
         for target_cpu in ${{ inputs.target-archs }}
         do
           e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu $target_cpu --remote-build none
-          cd src
+          cd src/electron
           export GN_EXTRA_ARGS="target_cpu=\"$target_cpu\""
           if [ "${{ inputs.target-platform }}" = "linux" ]; then
             if [ "$target_cpu" = "arm" ]; then
@@ -144,15 +144,17 @@ jobs:
 
           e build --gen=only
 
-          e d gn check out/Default //electron:electron_lib
-          e d gn check out/Default //electron:electron_app
-          e d gn check out/Default //electron/shell/common:mojo
-          e d gn check out/Default //electron/shell/common:plugin
+          e d gn check ../out/Default //electron:electron_lib
+          e d gn check ../out/Default //electron:electron_app
+          e d gn check ../out/Default //electron/shell/common:mojo
+          e d gn check ../out/Default //electron/shell/common:plugin
 
           # Check the hunspell filenames
-          node electron/script/gen-hunspell-filenames.js --check
-          node electron/script/gen-libc++-filenames.js --check
-          cd ..
+          node script/gen-hunspell-filenames.js --check
+
+          node script/gen-libc++-filenames.js --check
+          node script/yarn.js ts-node script/gen-filenames.ts -- --check
+          cd ../..
         done
     - name: Wait for active SSH sessions
       if: always() && !cancelled()

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -767,7 +767,6 @@ auto_filenames = {
     "lib/renderer/api/ipc-renderer.ts",
     "lib/renderer/ipc-native-setup.ts",
     "lib/renderer/ipc-renderer-bindings.ts",
-    "lib/renderer/ipc-renderer-internal-utils.ts",
     "lib/renderer/ipc-renderer-internal.ts",
     "lib/sandboxed_renderer/pre-init.ts",
     "lib/sandboxed_renderer/preload.ts",

--- a/script/gen-filenames.ts
+++ b/script/gen-filenames.ts
@@ -142,9 +142,7 @@ const main = async () => {
     })
   );
 
-  fs.writeFileSync(
-    gniPath,
-    `# THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT BY HAND
+  const generated = `# THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT BY HAND
 auto_filenames = {
   api_docs = [
 ${allDocs.map((doc) => `    "${doc}",`).join('\n')}
@@ -162,8 +160,19 @@ ${target.dependencies.map((dep) => `    "${dep}",`).join('\n')}
   )
   .join('\n\n')}
 }
-`
-  );
+`;
+
+  if (process.argv.includes('--check')) {
+    const existing = fs.existsSync(gniPath) ? fs.readFileSync(gniPath, 'utf8') : '';
+    if (existing !== generated) {
+      console.error(
+        `${path.relative(rootPath, gniPath)} is out of date. Run 'node script/gen-filenames.ts' to regenerate.`
+      );
+      process.exit(1);
+    }
+  } else {
+    fs.writeFileSync(gniPath, generated);
+  }
 };
 
 if (require.main === module) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Adds a `--check` option which matches our other `script/gen-*` scripts and extends the CI check so we can ensure these get caught in the PR that's causing them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
