### PR TITLE
fix: avoid crash by explicitly calling `GetOrCreateProcess`

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -481,7 +481,11 @@ void ElectronBrowserClient::RegisterPendingSiteInstance(
     content::SiteInstance* pending_site_instance) {
   // Remember the original web contents for the pending renderer process.
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
-  const auto pending_process_id = pending_site_instance->GetProcess()->GetID();
+  const auto pending_process_id =
+      pending_site_instance
+          ->GetOrCreateProcess(ProcessAllocationContext{
+              ProcessAllocationSource::kNoProcessCreationExpected})
+          ->GetID();
   pending_processes_[pending_process_id] = web_contents;
 
   if (rfh->GetParent())


### PR DESCRIPTION
#### Description of Change

Chromium no longer supports (or is trying not to support) implicit process creation via `GetProcess` and [will crash with `CHECK(false)` if no process exists.](https://source.chromium.org/chromium/chromium/src/+/refs/tags/148.0.7778.180:content/browser/site_instance_impl.cc;l=443;drc=6bd89e56257f6ba76e1ad3f5c680f739aeded909) A crash related to this CHECK _has_ been reported, so this is something we should fix.

My change here is very naïve (I literally just copied the code directly from Chromium). We may want to be more thoughtful, though.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes

#### Release Notes

Notes: None.
