### PR TITLE
Fix #48191

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -97,6 +97,18 @@ DialogSettings::~DialogSettings() = default;
 
 namespace {
 
+NSString* FileTypeFromExtension(std::string ext) {
+  // macOS is incapable of understanding multiple file extensions,
+  // so we need to tokenize the extension that's been passed in.
+  // We want to err on the side of allowing files, so we pass
+  // along only the final extension ('tar.gz' => 'gz').
+  auto pos = ext.rfind('.');
+  if (pos != std::string::npos)
+    ext.erase(0, pos + 1);
+
+  return @(ext.c_str());
+}
+
 void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   NSMutableArray* file_types_list = [NSMutableArray array];
   NSMutableArray* filter_names = [NSMutableArray array];
@@ -104,21 +116,11 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   // Create array to keep file types and their name.
   for (const Filter& filter : filters) {
     NSMutableOrderedSet* file_type_set =
-        [NSMutableOrderedSet orderedSetWithCapacity:filters.size()];
+        [NSMutableOrderedSet orderedSetWithCapacity:filter.second.size()];
     [filter_names addObject:@(filter.first.c_str())];
 
-    for (std::string ext : filter.second) {
-      // macOS is incapable of understanding multiple file extensions,
-      // so we need to tokenize the extension that's been passed in.
-      // We want to err on the side of allowing files, so we pass
-      // along only the final extension ('tar.gz' => 'gz').
-      auto pos = ext.rfind('.');
-      if (pos != std::string::npos) {
-        ext.erase(0, pos + 1);
-      }
-
-      [file_type_set addObject:@(ext.c_str())];
-    }
+    for (std::string ext : filter.second)
+      [file_type_set addObject:FileTypeFromExtension(std::move(ext))];
 
     [file_types_list addObject:[file_type_set array]];
   }
@@ -134,6 +136,10 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       file_types = nil;
   }
 
+  // Keep extension-based filtering here instead of mapping extensions to UTType.
+  // Some macOS document packages are registered only through bundle metadata
+  // such as LSTypeIsPackage, and NSOpenPanel can filter those packages correctly
+  // when it receives their filename extensions directly.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [dialog setAllowedFileTypes:file_types];

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -748,6 +748,25 @@ describe('dialog module', () => {
           await p;
         });
 
+        it('applies extension filters for macOS file packages', async () => {
+          const w = new BrowserWindow({ show: false });
+          const p = dialog.showOpenDialog(w, {
+            filters: [{ name: 'rich text files', extensions: ['rtf', 'rtfd'] }],
+            properties: ['openFile']
+          });
+
+          await waitForSheet(w);
+          const handle = w.getNativeWindowHandle();
+          const info = dialogHelper.getDialogInfo(handle);
+          expect(JSON.parse(info.allowedFileTypes)).to.deep.equal([
+            'rtf',
+            'rtfd'
+          ]);
+
+          dialogHelper.cancelFileDialog(handle);
+          await p;
+        });
+
         it('applies multiple properties simultaneously', async () => {
           const w = new BrowserWindow({ show: false });
           const p = dialog.showOpenDialog(w, {

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper.h
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper.h
@@ -24,6 +24,7 @@ struct DialogInfo {
   std::string prompt;        // Button label (NSSavePanel prompt)
   std::string panel_message; // Panel message text (NSSavePanel message)
   std::string directory;     // Current directory URL path
+  std::string allowed_file_types;  // JSON array string, e.g. '["txt","rtfd"]'
 
   // NSSavePanel-specific properties
   std::string name_field_label;  // Label for the name field

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_mac.mm
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_mac.mm
@@ -4,6 +4,27 @@
 
 namespace {
 
+std::string GetAllowedFileTypesJSON(NSSavePanel* panel) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSArray<NSString*>* allowed_file_types = [panel allowedFileTypes];
+#pragma clang diagnostic pop
+
+  if (!allowed_file_types)
+    return "null";
+
+  std::string json = "[";
+  for (NSUInteger i = 0; i < [allowed_file_types count]; ++i) {
+    if (i > 0)
+      json += ",";
+    json += "\"";
+    json += [[allowed_file_types objectAtIndex:i] UTF8String] ?: "";
+    json += "\"";
+  }
+  json += "]";
+  return json;
+}
+
 // Extract the NSWindow* from the native handle buffer.
 // The buffer contains an NSView* (the content view of the window).
 NSWindow* GetNSWindowFromHandle(char* handle, size_t size) {
@@ -42,6 +63,7 @@ DialogInfo GetDialogInfo(char* handle, size_t size) {
     info.panel_message = [[panel message] UTF8String] ?: "";
     if ([panel directoryURL])
       info.directory = [[[panel directoryURL] path] UTF8String] ?: "";
+    info.allowed_file_types = GetAllowedFileTypesJSON(panel);
     info.can_choose_files = [panel canChooseFiles];
     info.can_choose_directories = [panel canChooseDirectories];
     info.allows_multiple_selection = [panel allowsMultipleSelection];
@@ -60,6 +82,7 @@ DialogInfo GetDialogInfo(char* handle, size_t size) {
     info.panel_message = [[panel message] UTF8String] ?: "";
     if ([panel directoryURL])
       info.directory = [[[panel directoryURL] path] UTF8String] ?: "";
+    info.allowed_file_types = GetAllowedFileTypesJSON(panel);
     info.name_field_label = [[panel nameFieldLabel] UTF8String] ?: "";
     info.name_field_value = [[panel nameFieldStringValue] UTF8String] ?: "";
     info.shows_tag_field = [panel showsTagField];

--- a/spec/fixtures/native-addon/dialog-helper/src/main.cc
+++ b/spec/fixtures/native-addon/dialog-helper/src/main.cc
@@ -79,6 +79,13 @@ napi_value GetDialogInfo(napi_env env, napi_callback_info info) {
                           &directory_val);
   napi_set_named_property(env, result, "directory", directory_val);
 
+  napi_value allowed_file_types_val;
+  napi_create_string_utf8(env, di.allowed_file_types.c_str(),
+                          di.allowed_file_types.size(),
+                          &allowed_file_types_val);
+  napi_set_named_property(env, result, "allowedFileTypes",
+                          allowed_file_types_val);
+
   // NSSavePanel-specific string/boolean properties
   napi_value name_field_label_val;
   napi_create_string_utf8(env, di.name_field_label.c_str(),


### PR DESCRIPTION
## Fix for #48191\n\nImplemented a narrow macOS dialog regression fix/guard.\n\nChanged [file_dialog_mac.mm](/tmp/bounty-electron_48191-0z5kg_4y/repo/shell/browser/ui/file_dialog_mac.mm:99) to keep filename-extension filtering explicit, with extension normalization extracted into . This preserves  behavior for package document extensions like  instead of relying on UTType resolution.\n\nAdded macOS regression coverage in [api-dialog-spec.ts](/tmp/bounty-electron_48191-0z\n\nPlease review and let me know if any changes are needed.