### PR TITLE
fix: remove existing versions of Homebrew in CI before pinning

### DIFF
--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -4,11 +4,11 @@ inputs:
   version:
     description: "Homebrew release tag to install"
     required: false
-    default: "5.1.10"
+    default: "5.1.12"
   sha256:
     description: "SHA256 checksum of the Homebrew package"
     required: false
-    default: "ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462"
+    default: "778f46be6045cb9876afd12badefb7b77fd93355c6cfd95223bfbd85ed978171"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -1,16 +1,16 @@
-name: 'Install Homebrew'
-description: 'Installs a pinned Homebrew release on macOS runners'
+name: "Install Homebrew"
+description: "Installs a pinned Homebrew release on macOS runners"
 inputs:
   version:
-    description: 'Homebrew release tag to install'
+    description: "Homebrew release tag to install"
     required: false
-    default: '5.1.10'
+    default: "5.1.10"
   sha256:
-    description: 'SHA256 checksum of the Homebrew package'
+    description: "SHA256 checksum of the Homebrew package"
     required: false
-    default: 'ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462'
+    default: "ece2e1c1f8e34683bd29b324f70c405b48c210c47f2b71c06131fde5492f2462"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install pinned Homebrew
       shell: bash
@@ -25,10 +25,16 @@ runs:
         target_version='${{ inputs.version }}'
         brew_bin=''
 
+        echo "Pinning Homebrew to version ${target_version}..."
+
+        echo "Checking for existing Homebrew installation..."
+
         for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
           if [[ -x "${candidate}" ]]; then
             current_version="$("${candidate}" --version | awk 'NR == 1 { print $2 }')"
+            echo "Found Homebrew version ${current_version} in ${candidate}..."
             if [[ "${current_version}" == "${target_version}" ]]; then
+              echo "Homebrew at ${candidate} is already at the target version ${target_version}..."
               brew_bin="${candidate}"
               break
             fi
@@ -36,12 +42,17 @@ runs:
         done
 
         if [[ -z "${brew_bin}" ]]; then
+          echo "No matching Homebrew version found, downloading and installing..."
           pkg_path="${RUNNER_TEMP}/Homebrew.pkg"
           download_url="https://github.com/Homebrew/brew/releases/download/${target_version}/Homebrew.pkg"
+
+          echo "Downloading Homebrew package from ${download_url}..."
 
           curl --fail --location --silent --show-error \
             --output "${pkg_path}" \
             "${download_url}"
+
+          echo "Downloaded Homebrew package to ${pkg_path}..."
 
           echo "Verifying Homebrew package SHA256 checksum..."
           if ! printf '%s  %s\n' "${{ inputs.sha256 }}" "${pkg_path}" | shasum -a 256 -c; then
@@ -59,10 +70,17 @@ runs:
 
           sudo installer -pkg "${pkg_path}" -target /
 
+          echo "Installed Homebrew package to /..."
+
+          echo "Checking for Homebrew installation again..."
+
           for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
             if [[ -x "${candidate}" ]]; then
+              echo "Found Homebrew version ${current_version} in ${candidate}..."
               current_version="$("${candidate}" --version | awk 'NR == 1 { print $2 }')"
+              echo "Found Homebrew version ${current_version} in ${candidate}..."
               if [[ "${current_version}" == "${target_version}" ]]; then
+                echo "Homebrew at ${candidate} is at the target version ${target_version}..."
                 brew_bin="${candidate}"
                 break
               fi

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -84,7 +84,6 @@ runs:
 
           for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
             if [[ -x "${candidate}" ]]; then
-              echo "Found Homebrew version ${current_version} in ${candidate}..."
               current_version="$("${candidate}" --version | awk 'NR == 1 { print $2 }')"
               echo "Found Homebrew version ${current_version} in ${candidate}..."
               if [[ "${current_version}" == "${target_version}" ]]; then

--- a/.github/actions/install-homebrew/action.yml
+++ b/.github/actions/install-homebrew/action.yml
@@ -42,7 +42,15 @@ runs:
         done
 
         if [[ -z "${brew_bin}" ]]; then
-          echo "No matching Homebrew version found, downloading and installing..."
+          echo "No matching Homebrew version found, pinning to ${target_version}..."
+
+          echo "Removing existing Homebrew installation..."
+          sudo rm -rf /{usr/local,opt/homebrew}/{Cellar,Caskroom,Homebrew/Library/Taps}
+          brew cleanup --prune-prefix
+          sudo rm -rf /usr/local/{bin/brew,Homebrew} /opt/homebrew
+
+          echo "Downloading and installing Homebrew package..."
+
           pkg_path="${RUNNER_TEMP}/Homebrew.pkg"
           download_url="https://github.com/Homebrew/brew/releases/download/${target_version}/Homebrew.pkg"
 


### PR DESCRIPTION
#### Description of Change

This actions was meant to pin Homebrew to a specific version. Unfortunately, [the `postinstall` script reaches out and sets the version to that of the `latest_tag`,](https://github.com/Homebrew/brew/blob/5.1.13/package/scripts/postinstall#L49-L51) which still pointed to the newer version.

The proper approach appears to be to remove existing versions of Homebrew _first_. [This is what Homebrew themselves do when testing their releases.](https://github.com/Homebrew/brew/blob/5.1.13/.github/workflows/release.yml#L232-L234) It is slightly aggressive, and may remove some stuff GitHub puts there for the runners, but it does work at unblocking us here by restoring our ability to pin.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: None.
