### PR TITLE
fix: invoke clang-format without shell parsing

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -130,12 +130,12 @@ def run_clang_format_diff(args, file_name):
         print(" ".join(invocation))
         return [], []
     try:
-        with subprocess.Popen(' '.join(invocation),
+        with subprocess.Popen(invocation,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               universal_newlines=True,
                               encoding='utf-8',
-                              shell=True) as proc:
+                              shell=False) as proc:
             outs = list(proc.stdout.readlines())
             errs = list(proc.stderr.readlines())
             proc.wait()


### PR DESCRIPTION
#### Description of Change

This updates `script/run-clang-format.py` to invoke `clang-format` by passing the argv list directly to `subprocess.Popen()` instead of joining the command into a shell string.

The current implementation uses `' '.join(invocation)` with `shell=True`, which breaks valid executable paths or filenames that contain spaces and allows shell parsing to reinterpret path characters that should be passed through literally.

This keeps the existing behavior but preserves the original arguments exactly.

Validation performed for this change:

- `python3 -m py_compile script/run-clang-format.py`
- Ran `script/run-clang-format.py` against a fake `clang-format` executable whose path contained spaces and a `.cc` file whose path also contained spaces

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [ ] I have reviewed and verified the changes
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [ ] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

#### Release Notes

Notes: none
