### PR TITLE
fix: npm package installation on Node 24.16.x

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 const { downloadArtifact } = require('@electron/get');
-
-const extract = require('extract-zip');
+const { ZipReaderStream } = require('@zip.js/zip.js');
 
 const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { Readable, Writable } = require('stream');
 
 const { version } = require('./package');
 
@@ -76,23 +76,51 @@ function isInstalled() {
 }
 
 // unzips and makes path.txt point at the correct executable
-function extractFile(zipPath) {
+async function extractFile(zipPath) {
   const distPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist');
+  const targetDir = path.join(__dirname, 'dist');
 
-  return extract(zipPath, { dir: path.join(__dirname, 'dist') }).then(() => {
-    // If the zip contains an "electron.d.ts" file,
-    // move that up
-    const srcTypeDefPath = path.join(distPath, 'electron.d.ts');
-    const targetTypeDefPath = path.join(__dirname, 'electron.d.ts');
-    const hasTypeDefinitions = fs.existsSync(srcTypeDefPath);
+  const fileStream = Readable.toWeb(fs.createReadStream(zipPath));
+  const zipStream = fileStream.pipeThrough(new ZipReaderStream());
 
-    if (hasTypeDefinitions) {
-      fs.renameSync(srcTypeDefPath, targetTypeDefPath);
+  for await (const entry of zipStream) {
+    const entryPath = path.join(targetDir, entry.filename);
+
+    if (!entryPath.startsWith(targetDir + path.sep) && entryPath !== targetDir) {
+      throw new Error(`Zip entry outside target directory: ${entry.filename}`);
     }
 
-    // Write a "path.txt" file.
-    return fs.promises.writeFile(path.join(__dirname, 'path.txt'), platformPath);
-  });
+    if (entry.directory) {
+      fs.mkdirSync(entryPath, { recursive: true });
+    } else {
+      fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+      const writable = fs.createWriteStream(entryPath);
+      await entry.readable.pipeTo(Writable.toWeb(writable));
+
+      if (entry.executable) {
+        fs.chmodSync(entryPath, 0o755);
+      } else if (entry.externalFileAttribute) {
+        // Restore Unix file permissions if available
+        const unixMode = (entry.externalFileAttribute >>> 16) & 0xFFFF;
+        if (unixMode !== 0) {
+          fs.chmodSync(entryPath, unixMode);
+        }
+      }
+    }
+  }
+
+  // If the zip contains an "electron.d.ts" file,
+  // move that up
+  const srcTypeDefPath = path.join(distPath, 'electron.d.ts');
+  const targetTypeDefPath = path.join(__dirname, 'electron.d.ts');
+  const hasTypeDefinitions = fs.existsSync(srcTypeDefPath);
+
+  if (hasTypeDefinitions) {
+    fs.renameSync(srcTypeDefPath, targetTypeDefPath);
+  }
+
+  // Write a "path.txt" file.
+  await fs.promises.writeFile(path.join(__dirname, 'path.txt'), platformPath);
 }
 
 function getPlatformPath() {

--- a/npm/package.json
+++ b/npm/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@electron/get": "^5.0.0",
     "@types/node": "^24.9.0",
-    "extract-zip": "^2.0.1"
+    "@zip.js/zip.js": "^2.8.26"
   },
   "engines": {
     "node": ">= 22.12.0"


### PR DESCRIPTION
#### Description of Change

fixes #51619

Replace unmaintained [extract-zip](https://github.com/max-mapper/extract-zip) (no commit in 5 years) with [@zip.js/zip.js](https://github.com/gildas-lormeau/zip.js) (modern looking)

I've used Claude Opus 4.7 High to do the migration, asking it to use streams.
TBH, the only part I'm not 100% sure about is the permissions (surprising, huh?), and could use your review. the rest is pretty straight forward.

Tested it as-is on Fedora 44 and Node 24.16.0 and everything appeared to work properly. This PR requires testing from Mac/Windows users.
New code uses newer syntax, such as async-await and const-await-for-of. Not sure if this is a problem with the Node versions you want to support.

In addition, `extract-zip` appears to be used in additional electron packages, such as `@electron/fiddle-core` and `@electron/packager`. This PR does not address those.

Also saw https://github.com/electron/extract-zip which @MarshallOfSound created. Appears to be rust-based. Not sure if this is the way you'd like to go instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: fix npm package installation on Node 24.16 and above