### PR TITLE
fix: append --disable-gpu switch in app.disableHardwareAcceleration()

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -39,6 +39,7 @@
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/common/content_switches.h"
 #include "crypto/crypto_buildflags.h"
 #include "electron/mas.h"
 #include "media/audio/audio_manager.h"
@@ -1149,6 +1150,14 @@ void App::DisableHardwareAcceleration(gin_helper::ErrorThrower thrower) {
         "before app is ready");
     return;
   }
+
+  // Append --disable-gpu to the command line so that all Chromium subsystems
+  // that check the switch (e.g. GpuProcessHost, viz compositor) respect the
+  // decision.  The switch must be set before GpuDataManager is initialised
+  // because InitializeGpuModes() reads it to decide which GPU modes to add.
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(::switches::kDisableGpu))
+    command_line->AppendSwitch(::switches::kDisableGpu);
 
   // If the GpuDataManager is already initialized, disable hardware
   // acceleration immediately. Otherwise, set a flag to disable it in


### PR DESCRIPTION
#### Description of Change

`app.disableHardwareAcceleration()` calls `content::GpuDataManager::DisableHardwareAcceleration()` but does not append `--disable-gpu` to the process command line. Starting with Chromium 139 (Electron 38), additional Chromium subsystems check the command line switch directly rather than querying GpuDataManager state, causing the GPU process to continue consuming GPU hardware resources.

This fix appends `--disable-gpu` to the command line when `disableHardwareAcceleration()` is called, ensuring all Chromium code paths respect the decision.

Tested on Windows: with the switch, Task Manager shows 0% GPU usage and no GPU engine activity. Without it, GPU process uses ~10.7% GPU and allocates ~375 MB GPU memory.

Fixes #51363

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `app.disableHardwareAcceleration()` not fully disabling GPU hardware usage on Windows starting from Electron 38.
