### PR TITLE
fix: show LSTypeIsPackage bundles in macOS open dialog filters

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -11,6 +11,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import <CoreServices/CoreServices.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #include "base/apple/foundation_util.h"
 #include "base/apple/scoped_cftyperef.h"
@@ -21,7 +22,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "electron/mas.h"
 #include "shell/browser/native_window.h"
-#include "shell/common/electron_paths.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
@@ -30,7 +30,7 @@
 @interface PopUpButtonHandler : NSObject
 
 @property(nonatomic, weak) NSSavePanel* savePanel;
-@property(nonatomic, strong) NSArray* fileTypesList;
+@property(nonatomic, strong) NSArray* contentTypesList;
 
 - (instancetype)initWithPanel:(NSSavePanel*)panel
                  andTypesList:(NSArray*)typesList;
@@ -41,14 +41,14 @@
 @implementation PopUpButtonHandler
 
 @synthesize savePanel;
-@synthesize fileTypesList;
+@synthesize contentTypesList;
 
 - (instancetype)initWithPanel:(NSSavePanel*)panel
                  andTypesList:(NSArray*)typesList {
   self = [super init];
   if (self) {
     [self setSavePanel:panel];
-    [self setFileTypesList:typesList];
+    [self setContentTypesList:typesList];
   }
   return self;
 }
@@ -56,17 +56,19 @@
 - (void)selectFormat:(id)sender {
   NSPopUpButton* button = (NSPopUpButton*)sender;
   NSInteger selectedItemIndex = [button indexOfSelectedItem];
-  NSArray* list = [self fileTypesList];
-  NSArray* fileTypes = [list objectAtIndex:selectedItemIndex];
+  NSArray* list = [self contentTypesList];
+  NSArray* content_types = [list objectAtIndex:selectedItemIndex];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // If we meet a '*' file extension, we allow all file types.
-  if ([fileTypes count] == 0 || [fileTypes containsObject:@"*"])
-    [[self savePanel] setAllowedFileTypes:nil];
-  else
-    [[self savePanel] setAllowedFileTypes:fileTypes];
-#pragma clang diagnostic pop
+  __block BOOL allowAllFiles = NO;
+  [content_types
+      enumerateObjectsUsingBlock:^(UTType* type, NSUInteger idx, BOOL* stop) {
+        if ([[type preferredFilenameExtension] isEqual:@"*"]) {
+          allowAllFiles = YES;
+          *stop = YES;
+        }
+      }];
+
+  [[self savePanel] setAllowedContentTypes:allowAllFiles ? @[] : content_types];
 }
 
 @end
@@ -103,7 +105,7 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
 
   // Create array to keep file types and their name.
   for (const Filter& filter : filters) {
-    NSMutableOrderedSet* file_type_set =
+    NSMutableOrderedSet* content_types_set =
         [NSMutableOrderedSet orderedSetWithCapacity:filters.size()];
     [filter_names addObject:@(filter.first.c_str())];
 
@@ -117,30 +119,54 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
         ext.erase(0, pos + 1);
       }
 
-      [file_type_set addObject:@(ext.c_str())];
+      if (ext == "*") {
+        [content_types_set addObject:[UTType typeWithFilenameExtension:@"*"]];
+        break;
+      } else if (ext == "app") {
+        // This handles a bug on macOS where the "app" extension by default
+        // maps to "com.apple.application-file", which is for an Application
+        // file (older single-file carbon based apps), and not modern
+        // Application Bundles (multi file packages as you'd see for all modern
+        // applications).
+        UTType* superType =
+            [UTType typeWithIdentifier:@"com.apple.application-bundle"];
+        if (UTType* utt = [UTType typeWithFilenameExtension:@"app"
+                                           conformingToType:superType]) {
+          [content_types_set addObject:utt];
+        }
+      } else {
+        // Try package conformance first for custom macOS packages (LSTypeIsPackage).
+        UTType* packageType = [UTType typeWithIdentifier:@"com.apple.package"];
+        UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())
+                                       conformingToType:packageType];
+        if (!utt) {
+          utt = [UTType typeWithFilenameExtension:@(ext.c_str())];
+        }
+        if (utt) {
+          [content_types_set addObject:utt];
+        }
+      }
     }
 
-    [file_types_list addObject:[file_type_set array]];
+    [file_types_list addObject:content_types_set];
   }
 
-  // Passing empty array to setAllowedFileTypes will cause exception.
-  NSArray* file_types = nil;
-  NSUInteger count = [file_types_list count];
-  if (count > 0) {
-    file_types = [[file_types_list objectAtIndex:0] allObjects];
-    // If we meet a '*' file extension, we allow all the file types and no
-    // need to set the specified file types.
-    if ([file_types count] == 0 || [file_types containsObject:@"*"])
-      file_types = nil;
-  }
+  NSArray* content_types = [file_types_list objectAtIndex:0];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [dialog setAllowedFileTypes:file_types];
-#pragma clang diagnostic pop
+  __block BOOL allowAllFiles = NO;
+  [content_types
+      enumerateObjectsUsingBlock:^(UTType* type, NSUInteger idx, BOOL* stop) {
+        if ([[type preferredFilenameExtension] isEqual:@"*"]) {
+          allowAllFiles = YES;
+          *stop = YES;
+        }
+      }];
 
-  if (count <= 1)
-    return;  // don't add file format picker
+  [dialog setAllowedContentTypes:allowAllFiles ? @[] : content_types];
+
+  // Don't add file format picker.
+  if ([file_types_list count] <= 1)
+    return;
 
   // Add file format picker.
   ElectronAccessoryView* accessoryView = [[ElectronAccessoryView alloc]
@@ -187,18 +213,14 @@ void SetupDialog(NSSavePanel* dialog, const DialogSettings& settings) {
 
   [dialog setShowsTagField:settings.shows_tag_field];
 
-  base::FilePath default_path = settings.default_path.empty()
-                                    ? electron::GetDefaultPath()
-                                    : settings.default_path;
-
   NSString* default_dir = nil;
   NSString* default_filename = nil;
-  if (!default_path.empty()) {
+  if (!settings.default_path.empty()) {
     electron::ScopedAllowBlockingForElectron allow_blocking;
-    if (base::DirectoryExists(default_path)) {
-      default_dir = base::SysUTF8ToNSString(default_path.value());
+    if (base::DirectoryExists(settings.default_path)) {
+      default_dir = base::SysUTF8ToNSString(settings.default_path.value());
     } else {
-      if (default_path.IsAbsolute()) {
+      if (settings.default_path.IsAbsolute()) {
         default_dir =
             base::SysUTF8ToNSString(settings.default_path.DirName().value());
       }


### PR DESCRIPTION
#### Description of Change

Restores `allowedContentTypes` / `UTType`-based macOS file dialog filters (replacing the temporary `setAllowedFileTypes` revert in #49444) and fixes package-type extensions (e.g. `.rtfd` with `LSTypeIsPackage`) by creating `UTType` with `com.apple.package` conformance before falling back to the default extension lookup.

Regression: #48191 (36.2.0+). Related: #47815, #48448.

**Test plan (manual, macOS):**
1. Create an `.rtfd` in TextEdit (rich text + drag an image in).
2. Run the [repro gist](https://gist.github.com/3afd1a232bdd7c2595ddb2cc885dcc98) on this branch.
3. `showOpenDialog` with `extensions: ['rtf', 'rtfd']` should list/select the `.rtfd` package.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed macOS `dialog.showOpenDialog` filters to include file packages (such as `.rtfd`) when filtering by extension.