### PR TITLE
ci: use gn-check script in gn-check job

### DIFF
--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -144,10 +144,7 @@ jobs:
 
           e build --gen=only
 
-          e d gn check ../out/Default //electron:electron_lib
-          e d gn check ../out/Default //electron:electron_app
-          e d gn check ../out/Default //electron/shell/common:mojo
-          e d gn check ../out/Default //electron/shell/common:plugin
+          npm run gn-check -- --outDir Default
 
           # Check the hunspell filenames
           node script/gen-hunspell-filenames.js --check

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -18,8 +18,8 @@ if (!OUT_DIR) {
 }
 
 const env = {
-  ...getDepotToolsEnv(),
-  DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
+  DEPOT_TOOLS_WIN_TOOLCHAIN: '0',
+  ...getDepotToolsEnv()
 };
 
 const gnCheckDirs = [

--- a/script/lint.js
+++ b/script/lint.js
@@ -168,8 +168,8 @@ const LINTERS = [
       const allOk = filenames
         .map((filename) => {
           const env = {
-            ...getDepotToolsEnv(),
-            DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
+            DEPOT_TOOLS_WIN_TOOLCHAIN: '0',
+            ...getDepotToolsEnv()
           };
           const args = ['format', filename];
           if (!opts.fix) args.push('--dry-run');


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Use the existing `gn-check` script instead of doing individual calls to `gn check` which can get out of date (which happened here). The change to the ordering of the `DEPOT_TOOLS_WIN_TOOLCHAIN` environment variable is because we set it to `0` as a default if it's not set, not to override the value in the environment (`build-tools` uses the toolchain).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
