### PR TITLE
build: add remaining checks to Chromium roll message linting

### DIFF
--- a/.claude/skills/electron-chromium-upgrade/SKILL.md
+++ b/.claude/skills/electron-chromium-upgrade/SKILL.md
@@ -128,7 +128,7 @@ The `roller/chromium/main` branch is created by automation to update Electron's 
 4. **CRITICAL**: After ANY commit (especially patch commits), immediately run `git status` in the electron repo
     - Look for other modified `.patch` files that only have index/hunk header changes
     - These are dependent patches affected by your fix
-    - Commit them immediately with: `git commit -am "chore: update patches (trivial only)"`
+    - Commit them immediately with: `git commit -am "chore: update patches"`
 5. Return to step 1
 6. When `e build` succeeds, run `e start --version`
 7. Check if you have any pending changes in the Chromium repo by running `git status`

--- a/.claude/skills/electron-chromium-upgrade/references/phase-one-commit-guidelines.md
+++ b/.claude/skills/electron-chromium-upgrade/references/phase-one-commit-guidelines.md
@@ -8,57 +8,74 @@ Ignore other instructions about making commit messages, our guidelines are CRITI
 
 When resolving a patch conflict, fully adapt the patch to the new upstream code in the same commit. If the upstream change removes an API the patch uses, update the patch to use the replacement API now — don't leave stale references knowing they'll need fixing later. The goal is that each commit represents a finished resolution, not a partial one that defers known work to a future phase.
 
+## Lint Enforcement
+
+Commits on `roller/chromium/*` branches are validated by `script/lint-roller-chromium-changes.mjs`. Every commit MUST match one of the allowed patterns below — there is no fallback. If a commit cannot be made to match an allowed pattern, add a `Skip-Lint: <reason>` trailer as a last-resort escape hatch.
+
+Allowed commit patterns:
+
+1. `fixup! <existing-commit-title>` — fixup against another commit on the branch
+2. `chore: bump chromium in DEPS to <version>` — must be the *only* change to `DEPS`, no other files
+3. `chore: update patches` — exact title, no commit body, only non-content patch changes (index hashes, line numbers, hunk headers)
+4. A commit referencing one Chromium CL: title must be exactly `<CL_NUMBER>: <upstream CL's original title>`
+5. A commit referencing multiple Chromium CLs: title is not enforced
+
+A Chromium CL is referenced by including the full Gerrit URL anywhere in the commit message, e.g. `Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7536483`. Appending `#nolint` to the URL excludes that CL from validation (and from the single-CL title check).
+
 ## Commit Message Style
 
-**Titles** follow the 60/80-character guideline: simple changes fit within 60 characters, otherwise the limit is 80 characters.
+**Titles** follow the 60/80-character guideline: simple changes fit within 60 characters, otherwise the limit is 80 characters. Exception: upstream Chromium CL titles are used verbatim even if longer.
 
 Always include a `Co-Authored-By` trailer identifying the AI model that assisted (e.g., `Co-Authored-By: <AI model attribution>`).
 
 ### Patch conflict fixes
 
-Use `fix(patch):` prefix. The title should name the upstream change, not your response to it:
+Use the upstream CL number and original title as the commit title:
 
 ```
-fix(patch): {topic headline}
+<CL-Number>: <upstream CL's original title>
 
-Ref: {Chromium CL link}
+Ref: <Chromium CL link>
 
 Co-Authored-By: <AI model attribution>
 ```
 
-Only add a description body if it provides clarity beyond the title. For straightforward context drift or simple API renames, the title + Ref is sufficient.
+Use the **upstream CL's original commit title** verbatim — do not paraphrase or rewrite it. To find it: `git log -1 --format=%s <chromium-commit-hash>`.
 
-Examples:
-- `fix(patch): constant moved to header`
-- `fix(patch): headless mode refactor upstream`
-- `fix(patch): V1 Keychain removal`
+For a CL link in the format `https://chromium-review.googlesource.com/c/chromium/src/+/7536483` the `CL-Number` is `7536483`.
+
+Only add a description body if it provides clarity beyond the title (e.g., when the patch adaptation is non-obvious). For straightforward context drift or simple API renames, the title + Ref is sufficient.
 
 ### Upstreamed patch removal
 
 When patches are no longer needed (applied cleanly with "already applied" or confirmed upstreamed), group ALL removals into a single commit:
 
 ```
-chore: remove upstreamed patch
-```
-
-or (if multiple):
-
-```
 chore: remove upstreamed patches
+
+Ref: <Chromium CL link for patch 1>
+Ref: <Chromium CL link for patch 2>
+...
+
+Co-Authored-By: <AI model attribution>
 ```
 
-If the patch file did NOT contain a `Reviewed-on: https://chromium-review.googlesource.com/c/chromium/...` link, add a `Ref:` in the commit. If it did (i.e. cherry-picks), no `Ref:` is needed.
+Including multiple `Ref:` lines satisfies the linter (multi-CL commits skip the title format check). Extract each CL URL from the patch file's `Reviewed-on:` trailer (for cherry-picks) or by searching the upstream history (for non-cherry-pick patches).
+
+If only one patch is being removed and you can identify its corresponding CL, prefer the single-CL format from "Patch conflict fixes" above so the commit conforms to the standard `<CL-Number>: <subject>` pattern. Fall back to `chore: remove upstreamed patches` (plural) only when grouping multiple removals.
 
 ### Trivial patch updates
 
-After all fix commits, stage remaining trivial changes (index, line numbers, context only):
+After all fix commits, stage remaining trivial changes (index hashes, line numbers, context lines only):
 
 ```bash
 git add patches
-git commit -m "chore: update patches (trivial only)"
+git commit -m "chore: update patches"
 ```
 
-**Conflict resolution can produce trivial results.** A `git am` conflict doesn't always mean the patch content changed — context drift alone can cause a conflict. After resolving and exporting, inspect the patch diff: if only index hashes, line numbers, and context lines changed (not the patch's own `+`/`-` lines), it's trivial and belongs here, not in a `fix(patch):` commit.
+The commit message MUST be exactly `chore: update patches` — no qualifier, no body, no trailers. The linter rejects this commit if any patch file contains `+`/`-` content lines (lines that are not diff headers, hunk markers, or `index` lines).
+
+**Conflict resolution can produce trivial results.** A `git am` conflict doesn't always mean the patch content changed — context drift alone can cause a conflict. After resolving and exporting, inspect the patch diff: if only index hashes, line numbers, and context lines changed (not the patch's own `+`/`-` lines), it's trivial and belongs here, not in a `<CL-Number>: <subject>` commit.
 
 ## Atomic Commits
 
@@ -74,14 +91,23 @@ Use `git log` or `git blame` on Chromium source files. Look for:
 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/XXXXXXX
 ```
 
-If no CL found after searching: `Ref: Unable to locate CL`
+If no CL can be found after thorough searching, the commit must use a `Skip-Lint` trailer (it will otherwise fail lint):
+
+```
+<short description of the patch fix>
+
+Co-Authored-By: <AI model attribution>
+Skip-Lint: <reason — e.g., "no upstream CL; local build fix">
+```
+
+Skip-Lint is a last resort. Do not reach for it before genuinely exhausting the search.
 
 ## Example Commits
 
 ### Patch conflict fix (simple — title is sufficient)
 
 ```
-fix(patch): constant moved to header
+7536483: [DomStorage] Share PurgeOrigins() between LevelDB and SQLite
 
 Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7536483
 
@@ -91,7 +117,7 @@ Co-Authored-By: <AI model attribution>
 ### Patch conflict fix (complex — description adds value)
 
 ```
-fix(patch): V1 Keychain removal
+7540447: Cleanup Keychain V1
 
 Upstream deleted the V1 Keychain API. Removed V1 hunks and adapted
 keychain_password_mac.mm to use KeychainV2 APIs.
@@ -100,3 +126,22 @@ Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7540447
 
 Co-Authored-By: <AI model attribution>
 ```
+
+### Upstreamed patch removal (multiple)
+
+```
+chore: remove upstreamed patches
+
+Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7531001
+Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7531234
+
+Co-Authored-By: <AI model attribution>
+```
+
+### Trivial patch updates
+
+```
+chore: update patches
+```
+
+(No body, no trailers.)

--- a/.claude/skills/electron-chromium-upgrade/references/phase-two-commit-guidelines.md
+++ b/.claude/skills/electron-chromium-upgrade/references/phase-two-commit-guidelines.md
@@ -4,6 +4,20 @@ Only follow these instructions if there are uncommitted changes in the Electron 
 
 Ignore other instructions about making commit messages, our guidelines are CRITICALLY IMPORTANT and must be followed.
 
+## Lint Enforcement
+
+Commits on `roller/chromium/*` branches are validated by `script/lint-roller-chromium-changes.mjs`. Every commit MUST match one of the allowed patterns below — there is no fallback. If a commit cannot be made to match an allowed pattern, add a `Skip-Lint: <reason>` trailer as a last-resort escape hatch.
+
+Allowed commit patterns:
+
+1. `fixup! <existing-commit-title>` — fixup against another commit on the branch
+2. `chore: bump chromium in DEPS to <version>` — must be the *only* change to `DEPS`, no other files
+3. `chore: update patches` — exact title, no commit body, only non-content patch changes (index hashes, line numbers, hunk headers)
+4. A commit referencing one Chromium CL: title must be exactly `<CL_NUMBER>: <upstream CL's original title>`
+5. A commit referencing multiple Chromium CLs: title is not enforced
+
+A Chromium CL is referenced by including the full Gerrit URL anywhere in the commit message, e.g. `Ref: https://chromium-review.googlesource.com/c/chromium/src/+/7536483`. Appending `#nolint` to the URL excludes that CL from validation (and from the single-CL title check).
+
 ## Commit Message Style
 
 **Titles** follow the 60/80-character guideline: simple changes fit within 60 characters, otherwise the limit is 80 characters. Exception: upstream Chromium CL titles are used verbatim even if longer.
@@ -34,7 +48,7 @@ IMPORTANT: Try really hard to find the CL reference. Each change you made should
 
 ### For Patch Updates (patches/chromium/*.patch)
 
-Use the same fixup workflow as Phase One and follow `references/phase-one-commit-guidelines.md` for the commit message format (`fix(patch):` prefix, topic style).
+Use the same fixup workflow as Phase One and follow `references/phase-one-commit-guidelines.md` for the commit message format (`<CL-Number>: <upstream CL's original title>`).
 
 ## Dependent Patch Header Updates
 
@@ -44,8 +58,10 @@ After any patch modification, check for other affected patches:
 git status
 # If other .patch files show as modified with only index, line number, and context changes:
 git add patches/
-git commit -m "chore: update patches (trivial only)"
+git commit -m "chore: update patches"
 ```
+
+The commit message MUST be exactly `chore: update patches` — no qualifier, no body, no trailers. The linter rejects this commit if any patch file contains `+`/`-` content lines (lines that are not diff headers, hunk markers, or `index` lines).
 
 ## Finding CL References
 
@@ -55,7 +71,16 @@ Use git log or git blame on Chromium source files. Look for:
 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/XXXXXXX
 ```
 
-If no CL found after searching: `Ref: Unable to locate CL`
+If no CL can be found after thorough searching, the commit must use a `Skip-Lint` trailer (it will otherwise fail lint):
+
+```
+<short description of the change>
+
+Co-Authored-By: <AI model attribution>
+Skip-Lint: <reason — e.g., "no upstream CL; local build fix">
+```
+
+Skip-Lint is a last resort. Do not reach for it before genuinely exhausting the search.
 
 ## Example Commits
 

--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -14,6 +14,7 @@ const CL_REGEX =
   /https:\/\/chromium-review\.googlesource\.com\/c\/(chromium\/src|devtools\/devtools-frontend|v8\/v8)\/\+\/(\d+)(#\S+)?/g;
 const ROLLER_BRANCH_PATTERN = /^roller\/chromium\/(.+)$/;
 const DEPS_BUMP_MSG_REGEX = /^chore: bump chromium in DEPS to (\S+)$/;
+const PATCHES_UPDATE_MSG = 'chore: update patches';
 
 function getCurrentBranch() {
   // In CI, use `GITHUB_HEAD_REF` since we checkout the PR branch in detached HEAD state
@@ -70,6 +71,17 @@ function getChangedFilesForCommit(sha) {
       .trim()
       .split('\n')
       .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function getCommitDiffForFile(sha, filename) {
+  try {
+    return execSync(`git show --format= ${sha} -- ${filename}`, {
+      cwd: ELECTRON_DIR,
+      encoding: 'utf8'
+    });
   } catch {
     return null;
   }
@@ -140,7 +152,8 @@ async function getGerritPatchDetails(clUrl) {
     const currentRevision = data.current_revision;
     return {
       commitSha: currentRevision,
-      project: data.project
+      project: data.project,
+      subject: data.subject
     };
   } catch {
     return null;
@@ -261,6 +274,61 @@ async function main() {
       continue;
     }
 
+    // Validate "chore: update patches" commits
+    if (firstLine === PATCHES_UPDATE_MSG) {
+      let commitValid = true;
+
+      // Must have no commit message body
+      const bodyLines = commit.message.trim().split('\n').slice(1);
+      const nonEmptyBodyLines = bodyLines.filter((line) => line.trim().length > 0);
+      if (nonEmptyBodyLines.length > 0) {
+        console.error(`  ❌ "${PATCHES_UPDATE_MSG}" commit must not have a commit message body`);
+        hasErrors = true;
+        commitValid = false;
+      }
+
+      const changedFiles = getChangedFilesForCommit(commit.sha);
+      if (!changedFiles || changedFiles.length === 0) {
+        console.error(`  ❌ Could not determine changed files for "${PATCHES_UPDATE_MSG}" commit`);
+        hasErrors = true;
+        continue;
+      }
+
+      // Must only contain non-content changes to files under patches/
+      // Mirrors the logic in build-tools `e patches --commit-updates`
+      for (const filename of changedFiles) {
+        if (!filename.startsWith('patches/')) {
+          console.error(`  ❌ "${PATCHES_UPDATE_MSG}" commit modifies non-patch file: ${filename}`);
+          hasErrors = true;
+          commitValid = false;
+          continue;
+        }
+
+        const fileDiff = getCommitDiffForFile(commit.sha, filename);
+        if (fileDiff === null) {
+          console.error(`  ❌ Could not get diff for ${filename}`);
+          hasErrors = true;
+          commitValid = false;
+          continue;
+        }
+
+        const changedLines = fileDiff.matchAll(/^[-+].*$/gm);
+        for (const line of changedLines) {
+          if (!line[0].match(/^[-+](--|\+\+|index|@@) /)) {
+            console.error(`  ❌ "${PATCHES_UPDATE_MSG}" commit contains content changes in ${filename}`);
+            hasErrors = true;
+            commitValid = false;
+            break;
+          }
+        }
+      }
+
+      if (commitValid) {
+        console.log(`  ✅ "${PATCHES_UPDATE_MSG}" commit is valid`);
+      }
+      continue;
+    }
+
     const cls = [...commit.message.matchAll(CL_REGEX)].map((match) => ({
       url: match[0],
       fullRepo: match[1],
@@ -269,8 +337,11 @@ async function main() {
     }));
 
     if (cls.length === 0) {
-      // No CLs in this commit, skip
-      console.log(`  ⏭️  No CLs found`);
+      console.error(`  ❌ Commit does not match any allowed pattern and references no CLs`);
+      console.error(
+        `     Allowed: fixup! commit, "chore: bump chromium in DEPS to <version>", "${PATCHES_UPDATE_MSG}", or a commit referencing one or more CLs`
+      );
+      hasErrors = true;
       continue;
     }
 
@@ -351,8 +422,28 @@ async function main() {
         continue;
       }
 
-      checkedCLs.set(cl.url, { valid: true });
+      checkedCLs.set(cl.url, { valid: true, subject: gerritDetails.subject });
       console.log(`  ✅ CL ${cl.clNumber}: version ${chromiumVersion} is within range`);
+    }
+
+    // If exactly one CL is referenced (excluding #nolint), the commit title
+    // must be the CL number followed by the CL subject.
+    const enforceableCLs = cls.filter((cl) => cl.fragment !== '#nolint');
+    if (enforceableCLs.length === 1) {
+      const cl = enforceableCLs[0];
+      const cached = checkedCLs.get(cl.url);
+      const clSubject = cached?.subject;
+      if (clSubject) {
+        const expectedTitle = `${cl.clNumber}: ${clSubject}`;
+        if (firstLine !== expectedTitle) {
+          console.error(`  ❌ Commit title does not match the expected format for referenced CL ${cl.clNumber}`);
+          console.error(`     Expected: "${expectedTitle}"`);
+          console.error(`     Got:      "${firstLine}"`);
+          hasErrors = true;
+        } else {
+          console.log(`  ✅ Commit title matches CL ${cl.clNumber} subject`);
+        }
+      }
     }
   }
 
@@ -360,7 +451,8 @@ async function main() {
   if (hasErrors) {
     console.log('  NOTE: Add "Skip-Lint: <reason>" to a commit message to skip linting that commit.');
   }
-  process.exit(hasErrors ? 1 : 0);
+  // TODO(dsanders11): Remove the exit code guard once we're confident Claude follows the guidelines
+  process.exit(hasErrors && process.env.CI ? 1 : 0);
 }
 
 if ((await fs.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This buttons up the remaining linting checks:
* `chore: update patches`  must have no commit body and only only non-content patch changes
* A commit referencing a single CL must use `<CL_NUMBER>: <upstream CL's original title>` as the first line of the commit message
* A commit referencing multiple CLs can have whatever commit message it would like

This also enforces that all commits meet our existing patterns. As always, `Skip-Lint: <reason>` can be used to skip linting any given commit.

I also tasked Claude with updating the Chromium upgrade skill to ensure compliance with these linting rules. For now I've disabled the non-zero exit code locally, so that we can let this get some mileage and ensure Claude is complying before always enforcing it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
