### PR TITLE
fix: win.center() sets the correct size and position on frameless windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -93,7 +93,6 @@
 #include "shell/common/color_util.h"
 #include "skia/ext/skia_utils_win.h"
 #include "ui/display/win/screen_win.h"
-#include "ui/gfx/win/hwnd_util.h"
 #include "ui/gfx/win/msg_util.h"
 #endif
 
@@ -435,7 +434,10 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   if ((has_frame() || has_client_frame()) && use_content_size_)
     size = ContentBoundsToWindowBounds(gfx::Rect(size)).size();
 
-  widget()->CenterWindow(size);
+  // Bounds need to be re-applied before centering to account for frame
+  // insets, which weren't available on init.
+  SetSize(size);
+  Center();
 
 #if BUILDFLAG(IS_WIN)
   // Save initial window state.
@@ -449,13 +451,6 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   aura::Window* window = GetNativeWindow();
   if (window)
     window->AddPreTargetHandler(this);
-
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
-  // The initial params.bounds was applied before the frame view existed, so
-  // non-client insets weren't accounted for and bounds need to be set again.
-  if (!GetRestoredFrameBorderInsets().IsEmpty())
-    SetBounds(gfx::Rect(GetPosition(), size), false);
-#endif
 }
 
 NativeWindowViews::~NativeWindowViews() {
@@ -1187,24 +1182,21 @@ ui::ZOrderLevel NativeWindowViews::GetZOrderLevel() const {
   return widget()->GetZOrderLevel();
 }
 
-// We previous called widget()->CenterWindow() here, but in
-// Chromium CL 4916277 behavior was changed to center relative to the
-// parent window if there is one. We want to keep the old behavior
-// for now to avoid breaking API contract, but should consider the long
-// term plan for this aligning with upstream.
 void NativeWindowViews::Center() {
-#if BUILDFLAG(IS_LINUX)
+  // On Windows we previously called gfx::CenterAndSizeWindow on the HWND.
+  // That had the problem of placing windows slightly too high if they have
+  // insets, since top/bottom insets are asymmetric. It also introduces
+  // DIP/pixel conversion errors at fractional scales. We also avoid
+  // widget()->CenterWindow(), since in addition to those issues it centers
+  // relative to the parent window when one exists as of Chromium CL 4916277.
+  //
+  // Centering the logical rect (size without insets) avoids all of the above
+  // and works on Windows and Linux.
   auto display =
       display::Screen::Get()->GetDisplayNearestWindow(GetNativeWindow());
-  gfx::Rect window_bounds_in_screen = display.work_area();
-  window_bounds_in_screen.ClampToCenteredSize(GetSize());
-  widget()->SetBounds(window_bounds_in_screen);
-#else
-  HWND hwnd = GetAcceleratedWidget();
-  gfx::Size size =
-      display::win::GetScreenWin()->DIPToScreenSize(hwnd, GetSize());
-  gfx::CenterAndSizeWindow(nullptr, hwnd, size);
-#endif
+  gfx::Rect bounds = display.work_area();
+  bounds.ClampToCenteredSize(GetSize());
+  SetBounds(bounds, false);
 }
 
 void NativeWindowViews::Invalidate() {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -64,6 +64,17 @@ const expectBoundsEqual = (actual: any, expected: any) => {
   }
 };
 
+// Is the window centered at the given size?
+const expectCenteredBounds = (win: BrowserWindow, width: number, height: number) => {
+  const { workArea } = screen.getDisplayMatching(win.getBounds());
+  expectBoundsEqual(win.getBounds(), {
+    x: workArea.x + Math.floor((workArea.width - width) / 2),
+    y: workArea.y + Math.floor((workArea.height - height) / 2),
+    width,
+    height
+  });
+};
+
 const isBeforeUnload = (event: Event, level: number, message: string) => {
   return message === 'beforeunload';
 };
@@ -103,6 +114,14 @@ describe('BrowserWindow module', () => {
         w.destroy();
       }).not.to.throw();
     });
+
+    for (const frame of [true, false]) {
+      ifit(process.platform !== 'darwin')(`creates a window centered at the requested size (frame: ${frame})`, () => {
+        const w = new BrowserWindow({ show: false, frame, width: 600, height: 400 });
+        expectCenteredBounds(w, 600, 400);
+        w.destroy();
+      });
+    }
   });
 
   describe('garbage collection', () => {
@@ -1901,6 +1920,20 @@ describe('BrowserWindow module', () => {
         await move;
         expect(w.getPosition()).to.deep.equal(pos);
       });
+    });
+
+    ifdescribe(process.platform !== 'darwin')('BrowserWindow.center()', () => {
+      for (const frame of [true, false]) {
+        it(`moves a window to the center and preserves its size (frame: ${frame})`, () => {
+          const w = new BrowserWindow({ show: false, frame, width: 600, height: 400 });
+
+          const { workArea } = screen.getDisplayMatching(w.getBounds());
+          w.setPosition(workArea.x, workArea.y);
+          w.center();
+          expectCenteredBounds(w, 600, 400);
+          w.destroy();
+        });
+      }
     });
 
     describe('BrowserWindow.setContentSize(width, height)', () => {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/51731.

Calling `win.center()` caused frameless windows with insets to shrink on both Windows and Linux.  Additionally, on Windows, frameless windows were not centered correctly on launch or when calling `win.center()`.

This PR corrects both the shrinking and the positioning by introducing a shared implementation for `NativeWindowViews::Center()` for Linux and Windows. It is based on the existing Linux codepath but has been updated to use  `SetBounds()`, which properly handles insets, instead of the lower level `widget()->SetBounds()`. On Windows, it replaces the call to  `gfx::CenterAndSizeWindow(size)`, which places windows too high if they have asymmetric insets.

While  `CenterAndSizeWindow`  could be patched upstream (this is an approach I have taken for other APIs) I looked at its implementation and do not see a benefit in having a divergent path for Windows in this instance. The upstream API is not cross-platform and is not used much even on Windows, and Electron isn't getting anything for free that it doesn't already have to support to position windows correctly. It is possible that I'm missing something, but I have done my best to test this simplification thoroughly.

With the new shared implementation, centering on both platforms is now accurate (at least at 100% DPI) and does not change the window's size. I was also able to get rid of an extra call to set bounds on init now that `Center()` has an improved implementation.

I added new tests for both initial window bounds and `win.center()` for framed and frameless windows. I also verified that frameless and framed windows are centered in the exact size and position on Windows as in 41.2.0 (prior to the insets changes).

(On Wayland, `win.center()` is still effectively a no-op, as the compositor will not honour the move. However, the window will no longer shrink if it is called.)

Backports to 41, 42, 43.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Linux and Windows where frameless windows would shrink when calling `win.center()`. Additionally, fixed an issue where frameless windows would appear slightly off-center on Windows.