### PR TITLE
refactor: migrate `electron::api::DesktopCapturer` to cppgc

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -21,16 +21,20 @@
 #include "chrome/browser/media/webrtc/window_icon_util.h"
 #include "content/public/browser/desktop_capture.h"
 #include "gin/object_template_builder.h"
+#include "gin/persistent.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/gin_helper/handle.h"
+#include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capture_options.h"
 #include "third_party/webrtc/modules/desktop_capture/desktop_capturer.h"
 #include "ui/base/ozone_buildflags.h"
+#include "v8/include/cppgc/allocation.h"
+#include "v8/include/v8-cppgc.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "third_party/webrtc/modules/desktop_capture/win/dxgi_duplicator_controller.h"
@@ -229,8 +233,8 @@ struct Converter<electron::api::DesktopCapturer::Source> {
 
 namespace electron::api {
 
-gin::DeprecatedWrapperInfo DesktopCapturer::kWrapperInfo = {
-    gin::kEmbedderNativeGin};
+const gin::WrapperInfo DesktopCapturer::kWrapperInfo =
+    electron::MakeWrapperInfo(electron::kElectronDesktopCapturer);
 
 // Observer that forwards DesktopMediaListObserver events back to
 // the owning DesktopCapturer, tagging them with the list type so
@@ -240,7 +244,7 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
   ListObserver(DesktopCapturer* capturer,
                DesktopMediaList* list,
                bool need_thumbnails)
-      : capturer_{capturer},
+      : capturer_{capturer->WeakCallbackTarget()},
         list_{list},
         list_type_{list->GetMediaListType()},
         is_delegated_{list->IsSourceListDelegated()},
@@ -270,8 +274,7 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
     notified_ = true;
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
-        base::BindOnce(&DesktopCapturer::OnListReady,
-                       capturer_->weak_ptr_factory_.GetWeakPtr(), list_type_));
+        base::BindOnce(&DesktopCapturer::OnListReady, capturer_, list_type_));
   }
 
   // DesktopMediaListObserver:
@@ -294,11 +297,10 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
   }
   void OnDelegatedSourceListDismissed() override {
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-        FROM_HERE, base::BindOnce(&DesktopCapturer::HandleFailure,
-                                  capturer_->weak_ptr_factory_.GetWeakPtr()));
+        FROM_HERE, base::BindOnce(&DesktopCapturer::HandleFailure, capturer_));
   }
 
-  raw_ptr<DesktopCapturer> capturer_;
+  cppgc::Persistent<gin::WeakCell<DesktopCapturer>> capturer_;
   raw_ptr<DesktopMediaList> list_;
   DesktopMediaList::Type list_type_;
   bool is_delegated_ = false;
@@ -310,6 +312,13 @@ class DesktopCapturer::ListObserver : public DesktopMediaListObserver {
 DesktopCapturer::DesktopCapturer() = default;
 
 DesktopCapturer::~DesktopCapturer() = default;
+
+cppgc::Persistent<gin::WeakCell<DesktopCapturer>>
+DesktopCapturer::WeakCallbackTarget() {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  return gin::WrapPersistent(
+      weak_factory_.GetWeakCell(isolate->GetCppHeap()->GetAllocationHandle()));
+}
 
 void DesktopCapturer::FinalizeList(std::unique_ptr<ListObserver>& observer,
                                    std::unique_ptr<DesktopMediaList>& list) {
@@ -417,9 +426,9 @@ void DesktopCapturer::StartHandling(bool capture_window,
       (window_capturer_ && window_capturer_->IsSourceListDelegated()) ||
       (screen_capturer_ && screen_capturer_->IsSourceListDelegated());
   if (!any_delegated) {
-    deadline_.Start(FROM_HERE, kDesktopCapturerReadyTimeout,
-                    base::BindOnce(&DesktopCapturer::OnReadyTimeout,
-                                   weak_ptr_factory_.GetWeakPtr()));
+    deadline_.Start(
+        FROM_HERE, kDesktopCapturerReadyTimeout,
+        base::BindOnce(&DesktopCapturer::OnReadyTimeout, WeakCallbackTarget()));
   }
 }
 
@@ -557,7 +566,7 @@ void DesktopCapturer::HandleSuccess() {
   window_observer_.reset();
   screen_observer_.reset();
 
-  Unpin();
+  keep_alive_.Clear();
 }
 
 void DesktopCapturer::HandleFailure() {
@@ -576,18 +585,13 @@ void DesktopCapturer::HandleFailure() {
   window_observer_.reset();
   screen_observer_.reset();
 
-  Unpin();
+  keep_alive_.Clear();
 }
 
 // static
-gin_helper::Handle<DesktopCapturer> DesktopCapturer::Create(
-    v8::Isolate* isolate) {
-  auto handle = gin_helper::CreateHandle(isolate, new DesktopCapturer());
-
-  // Keep reference alive until capturing has finished.
-  handle->Pin(isolate);
-
-  return handle;
+DesktopCapturer* DesktopCapturer::Create(v8::Isolate* isolate) {
+  return cppgc::MakeGarbageCollected<DesktopCapturer>(
+      isolate->GetCppHeap()->GetAllocationHandle());
 }
 
 // static
@@ -599,13 +603,21 @@ bool DesktopCapturer::IsDisplayMediaSystemPickerAvailable() {
 
 gin::ObjectTemplateBuilder DesktopCapturer::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin_helper::DeprecatedWrappable<
-             DesktopCapturer>::GetObjectTemplateBuilder(isolate)
+  return gin::Wrappable<DesktopCapturer>::GetObjectTemplateBuilder(isolate)
       .SetMethod("startHandling", &DesktopCapturer::StartHandling);
 }
 
-const char* DesktopCapturer::GetTypeName() {
-  return "DesktopCapturer";
+void DesktopCapturer::Trace(cppgc::Visitor* visitor) const {
+  gin::Wrappable<DesktopCapturer>::Trace(visitor);
+  visitor->Trace(weak_factory_);
+}
+
+const gin::WrapperInfo* DesktopCapturer::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* DesktopCapturer::GetHumanReadableName() const {
+  return "Electron / DesktopCapturer";
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -9,22 +9,15 @@
 #include <string>
 #include <vector>
 
-#include "base/memory/weak_ptr.h"
 #include "base/timer/timer.h"
 #include "chrome/browser/media/webrtc/desktop_media_list.h"
-#include "shell/common/gin_helper/pinnable.h"
-#include "shell/common/gin_helper/wrappable.h"
-
-namespace gin_helper {
-template <typename T>
-class Handle;
-}  // namespace gin_helper
+#include "gin/weak_cell.h"
+#include "gin/wrappable.h"
+#include "shell/common/gin_helper/self_keep_alive.h"
 
 namespace electron::api {
 
-class DesktopCapturer final
-    : public gin_helper::DeprecatedWrappable<DesktopCapturer>,
-      public gin_helper::Pinnable<DesktopCapturer> {
+class DesktopCapturer final : public gin::Wrappable<DesktopCapturer> {
  public:
   struct Source {
     DesktopMediaList::Source media_list_source;
@@ -35,7 +28,7 @@ class DesktopCapturer final
     bool fetch_icon = false;
   };
 
-  static gin_helper::Handle<DesktopCapturer> Create(v8::Isolate* isolate);
+  static DesktopCapturer* Create(v8::Isolate* isolate);
 
   static bool IsDisplayMediaSystemPickerAvailable();
 
@@ -44,22 +37,26 @@ class DesktopCapturer final
                      const gfx::Size& thumbnail_size,
                      bool fetch_window_icons);
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  // gin::Wrappable
+  static const gin::WrapperInfo kWrapperInfo;
+  void Trace(cppgc::Visitor* visitor) const override;
+  const gin::WrapperInfo* wrapper_info() const override;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+  const char* GetHumanReadableName() const override;
 
   // disable copy
   DesktopCapturer(const DesktopCapturer&) = delete;
   DesktopCapturer& operator=(const DesktopCapturer&) = delete;
 
- protected:
+  // Make public for cppgc::MakeGarbageCollected.
   DesktopCapturer();
   ~DesktopCapturer() override;
 
  private:
   class ListObserver;
+
+  cppgc::Persistent<gin::WeakCell<DesktopCapturer>> WeakCallbackTarget();
 
   void FinalizeList(std::unique_ptr<ListObserver>& observer,
                     std::unique_ptr<DesktopMediaList>& list);
@@ -82,7 +79,8 @@ class DesktopCapturer final
   bool using_directx_capturer_ = false;
 #endif  // BUILDFLAG(IS_WIN)
 
-  base::WeakPtrFactory<DesktopCapturer> weak_ptr_factory_{this};
+  gin_helper::SelfKeepAlive<DesktopCapturer> keep_alive_{this};
+  gin::WeakCellFactory<DesktopCapturer> weak_factory_{this};
 };
 
 }  // namespace electron::api

--- a/shell/common/gin_helper/wrappable_pointer_tags.h
+++ b/shell/common/gin_helper/wrappable_pointer_tags.h
@@ -17,6 +17,7 @@ enum ElectronWrappablePointerTag : uint16_t {
   kElectronChunkedDataPipeReadableStream,   // ChunkedDataPipeReadableStream
   kElectronCookies,                         // electron::api::Cookies
   kElectronDataPipeHolder,                  // electron::api::DataPipeHolder
+  kElectronDesktopCapturer,                 // electron::api::DesktopCapturer
   kElectronDebugger,                        // electron::api::Debugger
   kElectronDownloadItem,                    // electron::api::DownloadItem
   kElectronEvent,                           // gin_helper::internal::Event


### PR DESCRIPTION
#### Description of Change

Migrate `electron::api::DesktopCapturer` to cppgc. Part of  #47922.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none