### PR TITLE
refactor: move `electron::api::GlobalShortcut` to cppgc (#50192)

### DIFF
--- a/lib/browser/api/global-shortcut.ts
+++ b/lib/browser/api/global-shortcut.ts
@@ -1,2 +1,39 @@
-const { globalShortcut } = process._linkedBinding('electron_browser_global_shortcut');
-export default globalShortcut;
+const { createGlobalShortcut } = process._linkedBinding('electron_browser_global_shortcut');
+
+let globalShortcut: Electron.GlobalShortcut;
+
+const createGlobalShortcutIfNeeded = () => {
+  if (globalShortcut === undefined) {
+    globalShortcut = createGlobalShortcut();
+  }
+};
+
+export default new Proxy(
+  {},
+  {
+    get: (_target, property: keyof Electron.GlobalShortcut) => {
+      createGlobalShortcutIfNeeded();
+      const value = globalShortcut[property];
+      if (typeof value === 'function') {
+        return value.bind(globalShortcut);
+      }
+      return value;
+    },
+    set: (_target, property: string, value: unknown) => {
+      createGlobalShortcutIfNeeded();
+      return Reflect.set(globalShortcut, property, value);
+    },
+    ownKeys: () => {
+      createGlobalShortcutIfNeeded();
+      return Reflect.ownKeys(globalShortcut);
+    },
+    has: (_target, property: string) => {
+      createGlobalShortcutIfNeeded();
+      return property in globalShortcut;
+    },
+    getOwnPropertyDescriptor: (_target, property: string) => {
+      createGlobalShortcutIfNeeded();
+      return Reflect.getOwnPropertyDescriptor(globalShortcut, property);
+    }
+  }
+);

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -15,14 +15,17 @@
 #include "electron/shell/browser/electron_browser_context.h"
 #include "electron/shell/common/electron_constants.h"
 #include "extensions/common/command.h"
-#include "gin/dictionary.h"
 #include "gin/object_template_builder.h"
+#include "gin/persistent.h"
 #include "shell/browser/api/electron_api_system_preferences.h"
 #include "shell/browser/browser.h"
 #include "shell/common/gin_converters/accelerator_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
-#include "shell/common/gin_helper/handle.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
+#include "v8/include/cppgc/allocation.h"
+#include "v8/include/v8-cppgc.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "base/mac/mac_util.h"
@@ -50,21 +53,28 @@ bool MapHasMediaKeys(
 
 namespace electron::api {
 
-gin::DeprecatedWrapperInfo GlobalShortcut::kWrapperInfo = {
-    gin::kEmbedderNativeGin};
+const gin::WrapperInfo GlobalShortcut::kWrapperInfo =
+    electron::MakeWrapperInfo(electron::kElectronGlobalShortcut);
 
-GlobalShortcut::GlobalShortcut() = default;
+GlobalShortcut::GlobalShortcut(v8::Isolate* isolate) {
+  gin::PerIsolateData* data = gin::PerIsolateData::From(isolate);
+  data->AddDisposeObserver(this);
+}
 
-GlobalShortcut::~GlobalShortcut() {
+GlobalShortcut::~GlobalShortcut() = default;
+
+void GlobalShortcut::Dispose() {
+  is_disposed_ = true;
+
   auto* instance = ui::GlobalAcceleratorListener::GetInstance();
   if (instance && instance->IsRegistrationHandledExternally()) {
     // Eagerly cancel callbacks so PruneStaleCommands() can clear them before
     // the WeakPtrFactory destructor runs.
-    weak_ptr_factory_.InvalidateWeakPtrs();
+    weak_factory_.Invalidate();
     instance->PruneStaleCommands();
   }
 
-  UnregisterAll();
+  UnregisterAllInternal();
 }
 
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
@@ -73,7 +83,9 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
   } else {
     // This should never occur, because if it does,
     // ui::GlobalAcceleratorListener notifies us with wrong accelerator.
-    NOTREACHED();
+    if (!is_disposed_) {
+      NOTREACHED();
+    }
   }
 }
 
@@ -84,7 +96,9 @@ void GlobalShortcut::ExecuteCommand(const extensions::ExtensionId& extension_id,
   } else {
     // This should never occur, because if it does, GlobalAcceleratorListener
     // notifies us with wrong command.
-    NOTREACHED();
+    if (!is_disposed_) {
+      NOTREACHED();
+    }
   }
 }
 
@@ -112,11 +126,14 @@ bool GlobalShortcut::RegisterAll(
 
 bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
                               const base::RepeatingClosure& callback) {
+  v8::Isolate* const isolate = JavascriptEnvironment::GetIsolate();
+
   if (!electron::Browser::Get()->is_ready()) {
-    gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
-        .ThrowError("globalShortcut cannot be used before the app is ready");
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "globalShortcut cannot be used before the app is ready");
     return false;
   }
+
 #if BUILDFLAG(IS_MAC)
   if (accelerator.IsMediaKey()) {
     if (RegisteringMediaKeyForUntrustedClient(accelerator))
@@ -170,8 +187,10 @@ bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
     const std::string fake_extension_id = command_str + "+" + profile_id;
     instance->OnCommandsChanged(
         fake_extension_id, profile_id, commands, gfx::kNullAcceleratedWidget,
-        base::BindRepeating(&GlobalShortcut::ExecuteCommand,
-                            weak_ptr_factory_.GetWeakPtr()));
+        base::BindRepeating(
+            &GlobalShortcut::ExecuteCommand,
+            gin::WrapPersistent(weak_factory_.GetWeakCell(
+                isolate->GetCppHeap()->GetAllocationHandle()))));
     command_callback_map_[command_str] = callback;
     return true;
   } else {
@@ -189,19 +208,24 @@ void GlobalShortcut::Unregister(const ui::Accelerator& accelerator) {
         .ThrowError("globalShortcut cannot be used before the app is ready");
     return;
   }
-  if (accelerator_callback_map_.erase(accelerator) == 0)
+  if (!accelerator_callback_map_.contains(accelerator))
     return;
+
+  if (ui::GlobalAcceleratorListener::GetInstance()) {
+    ui::GlobalAcceleratorListener::GetInstance()->UnregisterAccelerator(
+        accelerator, this);
+  }
+
+  // Remove from local callback map after unregistering from UI listener to
+  // avoid reentrancy races where in-flight key notifications arrive while the
+  // platform listener is stopping.
+  accelerator_callback_map_.erase(accelerator);
 
 #if BUILDFLAG(IS_MAC)
   if (accelerator.IsMediaKey() && !MapHasMediaKeys(accelerator_callback_map_)) {
     ui::GlobalAcceleratorListener::SetShouldUseInternalMediaKeyHandling(true);
   }
 #endif
-
-  if (ui::GlobalAcceleratorListener::GetInstance()) {
-    ui::GlobalAcceleratorListener::GetInstance()->UnregisterAccelerator(
-        accelerator, this);
-  }
 }
 
 void GlobalShortcut::UnregisterSome(
@@ -226,10 +250,15 @@ void GlobalShortcut::UnregisterAll() {
         .ThrowError("globalShortcut cannot be used before the app is ready");
     return;
   }
-  accelerator_callback_map_.clear();
+  UnregisterAllInternal();
+}
+
+void GlobalShortcut::UnregisterAllInternal() {
   if (ui::GlobalAcceleratorListener::GetInstance()) {
     ui::GlobalAcceleratorListener::GetInstance()->UnregisterAccelerators(this);
   }
+  accelerator_callback_map_.clear();
+  command_callback_map_.clear();
 }
 
 void GlobalShortcut::SetSuspended(bool suspend) {
@@ -257,16 +286,15 @@ bool GlobalShortcut::IsSuspended() {
 }
 
 // static
-gin_helper::Handle<GlobalShortcut> GlobalShortcut::Create(
-    v8::Isolate* isolate) {
-  return gin_helper::CreateHandle(isolate, new GlobalShortcut());
+GlobalShortcut* GlobalShortcut::Create(v8::Isolate* isolate) {
+  return cppgc::MakeGarbageCollected<GlobalShortcut>(
+      isolate->GetCppHeap()->GetAllocationHandle(), isolate);
 }
 
 // static
 gin::ObjectTemplateBuilder GlobalShortcut::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
-  return gin_helper::DeprecatedWrappable<
-             GlobalShortcut>::GetObjectTemplateBuilder(isolate)
+  return gin::Wrappable<GlobalShortcut>::GetObjectTemplateBuilder(isolate)
       .SetMethod("registerAll", &GlobalShortcut::RegisterAll)
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
@@ -276,8 +304,23 @@ gin::ObjectTemplateBuilder GlobalShortcut::GetObjectTemplateBuilder(
       .SetMethod("isSuspended", &GlobalShortcut::IsSuspended);
 }
 
-const char* GlobalShortcut::GetTypeName() {
-  return "GlobalShortcut";
+void GlobalShortcut::Trace(cppgc::Visitor* visitor) const {
+  gin::Wrappable<GlobalShortcut>::Trace(visitor);
+  visitor->Trace(weak_factory_);
+}
+
+const gin::WrapperInfo* GlobalShortcut::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* GlobalShortcut::GetHumanReadableName() const {
+  return "Electron / GlobalShortcut";
+}
+
+void GlobalShortcut::OnBeforeMicrotasksRunnerDispose(v8::Isolate* isolate) {
+  gin::PerIsolateData* data = gin::PerIsolateData::From(isolate);
+  data->RemoveDisposeObserver(this);
+  Dispose();
 }
 
 }  // namespace electron::api
@@ -289,8 +332,9 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* const isolate = electron::JavascriptEnvironment::GetIsolate();
-  gin::Dictionary dict{isolate, exports};
-  dict.Set("globalShortcut", electron::api::GlobalShortcut::Create(isolate));
+  gin_helper::Dictionary dict{isolate, exports};
+  dict.SetMethod("createGlobalShortcut",
+                 base::BindRepeating(&electron::api::GlobalShortcut::Create));
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -11,42 +11,47 @@
 #include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
 #include "extensions/common/extension_id.h"
-#include "shell/common/gin_helper/wrappable.h"
+#include "gin/per_isolate_data.h"
+#include "gin/weak_cell.h"
+#include "gin/wrappable.h"
 #include "ui/base/accelerators/accelerator.h"
 #include "ui/base/accelerators/global_accelerator_listener/global_accelerator_listener.h"
 
-namespace gin_helper {
-template <typename T>
-class Handle;
-}  // namespace gin_helper
-
 namespace electron::api {
 
-class GlobalShortcut final
-    : private ui::GlobalAcceleratorListener::Observer,
-      public gin_helper::DeprecatedWrappable<GlobalShortcut> {
+class GlobalShortcut final : public gin::Wrappable<GlobalShortcut>,
+                             private ui::GlobalAcceleratorListener::Observer,
+                             public gin::PerIsolateData::DisposeObserver {
  public:
-  static gin_helper::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
+  static GlobalShortcut* Create(v8::Isolate* isolate);
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  // gin::Wrappable
+  static const gin::WrapperInfo kWrapperInfo;
+  void Trace(cppgc::Visitor* visitor) const override;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+
+  // gin::PerIsolateData::DisposeObserver
+  void OnBeforeDispose(v8::Isolate* isolate) override {}
+  void OnBeforeMicrotasksRunnerDispose(v8::Isolate* isolate) override;
+  void OnDisposed() override {}
+
+  // Make public for cppgc::MakeGarbageCollected.
+  explicit GlobalShortcut(v8::Isolate* isolate);
+  ~GlobalShortcut() override;
 
   // disable copy
   GlobalShortcut(const GlobalShortcut&) = delete;
   GlobalShortcut& operator=(const GlobalShortcut&) = delete;
-
- protected:
-  GlobalShortcut();
-  ~GlobalShortcut() override;
 
  private:
   typedef std::map<ui::Accelerator, base::RepeatingClosure>
       AcceleratorCallbackMap;
   typedef std::map<std::string, base::RepeatingClosure> CommandCallbackMap;
 
+  void Dispose();
   bool RegisterAll(const std::vector<ui::Accelerator>& accelerators,
                    const base::RepeatingClosure& callback);
   bool Register(const ui::Accelerator& accelerator,
@@ -55,6 +60,7 @@ class GlobalShortcut final
   void Unregister(const ui::Accelerator& accelerator);
   void UnregisterSome(const std::vector<ui::Accelerator>& accelerators);
   void UnregisterAll();
+  void UnregisterAllInternal();
   void SetSuspended(bool suspend);
   bool IsSuspended();
 
@@ -65,8 +71,9 @@ class GlobalShortcut final
 
   AcceleratorCallbackMap accelerator_callback_map_;
   CommandCallbackMap command_callback_map_;
+  bool is_disposed_ = false;
 
-  base::WeakPtrFactory<GlobalShortcut> weak_ptr_factory_{this};
+  gin::WeakCellFactory<GlobalShortcut> weak_factory_{this};
 };
 
 }  // namespace electron::api

--- a/shell/common/gin_helper/wrappable_pointer_tags.h
+++ b/shell/common/gin_helper/wrappable_pointer_tags.h
@@ -16,6 +16,7 @@ enum ElectronWrappablePointerTag : uint16_t {
   kElectronDataPipeHolder,                  // electron::api::DataPipeHolder
   kElectronDebugger,                        // electron::api::Debugger
   kElectronEvent,                           // gin_helper::internal::Event
+  kElectronGlobalShortcut,                  // electron::api::GlobalShortcut
   kElectronExtensions,                      // electron::api::Extensions
   kElectronMenu,                            // electron::api::Menu
   kElectronNetLog,                          // electron::api::NetLog

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -4,9 +4,14 @@ declare const BUILDFLAG: (flag: boolean) => boolean;
 
 declare namespace NodeJS {
   interface ModuleInternal extends NodeJS.Module {
-    new(id: string, parent?: NodeJS.Module | null): NodeJS.Module;
+    new (id: string, parent?: NodeJS.Module | null): NodeJS.Module;
     _load(request: string, parent?: NodeJS.Module | null, isMain?: boolean): any;
-    _resolveFilename(request: string, parent?: NodeJS.Module | null, isMain?: boolean, options?: { paths: string[] }): string;
+    _resolveFilename(
+      request: string,
+      parent?: NodeJS.Module | null,
+      isMain?: boolean,
+      options?: { paths: string[] }
+    ): string;
     _preloadModules(requests: string[]): void;
     _nodeModulePaths(from: string): string[];
     _extensions: Record<string, (module: NodeJS.Module, filename: string) => any>;
@@ -27,7 +32,7 @@ declare namespace NodeJS {
     send(internal: boolean, channel: string, args: any[]): void;
     sendSync(internal: boolean, channel: string, args: any[]): any;
     sendToHost(channel: string, args: any[]): void;
-    invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string, result: T }>;
+    invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string; result: T }>;
     postMessage(channel: string, message: any, transferables: MessagePort[]): void;
   }
 
@@ -45,15 +50,17 @@ declare namespace NodeJS {
   }
 
   type CrashReporterBinding = Omit<Electron.CrashReporter, 'start'> & {
-    start(submitUrl: string,
+    start(
+      submitUrl: string,
       uploadToServer: boolean,
       ignoreSystemCrashHandler: boolean,
       rateLimit: boolean,
       compress: boolean,
       globalExtra: Record<string, string>,
       extra: Record<string, string>,
-      isNodeProcess: boolean): void;
-  }
+      isNodeProcess: boolean
+    ): void;
+  };
 
   interface EnvironmentBinding {
     getVar(name: string): string | null;
@@ -68,14 +75,14 @@ declare namespace NodeJS {
     integrity?: {
       algorithm: 'SHA256';
       hash: string;
-    }
+    };
   };
 
   type AsarFileStat = {
     size: number;
     offset: number;
     type: number;
-  }
+  };
 
   interface AsarArchive {
     getFileInfo(path: string): AsarFileInfo | false;
@@ -87,14 +94,16 @@ declare namespace NodeJS {
   }
 
   interface AsarBinding {
-    Archive: { new(path: string): AsarArchive };
-    splitPath(path: string): {
-      isAsar: false;
-    } | {
-      isAsar: true;
-      asarPath: string;
-      filePath: string;
-    };
+    Archive: { new (path: string): AsarArchive };
+    splitPath(path: string):
+      | {
+          isAsar: false;
+        }
+      | {
+          isAsar: true;
+          asarPath: string;
+          filePath: string;
+        };
   }
 
   interface NetBinding {
@@ -137,13 +146,18 @@ declare namespace NodeJS {
   }
 
   interface SessionBinding {
-    fromPartition: typeof Electron.Session.fromPartition,
-    fromPath: typeof Electron.Session.fromPath,
-    Session: typeof Electron.Session
+    fromPartition: typeof Electron.Session.fromPartition;
+    fromPath: typeof Electron.Session.fromPath;
+    Session: typeof Electron.Session;
   }
 
   interface WebViewManagerBinding {
-    addGuest(guestInstanceId: number, embedder: Electron.WebContents, guest: Electron.WebContents, webPreferences: Electron.WebPreferences): void;
+    addGuest(
+      guestInstanceId: number,
+      embedder: Electron.WebContents,
+      guest: Electron.WebContents,
+      webPreferences: Electron.WebPreferences
+    ): void;
     removeGuest(embedder: Electron.WebContents, guestInstanceId: number): void;
   }
 
@@ -201,8 +215,8 @@ declare namespace NodeJS {
   type ResponseHead = {
     statusCode: number;
     statusMessage: string;
-    httpVersion: { major: number, minor: number };
-    rawHeaders: { key: string, value: string }[];
+    httpVersion: { major: number; minor: number };
+    rawHeaders: { key: string; value: string }[];
     headers: Record<string, string[]>;
   };
 
@@ -214,16 +228,29 @@ declare namespace NodeJS {
     newReferrer: string;
     insecureSchemeWasUpgraded: boolean;
     isSignedExchangeFallbackRedirect: boolean;
-  }
+  };
 
   interface URLLoader extends EventEmitter {
     cancel(): void;
     on(eventName: 'data', listener: (event: any, data: ArrayBuffer, resume: () => void) => void): this;
-    on(eventName: 'response-started', listener: (event: any, finalUrl: string, responseHead: ResponseHead) => void): this;
+    on(
+      eventName: 'response-started',
+      listener: (event: any, finalUrl: string, responseHead: ResponseHead) => void
+    ): this;
     on(eventName: 'complete', listener: (event: any) => void): this;
     on(eventName: 'error', listener: (event: any, netErrorString: string) => void): this;
-    on(eventName: 'login', listener: (event: any, authInfo: Electron.AuthInfo, callback: (username?: string, password?: string) => void) => void): this;
-    on(eventName: 'redirect', listener: (event: any, redirectInfo: RedirectInfo, headers: Record<string, string>) => void): this;
+    on(
+      eventName: 'login',
+      listener: (
+        event: any,
+        authInfo: Electron.AuthInfo,
+        callback: (username?: string, password?: string) => void
+      ) => void
+    ): this;
+    on(
+      eventName: 'redirect',
+      listener: (event: any, redirectInfo: RedirectInfo, headers: Record<string, string>) => void
+    ): this;
     on(eventName: 'upload-progress', listener: (event: any, position: number, total: number) => void): this;
     on(eventName: 'download-progress', listener: (event: any, current: number) => void): this;
   }
@@ -241,15 +268,20 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_common_net'): NetBinding;
     _linkedBinding(name: 'electron_common_shell'): Electron.Shell;
     _linkedBinding(name: 'electron_common_v8_util'): V8UtilBinding;
-    _linkedBinding(name: 'electron_browser_app'): { app: Electron.App, App: Function };
+    _linkedBinding(name: 'electron_browser_app'): { app: Electron.App; App: Function };
     _linkedBinding(name: 'electron_browser_auto_updater'): { autoUpdater: Electron.AutoUpdater };
     _linkedBinding(name: 'electron_browser_crash_reporter'): CrashReporterBinding;
-    _linkedBinding(name: 'electron_browser_desktop_capturer'): { createDesktopCapturer(): ElectronInternal.DesktopCapturer; isDisplayMediaSystemPickerAvailable(): boolean; };
-    _linkedBinding(name: 'electron_browser_event_emitter'): { setEventEmitterPrototype(prototype: Object): void; };
-    _linkedBinding(name: 'electron_browser_global_shortcut'): { globalShortcut: Electron.GlobalShortcut };
+    _linkedBinding(name: 'electron_browser_desktop_capturer'): {
+      createDesktopCapturer(): ElectronInternal.DesktopCapturer;
+      isDisplayMediaSystemPickerAvailable(): boolean;
+    };
+    _linkedBinding(name: 'electron_browser_event_emitter'): { setEventEmitterPrototype(prototype: Object): void };
+    _linkedBinding(name: 'electron_browser_global_shortcut'): { createGlobalShortcut(): Electron.GlobalShortcut };
     _linkedBinding(name: 'electron_browser_image_view'): { ImageView: any };
     _linkedBinding(name: 'electron_browser_in_app_purchase'): { inAppPurchase: Electron.InAppPurchase };
-    _linkedBinding(name: 'electron_browser_message_port'): { createPair(): { port1: Electron.MessagePortMain, port2: Electron.MessagePortMain }; };
+    _linkedBinding(name: 'electron_browser_message_port'): {
+      createPair(): { port1: Electron.MessagePortMain; port2: Electron.MessagePortMain };
+    };
     _linkedBinding(name: 'electron_browser_native_theme'): { nativeTheme: Electron.NativeTheme };
     _linkedBinding(name: 'electron_browser_notification'): NotificationBinding;
     _linkedBinding(name: 'electron_browser_power_monitor'): PowerMonitorBinding;
@@ -308,19 +340,19 @@ declare interface Window {
   ELECTRON_DISABLE_SECURITY_WARNINGS?: boolean;
   ELECTRON_ENABLE_SECURITY_WARNINGS?: boolean;
   InspectorFrontendHost?: {
-    showContextMenuAtPoint: (x: number, y: number, items: ContextMenuItem[]) => void
+    showContextMenuAtPoint: (x: number, y: number, items: ContextMenuItem[]) => void;
   };
   DevToolsAPI?: {
     contextMenuItemSelected: (id: number) => void;
-    contextMenuCleared: () => void
+    contextMenuCleared: () => void;
   };
   UI?: {
-    createFileSelectorElement: (callback: () => void) => HTMLSpanElement
+    createFileSelectorElement: (callback: () => void) => HTMLSpanElement;
   };
   Persistence?: {
     FileSystemWorkspaceBinding: {
       completeURL: (project: string, path: string) => string;
-    }
+    };
   };
   WebView: typeof ElectronInternal.WebViewElement;
   trustedTypes: TrustedTypePolicyFactory;
@@ -359,7 +391,7 @@ interface TrustedTypePolicyOptions {
 // https://w3c.github.io/webappsec-trusted-types/dist/spec/#typedef-trustedtypepolicyfactory
 
 interface TrustedTypePolicyFactory {
-  createPolicy(policyName: string, policyOptions: TrustedTypePolicyOptions): TrustedTypePolicy
+  createPolicy(policyName: string, policyOptions: TrustedTypePolicyOptions): TrustedTypePolicy;
   isHTML(value: any): boolean;
   isScript(value: any): boolean;
   isScriptURL(value: any): boolean;


### PR DESCRIPTION
Manually backport #50192. See that PR for details.

Notes: none.