### PR TITLE
build: enable ThinLTO link-time optimization for the main binary

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1148,6 +1148,15 @@ if (is_mac) {
   mac_framework_bundle("electron_framework") {
     output_name = electron_framework_name
     framework_version = electron_framework_version
+
+    # Perform full ThinLTO optimization in the link step for the framework
+    # (where all of Chromium/Electron's code lives on macOS), matching what
+    # Chrome does for its framework. The default thinlto_optimize_default
+    # config links with --lto-O0, which skips link-time optimization entirely
+    # and gives up most of the benefit of ThinLTO and PGO.
+    configs -= [ "//build/config/compiler:thinlto_optimize_default" ]
+    configs += [ "//build/config/compiler:thinlto_optimize_max" ]
+
     framework_contents = [
       "Resources",
       "Libraries",
@@ -1480,6 +1489,15 @@ if (is_mac) {
 
   executable("electron_app") {
     output_name = electron_project_name
+
+    # Perform full ThinLTO optimization in the link step for the main binary,
+    # matching what Chrome does for its main executable. The default
+    # thinlto_optimize_default config links with --lto-O0, which skips
+    # link-time optimization entirely and gives up most of the benefit of
+    # ThinLTO and PGO.
+    configs -= [ "//build/config/compiler:thinlto_optimize_default" ]
+    configs += [ "//build/config/compiler:thinlto_optimize_max" ]
+
     if (is_win) {
       sources = [ "shell/app/electron_main_win.cc" ]
     } else if (is_linux) {


### PR DESCRIPTION
#### Description of Change

Chromium's build system applies the `thinlto_optimize_default` config to every target by default. That config passes `--lto-O0` (Windows: `/opt:lldlto=0`) to the linker, meaning **no optimization is performed during the ThinLTO link step** — it exists to keep developer links fast. Targets that want real link-time optimization must explicitly swap in `thinlto_optimize_max`, which Chrome does for its three main binaries (`chrome_initial`, `chrome_dll` on Windows, and `chrome_framework` on macOS).

Electron has never done this swap, so every release build of Electron that uses ThinLTO (Linux and Windows today; macOS once #51669 lands) links the main binary with `--lto-O0`, giving up cross-module inlining and most of the link-time benefit of PGO.

This change applies the same config swap to `electron_app` (Linux/Windows executable) and `electron_framework` (macOS framework), exactly mirroring what `chrome/BUILD.gn` does for its equivalent targets.

#### Performance impact (measured)

Speedometer 3.1, Linux x64 release build from `main`, interleaved benchmark rounds of 10 iterations each on the same machine:

| Build | Score |
|---|---|
| Electron release build today (`--lto-O0`) | 22.08 ± 0.19 |
| Electron with this change (`--lto-O2`) | 24.99 ± 0.79 |

**+13.2% improvement.** For reference, Chrome for Testing at the same Chromium version (150.0.7863.0) scores ~28.4 in the same environment, so this change closes roughly half of the gap between Electron release builds and Chrome.

#### Build cost

- The final ThinLTO link of the main binary becomes more expensive: observed ~8 min → ~15 min on a 64-core machine, peak link RAM ~38 GB.
- `.text` grows ~8.4% from more aggressive cross-module inlining — the same trade-off Chrome makes for its binaries.
- Component/testing builds (which don't use ThinLTO) are unaffected.

#### Related

- #51669 — complementary: without this change, macOS would still link at `--lto-O0` once ThinLTO is re-enabled there; with it, that PR delivers full link-time optimization on macOS too.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved performance of Linux and Windows release builds by enabling ThinLTO link-time optimization for the main Electron binary.
