### PR TITLE
docs: add Wayland note for minimize event

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -208,6 +208,10 @@ Emitted when the window exits from a maximized state.
 
 Emitted when the window is minimized.
 
+> [!NOTE]
+> On Wayland, “minimized” is not currently a supported state. The minimize event will only fire when triggered by client-side decoration (e.g. clicking the minimize
+> button on a frameless window’s Window Control Overlay)
+
 #### Event: 'restore'
 
 Emitted when the window is restored from a minimized state.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -284,6 +284,10 @@ Emitted when the window exits from a maximized state.
 
 Emitted when the window is minimized.
 
+> [!NOTE]
+> On Wayland, “minimized” is not currently a supported state. The minimize event will only fire when triggered by client-side decoration (e.g. clicking the minimize
+> button on a frameless window’s Window Control Overlay)
+
 #### Event: 'restore'
 
 Emitted when the window is restored from a minimized state.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1986,7 +1986,7 @@ Opens the DevTools.
 When `contents` is a `<webview>` tag, the `mode` would be `detach` by default,
 explicitly passing an empty `mode` can force using last used dock state.
 
-On Windows, if Windows Control Overlay is enabled, DevTools will be opened with `mode: 'detach'`.
+On Windows, if Window Control Overlay is enabled, DevTools will be opened with `mode: 'detach'`.
 
 #### `contents.closeDevTools()`
 

--- a/patches/chromium/chore_modify_chromium_handling_of_mouse_events.patch
+++ b/patches/chromium/chore_modify_chromium_handling_of_mouse_events.patch
@@ -5,7 +5,7 @@ Subject: chore: modify chromium handling of mouse events
 
 This patch does the following:
 
-1. When Windows Control Overlay is enabled, it allows chromium to handle synthetic mouse events generated for touch
+1. When Window Control Overlay is enabled, it allows chromium to handle synthetic mouse events generated for touch
 actions in the non-client caption area.
 2. It calls HandleMouseEvent on the delegate earlier in HandleMouseEventInternal, so that Electron can selectively disable
 draggable regions to allow events to propagate to the underlying renderer.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/51766

This PR add a note to address the lack of a minimized state in Wayland that affects how are events fire. There are also 2 typo fixes for references to "Window Control Overlay" containing an extra "s" that I just threw in here since they were trivial changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
