### PR TITLE
build: consume Electron-generated PGO profiles in release builds (42-x-y)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -40,7 +40,11 @@ vars = {
   'checkout_chromium': True,
   'checkout_node': True,
   'checkout_nan': True,
-  'checkout_pgo_profiles': True,
+  # Chrome's published PGO profiles are not consumed - Electron release
+  # builds use Electron-generated profiles (see build/pgo_profiles/). Set to
+  # True (and set the pgo_data_path GN arg) to build against Chrome's
+  # profiles instead.
+  'checkout_pgo_profiles': False,
 
   # It's only needed to parse the native tests configurations.
   'checkout_pyyaml': False,
@@ -202,6 +206,38 @@ hooks = [
     'action': ['python3', 'src/build/linux/sysroot_scripts/install-sysroot.py',
                '--sysroots-json-path=' + Var('sysroots_json_path'),
                '--arch=x64'],
+  },
+  # Electron-collected PGO profiles, consumed by official builds in place of
+  # Chrome's published profiles (which cannot cover Electron's code). The
+  # state files in src/electron/build/pgo_profiles name the profile to use;
+  # these hooks download them.
+  {
+    'name': 'electron_pgo_profiles_linux',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_linux and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'linux-x64,linux-arm,linux-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_win',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_win and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'win-x64,win-x86,win-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_mac',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'checkout_mac and process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'macos-x64,macos-arm64'],
+  },
+  {
+    'name': 'electron_pgo_profiles_v8_builtins',
+    'pattern': 'src/electron/build/pgo_profiles',
+    'condition': 'process_deps',
+    'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
+               '--targets', 'v8-builtins'],
   },
 ]
 

--- a/build/args/release.gn
+++ b/build/args/release.gn
@@ -7,3 +7,13 @@ is_official_build = true
 # who have an LGPL requirement to ship ffmpeg as a dynamically linked library,
 # we build ffmpeg as a shared library.
 is_component_ffmpeg = true
+
+# Electron-generated PGO profiles. The C++ profiles are resolved by Chromium's
+# standard chrome_pgo_phase = 2 machinery (patched to read Electron's state
+# files - see
+# patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch),
+# so this file only needs to point V8's builtins profiling at the Electron
+# profile. Both are downloaded by gclient hooks; see
+# build/pgo_profiles/README.md.
+v8_builtins_profiling_log_file =
+    "//electron/build/pgo_profiles/electron-v8-builtins.profile"

--- a/build/pgo_profiles/.gitignore
+++ b/build/pgo_profiles/.gitignore
@@ -1,0 +1,5 @@
+# Downloaded profile data (fetched by script/pgo/download-profiles.py via
+# gclient hooks); only the .pgo.txt state files are checked in.
+*.profdata
+*.profile
+*.version

--- a/build/pgo_profiles/README.md
+++ b/build/pgo_profiles/README.md
@@ -1,0 +1,61 @@
+# Electron PGO profiles
+
+Electron release builds are optimized with Electron-collected PGO profiles
+instead of Chrome's published ones. PGO profiles match functions by symbol
+name and control-flow hash, so Chrome's profiles cannot cover code that
+differs in Electron - all of Node.js, patched Chromium files, V8 built with
+Node's flags, and the Electron shell - and uncovered functions are laid out
+as cold.
+
+Profiles are generated and uploaded by Electron's PGO generation pipeline and
+served from `https://dev-cdn-experimental.electronjs.org/pgo/`.
+
+## How consumption works
+
+1. **State files** - `<target>.pgo.txt` in this directory names the profile
+   each target uses (e.g. `electron-linux-x64-<timestamp>-<sha>.profdata`).
+   Updating a profile means updating the state file; profile binaries are
+   never checked in.
+2. **Download** - gclient hooks (see `DEPS`) run
+   `script/pgo/download-profiles.py`, which downloads each state file's
+   profile into this directory under its versioned name (the V8 builtins
+   profile uses the fixed name `electron-v8-builtins.profile`, since GN args
+   files reference it statically).
+3. **Build wiring** - Chromium's standard `chrome_pgo_phase = 2` machinery
+   applies the profile. A small patch
+   (`patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch`)
+   teaches its profile resolution to read Electron's state files - including
+   per-arch Linux profiles, which upstream does not have - so every compiler
+   and linker flag upstream maintains for PGO (`-fprofile-use`, warning
+   suppressions, extended-TSP block layout, and anything they add in the
+   future) applies to Electron's profiles unchanged.
+
+`chrome_pgo_phase` already defaults to 2 for official builds, so no
+per-platform configuration is needed - any release build on any platform/arch
+picks up its profile automatically:
+
+```sh
+e init my-release --root=$PWD --import release
+e build
+```
+
+The V8 builtins profile is wired separately (it is consumed by mksnapshot,
+not clang): `release.gn` points `v8_builtins_profiling_log_file` at the
+downloaded Electron builtins profile.
+
+## Fallbacks
+
+- Build against Chrome's published profiles: set the `pgo_data_path` GN arg
+  to a Chrome profile (explicitly set paths take precedence over Electron's
+  state-file resolution) and set `checkout_pgo_profiles=True` in gclient
+  custom vars so Chrome's profile is downloaded.
+- Build without PGO entirely: `chrome_pgo_phase = 0`.
+
+## Platform notes
+
+| Target | C++ profile | V8 builtins profile |
+|---|---|---|
+| linux-x64, linux-arm64 | yes | yes (64-bit profile) |
+| macos-x64, macos-arm64 | yes | yes (64-bit profile) |
+| win-x64, win-arm64 | yes | yes (64-bit profile) |
+| linux-arm, win-x86 | yes | no - Electron only generates a 64-bit builtins profile; the mismatch is skipped (mksnapshot warns rather than aborts) |

--- a/build/pgo_profiles/linux-arm.pgo.txt
+++ b/build/pgo_profiles/linux-arm.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-arm-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/linux-arm64.pgo.txt
+++ b/build/pgo_profiles/linux-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-arm64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/linux-x64.pgo.txt
+++ b/build/pgo_profiles/linux-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-linux-x64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/macos-arm64.pgo.txt
+++ b/build/pgo_profiles/macos-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-macos-arm64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/macos-x64.pgo.txt
+++ b/build/pgo_profiles/macos-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-macos-x64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/v8-builtins.pgo.txt
+++ b/build/pgo_profiles/v8-builtins.pgo.txt
@@ -1,0 +1,1 @@
+electron-v8-x64-1780344845-02044ed2bc.profile

--- a/build/pgo_profiles/win-arm64.pgo.txt
+++ b/build/pgo_profiles/win-arm64.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-arm64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/win-x64.pgo.txt
+++ b/build/pgo_profiles/win-x64.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-x64-1780350052-02044ed2bc.profdata

--- a/build/pgo_profiles/win-x86.pgo.txt
+++ b/build/pgo_profiles/win-x86.pgo.txt
@@ -1,0 +1,1 @@
+electron-win-x86-1780350052-02044ed2bc.profdata

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -1,4 +1,5 @@
 build_gn.patch
+build_resolve_pgo_profiles_from_electron_state_files.patch
 accelerator.patch
 blink_local_frame.patch
 can_create_window.patch

--- a/patches/chromium/build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch
+++ b/patches/chromium/build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch
@@ -29,7 +29,7 @@ and Chrome's instrumented Windows builds compile natively on Windows.
 This patch can be upstreamed.
 
 diff --git a/build/config/compiler/pgo/BUILD.gn b/build/config/compiler/pgo/BUILD.gn
-index 37251f8e9ba3848b4f8bd1fc487b54d5905fb705..ff5f5627dde1c736ddafbb2adf352b8cc32e774c 100644
+index 7a412483528f4342517c51ba5e07a56c68fea946..46d945f70b2e2b5fb4b17d2f7737e14a80b85c99 100644
 --- a/build/config/compiler/pgo/BUILD.gn
 +++ b/build/config/compiler/pgo/BUILD.gn
 @@ -42,6 +42,34 @@ config("pgo_instrumentation_flags") {

--- a/patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch
+++ b/patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sam Attard <sattard@anthropic.com>
+Date: Mon, 1 Jun 2026 05:48:08 +0000
+Subject: build: resolve PGO profiles from Electron state files
+
+Electron generates its own PGO profiles because Chrome's published
+profiles cannot cover code that differs in Electron (Node.js, patched
+Chromium files, V8 built with Node's flags, the Electron shell). This
+resolves the profile for the standard chrome_pgo_phase = 2 optimization
+flow from Electron's per-platform/arch state files - including per-arch
+Linux profiles, which upstream does not have - so every flag upstream
+adds to its PGO configuration applies to Electron's profiles unchanged.
+
+An explicitly set pgo_data_path still takes precedence, preserving the
+existing override behavior.
+
+diff --git a/build/config/compiler/pgo/BUILD.gn b/build/config/compiler/pgo/BUILD.gn
+index 37251f8e9ba3848b4f8bd1fc487b54d5905fb705..7a412483528f4342517c51ba5e07a56c68fea946 100644
+--- a/build/config/compiler/pgo/BUILD.gn
++++ b/build/config/compiler/pgo/BUILD.gn
+@@ -117,6 +117,46 @@ config("pgo_optimization_flags") {
+       inputs = [ "//chrome/build/android-desktop-x64.pgo.txt" ]
+     }
+ 
++    # Electron generates and consumes its own PGO profiles. They are named per
++    # platform/arch - including per-arch Linux profiles, which Chrome does not
++    # have - and resolved through state files in Electron's tree, downloaded
++    # by Electron's gclient hooks. Resolution is skipped when pgo_data_path is
++    # set explicitly, preserving that arg as an override.
++    # See //electron/build/pgo_profiles/README.md.
++    if (is_electron_build && pgo_data_path == "") {
++      _electron_pgo_target = ""
++      if (is_win) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "win-arm64"
++        } else if (target_cpu == "x64") {
++          _electron_pgo_target = "win-x64"
++        } else {
++          _electron_pgo_target = "win-x86"
++        }
++      } else if (is_mac) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "macos-arm64"
++        } else {
++          _electron_pgo_target = "macos-x64"
++        }
++      } else if (is_linux) {
++        if (target_cpu == "arm64") {
++          _electron_pgo_target = "linux-arm64"
++        } else if (target_cpu == "arm") {
++          _electron_pgo_target = "linux-arm"
++        } else {
++          _electron_pgo_target = "linux-x64"
++        }
++      }
++      if (_electron_pgo_target != "") {
++        _electron_state_file =
++            "//electron/build/pgo_profiles/${_electron_pgo_target}.pgo.txt"
++        inputs += [ _electron_state_file ]
++        pgo_data_path = "//electron/build/pgo_profiles/" +
++                        read_file(_electron_state_file, "trim string")
++      }
++    }
++
+     if (_pgo_target != "" && pgo_data_path == "") {
+       common_args = [
+         "--target",

--- a/script/pgo/download-profiles.py
+++ b/script/pgo/download-profiles.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Downloads Electron PGO profiles named by the build/pgo_profiles state files.
+
+Each target has a <target>.pgo.txt state file naming the profile to download
+(generated and uploaded by .github/workflows/pgo-generation.yml).
+
+C++ profiles are saved under their full versioned names - the same name the
+state file contains - because the build resolves the profile path by reading
+the state file (see
+patches/chromium/build_resolve_pgo_profiles_from_electron_state_files.patch).
+Stale versions of a target's profile are removed after a successful download.
+
+The V8 builtins profile is saved under the fixed name
+electron-v8-builtins.profile, which release.gn references statically (GN args
+files cannot read state files).
+
+Run by gclient hooks (see electron's DEPS) and safe to run manually:
+
+  python3 script/pgo/download-profiles.py --targets linux-x64,v8-builtins
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+CDN_BASE_URL = os.environ.get(
+    'ELECTRON_PGO_CDN_URL', 'https://dev-cdn-experimental.electronjs.org/pgo/'
+)
+
+PROFILES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', '..', 'build', 'pgo_profiles'
+)
+
+DOWNLOAD_RETRIES = 3
+DOWNLOAD_RETRY_DELAY_S = 5
+
+# Profile names have a strict format (electron-<target>-<timestamp>-<sha> plus
+# an extension); reject anything else so a state file can never alter the
+# download URL beyond selecting a file under the CDN prefix.
+SAFE_PROFILE_NAME = re.compile(r'^[A-Za-z0-9._-]+$')
+
+V8_BUILTINS_TARGET = 'v8-builtins'
+V8_BUILTINS_LOCAL_NAME = 'electron-v8-builtins.profile'
+
+
+def read_state_file(target):
+    state_path = os.path.join(PROFILES_DIR, f'{target}.pgo.txt')
+    if not os.path.isfile(state_path):
+        raise SystemExit(
+            f'error: no state file for target "{target}" at {state_path}'
+        )
+    with open(state_path, encoding='utf-8') as f:
+        profile_name = f.read().strip()
+    if (
+        not profile_name
+        or not SAFE_PROFILE_NAME.match(profile_name)
+        # The regex bans path separators, so the only traversal-capable names
+        # are the dot directories themselves.
+        or profile_name in ('.', '..')
+    ):
+        raise SystemExit(
+            f'error: invalid profile name {profile_name!r} in {state_path}'
+        )
+    return profile_name
+
+
+def remove_stale_profiles(target, keep_name):
+    """Removes old versions of a target's profile after an update."""
+    prefix = f'electron-{target}-'
+    for name in os.listdir(PROFILES_DIR):
+        if (
+            name.startswith(prefix)
+            and name.endswith('.profdata')
+            and name != keep_name
+        ):
+            os.remove(os.path.join(PROFILES_DIR, name))
+            print(f'{target}: removed stale {name}')
+
+
+def fetch(url, dest):
+    for attempt in range(1, DOWNLOAD_RETRIES + 1):
+        try:
+            tmp_dest = dest + '.tmp'
+            with urllib.request.urlopen(url, timeout=300) as response, open(
+                tmp_dest, 'wb'
+            ) as out:
+                while True:
+                    chunk = response.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            os.replace(tmp_dest, dest)
+            return
+        except (urllib.error.URLError, OSError) as e:
+            if os.path.isfile(dest + '.tmp'):
+                os.remove(dest + '.tmp')
+            if attempt == DOWNLOAD_RETRIES:
+                raise SystemExit(f'error: failed to download {url}: {e}') from e
+            print(f'attempt {attempt} failed ({e}), retrying')
+            time.sleep(DOWNLOAD_RETRY_DELAY_S * attempt)
+
+
+def download_cpp_profile(target):
+    cdn_name = read_state_file(target)
+    dest = os.path.join(PROFILES_DIR, cdn_name)
+
+    # Versioned names mean presence implies correctness.
+    if os.path.isfile(dest):
+        print(f'{target}: {cdn_name} already present')
+        return
+
+    url = CDN_BASE_URL + cdn_name
+    print(f'{target}: downloading {url}')
+    fetch(url, dest)
+    remove_stale_profiles(target, cdn_name)
+    size_mb = os.path.getsize(dest) / (1024 * 1024)
+    print(f'{target}: wrote {cdn_name} ({size_mb:.1f} MB)')
+
+
+def download_v8_builtins_profile():
+    cdn_name = read_state_file(V8_BUILTINS_TARGET)
+    dest = os.path.join(PROFILES_DIR, V8_BUILTINS_LOCAL_NAME)
+    version_marker = dest + '.version'
+
+    # Fixed local name: a version marker tracks which CDN profile it holds.
+    if os.path.isfile(dest) and os.path.isfile(version_marker):
+        with open(version_marker, encoding='utf-8') as f:
+            if f.read().strip() == cdn_name:
+                print(f'{V8_BUILTINS_TARGET}: {cdn_name} already present')
+                return
+
+    url = CDN_BASE_URL + cdn_name
+    print(f'{V8_BUILTINS_TARGET}: downloading {url}')
+    fetch(url, dest)
+    with open(version_marker, 'w', encoding='utf-8') as f:
+        f.write(cdn_name + '\n')
+    size_mb = os.path.getsize(dest) / (1024 * 1024)
+    print(
+        f'{V8_BUILTINS_TARGET}: wrote {V8_BUILTINS_LOCAL_NAME} '
+        f'({size_mb:.1f} MB, {cdn_name})'
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--targets',
+        required=True,
+        help='comma-separated profile targets, e.g. linux-x64,linux-arm,v8-builtins',
+    )
+    args = parser.parse_args()
+
+    os.makedirs(PROFILES_DIR, exist_ok=True)
+    for target in args.targets.split(','):
+        target = target.strip()
+        if target == V8_BUILTINS_TARGET:
+            download_v8_builtins_profile()
+        else:
+            download_cpp_profile(target)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Manual backport of #51815 to 42-x-y.

- Wires 42-x-y release builds to consume the Electron-generated PGO profiles collected on this branch (run [26778371370](https://github.com/electron/electron/actions/runs/26778371370): 8/8 platforms + V8 builtins, Chromium 148)
- State files point at the `02044ed2bc`-stamped profiles uploaded from that run
- Identical mechanics to main: state files + gclient download hooks + a Chromium patch that resolves profiles through the standard `chrome_pgo_phase = 2` machinery

Notes: Improved runtime performance.
