### PR TITLE
build: update PGO profiles (42-x-y)

### DIFF
--- a/build/pgo_profiles/linux-arm64.pgo.txt
+++ b/build/pgo_profiles/linux-arm64.pgo.txt
@@ -1,1 +1,1 @@
-electron-linux-arm64-1780350052-02044ed2bc.profdata
+electron-linux-arm64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/linux-x64.pgo.txt
+++ b/build/pgo_profiles/linux-x64.pgo.txt
@@ -1,1 +1,1 @@
-electron-linux-x64-1780350052-02044ed2bc.profdata
+electron-linux-x64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/macos-arm64.pgo.txt
+++ b/build/pgo_profiles/macos-arm64.pgo.txt
@@ -1,1 +1,1 @@
-electron-macos-arm64-1780350052-02044ed2bc.profdata
+electron-macos-arm64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/macos-x64.pgo.txt
+++ b/build/pgo_profiles/macos-x64.pgo.txt
@@ -1,1 +1,1 @@
-electron-macos-x64-1780350052-02044ed2bc.profdata
+electron-macos-x64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/v8-builtins.pgo.txt
+++ b/build/pgo_profiles/v8-builtins.pgo.txt
@@ -1,1 +1,1 @@
-electron-v8-x64-1780344845-02044ed2bc.profile
+electron-v8-x64-1780455973-c9effa60a6.profile

--- a/build/pgo_profiles/win-arm64.pgo.txt
+++ b/build/pgo_profiles/win-arm64.pgo.txt
@@ -1,1 +1,1 @@
-electron-win-arm64-1780350052-02044ed2bc.profdata
+electron-win-arm64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/win-x64.pgo.txt
+++ b/build/pgo_profiles/win-x64.pgo.txt
@@ -1,1 +1,1 @@
-electron-win-x64-1780350052-02044ed2bc.profdata
+electron-win-x64-1780466095-c9effa60a6.profdata

--- a/build/pgo_profiles/win-x86.pgo.txt
+++ b/build/pgo_profiles/win-x86.pgo.txt
@@ -1,1 +1,1 @@
-electron-win-x86-1780350052-02044ed2bc.profdata
+electron-win-x86-1780466095-c9effa60a6.profdata


### PR DESCRIPTION
## Description

Updates the PGO state files to the profiles from the latest [Generate PGO Profiles run](https://github.com/electron/electron/actions/runs/26860794962) on `42-x-y` (`c9effa60a6`).

All collect jobs passed except `collect-linux-arm`, so `linux-arm.pgo.txt` keeps its previous profile; every other target moves to the new `1780466095-c9effa60a6` profiles (and the V8 builtins profile to `1780455973-c9effa60a6`).

All referenced profiles verified present on `dev-cdn-experimental.electronjs.org/pgo/`.

Notes: none