### PR TITLE
fix: implement setIgnoreMouseEvents on Wayland

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -71,6 +71,7 @@
 #include "ui/linux/linux_ui_factory.h"
 #include "ui/linux/window_frame_provider.h"
 #include "ui/views/widget/desktop_aura/desktop_native_widget_aura.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
 #include "ui/views/window/frame_view_linux.h"
 #include "ui/views/window/native_frame_view.h"
 
@@ -1393,6 +1394,16 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
               static_cast<x11::Window>(GetAcceleratedWidget()),
           .source_bitmap = x11::Pixmap::None,
       });
+    }
+  } else {
+    // Wayland: delegate to the host so the input region of the underlying
+    // surface is updated through UpdateFrameHints(), which matches the
+    // per-platform behavior of this API (the whole window passes events
+    // through, including any CSD chrome).
+    if (auto* host = views::DesktopWindowTreeHostLinux::GetHostForWidget(
+            GetAcceleratedWidget())) {
+      static_cast<ElectronDesktopWindowTreeHostLinux*>(host)
+          ->SetIgnoreMouseEvents(ignore);
     }
   }
 #endif

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -11,11 +11,13 @@
 #include <vector>
 
 #include "base/i18n/rtl.h"
+#include "base/no_destructor.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/linux/x11_util.h"
 #include "shell/browser/native_window_views.h"
 #include "ui/aura/window_delegate.h"
 #include "ui/base/hit_test.h"
+#include "ui/compositor/compositor.h"
 #include "ui/display/screen.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/linux/linux_ui.h"
@@ -212,10 +214,34 @@ void ElectronDesktopWindowTreeHostLinux::OnDeviceScaleFactorChanged() {
   UpdateFrameHints();
 }
 
+void ElectronDesktopWindowTreeHostLinux::SetIgnoreMouseEvents(bool ignore) {
+  if (ignore_mouse_events_ == ignore)
+    return;
+  ignore_mouse_events_ = ignore;
+  UpdateFrameHints();
+  // The input region was queued on the surface's pending state, but it is
+  // only flushed to the compositor when the next frame is submitted. On an
+  // idle transparent overlay (no animation, no GL context), that can be
+  // many seconds away, so callers see a delay before clicks pass through.
+  // Force a redraw so the change takes effect immediately.
+  if (auto* c = compositor())
+    c->ScheduleFullRedraw();
+}
+
 void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
+  // An empty input region means no part of the surface receives pointer
+  // events, so the compositor passes them through to whatever is below.
+  // This mirrors the X11 ShapeInput / Win32 WS_EX_TRANSPARENT behavior of
+  // setIgnoreMouseEvents() and applies regardless of whether the window
+  // has a frame (callers asking to ignore mouse events accept that any
+  // CSD chrome on the window also becomes non-interactive).
+  static const base::NoDestructor<std::optional<std::vector<gfx::Rect>>>
+      kIgnoreRegion{std::vector<gfx::Rect>{gfx::Rect()}};
+
   auto* fvl = native_window_view_->GetFrameViewLinux();
   if (!fvl || !fvl->ShouldDrawRestoredFrameShadow()) {
-    platform_window()->SetInputRegion(std::nullopt);
+    platform_window()->SetInputRegion(ignore_mouse_events_ ? *kIgnoreRegion
+                                                           : std::nullopt);
     if (ui::OzonePlatform::GetInstance()->IsWindowCompositingSupported()) {
       if (native_window_view_->IsTranslucent()) {
         platform_window()->SetOpaqueRegion(std::vector<gfx::Rect>{});
@@ -231,6 +257,11 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
   }
 
   views::DesktopWindowTreeHostLinux::UpdateFrameHints();
+  if (ignore_mouse_events_) {
+    // Override the input region set by the base class so the ignore state
+    // also covers windows that draw CSD frame shadows.
+    platform_window()->SetInputRegion(*kIgnoreRegion);
+  }
   // Clear the opaque region for translucent windows.
   if (native_window_view_->IsTranslucent() &&
       views::Widget::IsWindowCompositingSupported()) {

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.h
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.h
@@ -41,6 +41,12 @@ class ElectronDesktopWindowTreeHostLinux
 
   bool SupportsClientFrameShadow() const;
 
+  // Controls whether mouse events are ignored on this window. On Wayland
+  // this is implemented via the input region of the underlying surface and
+  // takes effect through UpdateFrameHints(); on X11 the shape extension is
+  // used directly from NativeWindowViews.
+  void SetIgnoreMouseEvents(bool ignore);
+
  protected:
   // views::DesktopWindowTreeHostLinuxImpl:
   void OnWidgetInitDone() override;
@@ -87,6 +93,7 @@ class ElectronDesktopWindowTreeHostLinux
   base::ScopedObservation<ui::LinuxUi, ui::DeviceScaleFactorObserver>
       scale_observation_{this};
   ui::PlatformWindowState window_state_ = ui::PlatformWindowState::kUnknown;
+  bool ignore_mouse_events_ = false;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

On Wayland the X11 code path inside `NativeWindowViews::SetIgnoreMouseEvents`
never executed, so transparent overlay windows (e.g. desktop pets) kept
intercepting pointer events instead of passing them through.

This wires the Wayland path to the platform window's input region via
`ElectronDesktopWindowTreeHostLinux::SetIgnoreMouseEvents`, persisting the
new state on the host so subsequent `UpdateFrameHints()` calls (bounds,
theme, scale changes) keep the requested behavior. The input region is
set to a single empty rect, so no part of the surface receives pointer
events — the compositor passes them through to whatever sits below. This
mirrors the existing X11 ShapeInput and Win32 `WS_EX_TRANSPARENT`
behavior of the same API. The override is applied on both branches of
`UpdateFrameHints()` (frameless and CSD-frame-shadow) so the ignore state
covers all window styles.

This supersedes #51144 by @wislap, who is a friend of mine and has agreed
to hand the change off. The new revision incorporates the review feedback
that was left there:

- @MarshallOfSound — state persisted on the host across `UpdateFrameHints()`
  invocations; `static_cast` no longer wrapped in a misleading
  `if (auto* x = static_cast<...>(...))`; include ordering fixed.
- @ckerr — lint failures resolved (verified locally with
  `script/run-clang-format.py` + `cpplint` using the project's filter set).
- @aiddya — on the original review you raised that translucent CSD
  windows would lose their move/resize/control affordances when the
  whole input region is dropped. After more thought I think matching
  the platform-consistent behavior is the right call: `setIgnoreMouseEvents`
  on X11, Win32 and macOS already makes the whole window non-interactive,
  including any chrome, and the API contract is *"all mouse events
  happened in this window will be passed to the window below"*. Apps
  that need parts of the surface to remain interactive should not toggle
  this flag on a CSD window. Happy to revisit if you'd prefer a chrome-
  preserving variant gated behind an option.

The original PR also had a latent compile error (the new method was
declared `protected` but called from outside the class); it is now `public`.

> Note / follow-up (#51808): Further investigation found a residual
reliability issue when setIgnoreMouseEvents runs on the software / non-GL
rendering path - GLSurfaceWayland is never created there, so
apply_state_immediately_ stays false and the input region change waits for
the next frame submission. On the GL/EGL path (typical GPU desktop),
GLSurfaceWayland forces immediate state application, so it should flush
synchronously. Tracked separately in #51808 so it doesn't block this PR.

#### Verification

Built locally (`e sync` + `e build`) and exercised on a GNOME-on-Wayland
session with a minimal Electron app:

- Frameless, transparent, `alwaysOnTop` overlay window over another
  application window.
- Initial state (`setIgnoreMouseEvents(false)`): clicks and the cursor
  shape land on the overlay's contents — expected.
- After `setIgnoreMouseEvents(true)`: the cursor shape changes to that of
  the underlying window, and clicks reach the underlying window (it
  gains focus / its controls activate) — confirms the input region is
  empty and Wayland is passing events through.
- Toggling back to `false` restores normal interaction.

Also ran the project's C++ lint locally (`script/run-clang-format.py` +
`cpplint` with electron's filter set) — clean.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide (no doc change needed; this is a platform-enablement fix for an existing API)

> Items removed per the template's "Remove items that do not apply" guidance:
> - **`npm test` passes**: I have not run the full spec suite. The change
>   is a small, isolated Wayland-only code path; existing tests don't
>   cover Wayland input-region behavior, so a green or red local run
>   wouldn't tell us much. Happy to run a targeted subset if maintainers
>   point at one.
> - **Tests changed/added**: Wayland input-region behavior is not
>   trivially testable in CI (no compositor in the test env), and a
>   smoke test on non-Wayland Linux would pass even without this fix.
>   Happy to add one if the maintainers want it.

#### Release Notes

Notes: Fixed `setIgnoreMouseEvents()` not having any effect on Wayland.