### PR TITLE
ci: log macOS free space after build to Datadog

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -276,6 +276,39 @@ runs:
       run: |
         cd src/electron
         node script/yarn.js create-typescript-definitions
+    - name: Log Disk Space to Datadog (macOS)
+      if: ${{ runner.os == 'macOS' && env.DD_API_KEY != '' }}
+      shell: bash
+      env:
+        IS_RELEASE: ${{ inputs.is-release }}
+      run: |
+        TIMESTAMP=$(date +%s)
+
+        echo "Disk space after build:"
+        df -h /
+        FREE_SPACE_AFTER=$(df -k / | tail -1 | awk '{print $4}')
+        FREE_AFTER_GB=$(echo "scale=2; $FREE_SPACE_AFTER / 1024 / 1024" | bc)
+
+        echo "Free space after: ${FREE_AFTER_GB}GB"
+
+        curl -s -X POST "https://api.datadoghq.com/api/v2/series" \
+          -H "Content-Type: application/json" \
+          -H "DD-API-KEY: ${DD_API_KEY}" \
+          -d @- << EOF
+        {
+          "series": [
+            {
+              "metric": "electron.macos.disk.free_space_after_build_gb",
+              "points": [{"timestamp": ${TIMESTAMP}, "value": ${FREE_AFTER_GB}}],
+              "type": 3,
+              "unit": "gigabyte",
+              "tags": ["runner:${RUNNER_LABEL}", "platform:macos", "is-release:${IS_RELEASE}"]
+            }
+          ]
+        }
+        EOF
+
+        echo "Disk space metrics logged to Datadog"
     - name: Publish Electron Dist ${{ inputs.step-suffix }}
       if: ${{ inputs.is-release == 'true' }}
       shell: bash

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -90,6 +90,7 @@ env:
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || inputs.target-platform == 'win' && '--custom-var=checkout_win=True' || '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  RUNNER_LABEL: ${{ inputs.build-runs-on }}
 
 jobs:
   build:

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -95,6 +95,7 @@ env:
     '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  RUNNER_LABEL: ${{ inputs.build-runs-on }}
 jobs:
   build:
     defaults:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We currently [track free space after macOS disk space cleanup](https://github.com/electron/electron/blob/281aa56cd8dab7a42fc0b7133567dd0a19abb634/.github/workflows/macos-disk-cleanup.yml), but that doesn't catch free space regressions caused by Chromium rolls or change to build configurations, which have recently bit us.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
