### PR TITLE
fix: `process` undefined in ESM preload when contextIsolation is disabled

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -120,24 +120,34 @@ if (nodeIntegration) {
       return false;
     }
   };
-} else {
-  // Delete Node's symbols after the Environment has been loaded in a
-  // non context-isolated environment
-  if (!process.contextIsolated) {
-    process.once('loaded', function () {
-      delete (global as any).process;
-      delete (global as any).Buffer;
-      delete (global as any).setImmediate;
-      delete (global as any).clearImmediate;
-      delete (global as any).global;
-      delete (global as any).root;
-      delete (global as any).GLOBAL;
-    });
-  }
 }
+
+// In a non context-isolated renderer without Node integration, the Node
+// globals (process, Buffer, ...) must be removed from the renderer's main
+// world before the page's own scripts run, but only after the preload
+// scripts have had a chance to use them. The 'loaded' event fires on the
+// next tick after init returns, which is before any async ESM preload
+// finishes executing, leaving its code with no `process` (#46142). So we
+// instead schedule the deletion explicitly once preloads are loaded.
+const shouldDeleteRendererNodeGlobals = !nodeIntegration && !process.contextIsolated;
 
 const { appCodeLoaded } = process;
 delete process.appCodeLoaded;
+
+const onPreloadsLoaded = () => {
+  if (shouldDeleteRendererNodeGlobals) {
+    delete (global as any).process;
+    delete (global as any).Buffer;
+    delete (global as any).setImmediate;
+    delete (global as any).clearImmediate;
+    delete (global as any).global;
+    // eslint-disable-next-line n/no-deprecated-api
+    delete (global as any).root;
+    // eslint-disable-next-line n/no-deprecated-api
+    delete (global as any).GLOBAL;
+  }
+  appCodeLoaded!();
+};
 
 const { preloadPaths } = ipcRendererUtils.invokeSync<{ preloadPaths: string[] }>(IPC_MESSAGES.BROWSER_NONSANDBOX_LOAD);
 const cjsPreloads = preloadPaths.filter((p) => path.extname(p) !== '.mjs');
@@ -172,7 +182,7 @@ if (esmPreloads.length) {
           ipcRendererInternal.send(IPC_MESSAGES.BROWSER_PRELOAD_ERROR, preloadScript, err);
         });
     }
-  }).finally(() => appCodeLoaded!());
+  }).finally(onPreloadsLoaded);
 } else {
-  appCodeLoaded!();
+  onPreloadsLoaded();
 }

--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -256,6 +256,55 @@ describe('esm', () => {
       });
     });
 
+    describe('without nodeIntegration and contextIsolation', () => {
+      it('exposes Node globals to an ESM preload script', async () => {
+        const [webContents] = await loadWindowWithPreload(
+          `globalThis.preloadNodeGlobals = {
+            processType: typeof process,
+            bufferType: typeof Buffer,
+            setImmediateType: typeof setImmediate,
+            globalType: typeof global
+          };`,
+          {
+            nodeIntegration: false,
+            sandbox: false,
+            contextIsolation: false
+          }
+        );
+
+        const globals = await webContents.executeJavaScript('globalThis.preloadNodeGlobals');
+        expect(globals).to.deep.equal({
+          processType: 'object',
+          bufferType: 'function',
+          setImmediateType: 'function',
+          globalType: 'object'
+        });
+      });
+
+      it('removes Node globals from the renderer main world after the preload runs', async () => {
+        const [webContents] = await loadWindowWithPreload('globalThis.preloadFinished = true;', {
+          nodeIntegration: false,
+          sandbox: false,
+          contextIsolation: false
+        });
+
+        const pageGlobals = await webContents.executeJavaScript(`({
+          preloadFinished: globalThis.preloadFinished,
+          processType: typeof process,
+          bufferType: typeof Buffer,
+          setImmediateType: typeof setImmediate,
+          globalType: typeof global
+        })`);
+        expect(pageGlobals).to.deep.equal({
+          preloadFinished: true,
+          processType: 'undefined',
+          bufferType: 'undefined',
+          setImmediateType: 'undefined',
+          globalType: 'undefined'
+        });
+      });
+    });
+
     describe('electron modules', () => {
       it("import 'electron/lol' should throw", async () => {
         const [, error] = await loadWindowWithPreload('import { ipcRenderer } from "electron/lol";', {


### PR DESCRIPTION
Manually backport #51693 to 42-x-y. See that PR for details.

Tested by building and testing with `e test -g 'without nodeIntegration and contextIsolation'`.

Notes: Fixed an issue where `process` and other Node globals were undefined in ESM preload scripts when `contextIsolation` was disabled.