### PR TITLE
chore: do not require infr singoff for github workflows/actions (#51738)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,4 @@ DEPS                                    @electron/wg-upgrades
 /lib/renderer/security-warnings.ts      @electron/wg-security
 
 # Infra WG
-/.github/actions/                       @electron/wg-infra
-/.github/workflows/*-publish.yml        @electron/wg-infra
-/.github/workflows/build.yml            @electron/wg-infra
-/.github/workflows/pipeline-*.yml       @electron/wg-infra
+/.claude/                               @electron/wg-infra


### PR DESCRIPTION
Manual backport of #51738 to 42-x-y. See that PR for details.

Notes: none