### PR TITLE
chore: do not require infr singoff for github workflows/actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,3 @@ DEPS                                    @electron/wg-upgrades
 
 # Infra WG
 /.claude/                               @electron/wg-infra
-/.github/actions/                       @electron/wg-infra
-/.github/workflows/*-publish.yml        @electron/wg-infra
-/.github/workflows/build.yml            @electron/wg-infra
-/.github/workflows/pipeline-*.yml       @electron/wg-infra


### PR DESCRIPTION
Don't require wg-infr signoff for github workflows/actions. As per discussion with @MarshallOfSound 

Notes: none.