### PR TITLE
ci: turn off analytics setup assistant prompts on macOS

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Turn off the analytics setup assistant prompts on macOS
       if: ${{ inputs.target-platform == 'macos' }}
-      run: killall "Setup Assistant"
+      run: sudo killall "Setup Assistant"
 
     - name: Turn off the reopen windows prompt on macOS
       if: ${{ inputs.target-platform == 'macos' }}

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Turn off the analytics setup assistant prompts on macOS
       if: ${{ inputs.target-platform == 'macos' }}
-      run: defaults write com.apple.SetupAssistant DidSeeAnalytics -bool true
+      run: killall "Setup Assistant"
 
     - name: Turn off the reopen windows prompt on macOS
       if: ${{ inputs.target-platform == 'macos' }}

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -122,6 +122,11 @@ jobs:
     - name: Turn off the unexpectedly quit dialog on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: defaults write com.apple.CrashReporter DialogType server
+
+    - name: Turn off the analytics setup assistant prompts on macOS
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: defaults write com.apple.SetupAssistant DidSeeAnalytics -bool true
+
     - name: Turn off the reopen windows prompt on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       # Tests spawn Electron child apps and SIGINT them; after enough abnormal

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Turn off the analytics setup assistant prompts on macOS
       if: ${{ inputs.target-platform == 'macos' }}
-      run: sudo killall "Setup Assistant"
+      run: sudo su root -c "killall 'Setup Assistant'" || true
 
     - name: Turn off the reopen windows prompt on macOS
       if: ${{ inputs.target-platform == 'macos' }}


### PR DESCRIPTION
#### Description of Change
Recently, probably due to GitHub actions updating the macOS image, tests have been failing on macos-arm64.  It looks like this prompt is blocking our tests:
<img width="1024" height="768" alt="screenshot-timeout-20260526043001" src="https://github.com/user-attachments/assets/cca107a9-a6b6-4e4f-8624-ab78be335d09" />
This PR should disable that prompt

- Resolves #51775
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
