### PR TITLE
build: consume Electron-generated PGO profiles in release builds

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -172,6 +172,10 @@ runs:
           SEDOPTION="-i ''"
         fi
         sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
+        # The Electron builtins profile path is a bare value on the line after
+        # --turbo-profiling-input; both lines must go or mksnapshot treats the
+        # leftover path as a script to execute.
+        sed $SEDOPTION '/.*pgo_profiles/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--reorder-builtins/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--warn-about-builtin-profile-data/d' out/Default/mksnapshot_args

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -195,6 +195,17 @@ jobs:
     - name: Run Electron Only Hooks
       run: |
         e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
+    # Release builds consume Electron-generated PGO profiles, resolved through
+    # the state files in build/pgo_profiles. The gclient hooks that download
+    # them do not run in build jobs ("Run Electron Only Hooks" sets
+    # process_deps=False, and cross-compiled targets do not match the host's
+    # checkout_* vars), so fetch exactly this build's profile here.
+    - name: Download PGO Profiles
+      if: ${{ inputs.gn-build-type == 'release' }}
+      env:
+        PGO_TARGET: ${{ inputs.target-platform }}-${{ inputs.target-arch }}
+      run: |
+        python3 src/electron/script/pgo/download-profiles.py --targets "$PGO_TARGET,v8-builtins"
     - name: Regenerate DEPS Hash
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -206,6 +206,13 @@ jobs:
       - name: Run Electron Only Hooks
         run: |
           e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
+      - name: Download PGO Profiles
+        if: ${{ inputs.gn-build-type == 'release' }}
+        env:
+          PGO_TARGET: ${{ inputs.target-platform }}-${{ inputs.target-arch }}
+        run: >
+          python3 src/electron/script/pgo/download-profiles.py --targets
+          "$PGO_TARGET,v8-builtins"
       - name: Regenerate DEPS Hash
         run: >
           (cd src/electron && git checkout .) && node

--- a/DEPS
+++ b/DEPS
@@ -40,7 +40,11 @@ vars = {
   'checkout_chromium': True,
   'checkout_node': True,
   'checkout_nan': True,
-  'checkout_pgo_profiles': True,
+  # Chrome's published PGO profiles are not consumed - Electron release
+  # builds use Electron-generated profiles (see build/pgo_profiles/). Set to
+  # True (and set the pgo_data_path GN arg) to build against Chrome's
+  # profiles instead.
+  'checkout_pgo_profiles': False,
 
   # It's only needed to parse the native tests configurations.
   'checkout_pyyaml': False,
@@ -202,6 +206,38 @@ hooks = [
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=x64'],
+  },
+  # Electron-collected PGO profiles, consumed by official builds in place of
+  # Chrome's published profiles (which cannot cover Electron's code). The
+  # state files in src/electron/build/pgo_profiles name the profile to use;
+  # these hooks download them.
+  {
+    'name': 'electron_pgo_profiles_linux',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_linux and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'linux-x64,linux-arm,linux-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_win',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_win and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'win-x64,win-x86,win-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_mac',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_mac and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'macos-x64,macos-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_v8_builtins',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'v8-builtins'],
   },
 ]
 

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -7,3 +7,13 @@ is_official_build = true
 # who have an LGPL requirement to ship ffmpeg as a dynamically linked library,
 # we build ffmpeg as a shared library.
 is_component_ffmpeg = true
+
+# Electron-generated PGO profiles. The C++ profiles are resolved by Chromium's
+# standard chrome_pgo_phase = 2 machinery (patched to read Electron's state
+# files - see
+# patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch),
+# so this file only needs to point V8's builtins profiling at the Electron
+# profile. Both are downloaded by gclient hooks; see
+# build/pgo_profiles/README.md.
+v8_builtins_profiling_log_file =
+    "//electron/build/pgo_profiles/electron-v8-builtins.profile"

--- a/build/pgo_profiles/.gitignore
+++ b/build/pgo_profiles/.gitignore
@@ -1,0 +1,5 @@
+# Downloaded profile data (fetched by script/pgo/download-profiles.py via
+# gclient hooks); only the .pgo.txt state files are checked in.
+*.profdata
+*.profile
+*.version

--- a/build/pgo_profiles/README.md
+++ b/build/pgo_profiles/README.md
@@ -1,0 +1,61 @@
+# Electron PGO profiles
+
+Electron release builds are optimized with Electron-collected PGO profiles
+instead of Chrome's published ones. PGO profiles match functions by symbol
+name and control-flow hash, so Chrome's profiles cannot cover code that
+differs in Electron - all of Node.js, patched Chromium files, V8 built with
+Node's flags, and the Electron shell - and uncovered functions are laid out
+as cold.
+
+Profiles are generated and uploaded by Electron's PGO generation pipeline and
+served from `https://dev-cdn-experimental.electronjs.org/pgo/`.
+
+## How consumption works
+
+1. **State files** - `<target>.pgo.txt` in this directory names the profile
+   each target uses (e.g. `electron-linux-x64-<timestamp>-<sha>.profdata`).
+   Updating a profile means updating the state file; profile binaries are
+   never checked in.
+2. **Download** - gclient hooks (see `DEPS`) run
+   `script/pgo/download-profiles.py`, which downloads each state file's
+   profile into this directory under its versioned name (the V8 builtins
+   profile uses the fixed name `electron-v8-builtins.profile`, since GN args
+   files reference it statically).
+3. **Build wiring** - Chromium's standard `chrome_pgo_phase = 2` machinery
+   applies the profile. A small patch
+   (`patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch`)
+   teaches its profile resolution to read Electron's state files - including
+   per-arch Linux profiles, which upstream does not have - so every compiler
+   and linker flag upstream maintains for PGO (`-fprofile-use`, warning
+   suppressions, extended-TSP block layout, and anything they add in the
+   future) applies to Electron's profiles unchanged.
+
+`chrome_pgo_phase` already defaults to 2 for official builds, so no
+per-platform configuration is needed - any release build on any platform/arch
+picks up its profile automatically:
+
+```sh
+e init my-release --root=$PWD --import release
+e build
+```
+
+The V8 builtins profile is wired separately (it is consumed by mksnapshot,
+not clang): `release.gn` points `v8_builtins_profiling_log_file` at the
+downloaded Electron builtins profile.
+
+## Fallbacks
+
+- Build against Chrome's published profiles: set the `pgo_data_path` GN arg
+  to a Chrome profile (explicitly set paths take precedence over Electron's
+  state-file resolution) and set `checkout_pgo_profiles=True` in gclient
+  custom vars so Chrome's profile is downloaded.
+- Build without PGO entirely: `chrome_pgo_phase = 0`.
+
+## Platform notes
+
+| Target | C++ profile | V8 builtins profile |
+|---|---|---|
+| linux-x64, linux-arm64 | yes | yes (64-bit profile) |
+| macos-x64, macos-arm64 | yes | yes (64-bit profile) |
+| win-x64, win-arm64 | yes | yes (64-bit profile) |
+| linux-arm, win-x86 | yes | no - Electron only generates a 64-bit builtins profile; the mismatch is skipped (mksnapshot warns rather than aborts) |

--- a/build/pgo_profiles/linux-arm.pgo.txt
+++ b/build/pgo_profiles/linux-arm.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-arm-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/linux-arm64.pgo.txt
+++ b/build/pgo_profiles/linux-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-arm64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/linux-x64.pgo.txt
+++ b/build/pgo_profiles/linux-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-x64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/macos-arm64.pgo.txt
+++ b/build/pgo_profiles/macos-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-macos-arm64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/macos-x64.pgo.txt
+++ b/build/pgo_profiles/macos-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-macos-x64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/v8-builtins.pgo.txt
+++ b/build/pgo_profiles/v8-builtins.pgo.txt
@@ -1,0 +1,1 @@
+electron-v8-x64-1780284798-e059bcf24f.profile

--- a/build/pgo_profiles/win-arm64.pgo.txt
+++ b/build/pgo_profiles/win-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-arm64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/win-x64.pgo.txt
+++ b/build/pgo_profiles/win-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-x64-1780290387-e059bcf24f.profdata

--- a/build/pgo_profiles/win-x86.pgo.txt
+++ b/build/pgo_profiles/win-x86.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-x86-1780290387-e059bcf24f.profdata

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -1,4 +1,5 @@
 build_gn.patch
+build_resolve_pgo_profiles_from_electron_state_files.patch
 accelerator.patch
 blink_local_frame.patch
 can_create_window.patch

--- a/patches/chromium/build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch
+++ b/patches/chromium/build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch
@@ -29,7 +29,7 @@ and Chrome's instrumented Windows builds compile natively on Windows.
 This patch can be upstreamed.
 
 diff --git a/build/config/compiler/pgo/BUILD.gn b/build/config/compiler/pgo/BUILD.gn
-index 37251f8e9ba3848b4f8bd1fc487b54d5905fb705..ff5f5627dde1c736ddafbb2adf352b8cc32e774c 100644
+index 7a412483528f4342517c51ba5e07a56c68fea946..46d945f70b2e2b5fb4b17d2f7737e14a80b85c99 100644
 --- a/build/config/compiler/pgo/BUILD.gn
 +++ b/build/config/compiler/pgo/BUILD.gn
 @@ -42,6 +42,34 @@ config("pgo_instrumentation_flags") {

--- a/patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch
+++ b/patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sam Attard <sattard@anthropic.com>
+Date: Mon, 1 Jun 2026 05:48:08 +0000
+Subject: build: resolve PGO profiles from Electron state files
+
+Electron generates its own PGO profiles because Chrome's published
+profiles cannot cover code that differs in Electron (Node.js, patched
+Chromium files, V8 built with Node's flags, the Electron shell). This
+resolves the profile for the standard chrome_pgo_phase = 2 optimization
+flow from Electron's per-platform/arch state files - including per-arch
+Linux profiles, which upstream does not have - so every flag upstream
+adds to its PGO configuration applies to Electron's profiles unchanged.
+
+An explicitly set pgo_data_path still takes precedence, preserving the
+existing override behavior.
+
+diff --git a/build/config/compiler/pgo/BUILD.gn b/build/config/compiler/pgo/BUILD.gn
+index 37251f8e9ba3848b4f8bd1fc487b54d5905fb705..7a412483528f4342517c51ba5e07a56c68fea946 100644
+--- a/build/config/compiler/pgo/BUILD.gn
++++ b/build/config/compiler/pgo/BUILD.gn
+@@ -117,6 +117,46 @@ config("pgo_optimization_flags") {
+       inputs = [ "//chrome/build/android-desktop-x64.pgo.txt" ]
+     }
+ 
++    # Electron generates and consumes its own PGO profiles. They are named per
++    # platform/arch - including per-arch Linux profiles, which Chrome does not
++    # have - and resolved through state files in Electron's tree, downloaded
++    # by Electron's gclient hooks. Resolution is skipped when pgo_data_path is
++    # set explicitly, preserving that arg as an override.
++    # See //electron/build/pgo_profiles/README.md.
++    if (is_electron_build && pgo_data_path == "") {
++      _electron_pgo_target = ""
++      if (is_win) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "win-arm64"
++        } else if (target_cpu == "x64") {
++          _electron_pgo_target = "win-x64"
++        } else {
++          _electron_pgo_target = "win-x86"
++        }
++      } else if (is_mac) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "macos-arm64"
++        } else {
++          _electron_pgo_target = "macos-x64"
++        }
++      } else if (is_linux) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "linux-arm64"
++        } else if (target_cpu == "arm") {
++          _electron_pgo_target = "linux-arm"
++        } else {
++          _electron_pgo_target = "linux-x64"
++        }
++      }
++      if (_electron_pgo_target != "") {
++        _electron_state_file =
++            "//electron/build/pgo_profiles/${_electron_pgo_target}.pgo.txt"
++        inputs += [ _electron_state_file ]
++        pgo_data_path = "//electron/build/pgo_profiles/" +
++                        read_file(_electron_state_file, "trim string")
++      }
++    }
++
+     if (_pgo_target != "" && pgo_data_path == "") {
+       common_args = [
+         "--target",

--- a/script/pgo/download-profiles.py
+++ b/script/pgo/download-profiles.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Downloads Electron PGO profiles named by the build/pgo_profiles state files.
+
+Each target has a <target>.pgo.txt state file naming the profile to download
+(generated and uploaded by .github/workflows/pgo-generation.yml).
+
+C++ profiles are saved under their full versioned names - the same name the
+state file contains - because the build resolves the profile path by reading
+the state file (see
+patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch).
+Stale versions of a target's profile are removed after a successful download.
+
+The V8 builtins profile is saved under the fixed name
+electron-v8-builtins.profile, which release.gn references statically (GN args
+files cannot read state files).
+
+Run by gclient hooks (see electron's DEPS) and safe to run manually:
+
+  python3 script/pgo/download-profiles.py --targets linux-x64,v8-builtins
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+CDN_BASE_URL = os.environ.get(
+    'ELECTRON_PGO_CDN_URL', 'https://dev-cdn-experimental.electronjs.org/pgo/'
+)
+
+PROFILES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', '..', 'build', 'pgo_profiles'
+)
+
+DOWNLOAD_RETRIES = 3
+DOWNLOAD_RETRY_DELAY_S = 5
+
+# Profile names have a strict format (electron-<target>-<timestamp>-<sha> plus
+# an extension); reject anything else so a state file can never alter the
+# download URL beyond selecting a file under the CDN prefix.
+SAFE_PROFILE_NAME = re.compile(r'^[A-Za-z0-9._-]+$')
+
+V8_BUILTINS_TARGET = 'v8-builtins'
+V8_BUILTINS_LOCAL_NAME = 'electron-v8-builtins.profile'
+
+
+def read_state_file(target):
+    state_path = os.path.join(PROFILES_DIR, f'{target}.pgo.txt')
+    if not os.path.isfile(state_path):
+        raise SystemExit(
+            f'error: no state file for target "{target}" at {state_path}'
+        )
+    with open(state_path, encoding='utf-8') as f:
+        profile_name = f.read().strip()
+    if (
+        not profile_name
+        or not SAFE_PROFILE_NAME.match(profile_name)
+        # The regex bans path separators, so the only traversal-capable names
+        # are the dot directories themselves.
+        or profile_name in ('.', '..')
+    ):
+        raise SystemExit(
+            f'error: invalid profile name {profile_name!r} in {state_path}'
+        )
+    return profile_name
+
+
+def remove_stale_profiles(target, keep_name):
+    """Removes old versions of a target's profile after an update."""
+    prefix = f'electron-{target}-'
+    for name in os.listdir(PROFILES_DIR):
+        if (
+            name.startswith(prefix)
+            and name.endswith('.profdata')
+            and name != keep_name
+        ):
+            os.remove(os.path.join(PROFILES_DIR, name))
+            print(f'{target}: removed stale {name}')
+
+
+def fetch(url, dest):
+    for attempt in range(1, DOWNLOAD_RETRIES + 1):
+        try:
+            tmp_dest = dest + '.tmp'
+            with urllib.request.urlopen(url, timeout=300) as response, open(
+                tmp_dest, 'wb'
+            ) as out:
+                while True:
+                    chunk = response.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            os.replace(tmp_dest, dest)
+            return
+        except (urllib.error.URLError, OSError) as e:
+            if os.path.isfile(dest + '.tmp'):
+                os.remove(dest + '.tmp')
+            if attempt == DOWNLOAD_RETRIES:
+                raise SystemExit(f'error: failed to download {url}: {e}') from e
+            print(f'attempt {attempt} failed ({e}), retrying')
+            time.sleep(DOWNLOAD_RETRY_DELAY_S * attempt)
+
+
+def download_cpp_profile(target):
+    cdn_name = read_state_file(target)
+    dest = os.path.join(PROFILES_DIR, cdn_name)
+
+    # Versioned names mean presence implies correctness.
+    if os.path.isfile(dest):
+        print(f'{target}: {cdn_name} already present')
+        return
+
+    url = CDN_BASE_URL + cdn_name
+    print(f'{target}: downloading {url}')
+    fetch(url, dest)
+    remove_stale_profiles(target, cdn_name)
+    size_mb = os.path.getsize(dest) / (1024 * 1024)
+    print(f'{target}: wrote {cdn_name} ({size_mb:.1f} MB)')
+
+
+def download_v8_builtins_profile():
+    cdn_name = read_state_file(V8_BUILTINS_TARGET)
+    dest = os.path.join(PROFILES_DIR, V8_BUILTINS_LOCAL_NAME)
+    version_marker = dest + '.version'
+
+    # Fixed local name: a version marker tracks which CDN profile it holds.
+    if os.path.isfile(dest) and os.path.isfile(version_marker):
+        with open(version_marker, encoding='utf-8') as f:
+            if f.read().strip() == cdn_name:
+                print(f'{V8_BUILTINS_TARGET}: {cdn_name} already present')
+                return
+
+    url = CDN_BASE_URL + cdn_name
+    print(f'{V8_BUILTINS_TARGET}: downloading {url}')
+    fetch(url, dest)
+    with open(version_marker, 'w', encoding='utf-8') as f:
+        f.write(cdn_name + '\n')
+    size_mb = os.path.getsize(dest) / (1024 * 1024)
+    print(
+        f'{V8_BUILTINS_TARGET}: wrote {V8_BUILTINS_LOCAL_NAME} '
+        f'({size_mb:.1f} MB, {cdn_name})'
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--targets',
+        required=True,
+        help='comma-separated profile targets, e.g. linux-x64,linux-arm,v8-builtins',
+    )
+    args = parser.parse_args()
+
+    os.makedirs(PROFILES_DIR, exist_ok=True)
+    for target in args.targets.split(','):
+        target = target.strip()
+        if target == V8_BUILTINS_TARGET:
+            download_v8_builtins_profile()
+        else:
+            download_cpp_profile(target)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
#### Description of Change

Wires Electron release builds to consume **Electron-generated PGO profiles** instead of Chrome's published ones. This is the consumption side of the PGO pipeline (generation side: #51812 — the two PRs are independent and can merge in either order).

**The problem**

Release builds apply Chrome's published PGO profile (`chrome_pgo_phase = 2`). PGO profiles match functions by symbol name + control-flow hash, so every function that differs from Chrome — **all of Node.js, patched Chromium files, V8 built with Node's flags, and the Electron shell** — gets no optimization guidance and is laid out as cold. The same applies to V8's builtins profile: Chrome's rejects Electron's promise/async builtins (`RunMicrotasks`, `AsyncFunctionAwait`, `FulfillPromise`, …) because Node's integration changes their codegen.

This isn't theoretical. Shipping Electron 44 has a **2.1× regression in `crypto.randomBytes`** vs Electron 42 (829K → 390K ops/s) caused by exactly this: a BoringSSL patch changed function hashes, Chrome's profile silently stopped covering them. The Electron profile recovers it completely (839K ops/s).

**How it works**

```
build/pgo_profiles/<target>.pgo.txt     state files name the profile per target (only these change on updates)
        |
        v  gclient hooks (DEPS) run script/pgo/download-profiles.py
build/pgo_profiles/electron-<target>-<version>.profdata     downloaded under their versioned names
        |
        v  Chromium's standard chrome_pgo_phase = 2 machinery
-fprofile-use + every other flag upstream      a small Chromium patch teaches its profile
maintains (warning suppressions, ext-TSP       resolution to read Electron's state files,
block layout, future additions) applied        including per-arch Linux profiles which
to Electron's profiles unchanged               upstream does not have
```

- **Chromium's PGO configuration stays authoritative**: the patch only redirects *which profile* the standard `chrome_pgo_phase = 2` flow resolves; all compiler/linker flags come from upstream's config and track it automatically (this addresses the cflags-drift concern raised in review — the parallel-config approach had in fact already drifted, missing `-enable-ext-tsp-block-placement`)
- A single `release.gn` import works on every platform/arch — `chrome_pgo_phase` already defaults to 2 for official builds, so it only wires the V8 builtins profile
- Chrome's published profiles are no longer downloaded (`checkout_pgo_profiles = False`); an explicitly set `pgo_data_path` still takes precedence as an escape hatch back to them
- 32-bit targets (`win-x86`, `linux-arm`) get the C++ profile but keep no builtins PGO (Electron only generates a 64-bit builtins profile)

---

### Benchmark results

> **37 statistically significant improvements, 0 regressions, 1 tie across 38 app-operation benchmarks — overall geomean +19.5% vs the shipping nightly.** Full data below.

<details>
<summary><b>All benchmark records (click to expand)</b></summary>

#### 1. Headline: shipping nightly vs this work (conclusive, statistically controlled)

**Methodology**: official `v44.0.0-nightly.20260529` vs an identical-source build with Electron PGO profiles + ThinLTO¹, Linux x64, **38 benchmarks × 5 interleaved rounds per build** (A,B,A,B,… to cancel thermal/cache drift), idle machine, Welch's t-test at p < 0.05.

| Area | Geomean | Largest wins |
|---|---|---|
| **contextBridge** | **+28.1%** | deep nested objects **+54.6%**, small objects **+49.6%**, arrays **+48.3%**, callbacks **+40.9%** |
| **Networking** | **+18.8%** | POST echo **+39.5%**, `response.json()` **+36.6%**, fetch 1KB **+28.9%**, XHR **+27.7%** |
| **IPC** | **+10.9%** | structured clone (Map/Set/Date) **+16.1%**, 1MB payloads **+14.7%**, 5MB throughput **+13.0%** |

¹ The comparison build also includes ThinLTO `--lto-O2` (#51669/#51809), since that is the configuration releases will ship with once both land. For PGO's isolated contribution see section 2.

<details>
<summary><b>Full 38-test table (click to expand)</b></summary>

| Test | Nightly | With profiles | Δ | Significant |
|---|---|---|---|---|
| bridge: void call (no args) | 1,823,713 | 2,292,331 | +25.7% | ✅ |
| bridge: echo number | 1,449,493 | 1,880,806 | +29.8% | ✅ |
| bridge: echo 1KB string | 1,446,386 | 1,884,338 | +30.3% | ✅ |
| bridge: echo small object | 369,786 | 553,153 | +49.6% | ✅ |
| bridge: echo deep nested object | 103,109 | 159,361 | +54.6% | ✅ |
| bridge: echo 500-elem array | 1,133 | 1,681 | +48.3% | ✅ |
| bridge: echo 64KB typed array | 15,362 | 15,966 | +3.9% | ✅ |
| bridge: echo 1MB typed array | 637 | 650 | +2.0% | tie (memcpy-bound) |
| bridge: transform object | 342,173 | 506,416 | +48.0% | ✅ |
| bridge: callback round-trip | 144,697 | 203,861 | +40.9% | ✅ |
| bridge: exposed property access | 7,419,663 | 8,031,797 | +8.3% | ✅ |
| bridge: async function (promise) | 159,229 | 202,957 | +27.5% | ✅ |
| bridge: invoke round-trip (small) | 10,603 | 11,920 | +12.4% | ✅ |
| ipc: invoke small object | 11,529 | 12,373 | +7.3% | ✅ |
| ipc: invoke 10KB JSON object | 3,070 | 3,478 | +13.3% | ✅ |
| ipc: invoke 64KB typed array | 2,276 | 2,592 | +13.9% | ✅ |
| ipc: invoke 1MB typed array | 210 | 241 | +14.7% | ✅ |
| ipc: invoke structured clone (Map/Set/Date) | 4,702 | 5,462 | +16.1% | ✅ |
| ipc: invoke 5MB throughput (MB/s) | 223 | 252 | +13.0% | ✅ |
| ipc: invoke 20MB throughput (MB/s) | 227 | 254 | +11.7% | ✅ |
| ipc: one-way send throughput (msgs/s) | 23,392 | 23,747 | +1.5% | ✅ |
| ipc: webContents.send round-trip | 12,250 | 13,646 | +11.4% | ✅ |
| ipc: MessagePort round-trip | 14,033 | 15,239 | +8.6% | ✅ |
| ipc: executeJavaScript round-trip | 11,795 | 12,844 | +8.9% | ✅ |
| net: fetch 1KB round-trip | 761 | 981 | +28.9% | ✅ |
| net: fetch 64KB round-trip | 735 | 907 | +23.4% | ✅ |
| net: fetch 1MB round-trip | 279 | 317 | +13.7% | ✅ |
| net: fetch 8MB throughput (MB/s) | 524 | 554 | +5.9% | ✅ |
| net: 4x parallel 64KB fetches | 237 | 288 | +21.4% | ✅ |
| net: POST echo 2KB | 821 | 1,146 | +39.5% | ✅ |
| net: POST echo 256KB | 287 | 347 | +21.1% | ✅ |
| net: fetch + response.json() (10KB) | 727 | 993 | +36.6% | ✅ |
| net: fetch + response.text() (64KB) | 665 | 840 | +26.3% | ✅ |
| net: XHR 64KB round-trip | 691 | 883 | +27.7% | ✅ |
| net: WebSocket echo 1KB | 9,955 | 10,643 | +6.9% | ✅ |
| net: WebSocket echo 64KB | 1,574 | 1,685 | +7.1% | ✅ |
| net: node https.get 64KB | 4,003 | 4,355 | +8.8% | ✅ |
| net: node https.get 1MB | 358 | 372 | +4.0% | ✅ |

All values ops/s unless noted. The single non-win (1MB typed array marshaling) is dominated by raw memcpy, which PGO cannot accelerate.

</details>

#### 2. PGO's isolated contribution (Chrome profile vs Electron profile, same build otherwise)

| Benchmark | Improvement |
|---|---|
| Speedometer 3.1 (Linux x64) | **+9.5%** |
| `crypto.randomBytes` | **+118%** (regression recovery: 390K → 839K ops/s, matching Electron 42's 829K) |
| Startup → app ready (macOS M1) | **−13%** (45.2ms → 39.2ms) |

#### 3. The training-coverage story (why profiles must cover app workloads)

A profile trained only on browser benchmarks *pessimizes* code those benchmarks never run (PGO marks uncovered functions cold). Measured cost on a benchmark-only profile, and recovery after adding Electron-specific training (main-process Node.js, contextBridge/IPC marshaling, networking over TLS — see #51812):

| Path | Benchmark-only profile | Enriched profile |
|---|---|---|
| Node Buffer ops (macOS arm64) | **−63%** vs unprofiled | recovered |
| contextBridge calls | baseline | **+23–27%** further |
| Large-payload IPC | baseline | **+24%** further |
| Geomean of 22 app operations | baseline | **+8%** further |

#### 4. V8 builtins profile coverage

| | Chrome's published profile | Electron's profile |
|---|---|---|
| Promise/async builtins (`RunMicrotasks`, `AsyncFunctionAwait`, `FulfillPromise`, `PromiseConstructor`, …) | **Rejected** (hash mismatch from Node's codegen flags) | Covered (113–306 block hints each) |
| All other builtins | Covered | Covered |

#### 5. Cumulative Speedometer 3.1 progression (Linux x64, containerized; same source, same V8)

| Configuration | Score | Step |
|---|---|---|
| Shipping configuration (Chrome profile, default LTO) | 22.08 | baseline |
| + ThinLTO `--lto-O2` (#51669 / #51809) | 24.99 | +13.2% |
| + Electron C++ PGO profile **(this PR)** | 27.37 | **+9.5%** |
| + Electron V8 builtins profile **(this PR)** | ~27.8 | +1.6% |

With the full optimization stack, Electron is **as fast as — and in some cases faster than — Chrome** on the same workloads.

#### 6. Real-hardware corroboration (macOS, Apple Silicon)

ThinLTO-only numbers from #51669/#51809 testing — included to show container results translate to real hardware (PGO stacks on top of these):

| Hardware | Speedometer 3.1 | Gain |
|---|---|---|
| M1 | 26.8 → 31.7 | +18.3% |
| M5 | 56.6 → 65.5 | +15.7% |

</details>

---

#### Relationship to other PRs

- **#51812** — generates and publishes the profiles this PR consumes (independent; either merge order works — the profiles referenced by this PR's state files are already published)
- **#51669 / #51809** — ThinLTO link-time optimization (independent; benefits multiply)

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [ ] I have reviewed and verified the changes
- [ ] `npm test` passes
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Improved runtime performance.
