### PR TITLE
refactor: deferred process registration

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1019,6 +1019,11 @@ void ElectronBrowserClient::RenderProcessHostDestroyed(
   content::ChildProcessId process_id = host->GetID();
   pending_processes_.erase(process_id);
   renderer_is_subframe_.erase(process_id);
+  // Prune deferred registrations with dead WebContents.
+  std::erase_if(
+      deferred_process_registrations_,
+      [](const DeferredProcessRegistration& r) { return !r.web_contents; });
+
   host->RemoveObserver(this);
 }
 

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -479,12 +479,23 @@ bool ElectronBrowserClient::WebPreferencesNeedUpdateForColorRelatedStateChanges(
 void ElectronBrowserClient::RegisterPendingSiteInstance(
     content::RenderFrameHost* rfh,
     content::SiteInstance* pending_site_instance) {
-  // Remember the original web contents for the pending renderer process.
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+  const bool is_subframe = rfh->GetParent() != nullptr;
+
+  if (!pending_site_instance->HasProcess()) {
+    // Process hasn't been assigned yet. Defer registration until
+    // RenderProcessWillLaunch fires, which is guaranteed to happen before
+    // AppendExtraCommandLineSwitches. See crbug.com/388998723.
+    deferred_process_registrations_.push_back(
+        {scoped_refptr<content::SiteInstance>(pending_site_instance),
+         web_contents->GetWeakPtr(), is_subframe});
+    return;
+  }
+
   const auto pending_process_id = pending_site_instance->GetProcess()->GetID();
   pending_processes_[pending_process_id] = web_contents;
 
-  if (rfh->GetParent())
+  if (is_subframe)
     renderer_is_subframe_.insert(pending_process_id);
   else
     renderer_is_subframe_.erase(pending_process_id);

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -400,35 +400,26 @@ bool ElectronBrowserClient::IsRendererSubFrame(
   return renderer_is_subframe_.contains(process_id);
 }
 
+void ElectronBrowserClient::RegisterPendingProcess(
+    content::ChildProcessId process_id,
+    content::WebContents* web_contents,
+    bool is_subframe) {
+  pending_processes_[process_id] = web_contents;
+
+  if (is_subframe)
+    renderer_is_subframe_.insert(process_id);
+  else
+    renderer_is_subframe_.erase(process_id);
+}
+
+void ElectronBrowserClient::PruneDeadDeferredProcessRegistrations() {
+  base::EraseIf(deferred_process_registrations_, [](const auto& registration) {
+    return !registration.second.web_contents;
+  });
+}
+
 void ElectronBrowserClient::RenderProcessWillLaunch(
     content::RenderProcessHost* host) {
-  // Drain any site instances that were registered before their process was
-  // created. HasProcess() is now true and GetProcess() won't trigger the
-  // CHECK in SiteInstanceImpl::GetProcess(). This fires before
-  // AppendRendererCommandLine, so pending_processes_ will be populated
-  // in time for AppendExtraCommandLineSwitches.
-  auto it = deferred_process_registrations_.begin();
-  while (it != deferred_process_registrations_.end()) {
-    // if WebContents was destroyed (tab closed, etc.), discard.
-    if (!it->web_contents) {
-      it = deferred_process_registrations_.erase(it);
-      continue;
-    }
-
-    if (it->site_instance->HasProcess() &&
-        it->site_instance->GetProcess() == host) {
-      const auto process_id = host->GetID();
-      pending_processes_[process_id] = it->web_contents.get();
-      if (it->is_subframe)
-        renderer_is_subframe_.insert(process_id);
-      else
-        renderer_is_subframe_.erase(process_id);
-      it = deferred_process_registrations_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-
   // Remove in case the host is reused after a crash, otherwise noop.
   host->RemoveObserver(this);
 
@@ -511,21 +502,17 @@ void ElectronBrowserClient::RegisterPendingSiteInstance(
 
   if (!pending_site_instance->HasProcess()) {
     // Process hasn't been assigned yet. Defer registration until
-    // RenderProcessWillLaunch fires, which is guaranteed to happen before
-    // AppendExtraCommandLineSwitches. See crbug.com/388998723.
-    deferred_process_registrations_.push_back(
-        {scoped_refptr<content::SiteInstance>(pending_site_instance),
-         web_contents->GetWeakPtr(), is_subframe});
+    // SiteInstanceGotProcessAndSite fires, which is guaranteed to happen
+    // before AppendExtraCommandLineSwitches. See crbug.com/388998723.
+    PruneDeadDeferredProcessRegistrations();
+    deferred_process_registrations_.insert_or_assign(
+        pending_site_instance->GetId(),
+        DeferredProcessRegistration{web_contents->GetWeakPtr(), is_subframe});
     return;
   }
 
-  const auto pending_process_id = pending_site_instance->GetProcess()->GetID();
-  pending_processes_[pending_process_id] = web_contents;
-
-  if (is_subframe)
-    renderer_is_subframe_.insert(pending_process_id);
-  else
-    renderer_is_subframe_.erase(pending_process_id);
+  RegisterPendingProcess(pending_site_instance->GetProcess()->GetID(),
+                         web_contents, is_subframe);
 }
 
 void ElectronBrowserClient::AppendExtraCommandLineSwitches(
@@ -876,6 +863,19 @@ void ElectronBrowserClient::GetAdditionalWebUISchemes(
 
 void ElectronBrowserClient::SiteInstanceGotProcessAndSite(
     content::SiteInstance* site_instance) {
+  DCHECK(site_instance->HasProcess());
+
+  PruneDeadDeferredProcessRegistrations();
+  if (auto it = deferred_process_registrations_.find(site_instance->GetId());
+      it != deferred_process_registrations_.end()) {
+    if (it->second.web_contents) {
+      RegisterPendingProcess(site_instance->GetProcess()->GetID(),
+                             it->second.web_contents.get(),
+                             it->second.is_subframe);
+    }
+    deferred_process_registrations_.erase(it);
+  }
+
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* browser_context =
       static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
@@ -1019,10 +1019,7 @@ void ElectronBrowserClient::RenderProcessHostDestroyed(
   content::ChildProcessId process_id = host->GetID();
   pending_processes_.erase(process_id);
   renderer_is_subframe_.erase(process_id);
-  // Prune deferred registrations with dead WebContents.
-  std::erase_if(
-      deferred_process_registrations_,
-      [](const DeferredProcessRegistration& r) { return !r.web_contents; });
+  PruneDeadDeferredProcessRegistrations();
 
   host->RemoveObserver(this);
 }

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -402,6 +402,33 @@ bool ElectronBrowserClient::IsRendererSubFrame(
 
 void ElectronBrowserClient::RenderProcessWillLaunch(
     content::RenderProcessHost* host) {
+  // Drain any site instances that were registered before their process was
+  // created. HasProcess() is now true and GetProcess() won't trigger the
+  // CHECK in SiteInstanceImpl::GetProcess(). This fires before
+  // AppendRendererCommandLine, so pending_processes_ will be populated
+  // in time for AppendExtraCommandLineSwitches.
+  auto it = deferred_process_registrations_.begin();
+  while (it != deferred_process_registrations_.end()) {
+    // if WebContents was destroyed (tab closed, etc.), discard.
+    if (!it->web_contents) {
+      it = deferred_process_registrations_.erase(it);
+      continue;
+    }
+
+    if (it->site_instance->HasProcess() &&
+        it->site_instance->GetProcess() == host) {
+      const auto process_id = host->GetID();
+      pending_processes_[process_id] = it->web_contents.get();
+      if (it->is_subframe)
+        renderer_is_subframe_.insert(process_id);
+      else
+        renderer_is_subframe_.erase(process_id);
+      it = deferred_process_registrations_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
   // Remove in case the host is reused after a crash, otherwise noop.
   host->RemoveObserver(this);
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -14,7 +14,6 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ptr.h"
-#include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "content/public/browser/content_browser_client.h"
@@ -36,7 +35,6 @@ class ClientCertificateDelegate;
 class NavigationHandle;
 class PlatformNotificationService;
 class NavigationThrottleRegistry;
-class SiteInstance;
 class QuotaPermissionContext;
 }  // namespace content
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -20,6 +20,7 @@
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/render_process_host_observer.h"
+#include "content/public/browser/site_instance.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/buildflags/buildflags.h"
 #include "net/ssl/client_cert_identity.h"
@@ -365,6 +366,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       content::RenderFrameHost* rfh) const;
 
   bool IsRendererSubFrame(content::ChildProcessId process_id) const;
+  void RegisterPendingProcess(content::ChildProcessId process_id,
+                              content::WebContents* web_contents,
+                              bool is_subframe);
+  void PruneDeadDeferredProcessRegistrations();
 
   // pending_render_process => web contents.
   base::flat_map<content::ChildProcessId, content::WebContents*>
@@ -373,14 +378,14 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   base::flat_set<content::ChildProcessId> renderer_is_subframe_;
 
   // Registrations from RegisterPendingSiteInstance() for site instances that
-  // did not yet have a process. Drained in RenderProcessWillLaunch() before
-  // the command line is built.
+  // did not yet have a process. Drained in SiteInstanceGotProcessAndSite()
+  // before the renderer command line is built.
   struct DeferredProcessRegistration {
-    scoped_refptr<content::SiteInstance> site_instance;
     base::WeakPtr<content::WebContents> web_contents;
     bool is_subframe;
   };
-  std::vector<DeferredProcessRegistration> deferred_process_registrations_;
+  base::flat_map<content::SiteInstanceId, DeferredProcessRegistration>
+      deferred_process_registrations_;
 
   std::unique_ptr<PlatformNotificationService> notification_service_;
   std::unique_ptr<NotificationPresenter> notification_presenter_;

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -14,6 +14,8 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/frame_tree_node_id.h"
@@ -33,6 +35,7 @@ class ClientCertificateDelegate;
 class NavigationHandle;
 class PlatformNotificationService;
 class NavigationThrottleRegistry;
+class SiteInstance;
 class QuotaPermissionContext;
 }  // namespace content
 
@@ -368,6 +371,16 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       pending_processes_;
 
   base::flat_set<content::ChildProcessId> renderer_is_subframe_;
+
+  // Registrations from RegisterPendingSiteInstance() for site instances that
+  // did not yet have a process. Drained in RenderProcessWillLaunch() before
+  // the command line is built.
+  struct DeferredProcessRegistration {
+    scoped_refptr<content::SiteInstance> site_instance;
+    base::WeakPtr<content::WebContents> web_contents;
+    bool is_subframe;
+  };
+  std::vector<DeferredProcessRegistration> deferred_process_registrations_;
 
   std::unique_ptr<PlatformNotificationService> notification_service_;
   std::unique_ptr<NotificationPresenter> notification_presenter_;

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -51,10 +51,6 @@ void InitializeFeatureList() {
       // See https://chromium-review.googlesource.com/c/chromium/src/+/6487926
       // this breaks PDFs locally as we don't have GLIC infra enabled.
       std::string(",") + ax::mojom::features::kScreenAIOCREnabled.name +
-      // See https://chromium-review.googlesource.com/c/chromium/src/+/6626905
-      // Needed so that ElectronBrowserClient::RegisterPendingSiteInstance does
-      // not throw a check.
-      std::string(", TraceSiteInstanceGetProcessCreation") +
       // See https://chromium-review.googlesource.com/c/chromium/src/+/6910012
       // Needed until we rework some of our logic and checks to enable this
       // properly.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4212,6 +4212,35 @@ describe('BrowserWindow module', () => {
         expect(typeofProcess).to.equal('undefined');
         expect(typeofBuffer).to.equal('undefined');
       });
+
+      // Verify that webPreferences switches are correctly applied to a renderer
+      // process created for a cross-origin navigation. The new SiteInstance may not
+      // have a process at RegisterPendingSiteInstance() time; this exercises the
+      // deferred-registration path through RenderProcessWillLaunch().
+      it('applies webPreferences to renderer after cross-origin navigation', async () => {
+        const server = http.createServer((_req, res) => {
+          res.end('<html><body>ok</body></html>');
+        });
+        const { port } = await listen(server);
+        defer(() => server.close());
+
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: { nodeIntegration: true, contextIsolation: false }
+        });
+
+        // First navigation establishes the initial SiteInstance on 127.0.0.1.
+        await w.loadURL(`http://127.0.0.1:${port}/`);
+
+        // Cross-origin navigation: 'localhost' and '127.0.0.1' are treated as
+        // separate origins by Chromium, so this triggers a new SiteInstance whose
+        // renderer process does not yet exist at the time
+        // RegisterPendingSiteInstance() is called.
+        await w.loadURL(`http://localhost:${port}/`);
+
+        const typeofVersions = await w.webContents.executeJavaScript('typeof process.versions.electron');
+        expect(typeofVersions).to.equal('string');
+      });
     });
 
     describe('"sandbox" option', () => {


### PR DESCRIPTION
#### Description of Change

Chromium is removing support for using `SiteInstance::GetProcess()` to implicitly create a renderer process when none exists. When used that way now, some calls will crash from a `CHECK(false)` added in https://crrev.com/c/6626905, and whose TODO plans [to make the check unconditional](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/site_instance_impl.cc;l=436). 

`ElectronBrowserClient::RegisterSiteInstance()` got bit when it relied on `GetProcess()` for implicit process creation, so this PR moves registration to `ElectronBrowserClient::SiteInstanceGotProcessAndSite()`, a callback that fires when Chromium assigns a process. This happens before AppendRendererCommandLine(), which is when we need the process' information.

Builds on https://github.com/electron/electron/pull/51795 by @nmggithub .

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed potential crash in cross-site redirection. 

