### PR TITLE
fix: route platform LNP permission requests through session

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -113,11 +113,11 @@ async function createWindow(backgroundColor?: string) {
   });
 
   mainWindow.webContents.session.setPermissionRequestHandler((webContents, permission, done) => {
-    const parsedUrl = new URL(webContents.getURL());
+    const origin = webContents ? new URL(webContents.getURL()).origin : 'the current session';
 
     const options: Electron.MessageBoxOptions = {
       title: 'Permission Request',
-      message: `Allow '${parsedUrl.origin}' to access '${permission}'?`,
+      message: `Allow '${origin}' to access '${permission}'?`,
       buttons: ['OK', 'Cancel'],
       cancelId: 1
     };

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -918,7 +918,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 #### `ses.setPermissionRequestHandler(handler)`
 
 * `handler` Function | null
-  * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
+  * `webContents` ([WebContents](web-contents.md) | null) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin. Platform local network requests may pass `null`.
   * `permission` string - The type of requested permission.
     * `clipboard-read` - Request access to read from the clipboard.
     * `clipboard-sanitized-write` - Request access to write to the clipboard.
@@ -926,6 +926,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `fullscreen` - Request control of the app's fullscreen state via the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).
     * `geolocation` - Request access to the user's location via the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API)
     * `idle-detection` - Request access to the user's idle state via the [IdleDetector API](https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector).
+    * `local-network` - Request access to devices or services on the user's local network.
     * `media` -  Request access to media devices such as camera, microphone and speakers.
     * `mediaKeySystem` - Request access to DRM protected content.
     * `midi` - Request MIDI access in the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API).
@@ -954,7 +955,7 @@ Most web APIs do a permission check and then make a permission request if the ch
 const { session } = require('electron')
 
 session.fromPartition('some-partition').setPermissionRequestHandler((webContents, permission, callback) => {
-  if (webContents.getURL() === 'some-host' && permission === 'notifications') {
+  if (webContents?.getURL() === 'some-host' && permission === 'notifications') {
     return callback(false) // denied.
   }
 

--- a/docs/api/structures/permission-request.md
+++ b/docs/api/structures/permission-request.md
@@ -1,4 +1,5 @@
 # PermissionRequest Object
 
-* `requestingUrl` string - The last URL the requesting frame loaded.
-* `isMainFrame` boolean - Whether the frame making the request is the main frame.
+* `requestingUrl` string (optional) - The last URL the requesting frame loaded.
+* `isMainFrame` boolean (optional) - Whether the frame making the request is the main frame.
+* `isPlatformRequest` boolean (optional) - Whether the request comes from the platform permission flow.

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -462,7 +462,8 @@ UtilityProcessWrapper::CreateURLLoaderFactoryParams() {
   loader_params->is_orb_enabled = false;
   loader_params->is_trusted = true;
   if (create_network_observer_) {
-    url_loader_network_observer_.emplace();
+    url_loader_network_observer_.emplace(session_ ? session_->browser_context()
+                                                  : nullptr);
     loader_params->url_loader_network_observer =
         url_loader_network_observer_->Bind();
   }

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -210,6 +210,21 @@ void ElectronPermissionManager::RequestPermissionWithDetails(
                      std::move(response_callback)));
 }
 
+void ElectronPermissionManager::RequestPermissionFromSession(
+    blink::PermissionType permission,
+    base::DictValue details,
+    StatusCallback callback) {
+  if (request_handler_.is_null()) {
+    std::move(callback).Run(content::PermissionResult(
+        blink::mojom::PermissionStatus::DENIED,
+        content::PermissionStatusSource::UNSPECIFIED));
+    return;
+  }
+
+  base::Value dict_value(std::move(details));
+  request_handler_.Run(nullptr, permission, std::move(callback), dict_value);
+}
+
 void ElectronPermissionManager::RequestPermissionsWithDetails(
     content::RenderFrameHost* render_frame_host,
     const content::PermissionRequestDescription& request_description,

--- a/shell/browser/electron_permission_manager.h
+++ b/shell/browser/electron_permission_manager.h
@@ -76,6 +76,10 @@ class ElectronPermissionManager : public content::PermissionControllerDelegate {
       base::DictValue details,
       StatusCallback response_callback);
 
+  void RequestPermissionFromSession(blink::PermissionType permission,
+                                    base::DictValue details,
+                                    StatusCallback callback);
+
   // Handler to dispatch permission requests in JS.
   void SetPermissionRequestHandler(const RequestHandler& handler);
   void SetPermissionCheckHandler(const CheckHandler& handler);

--- a/shell/browser/net/url_loader_network_observer.cc
+++ b/shell/browser/net/url_loader_network_observer.cc
@@ -7,6 +7,8 @@
 #include "base/functional/bind.h"
 #include "content/public/browser/browser_thread.h"
 #include "services/network/public/mojom/shared_storage.mojom.h"
+#include "shell/browser/electron_browser_context.h"
+#include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/login_handler.h"
 
 namespace electron {
@@ -59,6 +61,11 @@ class LoginHandlerDelegate {
 }  // namespace
 
 URLLoaderNetworkObserver::URLLoaderNetworkObserver() = default;
+
+URLLoaderNetworkObserver::URLLoaderNetworkObserver(
+    ElectronBrowserContext* browser_context)
+    : browser_context_(browser_context) {}
+
 URLLoaderNetworkObserver::~URLLoaderNetworkObserver() = default;
 
 mojo::PendingRemote<network::mojom::URLLoaderNetworkServiceObserver>
@@ -124,7 +131,25 @@ void URLLoaderNetworkObserver::Clone(
 
 void URLLoaderNetworkObserver::OnPlatformLocalNetworkPermissionRequired(
     OnPlatformLocalNetworkPermissionRequiredCallback callback) {
-  std::move(callback).Run(false);
+  if (!browser_context_) {
+    std::move(callback).Run(false);
+    return;
+  }
+
+  auto* permission_manager = static_cast<ElectronPermissionManager*>(
+      browser_context_->GetPermissionControllerDelegate());
+  base::DictValue details;
+  details.Set("isPlatformRequest", true);
+
+  permission_manager->RequestPermissionFromSession(
+      blink::PermissionType::LOCAL_NETWORK, std::move(details),
+      base::BindOnce(
+          [](OnPlatformLocalNetworkPermissionRequiredCallback callback,
+             content::PermissionResult result) {
+            std::move(callback).Run(result.status ==
+                                    blink::mojom::PermissionStatus::GRANTED);
+          },
+          std::move(callback)));
 }
 
 }  // namespace electron

--- a/shell/browser/net/url_loader_network_observer.h
+++ b/shell/browser/net/url_loader_network_observer.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_BROWSER_NET_URL_LOADER_NETWORK_OBSERVER_H_
 
 #include "base/byte_size.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/process/process_handle.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
@@ -13,10 +14,13 @@
 
 namespace electron {
 
+class ElectronBrowserContext;
+
 class URLLoaderNetworkObserver
     : public network::mojom::URLLoaderNetworkServiceObserver {
  public:
   URLLoaderNetworkObserver();
+  explicit URLLoaderNetworkObserver(ElectronBrowserContext* browser_context);
   ~URLLoaderNetworkObserver() override;
 
   URLLoaderNetworkObserver(const URLLoaderNetworkObserver&) = delete;
@@ -86,6 +90,7 @@ class URLLoaderNetworkObserver
 
   mojo::ReceiverSet<network::mojom::URLLoaderNetworkServiceObserver> receivers_;
   base::ProcessId process_id_ = base::kNullProcessId;
+  raw_ptr<ElectronBrowserContext> browser_context_ = nullptr;
   base::WeakPtrFactory<URLLoaderNetworkObserver> weak_factory_{this};
 };
 

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -37,6 +37,7 @@
 #include "services/network/public/mojom/url_loader_factory.mojom.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/electron_browser_context.h"
+#include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/net/asar/asar_url_loader_factory.h"
 #include "shell/browser/net/proxying_url_loader_factory.h"
@@ -486,7 +487,25 @@ void SimpleURLLoaderWrapper::Clone(
 
 void SimpleURLLoaderWrapper::OnPlatformLocalNetworkPermissionRequired(
     OnPlatformLocalNetworkPermissionRequiredCallback callback) {
-  std::move(callback).Run(false);
+  if (!browser_context_) {
+    std::move(callback).Run(false);
+    return;
+  }
+
+  auto* permission_manager = static_cast<ElectronPermissionManager*>(
+      browser_context_->GetPermissionControllerDelegate());
+  base::DictValue details;
+  details.Set("isPlatformRequest", true);
+
+  permission_manager->RequestPermissionFromSession(
+      blink::PermissionType::LOCAL_NETWORK, std::move(details),
+      base::BindOnce(
+          [](OnPlatformLocalNetworkPermissionRequiredCallback callback,
+             content::PermissionResult result) {
+            std::move(callback).Run(result.status ==
+                                    blink::mojom::PermissionStatus::GRANTED);
+          },
+          std::move(callback)));
 }
 
 void SimpleURLLoaderWrapper::Cancel() {

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1281,8 +1281,13 @@ session.defaultSession.setCertificateVerifyProc((request, callback) => {
   }
 });
 
-session.defaultSession.setPermissionRequestHandler(function (webContents, permission, callback) {
-  if (webContents.getURL() === 'github.com') {
+session.defaultSession.setPermissionRequestHandler(function (webContents, permission, callback, details) {
+  if (permission === 'local-network' && details.isPlatformRequest) {
+    callback(true);
+    return;
+  }
+
+  if (webContents?.getURL() === 'github.com') {
     if (permission === 'notifications') {
       callback(false);
       return;


### PR DESCRIPTION
#### Description of Change

Fixes #51464

Platform local network requests now go through ElectronPermissionManager on invocation of URLLoaderNetworkObserver::OnPlatformLocalNetworkPermissionRequired and SimpleURLLoaderWrapper::OnPlatformLocalNetworkPermissionRequired with the associated browser context rather than being denied. Webcontents is passed as nullptr as the requests are from network stack.

Refs https://chromium-review.googlesource.com/c/chromium/src/+/7672857

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Route platform LNP permission requests to ElectronPermissionManager with session <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
