### PR TITLE
build: calibrate PGO collection workloads and fix renderer profile loss

### DIFF
--- a/.github/workflows/pipeline-segment-pgo-collect.yml
+++ b/.github/workflows/pipeline-segment-pgo-collect.yml
@@ -118,10 +118,17 @@ jobs:
       timeout-minutes: 150
       run: |
         cd src
+        # --no-sandbox is safe and standard for profile collection: this is an
+        # instrumented, non-shippable build that only loads vendored benchmark
+        # content from a localhost server (no untrusted web content), on an
+        # ephemeral runner. It guarantees child processes can write their
+        # profile data; %c continuous mode in collect-profile.js is the
+        # primary mechanism and this is belt-and-braces (matches linux above).
         node electron/script/pgo/collect-profile.js \
           --electron "out/Default/Electron.app/Contents/MacOS/Electron" \
           --output out/Default/pgo-profraw \
           --work-dir /tmp/electron-pgo \
+          --no-sandbox \
           --no-merge
     - name: Collect PGO Profile (win)
       if: ${{ inputs.target-platform == 'win' }}

--- a/script/pgo/benchmark-app/main.js
+++ b/script/pgo/benchmark-app/main.js
@@ -90,6 +90,20 @@ const WORKLOADS = [
     timeoutMin: 30
   },
   {
+    name: 'speedometer3-run4',
+    url: `${BASE_URL}/speedometer/?startAutomatically=true&iterationCount=10`,
+    doneExpr: SPEEDOMETER_DONE,
+    successExpr: SPEEDOMETER_SUCCESS,
+    timeoutMin: 30
+  },
+  {
+    name: 'speedometer3-run5',
+    url: `${BASE_URL}/speedometer/?startAutomatically=true&iterationCount=10`,
+    doneExpr: SPEEDOMETER_DONE,
+    successExpr: SPEEDOMETER_SUCCESS,
+    timeoutMin: 30
+  },
+  {
     name: 'jetstream2',
     url: `${BASE_URL}/jetstream/index.html`,
     // The JetStream driver is ready once its async initialize() has run
@@ -108,7 +122,12 @@ const WORKLOADS = [
     startExpr: 'typeof benchmarkController !== "undefined" && (benchmarkController.startBenchmark(), true)',
     // MotionMark shows the results section when the run completes.
     doneExpr: '!!document.querySelector("section#results.selected")',
-    timeoutMin: 45
+    timeoutMin: 45,
+    // MotionMark's full ramp runs 5+ minutes and over-weights canvas/Skia
+    // paths in the merged profile (9-15% of hot mass vs ~4% in Chrome's
+    // corpus). The counters accumulated up to the cap are kept; the rest of
+    // the ramp adds mass to already-hot paths without improving coverage.
+    softCapMs: 120 * 1000
   }
 ];
 
@@ -284,6 +303,14 @@ async function runWorkload(win, workload, diag) {
   const deadline = Date.now() + workload.timeoutMin * 60 * 1000;
   while (Date.now() < deadline) {
     await sleep(5000);
+    // Soft cap: treat a long-running benchmark as complete. Profile counters
+    // accumulate continuously, so everything up to this point is kept.
+    if (workload.softCapMs && Date.now() - startTime > workload.softCapMs) {
+      log(
+        `workload ${workload.name} reached soft cap after ${Math.round((Date.now() - startTime) / 1000)}s; keeping counters collected so far`
+      );
+      return { name: workload.name, ok: true, seconds: Math.round((Date.now() - startTime) / 1000) };
+    }
     let done = false;
     try {
       done = await win.webContents.executeJavaScript(workload.doneExpr, true);
@@ -323,7 +350,7 @@ async function runWorkload(win, workload, diag) {
 // the event loop stays responsive.
 // ---------------------------------------------------------------------------
 
-async function runMainProcessWorkload(durationMs) {
+async function runMainProcessWorkload(durationMs, maxIterations) {
   log('starting workload: main-process');
   const startTime = Date.now();
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pgo-main-workload-'));
@@ -344,7 +371,7 @@ async function runMainProcessWorkload(durationMs) {
 
   const deadline = Date.now() + durationMs;
   let iterations = 0;
-  while (Date.now() < deadline) {
+  while (Date.now() < deadline && iterations < maxIterations) {
     for (let i = 0; i < 50; i++) {
       // Buffer operations: concat, slice, compare, base64/hex encode + decode.
       const joined = Buffer.concat([bufA, bufB]);
@@ -414,6 +441,54 @@ async function runMainProcessWorkload(durationMs) {
 // afterwards; over-weighting them in the profile takes optimization away
 // from the runtime-hot paths.
 // ---------------------------------------------------------------------------
+
+// Trains the per-async-operation machinery: AsyncHooks scopes, AsyncWrap,
+// BaseObject refcounts, StreamBase. Every async op in every app runs these,
+// but they only see a handful of counts per operation, so the heavyweight
+// workloads (whose op counts are deliberately capped) leave them below the
+// hot threshold. Each op here is intentionally tiny - the counts land in the
+// async plumbing rather than in payload processing, so volume is cheap.
+async function runAsyncChurnWorkload(maxOps) {
+  log('starting workload: async-churn');
+  const startTime = Date.now();
+  const net = require('node:net');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pgo-async-'));
+  const probeFile = path.join(tmp, 'probe');
+  fs.writeFileSync(probeFile, 'x');
+
+  // In-process TCP echo server: socket roundtrips exercise StreamBase and
+  // LibuvStreamWrap without depending on the benchmark HTTP server.
+  const echoServer = net.createServer((sock) => sock.on('data', (d) => sock.write(d)));
+  await new Promise((resolve) => echoServer.listen(0, '127.0.0.1', resolve));
+  const sock = net.connect(echoServer.address().port, '127.0.0.1');
+  await new Promise((resolve) => sock.once('connect', resolve));
+
+  let ops = 0;
+  while (ops < maxOps) {
+    const batch = [];
+    for (let i = 0; i < 100; i++) {
+      batch.push(fs.promises.stat(probeFile));
+      batch.push(new Promise((resolve) => setImmediate(resolve)));
+      batch.push(new Promise((resolve) => process.nextTick(resolve)));
+    }
+    // Socket roundtrip: one small write, await the echo.
+    batch.push(
+      new Promise((resolve) => {
+        sock.once('data', resolve);
+        sock.write('ping');
+      })
+    );
+    await Promise.all(batch);
+    ops += 301;
+  }
+
+  sock.destroy();
+  echoServer.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
+  log(`finished workload: async-churn in ${elapsed}s (${ops} async ops)`);
+  return { name: 'async-churn', ok: true, seconds: Number(elapsed) };
+}
 
 async function runPackagedAppWorkload() {
   log('starting workload: packaged-app');
@@ -492,7 +567,7 @@ async function runPackagedAppWorkload() {
 // configured the way real apps are configured (contextIsolation + preload).
 // ---------------------------------------------------------------------------
 
-async function runIpcBridgeWorkload(durationMs) {
+async function runIpcBridgeWorkload(durationMs, maxCalls) {
   log('starting workload: ipc-contextbridge');
   const startTime = Date.now();
 
@@ -522,9 +597,10 @@ async function runIpcBridgeWorkload(durationMs) {
     const big = new Uint8Array(${5 * 1024 * 1024}).fill(7);
 
     const deadline = Date.now() + ${durationMs};
+    const maxCalls = ${maxCalls};
     let bridgeCalls = 0;
     let ipcCalls = 0;
-    while (Date.now() < deadline) {
+    while (Date.now() < deadline && bridgeCalls < maxCalls) {
       // Pure bridge marshaling (no IPC): primitives, objects, arrays, typed arrays.
       for (let i = 0; i < 200; i++) {
         window.pgoBridge.echo(42);
@@ -573,7 +649,7 @@ async function runIpcBridgeWorkload(durationMs) {
 // to point at the collection CA (set by collect-profile.js).
 // ---------------------------------------------------------------------------
 
-async function runNetworkWorkload(win, durationMs) {
+async function runNetworkWorkload(win, durationMs, maxRequests) {
   log('starting workload: network');
   const startTime = Date.now();
   const isTls = BASE_URL.startsWith('https:');
@@ -586,13 +662,14 @@ async function runNetworkWorkload(win, durationMs) {
   const rendererResult = await win.webContents.executeJavaScript(
     `(async () => {
     const deadline = Date.now() + ${rendererBudget};
+    const maxRequests = ${maxRequests};
     let requests = 0;
     let wsMessages = 0;
 
     // Fetch loops: parallel requests at varied sizes plus POST echoes, plus
     // Content-Encoding responses so the network service's decompression
     // streams (gzip / brotli / zstd) are trained.
-    while (Date.now() < deadline) {
+    while (Date.now() < deadline && requests < maxRequests) {
       await Promise.all([
         fetch('/__pgo/data?bytes=1024').then(r => r.arrayBuffer()),
         fetch('/__pgo/data?bytes=65536').then(r => r.arrayBuffer()),
@@ -614,8 +691,9 @@ async function runNetworkWorkload(win, durationMs) {
         ws.onerror = () => reject(new Error('websocket failed to connect'));
       });
       const wsDeadline = Date.now() + 10000;
+      const wsMaxMessages = 30000; // cap: time-boxed loops run away on fast hosts
       const payload = 'pgo-websocket-payload-'.repeat(50);
-      while (Date.now() < wsDeadline) {
+      while (Date.now() < wsDeadline && wsMessages < wsMaxMessages) {
         await new Promise((resolve) => {
           ws.onmessage = resolve;
           ws.send(payload);
@@ -637,7 +715,7 @@ async function runNetworkWorkload(win, durationMs) {
   let nodeRequests = 0;
   const nodeDeadline = Date.now() + Math.floor(durationMs / 2);
   const dataUrl = `${BASE_URL}/__pgo/data?bytes=65536`;
-  while (Date.now() < nodeDeadline) {
+  while (Date.now() < nodeDeadline && nodeRequests < maxRequests) {
     // node:https / node:http via the classic API.
     await new Promise((resolve, reject) => {
       const mod = isTls ? https : require('node:http');
@@ -670,12 +748,25 @@ async function runNetworkWorkload(win, durationMs) {
 // Orchestration
 // ---------------------------------------------------------------------------
 
-// Durations for the non-browser phases. Long enough for meaningful counter
-// volume on instrumented builds (which run at roughly half speed), short
-// relative to the 30-50 minute browser benchmark phase.
-const MAIN_PROCESS_WORKLOAD_MS = 75 * 1000;
-const IPC_BRIDGE_WORKLOAD_MS = 75 * 1000;
-const NETWORK_WORKLOAD_MS = 90 * 1000;
+// The non-browser phases are capped by ITERATIONS, not duration. PGO hotness
+// is a threshold (a path is hot once it clears ~10^5-10^6 counts), so a few
+// thousand iterations mark every exercised path hot. Letting these tight
+// synthetic loops run for a fixed wall time instead generated billions of
+// counts (the top 2 blocks held ~10% of the entire profile), which inflated
+// the global hot threshold and crowded Blink out of the hot set. The
+// duration constants remain only as backstops for pathologically slow hosts.
+// Cap calibration: per-async-op overhead paths (AsyncHooks scopes, BaseObject
+// refcounts, StreamBase) see a handful of counts per operation, so they need
+// tens of thousands of operations to clear the hot threshold (~10^5 counts).
+// These values put them at 2-3x the threshold while keeping the hottest
+// serialization loops 4+ orders of magnitude below the old runaway counts.
+const MAIN_PROCESS_MAX_ITERATIONS = 25000;
+const MAIN_PROCESS_TIMEOUT_MS = 75 * 1000;
+const IPC_BRIDGE_MAX_CALLS = 50000;
+const IPC_BRIDGE_TIMEOUT_MS = 75 * 1000;
+const NETWORK_MAX_REQUESTS = 8000; // per side (renderer fetches / node requests)
+const ASYNC_CHURN_MAX_OPS = 250000;
+const NETWORK_TIMEOUT_MS = 90 * 1000;
 
 app.whenReady().then(async () => {
   const win = new BrowserWindow({
@@ -692,10 +783,11 @@ app.whenReady().then(async () => {
 
   let phases = [
     ...WORKLOADS.map((workload) => () => runWorkload(win, workload, diag)),
-    () => runMainProcessWorkload(MAIN_PROCESS_WORKLOAD_MS),
+    () => runMainProcessWorkload(MAIN_PROCESS_TIMEOUT_MS, MAIN_PROCESS_MAX_ITERATIONS),
+    () => runAsyncChurnWorkload(ASYNC_CHURN_MAX_OPS),
     () => runPackagedAppWorkload(),
-    () => runIpcBridgeWorkload(IPC_BRIDGE_WORKLOAD_MS),
-    () => runNetworkWorkload(win, NETWORK_WORKLOAD_MS)
+    () => runIpcBridgeWorkload(IPC_BRIDGE_TIMEOUT_MS, IPC_BRIDGE_MAX_CALLS),
+    () => runNetworkWorkload(win, NETWORK_TIMEOUT_MS, NETWORK_MAX_REQUESTS)
   ];
   let phaseNames = [...WORKLOADS.map((w) => w.name), 'main-process', 'packaged-app', 'ipc-contextbridge', 'network'];
 

--- a/script/pgo/collect-profile.js
+++ b/script/pgo/collect-profile.js
@@ -300,6 +300,9 @@ async function main() {
   if (!fs.existsSync(electronBinary)) {
     throw new Error(`instrumented electron binary not found: ${electronBinary}`);
   }
+  // Stale pool files from a previous run would silently merge into this
+  // collection (%m pools append counters); always start clean.
+  fs.rmSync(profrawDir, { recursive: true, force: true });
   fs.mkdirSync(profrawDir, { recursive: true });
   fs.mkdirSync(benchmarksDir, { recursive: true });
 
@@ -334,7 +337,16 @@ async function main() {
   // 2. Run the instrumented build through the workloads.
   //    %m = profile merge pools: multiple processes share pool files and merge
   //    counters atomically, keeping the file count manageable.
-  const profilePattern = path.join(profrawDir, 'electron-%4m.profraw');
+  // %c (continuous mode, Darwin): counters live in an mmap established at
+  // process startup, before the renderer sandbox locks down, so sandboxed
+  // child processes don't need an exit-time file write. Without it, renderer
+  // profraws race sandbox lockdown and lose ("Operation not permitted") on a
+  // per-process coin flip - collections that lose the web-benchmark renderers
+  // ship profiles with Blink effectively absent from the hot set.
+  const profilePattern = path.join(
+    profrawDir,
+    process.platform === 'darwin' ? 'electron-%c%4m.profraw' : 'electron-%4m.profraw'
+  );
   const resultsFile = path.join(workDir, 'benchmark-results.json');
 
   log(`launching instrumented electron: ${electronBinary}`);


### PR DESCRIPTION
## What

Fixes two independent problems in the PGO profile collection pipeline that combined to produce the badly-shaped macOS arm64 profiles consumed by v42.3.1 (and generated for 43-x-y):

**1. Renderer profile loss (the big one).** The macOS collection runs the instrumented app sandboxed, and sandboxed child processes fail their exit-time profraw write (`LLVM Profile Error: ... Operation not permitted`). Which processes lose is a per-run race — the 42-x-y and 43-x-y collection runs both lost their web-benchmark renderer data, shipping profiles where Blink is essentially absent from the hot set (**4** DOM functions in the top-50k vs ~400 expected). This is the root cause of the v42.3.1 Speedometer regression on Apple Silicon. Fixed with `%c` continuous-mode profiles on Darwin (counters live in an mmap established before sandbox lockdown — no exit-time write to lose) plus `--no-sandbox` on the macOS collect step, matching what the Linux step already does.

**2. Count-budget distortion.** The synthetic workloads were capped by wall time, so their tight loops dominated the merged profile: the top 2 blocks held ~10% of *all* counts, inflating the global hot threshold and demoting real Blink work out of the hot tier. Hotness is a threshold (~10^5 counts), not a share — capping the loops by iterations keeps every electron path 2–3 orders of magnitude above the bar while ending the distortion. MotionMark is soft-capped at 120s (it was 5.4 minutes — 57% of all web-benchmark time — and doubled Skia's weight vs Chrome's corpus), and the reclaimed time funds two extra Speedometer runs. A new `async-churn` workload (250k deliberately tiny async ops) keeps the per-async-op machinery (AsyncWrap, BaseObject lifecycle, stream plumbing) trained, since its counts ride on async op volume rather than loop iterations.

Also: the profraw directory is now cleaned at collection start — stale `%m` pool files from a previous run silently merge their counters into a new collection.

## Validation

Instrumented 42-x-y build, same scripts CI runs, before → after:

| Metric | before | after |
|---|---|---|
| profraw files collected | 9 (renderers lost, 5 write errors) | 23+ (zero errors) |
| blocks holding 90% of counts | 1,710 | 14,000+ |
| Blink DOM functions in top-50k | **4** | ~404 (Chrome-profile parity) |
| Blink share of hot mass | 14% | ~33–35% |
| top-2-block share | ~10% | 2.6% |
| node serialization paths | 1.1B-count spikes | hot at sane magnitudes (StringBytes::Write 410M, contextBridge 15M) |

A useful side effect: the simdutf dispatcher drops below the hot threshold, so profiles from the fixed collection no longer trigger the LLVM unroller miscompile that #51848 guards against (that flag stays as defense-in-depth until the upstream fix rolls in).

Suggested follow-up (not in this PR): a shape gate in the generation workflow — fail the run if blocks@90% < 8,000 or Blink DOM functions in the top-50k < 100 — so a malformed profile can never silently ship again.

Notes: none
