### PR TITLE
build: strip the Electron builtins profile path from mksnapshot_args (42-x-y)

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -143,6 +143,10 @@ runs:
           SEDOPTION="-i ''"
         fi
         sed $SEDOPTION '/.*builtins-pgo/d' out/Default/mksnapshot_args
+        # The Electron builtins profile path is a bare value on the line after
+        # --turbo-profiling-input; both lines must go or mksnapshot treats the
+        # leftover path as a script to execute.
+        sed $SEDOPTION '/.*pgo_profiles/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--turbo-profiling-input/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--reorder-builtins/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--warn-about-builtin-profile-data/d' out/Default/mksnapshot_args


### PR DESCRIPTION
Fixes the v42.3.1 publish-arm/arm64 failures ([arm64](https://github.com/electron/electron/actions/runs/26788955667/job/78971122788), [arm](https://github.com/electron/electron/actions/runs/26788955667/job/78971122822)).

The `mksnapshot_args` cleanup seds delete `--turbo-profiling-input` and matched its **value** line via upstream's path (`builtins-pgo`). Electron's builtins profile lives under `electron/build/pgo_profiles`, so the bare path survived and mksnapshot executed a 3.9MB binary profile as JavaScript → SIGTRAP in the cross-arch snapshot verification. x64 escaped only because it doesn't run that verification in-build — its shipped `mksnapshot.zip` args file was corrupted too.

- Adds `sed '/.*pgo_profiles/d'` alongside the existing `builtins-pgo` line

Notes: none