### PR TITLE
build: do not require the Electron builtins profile in instrumented builds

### DIFF
--- a/build/args/pgo-instrument.gn
+++ b/build/args/pgo-instrument.gn
@@ -13,6 +13,13 @@ chrome_pgo_phase = 1
 # the profiled binary and the final binary distorts hotness).
 dcheck_always_on = false
 
+# release.gn points v8_builtins_profiling_log_file at the downloaded Electron
+# builtins profile, but profile generation must work from a tree with no
+# Electron profiles present (the instrumented build is how the first profile
+# gets made). Reset to V8's stock resolution; builtin block layout does not
+# affect C++ counter semantics, so collection fidelity is unchanged.
+v8_builtins_profiling_log_file = "default"
+
 # Instrumented binaries are never shipped, so debug symbols and macOS dSYM
 # generation are pure overhead. Both are large enough to exhaust CI runner
 # disk space on macOS (the instrumented framework plus its dSYM does not fit),


### PR DESCRIPTION
The `Generate PGO Profiles` workflow's instrumented builds fail on every platform since the PGO consumption change reached the branch (e.g. [run 26859098350](https://github.com/electron/electron/actions/runs/26859098350) on 42-x-y):

```
../../electron/build/pgo_profiles/electron-v8-builtins.profile,
needed by gen/v8/embedded.S, missing and no known rule to make it
```

`pgo-instrument.gn` imports `release.gn`, which now pins `v8_builtins_profiling_log_file` to the downloaded Electron builtins profile. Release build jobs download that file explicitly, but generation build jobs don't — and shouldn't: the instrumented build is how the first profile gets made, so generation has to work from a tree with no Electron profiles present. The June 1 generation runs only succeeded because they ran before the consumption change landed on their branches.

Reset the arg to V8's stock resolution for instrumented builds, mirroring the reset `pgo-builtins-instrument.gn` already does for the d8 profiling build. Builtin block layout doesn't affect C++ counter semantics, so collection fidelity is unchanged.

The 42-x-y / 43-x-y generation workflows need a re-run once the backports land.

Notes: none
