### PR TITLE
build: download PGO profiles in release build jobs (42-x-y)

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -195,6 +195,17 @@ jobs:
     - name: Run Electron Only Hooks
       run: |
         e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
+    # Release builds consume Electron-generated PGO profiles, resolved through
+    # the state files in build/pgo_profiles. The gclient hooks that download
+    # them do not run in build jobs ("Run Electron Only Hooks" sets
+    # process_deps=False, and cross-compiled targets do not match the host's
+    # checkout_* vars), so fetch exactly this build's profile here.
+    - name: Download PGO Profiles
+      if: ${{ inputs.gn-build-type == 'release' }}
+      env:
+        PGO_TARGET: ${{ inputs.target-platform }}-${{ inputs.target-arch }}
+      run: |
+        python3 src/electron/script/pgo/download-profiles.py --targets "$PGO_TARGET,v8-builtins"
     - name: Regenerate DEPS Hash
       run: |
         (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -206,6 +206,13 @@ jobs:
       - name: Run Electron Only Hooks
         run: |
           e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
+      - name: Download PGO Profiles
+        if: ${{ inputs.gn-build-type == 'release' }}
+        env:
+          PGO_TARGET: ${{ inputs.target-platform }}-${{ inputs.target-arch }}
+        run: >
+          python3 src/electron/script/pgo/download-profiles.py --targets
+          "$PGO_TARGET,v8-builtins"
       - name: Regenerate DEPS Hash
         run: >
           (cd src/electron && git checkout .) && node


### PR DESCRIPTION
Fixes the v42.3.1 release build failure ([failing job](https://github.com/electron/electron/actions/runs/26787977847/job/78969028424)): `electron-linux-x64-....profdata ... missing and no known rule`.

The state-file resolution from #51828 works, but the gclient hooks that download the profiles never run in build jobs — "Run Electron Only Hooks" sets `process_deps=False`, and cross-compiled targets (win builds on linux hosts) don't match host `checkout_*` vars. PR CI didn't catch it because only official builds (`chrome_pgo_phase = 2`) reference the profile.

- Adds an explicit `Download PGO Profiles` step to the build segment, gated to release builds, fetching exactly the building target's profile + v8-builtins
- Publish segment regenerated via `copy-pipeline-segment-publish.js`

Notes: none