### PR TITLE
feat: add view.setLayout API exposing Chromium layout managers

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -175,6 +175,25 @@ struct Converter<views::MinimumFlexSizeRule> {
     }
     return true;
   }
+
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   views::MinimumFlexSizeRule in) {
+    switch (in) {
+      case views::MinimumFlexSizeRule::kScaleToZero:
+        return gin::StringToV8(isolate, "scale-to-zero");
+      case views::MinimumFlexSizeRule::kScaleToMinimumSnapToZero:
+        return gin::StringToV8(isolate, "scale-to-minimum-snap-to-zero");
+      case views::MinimumFlexSizeRule::kPreferredSnapToZero:
+        return gin::StringToV8(isolate, "preferred-snap-to-zero");
+      case views::MinimumFlexSizeRule::kScaleToMinimum:
+        return gin::StringToV8(isolate, "scale-to-minimum");
+      case views::MinimumFlexSizeRule::kPreferredSnapToMinimum:
+        return gin::StringToV8(isolate, "preferred-snap-to-minimum");
+      case views::MinimumFlexSizeRule::kPreferred:
+        return gin::StringToV8(isolate, "preferred");
+    }
+    return gin::StringToV8(isolate, "preferred");
+  }
 };
 
 template <>
@@ -193,6 +212,19 @@ struct Converter<views::MaximumFlexSizeRule> {
       return false;
     }
     return true;
+  }
+
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   views::MaximumFlexSizeRule in) {
+    switch (in) {
+      case views::MaximumFlexSizeRule::kPreferred:
+        return gin::StringToV8(isolate, "preferred");
+      case views::MaximumFlexSizeRule::kScaleToMaximum:
+        return gin::StringToV8(isolate, "scale-to-maximum");
+      case views::MaximumFlexSizeRule::kUnbounded:
+        return gin::StringToV8(isolate, "unbounded");
+    }
+    return gin::StringToV8(isolate, "preferred");
   }
 };
 
@@ -271,10 +303,11 @@ class JSLayoutManager : public views::LayoutManagerBase {
     base::AutoReset<bool> reset(&is_dispatching_, true);
     views::ProposedLayout result = layout_callback_.Run(size_bounds);
     if (try_catch.HasCaught()) {
-      // Best-effort: fall back to an empty layout and re-throw so Node's
-      // uncaught-exception handler can pick it up. Without this guard a
-      // thrown JS exception would propagate into Chromium's view machinery
-      // and crash the main process.
+      // Without this guard, a JS exception thrown from the callback would
+      // propagate into Chromium's view machinery and crash the main process.
+      // ReThrow() leaves the exception pending on the isolate; delivery to
+      // Node's uncaught-exception handler is best-effort and depends on when
+      // control next returns to JS.
       try_catch.ReThrow();
       return views::ProposedLayout{};
     }
@@ -646,6 +679,8 @@ void View::SetLayoutFlex(v8::Isolate* isolate, v8::Local<v8::Value> spec) {
     return;
   if (spec.IsEmpty() || spec->IsNullOrUndefined()) {
     view_->ClearProperty(views::kFlexBehaviorKey);
+    last_min_flex_rule_.reset();
+    last_max_flex_rule_.reset();
     view_->InvalidateLayout();
     return;
   }
@@ -654,6 +689,21 @@ void View::SetLayoutFlex(v8::Isolate* isolate, v8::Local<v8::Value> spec) {
     gin_helper::ErrorThrower(isolate).ThrowTypeError(
         "Invalid flex specification");
     return;
+  }
+  // Cache min/max so getLayoutFlex can return them — FlexSpecification has no
+  // accessor for these once they're baked into its FlexRule closure.
+  gin_helper::Dictionary dict;
+  if (gin::ConvertFromV8(isolate, spec, &dict)) {
+    views::MinimumFlexSizeRule cached_min;
+    if (dict.Get("minimum", &cached_min))
+      last_min_flex_rule_ = cached_min;
+    else
+      last_min_flex_rule_.reset();
+    views::MaximumFlexSizeRule cached_max;
+    if (dict.Get("maximum", &cached_max))
+      last_max_flex_rule_ = cached_max;
+    else
+      last_max_flex_rule_.reset();
   }
   view_->SetProperty(views::kFlexBehaviorKey, fs);
   view_->InvalidateLayout();
@@ -736,6 +786,8 @@ void View::SetBoxFlex(v8::Isolate* isolate,
   bool use_min_size = false;
   args->GetNext(&use_min_size);
   auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  if (!layout)
+    return;
   layout->SetFlexForView(child->view(), weight, use_min_size);
   view_->InvalidateLayout();
 }
@@ -747,7 +799,13 @@ v8::Local<v8::Value> View::GetLayoutFlex(v8::Isolate* isolate) const {
       view_->GetProperty(views::kFlexBehaviorKey);
   if (!spec)
     return v8::Null(isolate);
-  return gin::ConvertToV8(isolate, *spec);
+  gin::DataObjectBuilder builder(isolate);
+  builder.Set("weight", spec->weight()).Set("order", spec->order());
+  if (last_min_flex_rule_)
+    builder.Set("minimum", *last_min_flex_rule_);
+  if (last_max_flex_rule_)
+    builder.Set("maximum", *last_max_flex_rule_);
+  return builder.Build();
 }
 
 std::string View::GetOrientation() const {
@@ -755,12 +813,16 @@ std::string View::GetOrientation() const {
     return "";
   if (layout_type_ == LayoutType::kBox) {
     auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+    if (!layout)
+      return "";
     return layout->GetOrientation() == views::BoxLayout::Orientation::kHorizontal
                ? "horizontal"
                : "vertical";
   }
   if (layout_type_ == LayoutType::kFlex) {
     auto* layout = static_cast<views::FlexLayout*>(view_->GetLayoutManager());
+    if (!layout)
+      return "";
     return layout->orientation() == views::LayoutOrientation::kHorizontal
                ? "horizontal"
                : "vertical";
@@ -772,6 +834,8 @@ std::string View::GetMainAxisAlignment() const {
   if (!view_ || layout_type_ != LayoutType::kBox)
     return "";
   auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  if (!layout)
+    return "";
   switch (layout->main_axis_alignment()) {
     case views::LayoutAlignment::kStart:
       return "start";
@@ -791,6 +855,8 @@ std::string View::GetCrossAxisAlignment() const {
   if (!view_ || layout_type_ != LayoutType::kBox)
     return "";
   auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  if (!layout)
+    return "";
   switch (layout->cross_axis_alignment()) {
     case views::LayoutAlignment::kStart:
       return "start";
@@ -810,6 +876,8 @@ int View::GetBetweenChildSpacing() const {
   if (!view_ || layout_type_ != LayoutType::kBox)
     return 0;
   auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  if (!layout)
+    return 0;
   return layout->between_child_spacing();
 }
 
@@ -817,6 +885,8 @@ gfx::Insets View::GetInsideBorderInsets() const {
   if (!view_ || layout_type_ != LayoutType::kBox)
     return gfx::Insets();
   auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  if (!layout)
+    return gfx::Insets();
   return layout->inside_border_insets();
 }
 

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -236,8 +236,10 @@ struct Converter<views::FlexSpecification> {
     gin_helper::Dictionary dict;
     if (!gin::ConvertFromV8(isolate, val, &dict))
       return false;
-    views::MinimumFlexSizeRule min_rule = views::MinimumFlexSizeRule::kPreferred;
-    views::MaximumFlexSizeRule max_rule = views::MaximumFlexSizeRule::kPreferred;
+    views::MinimumFlexSizeRule min_rule =
+        views::MinimumFlexSizeRule::kPreferred;
+    views::MaximumFlexSizeRule max_rule =
+        views::MaximumFlexSizeRule::kPreferred;
     dict.Get("minimum", &min_rule);
     dict.Get("maximum", &max_rule);
     int weight = 0;
@@ -319,11 +321,16 @@ class JSLayoutManager : public views::LayoutManagerBase {
 namespace {
 std::string AlignmentToString(views::LayoutAlignment a) {
   switch (a) {
-    case views::LayoutAlignment::kStart:    return "start";
-    case views::LayoutAlignment::kCenter:   return "center";
-    case views::LayoutAlignment::kEnd:      return "end";
-    case views::LayoutAlignment::kStretch:  return "stretch";
-    case views::LayoutAlignment::kBaseline: return "baseline";
+    case views::LayoutAlignment::kStart:
+      return "start";
+    case views::LayoutAlignment::kCenter:
+      return "center";
+    case views::LayoutAlignment::kEnd:
+      return "end";
+    case views::LayoutAlignment::kStretch:
+      return "stretch";
+    case views::LayoutAlignment::kBaseline:
+      return "baseline";
   }
   return "";
 }
@@ -591,8 +598,8 @@ void View::SetLayout(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   // Custom JS layout callback path.
   LayoutCallback calculate_proposed_layout;
   if (dict.Get("calculateProposedLayout", &calculate_proposed_layout)) {
-    auto lm = std::make_unique<JSLayoutManager>(
-        std::move(calculate_proposed_layout));
+    auto lm =
+        std::make_unique<JSLayoutManager>(std::move(calculate_proposed_layout));
     js_layout_manager_ = lm.get();
     layout_type_ = LayoutType::kJs;
     view_->SetLayoutManager(std::move(lm));
@@ -834,7 +841,8 @@ std::string View::GetOrientation() const {
     auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
     if (!layout)
       return "";
-    return layout->GetOrientation() == views::BoxLayout::Orientation::kHorizontal
+    return layout->GetOrientation() ==
+                   views::BoxLayout::Orientation::kHorizontal
                ? "horizontal"
                : "vertical";
   }

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "ash/style/rounded_rect_cutout_path_builder.h"
+#include "base/auto_reset.h"
 #include "gin/data_object_builder.h"
 #include "gin/wrappable.h"
 #include "shell/browser/javascript_environment.h"
@@ -23,8 +24,12 @@
 #include "ui/compositor/layer.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
+#include "ui/views/layout/box_layout.h"
+#include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
+#include "ui/views/layout/flex_layout_types.h"
 #include "ui/views/layout/layout_manager_base.h"
+#include "ui/views/view_class_properties.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "shell/browser/animation_util.h"
@@ -148,6 +153,81 @@ struct Converter<views::SizeBounds> {
 };
 
 template <>
+struct Converter<views::MinimumFlexSizeRule> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     views::MinimumFlexSizeRule* out) {
+    std::string s = base::ToLowerASCII(gin::V8ToString(isolate, val));
+    if (s == "scale-to-zero") {
+      *out = views::MinimumFlexSizeRule::kScaleToZero;
+    } else if (s == "scale-to-minimum-snap-to-zero") {
+      *out = views::MinimumFlexSizeRule::kScaleToMinimumSnapToZero;
+    } else if (s == "preferred-snap-to-zero") {
+      *out = views::MinimumFlexSizeRule::kPreferredSnapToZero;
+    } else if (s == "scale-to-minimum") {
+      *out = views::MinimumFlexSizeRule::kScaleToMinimum;
+    } else if (s == "preferred-snap-to-minimum") {
+      *out = views::MinimumFlexSizeRule::kPreferredSnapToMinimum;
+    } else if (s == "preferred") {
+      *out = views::MinimumFlexSizeRule::kPreferred;
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
+template <>
+struct Converter<views::MaximumFlexSizeRule> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     views::MaximumFlexSizeRule* out) {
+    std::string s = base::ToLowerASCII(gin::V8ToString(isolate, val));
+    if (s == "preferred") {
+      *out = views::MaximumFlexSizeRule::kPreferred;
+    } else if (s == "scale-to-maximum") {
+      *out = views::MaximumFlexSizeRule::kScaleToMaximum;
+    } else if (s == "unbounded") {
+      *out = views::MaximumFlexSizeRule::kUnbounded;
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
+template <>
+struct Converter<views::FlexSpecification> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     views::FlexSpecification* out) {
+    gin_helper::Dictionary dict;
+    if (!gin::ConvertFromV8(isolate, val, &dict))
+      return false;
+    views::MinimumFlexSizeRule min_rule = views::MinimumFlexSizeRule::kPreferred;
+    views::MaximumFlexSizeRule max_rule = views::MaximumFlexSizeRule::kPreferred;
+    dict.Get("minimum", &min_rule);
+    dict.Get("maximum", &max_rule);
+    int weight = 0;
+    int order = 1;
+    dict.Get("weight", &weight);
+    dict.Get("order", &order);
+    *out = views::FlexSpecification(min_rule, max_rule)
+               .WithWeight(weight)
+               .WithOrder(order);
+    return true;
+  }
+
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const views::FlexSpecification& in) {
+    return gin::DataObjectBuilder(isolate)
+        .Set("weight", in.weight())
+        .Set("order", in.order())
+        .Build();
+  }
+};
+
+template <>
 struct Converter<gfx::Tween::Type> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
@@ -180,16 +260,30 @@ class JSLayoutManager : public views::LayoutManagerBase {
       : layout_callback_(std::move(layout_callback)) {}
   ~JSLayoutManager() override = default;
 
+  bool is_dispatching() const { return is_dispatching_; }
+
   // views::LayoutManagerBase
   views::ProposedLayout CalculateProposedLayout(
       const views::SizeBounds& size_bounds) const override {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
-    return layout_callback_.Run(size_bounds);
+    v8::TryCatch try_catch(isolate);
+    base::AutoReset<bool> reset(&is_dispatching_, true);
+    views::ProposedLayout result = layout_callback_.Run(size_bounds);
+    if (try_catch.HasCaught()) {
+      // Best-effort: fall back to an empty layout and re-throw so Node's
+      // uncaught-exception handler can pick it up. Without this guard a
+      // thrown JS exception would propagate into Chromium's view machinery
+      // and crash the main process.
+      try_catch.ReThrow();
+      return views::ProposedLayout{};
+    }
+    return result;
   }
 
  private:
   LayoutCallback layout_callback_;
+  mutable bool is_dispatching_ = false;
 };
 
 View::View(views::View* view) : view_(view) {
@@ -421,49 +515,309 @@ gfx::Rect View::GetBounds() const {
   return view_->bounds();
 }
 
-void View::SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value) {
+void View::SetLayout(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   if (!view_)
     return;
-  gin_helper::Dictionary dict(isolate, value);
+
+  // Re-entrancy guard: setLayout cannot be called from inside a JS layout
+  // callback because it would replace the layout manager mid-dispatch.
+  if (js_layout_manager_ && js_layout_manager_->is_dispatching()) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Cannot call setLayout from inside calculateProposedLayout");
+    return;
+  }
+
+  // null/undefined => clear the layout manager.
+  if (value.IsEmpty() || value->IsNullOrUndefined()) {
+    js_layout_manager_ = nullptr;
+    layout_type_ = LayoutType::kNone;
+    view_->SetLayoutManager(nullptr);
+    return;
+  }
+
+  // Reject primitives explicitly (V8's ToObject() auto-wraps Number/String
+  // into objects, which would silently fall through to a default FlexLayout).
+  if (!value->IsObject() || value->IsArray() || value->IsFunction()) {
+    gin_helper::ErrorThrower(isolate).ThrowTypeError(
+        "Layout options must be a plain object or null");
+    return;
+  }
+  v8::Local<v8::Object> obj = value.As<v8::Object>();
+  gin_helper::Dictionary dict(isolate, obj);
+
+  // Custom JS layout callback path.
   LayoutCallback calculate_proposed_layout;
   if (dict.Get("calculateProposedLayout", &calculate_proposed_layout)) {
-    view_->SetLayoutManager(std::make_unique<JSLayoutManager>(
-        std::move(calculate_proposed_layout)));
-  } else {
-    auto* layout =
-        view_->SetLayoutManager(std::make_unique<views::FlexLayout>());
-    views::LayoutOrientation orientation;
-    if (dict.Get("orientation", &orientation))
-      layout->SetOrientation(orientation);
-    views::LayoutAlignment main_axis_alignment;
-    if (dict.Get("mainAxisAlignment", &main_axis_alignment))
-      layout->SetMainAxisAlignment(main_axis_alignment);
-    views::LayoutAlignment cross_axis_alignment;
-    if (dict.Get("crossAxisAlignment", &cross_axis_alignment))
-      layout->SetCrossAxisAlignment(cross_axis_alignment);
-    gfx::Insets interior_margin;
-    if (dict.Get("interiorMargin", &interior_margin))
-      layout->SetInteriorMargin(interior_margin);
+    auto lm = std::make_unique<JSLayoutManager>(
+        std::move(calculate_proposed_layout));
+    js_layout_manager_ = lm.get();
+    layout_type_ = LayoutType::kJs;
+    view_->SetLayoutManager(std::move(lm));
+    return;
+  }
+
+  // Replacing any prior JSLayoutManager with a built-in.
+  js_layout_manager_ = nullptr;
+
+  std::string type;
+  dict.Get("type", &type);
+
+  if (type == "fill") {
+    layout_type_ = LayoutType::kFill;
+    auto* fill_layout =
+        view_->SetLayoutManager(std::make_unique<views::FillLayout>());
+    bool minimum_size_enabled;
+    if (dict.Has("minimumSizeEnabled") &&
+        dict.Get("minimumSizeEnabled", &minimum_size_enabled))
+      fill_layout->SetMinimumSizeEnabled(minimum_size_enabled);
+    bool include_insets;
+    if (dict.Has("includeInsets") && dict.Get("includeInsets", &include_insets))
+      fill_layout->SetIncludeInsets(include_insets);
+    return;
+  }
+
+  if (type == "box") {
+    views::LayoutOrientation orientation =
+        views::LayoutOrientation::kHorizontal;
+    dict.Get("orientation", &orientation);
+    layout_type_ = LayoutType::kBox;
+    auto* layout = view_->SetLayoutManager(
+        std::make_unique<views::BoxLayout>(orientation));
+    int between_child_spacing;
+    if (dict.Get("betweenChildSpacing", &between_child_spacing))
+      layout->set_between_child_spacing(between_child_spacing);
+    gfx::Insets inside_border_insets;
+    if (dict.Get("insideBorderInsets", &inside_border_insets))
+      layout->set_inside_border_insets(inside_border_insets);
+    views::LayoutAlignment box_main_axis;
+    if (dict.Get("mainAxisAlignment", &box_main_axis))
+      layout->set_main_axis_alignment(box_main_axis);
+    views::LayoutAlignment box_cross_axis;
+    if (dict.Get("crossAxisAlignment", &box_cross_axis))
+      layout->set_cross_axis_alignment(box_cross_axis);
     int minimum_cross_axis_size;
     if (dict.Get("minimumCrossAxisSize", &minimum_cross_axis_size))
-      layout->SetMinimumCrossAxisSize(minimum_cross_axis_size);
-    bool collapse_margins;
-    if (dict.Has("collapseMargins") &&
-        dict.Get("collapseMargins", &collapse_margins))
-      layout->SetCollapseMargins(collapse_margins);
-    bool include_host_insets_in_layout;
-    if (dict.Has("includeHostInsetsInLayout") &&
-        dict.Get("includeHostInsetsInLayout", &include_host_insets_in_layout))
-      layout->SetIncludeHostInsetsInLayout(include_host_insets_in_layout);
-    bool ignore_default_main_axis_margins;
-    if (dict.Has("ignoreDefaultMainAxisMargins") &&
-        dict.Get("ignoreDefaultMainAxisMargins",
-                 &ignore_default_main_axis_margins))
-      layout->SetIgnoreDefaultMainAxisMargins(ignore_default_main_axis_margins);
-    views::FlexAllocationOrder flex_allocation_order;
-    if (dict.Get("flexAllocationOrder", &flex_allocation_order))
-      layout->SetFlexAllocationOrder(flex_allocation_order);
+      layout->set_minimum_cross_axis_size(minimum_cross_axis_size);
+    int default_flex;
+    if (dict.Get("defaultFlex", &default_flex))
+      layout->SetDefaultFlex(default_flex);
+    return;
   }
+
+  // type == "flex" (default) or any unrecognised type: fall through to
+  // FlexLayout for backward compatibility with the previous setLayout shape.
+  layout_type_ = LayoutType::kFlex;
+  auto* layout = view_->SetLayoutManager(std::make_unique<views::FlexLayout>());
+  views::LayoutOrientation orientation;
+  if (dict.Get("orientation", &orientation))
+    layout->SetOrientation(orientation);
+  views::LayoutAlignment main_axis_alignment;
+  if (dict.Get("mainAxisAlignment", &main_axis_alignment))
+    layout->SetMainAxisAlignment(main_axis_alignment);
+  views::LayoutAlignment cross_axis_alignment;
+  if (dict.Get("crossAxisAlignment", &cross_axis_alignment))
+    layout->SetCrossAxisAlignment(cross_axis_alignment);
+  gfx::Insets interior_margin;
+  if (dict.Get("interiorMargin", &interior_margin))
+    layout->SetInteriorMargin(interior_margin);
+  int minimum_cross_axis_size;
+  if (dict.Get("minimumCrossAxisSize", &minimum_cross_axis_size))
+    layout->SetMinimumCrossAxisSize(minimum_cross_axis_size);
+  bool collapse_margins;
+  if (dict.Has("collapseMargins") &&
+      dict.Get("collapseMargins", &collapse_margins))
+    layout->SetCollapseMargins(collapse_margins);
+  bool include_host_insets_in_layout;
+  if (dict.Has("includeHostInsetsInLayout") &&
+      dict.Get("includeHostInsetsInLayout", &include_host_insets_in_layout))
+    layout->SetIncludeHostInsetsInLayout(include_host_insets_in_layout);
+  bool ignore_default_main_axis_margins;
+  if (dict.Has("ignoreDefaultMainAxisMargins") &&
+      dict.Get("ignoreDefaultMainAxisMargins",
+               &ignore_default_main_axis_margins))
+    layout->SetIgnoreDefaultMainAxisMargins(ignore_default_main_axis_margins);
+  views::FlexAllocationOrder flex_allocation_order;
+  if (dict.Get("flexAllocationOrder", &flex_allocation_order))
+    layout->SetFlexAllocationOrder(flex_allocation_order);
+}
+
+void View::SetLayoutFlex(v8::Isolate* isolate, v8::Local<v8::Value> spec) {
+  if (!view_)
+    return;
+  if (spec.IsEmpty() || spec->IsNullOrUndefined()) {
+    view_->ClearProperty(views::kFlexBehaviorKey);
+    view_->InvalidateLayout();
+    return;
+  }
+  views::FlexSpecification fs;
+  if (!gin::ConvertFromV8(isolate, spec, &fs)) {
+    gin_helper::ErrorThrower(isolate).ThrowTypeError(
+        "Invalid flex specification");
+    return;
+  }
+  view_->SetProperty(views::kFlexBehaviorKey, fs);
+  view_->InvalidateLayout();
+}
+
+void View::SetLayoutMargins(const gfx::Insets& margins) {
+  if (!view_)
+    return;
+  view_->SetProperty(views::kMarginsKey, margins);
+  view_->InvalidateLayout();
+}
+
+void View::Layout() {
+  if (!view_)
+    return;
+  // Force a synchronous layout pass. Useful in tests and for advanced
+  // consumers that have just mutated layout-affecting properties and
+  // want the new bounds reflected immediately.
+  view_->DeprecatedLayoutImmediately();
+}
+
+void View::InvalidateLayout() {
+  if (!view_)
+    return;
+  view_->InvalidateLayout();
+}
+
+void View::SetPreferredSize(const gfx::Size& size) {
+  if (!view_)
+    return;
+  view_->SetPreferredSize(size);
+  view_->InvalidateLayout();
+}
+
+gfx::Size View::GetPreferredSize() const {
+  if (!view_)
+    return {};
+  return view_->GetPreferredSize();
+}
+
+void View::SetUseDefaultFillLayout(bool use_default) {
+  if (!view_)
+    return;
+  view_->SetUseDefaultFillLayout(use_default);
+}
+
+std::string View::GetLayoutManagerType() const {
+  switch (layout_type_) {
+    case LayoutType::kFill:
+      return "fill";
+    case LayoutType::kBox:
+      return "box";
+    case LayoutType::kFlex:
+      return "flex";
+    case LayoutType::kJs:
+      return "js";
+    case LayoutType::kNone:
+    default:
+      return "";
+  }
+}
+
+void View::SetBoxFlex(v8::Isolate* isolate,
+                      gin_helper::Handle<View> child,
+                      int weight,
+                      gin::Arguments* args) {
+  if (!view_ || !child->view())
+    return;
+  if (layout_type_ != LayoutType::kBox) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "setBoxFlex requires a box layout. Call setLayout({type: 'box'}) "
+        "first.");
+    return;
+  }
+  if (child->view()->parent() != view_) {
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "setBoxFlex target must be a direct child of this view");
+    return;
+  }
+  bool use_min_size = false;
+  args->GetNext(&use_min_size);
+  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  layout->SetFlexForView(child->view(), weight, use_min_size);
+  view_->InvalidateLayout();
+}
+
+v8::Local<v8::Value> View::GetLayoutFlex(v8::Isolate* isolate) const {
+  if (!view_)
+    return v8::Null(isolate);
+  const views::FlexSpecification* spec =
+      view_->GetProperty(views::kFlexBehaviorKey);
+  if (!spec)
+    return v8::Null(isolate);
+  return gin::ConvertToV8(isolate, *spec);
+}
+
+std::string View::GetOrientation() const {
+  if (!view_)
+    return "";
+  if (layout_type_ == LayoutType::kBox) {
+    auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+    return layout->GetOrientation() == views::BoxLayout::Orientation::kHorizontal
+               ? "horizontal"
+               : "vertical";
+  }
+  if (layout_type_ == LayoutType::kFlex) {
+    auto* layout = static_cast<views::FlexLayout*>(view_->GetLayoutManager());
+    return layout->orientation() == views::LayoutOrientation::kHorizontal
+               ? "horizontal"
+               : "vertical";
+  }
+  return "";
+}
+
+std::string View::GetMainAxisAlignment() const {
+  if (!view_ || layout_type_ != LayoutType::kBox)
+    return "";
+  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  switch (layout->main_axis_alignment()) {
+    case views::LayoutAlignment::kStart:
+      return "start";
+    case views::LayoutAlignment::kCenter:
+      return "center";
+    case views::LayoutAlignment::kEnd:
+      return "end";
+    case views::LayoutAlignment::kStretch:
+      return "stretch";
+    case views::LayoutAlignment::kBaseline:
+      return "baseline";
+  }
+  return "";
+}
+
+std::string View::GetCrossAxisAlignment() const {
+  if (!view_ || layout_type_ != LayoutType::kBox)
+    return "";
+  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  switch (layout->cross_axis_alignment()) {
+    case views::LayoutAlignment::kStart:
+      return "start";
+    case views::LayoutAlignment::kCenter:
+      return "center";
+    case views::LayoutAlignment::kEnd:
+      return "end";
+    case views::LayoutAlignment::kStretch:
+      return "stretch";
+    case views::LayoutAlignment::kBaseline:
+      return "baseline";
+  }
+  return "";
+}
+
+int View::GetBetweenChildSpacing() const {
+  if (!view_ || layout_type_ != LayoutType::kBox)
+    return 0;
+  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  return layout->between_child_spacing();
+}
+
+gfx::Insets View::GetInsideBorderInsets() const {
+  if (!view_ || layout_type_ != LayoutType::kBox)
+    return gfx::Insets();
+  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+  return layout->inside_border_insets();
 }
 
 std::vector<v8::Local<v8::Value>> View::GetChildren() {
@@ -601,6 +955,21 @@ void View::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBorderRadius", &View::SetBorderRadius)
       .SetMethod("setBackgroundBlur", &View::SetBackgroundBlur)
       .SetMethod("setLayout", &View::SetLayout)
+      .SetMethod("setLayoutFlex", &View::SetLayoutFlex)
+      .SetMethod("setLayoutMargins", &View::SetLayoutMargins)
+      .SetMethod("getLayoutFlex", &View::GetLayoutFlex)
+      .SetMethod("layout", &View::Layout)
+      .SetMethod("invalidateLayout", &View::InvalidateLayout)
+      .SetMethod("setPreferredSize", &View::SetPreferredSize)
+      .SetMethod("getPreferredSize", &View::GetPreferredSize)
+      .SetMethod("setUseDefaultFillLayout", &View::SetUseDefaultFillLayout)
+      .SetMethod("getLayoutManagerType", &View::GetLayoutManagerType)
+      .SetMethod("getOrientation", &View::GetOrientation)
+      .SetMethod("getMainAxisAlignment", &View::GetMainAxisAlignment)
+      .SetMethod("getCrossAxisAlignment", &View::GetCrossAxisAlignment)
+      .SetMethod("getBetweenChildSpacing", &View::GetBetweenChildSpacing)
+      .SetMethod("getInsideBorderInsets", &View::GetInsideBorderInsets)
+      .SetMethod("setBoxFlex", &View::SetBoxFlex)
       .SetMethod("setVisible", &View::SetVisible)
       .SetMethod("getVisible", &View::GetVisible);
 }

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -299,25 +299,35 @@ class JSLayoutManager : public views::LayoutManagerBase {
       const views::SizeBounds& size_bounds) const override {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope handle_scope(isolate);
-    v8::TryCatch try_catch(isolate);
+    // is_dispatching_ blocks re-entrant setLayout(): swapping the layout
+    // manager mid-callback would destroy `this` while it is still on the
+    // stack.
     base::AutoReset<bool> reset(&is_dispatching_, true);
-    views::ProposedLayout result = layout_callback_.Run(size_bounds);
-    if (try_catch.HasCaught()) {
-      // Without this guard, a JS exception thrown from the callback would
-      // propagate into Chromium's view machinery and crash the main process.
-      // ReThrow() leaves the exception pending on the isolate; delivery to
-      // Node's uncaught-exception handler is best-effort and depends on when
-      // control next returns to JS.
-      try_catch.ReThrow();
-      return views::ProposedLayout{};
-    }
-    return result;
+    // Exceptions thrown from the JS callback are absorbed by gin's
+    // V8FunctionInvoker — it returns a default-constructed ProposedLayout
+    // and leaves the exception pending on the isolate. V8 observes it when
+    // control next returns to JS; Node then decides whether to surface it
+    // via uncaughtException or to swallow at the binding boundary.
+    return layout_callback_.Run(size_bounds);
   }
 
  private:
   LayoutCallback layout_callback_;
   mutable bool is_dispatching_ = false;
 };
+
+namespace {
+std::string AlignmentToString(views::LayoutAlignment a) {
+  switch (a) {
+    case views::LayoutAlignment::kStart:    return "start";
+    case views::LayoutAlignment::kCenter:   return "center";
+    case views::LayoutAlignment::kEnd:      return "end";
+    case views::LayoutAlignment::kStretch:  return "stretch";
+    case views::LayoutAlignment::kBaseline: return "baseline";
+  }
+  return "";
+}
+}  // namespace
 
 View::View(views::View* view) : view_(view) {
   view_->set_owned_by_client(views::View::OwnedByClientPassKey{});
@@ -637,8 +647,17 @@ void View::SetLayout(v8::Isolate* isolate, v8::Local<v8::Value> value) {
     return;
   }
 
-  // type == "flex" (default) or any unrecognised type: fall through to
-  // FlexLayout for backward compatibility with the previous setLayout shape.
+  // An explicit `type` we don't recognise is an error. An *absent* `type`
+  // falls through to FlexLayout, preserving backward compatibility with
+  // the legacy setLayout({orientation: ...}) shape from PR #35658.
+  if (!type.empty() && type != "flex") {
+    gin_helper::ErrorThrower(isolate).ThrowTypeError(
+        "Unknown layout type: '" + type +
+        "'. Expected one of 'fill', 'box', 'flex', or omit the field.");
+    return;
+  }
+
+  // type == "flex" or omitted: configure a FlexLayout.
   layout_type_ = LayoutType::kFlex;
   auto* layout = view_->SetLayoutManager(std::make_unique<views::FlexLayout>());
   views::LayoutOrientation orientation;
@@ -831,43 +850,29 @@ std::string View::GetOrientation() const {
 }
 
 std::string View::GetMainAxisAlignment() const {
-  if (!view_ || layout_type_ != LayoutType::kBox)
+  if (!view_)
     return "";
-  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
-  if (!layout)
-    return "";
-  switch (layout->main_axis_alignment()) {
-    case views::LayoutAlignment::kStart:
-      return "start";
-    case views::LayoutAlignment::kCenter:
-      return "center";
-    case views::LayoutAlignment::kEnd:
-      return "end";
-    case views::LayoutAlignment::kStretch:
-      return "stretch";
-    case views::LayoutAlignment::kBaseline:
-      return "baseline";
+  if (layout_type_ == LayoutType::kBox) {
+    auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+    return layout ? AlignmentToString(layout->main_axis_alignment()) : "";
+  }
+  if (layout_type_ == LayoutType::kFlex) {
+    auto* layout = static_cast<views::FlexLayout*>(view_->GetLayoutManager());
+    return layout ? AlignmentToString(layout->main_axis_alignment()) : "";
   }
   return "";
 }
 
 std::string View::GetCrossAxisAlignment() const {
-  if (!view_ || layout_type_ != LayoutType::kBox)
+  if (!view_)
     return "";
-  auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
-  if (!layout)
-    return "";
-  switch (layout->cross_axis_alignment()) {
-    case views::LayoutAlignment::kStart:
-      return "start";
-    case views::LayoutAlignment::kCenter:
-      return "center";
-    case views::LayoutAlignment::kEnd:
-      return "end";
-    case views::LayoutAlignment::kStretch:
-      return "stretch";
-    case views::LayoutAlignment::kBaseline:
-      return "baseline";
+  if (layout_type_ == LayoutType::kBox) {
+    auto* layout = static_cast<views::BoxLayout*>(view_->GetLayoutManager());
+    return layout ? AlignmentToString(layout->cross_axis_alignment()) : "";
+  }
+  if (layout_type_ == LayoutType::kFlex) {
+    auto* layout = static_cast<views::FlexLayout*>(view_->GetLayoutManager());
+    return layout ? AlignmentToString(layout->cross_axis_alignment()) : "";
   }
   return "";
 }

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -10,6 +10,7 @@
 #include "base/memory/raw_ptr.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/event_emitter.h"
+#include "ui/views/layout/flex_layout_types.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
 #include "v8/include/v8-value.h"
@@ -110,6 +111,12 @@ class View : public gin_helper::EventEmitter<View>,
   raw_ptr<views::View> view_ = nullptr;
   raw_ptr<JSLayoutManager> js_layout_manager_ = nullptr;
   LayoutType layout_type_ = LayoutType::kNone;
+
+  // Cached min/max flex rules: views::FlexSpecification bakes them into an
+  // opaque FlexRule closure and exposes no accessor, so we remember the
+  // user-provided values here for getLayoutFlex round-trip.
+  std::optional<views::MinimumFlexSizeRule> last_min_flex_rule_;
+  std::optional<views::MaximumFlexSizeRule> last_max_flex_rule_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -115,6 +115,8 @@ class View : public gin_helper::EventEmitter<View>,
   // Cached min/max flex rules: views::FlexSpecification bakes them into an
   // opaque FlexRule closure and exposes no accessor, so we remember the
   // user-provided values here for getLayoutFlex round-trip.
+  // Invariant: every write to view_->kFlexBehaviorKey MUST go through
+  // SetLayoutFlex(), otherwise these caches go stale silently.
   std::optional<views::MinimumFlexSizeRule> last_min_flex_rule_;
   std::optional<views::MaximumFlexSizeRule> last_max_flex_rule_;
 };

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -21,6 +21,16 @@ class Handle;
 
 namespace electron::api {
 
+class JSLayoutManager;
+
+enum class LayoutType {
+  kNone,
+  kFill,
+  kBox,
+  kFlex,
+  kJs,
+};
+
 class View : public gin_helper::EventEmitter<View>,
              private views::ViewObserver {
  public:
@@ -39,7 +49,25 @@ class View : public gin_helper::EventEmitter<View>,
 
   void SetBounds(const gfx::Rect& bounds, gin::Arguments* args);
   gfx::Rect GetBounds() const;
-  void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
+  void SetLayout(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  void SetLayoutFlex(v8::Isolate* isolate, v8::Local<v8::Value> spec);
+  void SetLayoutMargins(const gfx::Insets& margins);
+  void Layout();
+  void InvalidateLayout();
+  void SetPreferredSize(const gfx::Size& size);
+  gfx::Size GetPreferredSize() const;
+  void SetUseDefaultFillLayout(bool use_default);
+  std::string GetLayoutManagerType() const;
+  std::string GetOrientation() const;
+  std::string GetMainAxisAlignment() const;
+  std::string GetCrossAxisAlignment() const;
+  int GetBetweenChildSpacing() const;
+  gfx::Insets GetInsideBorderInsets() const;
+  void SetBoxFlex(v8::Isolate* isolate,
+                  gin_helper::Handle<View> child,
+                  int weight,
+                  gin::Arguments* args);
+  v8::Local<v8::Value> GetLayoutFlex(v8::Isolate* isolate) const;
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
   void SetBorderRadius(int radius);
@@ -80,6 +108,8 @@ class View : public gin_helper::EventEmitter<View>,
 
   bool delete_view_ = true;
   raw_ptr<views::View> view_ = nullptr;
+  raw_ptr<JSLayoutManager> js_layout_manager_ = nullptr;
+  LayoutType layout_type_ = LayoutType::kNone;
 };
 
 }  // namespace electron::api

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -4,6 +4,31 @@ import { expect } from 'chai';
 
 import { closeWindow } from './lib/window-helpers';
 
+// Layout API methods are added by the feature in this PR but the public
+// docs/api/view.md entries (and the regenerated electron.d.ts) are part of
+// @nikwen's separate documentation effort. Declare them here so the tests
+// type-check until the doc-generated types catch up.
+declare module 'electron/main' {
+  interface View {
+    setLayout(options: object | null): void;
+    setLayoutFlex(spec: object | null): void;
+    setLayoutMargins(margins: { top?: number; left?: number; bottom?: number; right?: number }): void;
+    setBoxFlex(child: View, weight: number, useMinSize?: boolean): void;
+    layout(): void;
+    invalidateLayout(): void;
+    setPreferredSize(size: { width: number; height: number }): void;
+    getPreferredSize(): { width: number; height: number };
+    setUseDefaultFillLayout(use: boolean): void;
+    getLayoutManagerType(): string;
+    getLayoutFlex(): object | null;
+    getOrientation(): string;
+    getMainAxisAlignment(): string;
+    getCrossAxisAlignment(): string;
+    getBetweenChildSpacing(): number;
+    getInsideBorderInsets(): { top: number; left: number; bottom: number; right: number };
+  }
+}
+
 describe('View', () => {
   let w: BaseWindow;
   afterEach(async () => {
@@ -170,6 +195,286 @@ describe('View', () => {
       expect(() => {
         v.setBackgroundBlur(10);
       }).to.not.throw();
+    });
+  });
+
+  describe('view.setLayout', () => {
+    it('accepts type:"fill" and stretches a child to host bounds', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'fill' } as any);
+      root.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+      (root as any).layout();
+      expect(child.getBounds()).to.deep.equal({ x: 0, y: 0, width: 400, height: 300 });
+    });
+
+    it('accepts type:"box" horizontal and lays out children side by side', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const a = new View();
+      const b = new View();
+      // Layout managers honour setPreferredSize, not setBounds.
+      a.setPreferredSize({ width: 100, height: 50 });
+      b.setPreferredSize({ width: 150, height: 50 });
+      root.addChildView(a);
+      root.addChildView(b);
+      root.setLayout({ type: 'box', orientation: 'horizontal', betweenChildSpacing: 10 } as any);
+      root.setBounds({ x: 0, y: 0, width: 400, height: 100 });
+      (root as any).layout();
+      expect(a.getBounds().x).to.equal(0);
+      expect(a.getBounds().width).to.equal(100);
+      // 100 (a width) + 10 spacing = 110
+      expect(b.getBounds().x).to.equal(110);
+      expect(b.getBounds().width).to.equal(150);
+    });
+
+    it('accepts type:"flex" (default) for backward compatibility', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      // Old shape (no `type` field) still produces a flex layout.
+      root.setLayout({ orientation: 'vertical', crossAxisAlignment: 'stretch' } as any);
+      expect((root as any).getLayoutManagerType()).to.equal('flex');
+    });
+
+    it('setLayout(null) removes the layout manager', () => {
+      const root = new View();
+      root.setLayout({ type: 'fill' } as any);
+      expect((root as any).getLayoutManagerType()).to.equal('fill');
+      root.setLayout(null as any);
+      expect((root as any).getLayoutManagerType()).to.equal('');
+    });
+
+    it('throws on non-object, non-null argument', () => {
+      const root = new View();
+      expect(() => root.setLayout(42 as any)).to.throw();
+    });
+
+    it('JS calculateProposedLayout callback is invoked', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      let invocations = 0;
+      root.setLayout({
+        calculateProposedLayout: (sb: any) => {
+          invocations++;
+          return {
+            size: { width: sb.width || 0, height: sb.height || 0 },
+            layouts: [{
+              view: child,
+              bounds: { x: 0, y: 0, width: (sb.width || 0) / 2, height: sb.height || 0 }
+            }]
+          };
+        }
+      } as any);
+      root.setBounds({ x: 0, y: 0, width: 400, height: 200 });
+      (root as any).layout();
+      expect(invocations).to.be.greaterThan(0);
+      expect(child.getBounds().width).to.equal(200);
+    });
+
+    it('catches exceptions from JS layout callback without crashing', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({
+        calculateProposedLayout: () => {
+          throw new Error('boom');
+        }
+      } as any);
+      // Should not crash the process; the exception is caught by v8::TryCatch
+      // and re-thrown so Node's uncaught-exception handler picks it up.
+      expect(() => {
+        root.setBounds({ x: 0, y: 0, width: 100, height: 100 });
+        (root as any).layout();
+      }).to.not.throw();
+    });
+
+    it('blocks re-entrant setLayout from within JS callback', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      let reentryError: Error | null = null;
+      root.setLayout({
+        calculateProposedLayout: (sb: any) => {
+          try {
+            root.setLayout({ type: 'fill' } as any);
+          } catch (e) {
+            reentryError = e as Error;
+          }
+          return { size: { width: sb.width || 0, height: sb.height || 0 }, layouts: [] };
+        }
+      } as any);
+      root.setBounds({ x: 0, y: 0, width: 100, height: 100 });
+      (root as any).layout();
+      expect(reentryError).to.not.equal(null);
+      expect(reentryError!.message).to.match(/Cannot call setLayout/);
+    });
+  });
+
+  describe('view.setLayoutFlex', () => {
+    it('flex unbounded grows the child to fill', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'flex', orientation: 'vertical', crossAxisAlignment: 'stretch' } as any);
+      (child as any).setLayoutFlex({ minimum: 'scale-to-minimum', maximum: 'unbounded', weight: 1 });
+      root.setBounds({ x: 0, y: 0, width: 500, height: 200 });
+      (root as any).layout();
+      expect(child.getBounds().width).to.equal(500);
+      expect(child.getBounds().height).to.equal(200);
+    });
+
+    it('setLayoutFlex(null) clears the flex behavior', () => {
+      const child = new View();
+      (child as any).setLayoutFlex({ minimum: 'scale-to-minimum', maximum: 'unbounded', weight: 1 });
+      (child as any).setLayoutFlex(null);
+      expect((child as any).getLayoutFlex()).to.equal(null);
+    });
+
+    it('throws on invalid spec', () => {
+      const child = new View();
+      expect(() => (child as any).setLayoutFlex(42)).to.throw();
+    });
+  });
+
+  describe('view.setLayoutMargins', () => {
+    it('applies margins around a flexed child', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'flex', orientation: 'vertical', crossAxisAlignment: 'stretch' } as any);
+      (child as any).setLayoutFlex({ minimum: 'scale-to-minimum', maximum: 'unbounded', weight: 1 });
+      (child as any).setLayoutMargins({ top: 10, left: 5, bottom: 10, right: 5 });
+      root.setBounds({ x: 0, y: 0, width: 200, height: 200 });
+      (root as any).layout();
+      const bounds = child.getBounds();
+      expect(bounds.x).to.equal(5);
+      expect(bounds.y).to.equal(10);
+      expect(bounds.width).to.equal(190);
+      expect(bounds.height).to.equal(180);
+    });
+  });
+
+  describe('view.getLayoutManagerType', () => {
+    it('returns empty string when no layout is set', () => {
+      const v = new View();
+      expect((v as any).getLayoutManagerType()).to.equal('');
+    });
+
+    it('returns "fill" for fill layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'fill' } as any);
+      expect((v as any).getLayoutManagerType()).to.equal('fill');
+    });
+
+    it('returns "box" for box layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'box' } as any);
+      expect((v as any).getLayoutManagerType()).to.equal('box');
+    });
+
+    it('returns "flex" for flex layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'flex' } as any);
+      expect((v as any).getLayoutManagerType()).to.equal('flex');
+    });
+
+    it('returns "js" for custom JS layout', () => {
+      const v = new View();
+      v.setLayout({
+        calculateProposedLayout: () => ({ size: { width: 0, height: 0 }, layouts: [] })
+      } as any);
+      expect((v as any).getLayoutManagerType()).to.equal('js');
+    });
+  });
+
+  describe('view.setPreferredSize|getPreferredSize', () => {
+    it('round-trips a preferred size', () => {
+      const v = new View();
+      (v as any).setPreferredSize({ width: 250, height: 175 });
+      expect((v as any).getPreferredSize()).to.deep.equal({ width: 250, height: 175 });
+    });
+  });
+
+  describe('view.setBoxFlex', () => {
+    it('throws when called outside a box layout', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'flex' } as any);
+      expect(() => (root as any).setBoxFlex(child, 1)).to.throw(/box layout/);
+    });
+
+    it('throws for a non-child view', () => {
+      const root = new View();
+      const stranger = new View();
+      root.setLayout({ type: 'box' } as any);
+      expect(() => (root as any).setBoxFlex(stranger, 1)).to.throw(/direct child/);
+    });
+
+    it('does not throw when applied to a real child', () => {
+      const root = new View();
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'box', orientation: 'horizontal' } as any);
+      expect(() => (root as any).setBoxFlex(child, 1, true)).to.not.throw();
+    });
+  });
+
+  describe('view.layout|invalidateLayout', () => {
+    it('layout() does not throw on a view without a layout manager', () => {
+      const v = new View();
+      expect(() => (v as any).layout()).to.not.throw();
+    });
+
+    it('invalidateLayout() does not throw on a view without a layout manager', () => {
+      const v = new View();
+      expect(() => (v as any).invalidateLayout()).to.not.throw();
+    });
+  });
+
+  describe('view box-layout getters', () => {
+    it('getOrientation returns the configured value for box layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'box', orientation: 'vertical' } as any);
+      expect((v as any).getOrientation()).to.equal('vertical');
+      v.setLayout({ type: 'box', orientation: 'horizontal' } as any);
+      expect((v as any).getOrientation()).to.equal('horizontal');
+    });
+
+    it('getOrientation returns "" when no box/flex layout is set', () => {
+      const v = new View();
+      expect((v as any).getOrientation()).to.equal('');
+      v.setLayout({ type: 'fill' } as any);
+      expect((v as any).getOrientation()).to.equal('');
+    });
+
+    it('getBetweenChildSpacing reflects the option set on the layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'box', betweenChildSpacing: 17 } as any);
+      expect((v as any).getBetweenChildSpacing()).to.equal(17);
+    });
+
+    it('getInsideBorderInsets returns zero insets by default', () => {
+      const v = new View();
+      v.setLayout({ type: 'box' } as any);
+      const insets = (v as any).getInsideBorderInsets();
+      expect(insets.top + insets.left + insets.bottom + insets.right).to.equal(0);
     });
   });
 });

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -346,6 +346,55 @@ describe('View', () => {
       const child = new View();
       expect(() => (child as any).setLayoutFlex(42)).to.throw();
     });
+
+    it('getLayoutFlex preserves minimum and maximum rules', () => {
+      const child = new View();
+      (child as any).setLayoutFlex({ minimum: 'scale-to-zero', maximum: 'unbounded', weight: 3, order: 2 });
+      const spec = (child as any).getLayoutFlex();
+      expect(spec).to.not.equal(null);
+      expect(spec.weight).to.equal(3);
+      expect(spec.order).to.equal(2);
+      expect(spec.minimum).to.equal('scale-to-zero');
+      expect(spec.maximum).to.equal('unbounded');
+    });
+
+    it('getLayoutFlex omits min/max after they are cleared', () => {
+      const child = new View();
+      (child as any).setLayoutFlex({ minimum: 'scale-to-minimum', maximum: 'unbounded', weight: 1 });
+      (child as any).setLayoutFlex(null);
+      expect((child as any).getLayoutFlex()).to.equal(null);
+      // Re-setting without min/max should not leak previous cached values.
+      (child as any).setLayoutFlex({ weight: 5 });
+      const spec = (child as any).getLayoutFlex();
+      expect(spec.weight).to.equal(5);
+      expect(spec.minimum).to.equal(undefined);
+      expect(spec.maximum).to.equal(undefined);
+    });
+  });
+
+  describe('view.setUseDefaultFillLayout', () => {
+    it('does not throw and stretches a single child to fill the parent', () => {
+      w = new BaseWindow({ show: false });
+      const root = new View();
+      w.setContentView(root);
+      const child = new View();
+      root.addChildView(child);
+      expect(() => (root as any).setUseDefaultFillLayout(true)).to.not.throw();
+      root.setBounds({ x: 0, y: 0, width: 300, height: 150 });
+      (root as any).layout();
+      const bounds = child.getBounds();
+      expect(bounds.width).to.equal(300);
+      expect(bounds.height).to.equal(150);
+    });
+
+    it('accepts toggling false without affecting layout manager type', () => {
+      const root = new View();
+      (root as any).setUseDefaultFillLayout(true);
+      (root as any).setUseDefaultFillLayout(false);
+      // setUseDefaultFillLayout doesn't go through our SetLayout(), so the
+      // tracked layout_type_ stays at its previous value (none in this test).
+      expect((root as any).getLayoutManagerType()).to.equal('');
+    });
   });
 
   describe('view.setLayoutMargins', () => {

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -254,6 +254,30 @@ describe('View', () => {
       expect(() => root.setLayout(42 as any)).to.throw();
     });
 
+    it('throws on an unknown type field', () => {
+      const v = new View();
+      expect(() => v.setLayout({ type: 'fluss' } as any))
+        .to.throw(/Unknown layout type/);
+    });
+
+    it('still accepts the legacy no-type shape as flex', () => {
+      // setLayout({orientation, crossAxisAlignment, ...}) from PR #35658
+      // was without a `type` field. Must keep working for back-compat.
+      const v = new View();
+      expect(() => v.setLayout({ orientation: 'vertical' } as any)).to.not.throw();
+      expect((v as any).getLayoutManagerType()).to.equal('flex');
+    });
+
+    it('setLayout(null) clears a JS layout manager', () => {
+      const v = new View();
+      v.setLayout({
+        calculateProposedLayout: () => ({ size: { width: 0, height: 0 }, layouts: [] })
+      } as any);
+      expect((v as any).getLayoutManagerType()).to.equal('js');
+      v.setLayout(null as any);
+      expect((v as any).getLayoutManagerType()).to.equal('');
+    });
+
     it('JS calculateProposedLayout callback is invoked', () => {
       w = new BaseWindow({ show: false });
       const root = new View();
@@ -279,7 +303,7 @@ describe('View', () => {
       expect(child.getBounds().width).to.equal(200);
     });
 
-    it('catches exceptions from JS layout callback without crashing', () => {
+    it('does not crash when the JS layout callback throws', () => {
       w = new BaseWindow({ show: false });
       const root = new View();
       w.setContentView(root);
@@ -290,8 +314,9 @@ describe('View', () => {
           throw new Error('boom');
         }
       } as any);
-      // Should not crash the process; the exception is caught by v8::TryCatch
-      // and re-thrown so Node's uncaught-exception handler picks it up.
+      // gin's V8FunctionInvoker absorbs the JS exception (it returns a
+      // default-constructed ProposedLayout) so the C++ side stays sane;
+      // the pending v8 exception is delivered to Node on next reentry.
       expect(() => {
         root.setBounds({ x: 0, y: 0, width: 100, height: 100 });
         (root as any).layout();
@@ -483,6 +508,14 @@ describe('View', () => {
       root.setLayout({ type: 'box', orientation: 'horizontal' } as any);
       expect(() => (root as any).setBoxFlex(child, 1, true)).to.not.throw();
     });
+
+    it('accepts weight 0 (child takes only its preferred size)', () => {
+      const root = new View();
+      const child = new View();
+      root.addChildView(child);
+      root.setLayout({ type: 'box', orientation: 'horizontal' } as any);
+      expect(() => (root as any).setBoxFlex(child, 0)).to.not.throw();
+    });
   });
 
   describe('view.layout|invalidateLayout', () => {
@@ -524,6 +557,21 @@ describe('View', () => {
       v.setLayout({ type: 'box' } as any);
       const insets = (v as any).getInsideBorderInsets();
       expect(insets.top + insets.left + insets.bottom + insets.right).to.equal(0);
+    });
+
+    it('getMainAxisAlignment works for flex layout', () => {
+      const v = new View();
+      v.setLayout({ type: 'flex', mainAxisAlignment: 'center' } as any);
+      expect((v as any).getMainAxisAlignment()).to.equal('center');
+    });
+
+    it('getCrossAxisAlignment works for flex layout', () => {
+      // Always set crossAxisAlignment explicitly when probing FlexLayout — the
+      // Chromium accessor dereferences an internal optional, undefined behavior
+      // if SetCrossAxisAlignment was never called. See flex_layout.h:101-103.
+      const v = new View();
+      v.setLayout({ type: 'flex', crossAxisAlignment: 'stretch' } as any);
+      expect((v as any).getCrossAxisAlignment()).to.equal('stretch');
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

We have developed a JavaScript API that exposes Chromium's native layout managers (FillLayout, BoxLayout, FlexLayout) to Electron applications. It lets developers declare how child views should be positioned and resized automatically, instead of writing resize listeners and computing bounds by hand.

Implementation in `shell/browser/api/electron_api_view.cc`:

- `setLayout({ type: 'fill' | 'box' | 'flex' })` picks the layout manager, or accepts a custom JavaScript callback.
- `setLayoutFlex`, `setLayoutMargins`, `setBoxFlex`  control growth, spacing, and per-child weight.
- 8 getters (`getLayoutManagerType`, etc.).
- `JSLayoutManager` class (`views::LayoutManagerBase` ↔ JS bridge) with a re-entrancy guard and a `v8::TryCatch` so exceptions thrown from the callback no longer crash the main process.
- 9 'gin' converters between C++ and V8.
- Input validation and back-compat with PR #35658.

Tests in `spec/api-view-spec.ts`: 27 cases covering each layout type, per-child properties, the JS callback path, the exception case, the re-entrancy guard, and the box-layout getters.

Closes #43802.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/contributing/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/electron/blob/main/docs/contributing/pull-requests.md#release-notes)

#### Release Notes

Notes: Added `view.setLayout()`, `view.setLayoutFlex()`, and `view.setLayoutMargins()` APIs for declarative child layout using Chromium's fill, box, and flex layout managers.
