### PR TITLE
ci: delete simulator runtime MobileAssets in macOS free-space action

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -74,6 +74,14 @@ runs:
           done
         fi
 
+        # Simulator runtime images (iOS/xrOS/watchOS/tvOS) staged as MobileAssets.
+        # tmpify of /Library/Developer/CoreSimulator above only removes the mount
+        # points; the backing images here are ~113GB that Electron never uses.
+        sudo rm -rf /System/Library/AssetsV2/com_apple_MobileAsset_iOSSimulatorRuntime
+        sudo rm -rf /System/Library/AssetsV2/com_apple_MobileAsset_xrOSSimulatorRuntime
+        sudo rm -rf /System/Library/AssetsV2/com_apple_MobileAsset_watchOSSimulatorRuntime
+        sudo rm -rf /System/Library/AssetsV2/com_apple_MobileAsset_appleTVOSSimulatorRuntime
+
         sudo rm -rf /Applications/Safari.app
         sudo rm -rf "/Applications/Google Chrome.app"
         sudo rm -rf "/Applications/Google Chrome for Testing.app"


### PR DESCRIPTION
The free-space action removes `/Library/Developer/CoreSimulator`, but the backing simulator runtime images (iOS/xrOS/watchOS/tvOS) are staged separately under `/System/Library/AssetsV2` as MobileAssets.

- Deletes the four simulator runtime asset trees, reclaiming ~113GB on arm64 macOS runners (verified live on a `macos-15-xlarge` runner: 167GB → 280GB free, takes <1s)

Notes: none