### PR TITLE
build: harden PGO profile collection against flaky failures

### DIFF
--- a/.github/workflows/pipeline-segment-pgo-collect.yml
+++ b/.github/workflows/pipeline-segment-pgo-collect.yml
@@ -152,3 +152,17 @@ jobs:
         path: src/out/Default/pgo-profraw/
         if-no-files-found: error
         retention-days: 7
+    # Instrumented processes crash without any usable message in the job log
+    # (a renderer dying surfaces as a bare ERR_FAILED, a browser-process CHECK
+    # as "killed by signal SIGTRAP"). The macOS crash reporter writes the real
+    # stack to DiagnosticReports - upload it so failures are diagnosable.
+    - name: Upload Crash Reports (macos)
+      if: ${{ failure() && inputs.target-platform == 'macos' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: pgo-crash-reports-${{ inputs.target-platform }}-${{ inputs.target-arch }}
+        path: |
+          /Users/runner/Library/Logs/DiagnosticReports/*.ips
+          /Users/runner/Library/Logs/DiagnosticReports/*.crash
+        if-no-files-found: warn
+        retention-days: 7

--- a/script/pgo/benchmark-app/main.js
+++ b/script/pgo/benchmark-app/main.js
@@ -832,7 +832,14 @@ app.whenReady().then(async () => {
     () => runIpcBridgeWorkload(IPC_BRIDGE_TIMEOUT_MS, IPC_BRIDGE_MAX_CALLS),
     () => runNetworkWorkload(win, NETWORK_TIMEOUT_MS, NETWORK_MAX_REQUESTS)
   ];
-  let phaseNames = [...WORKLOADS.map((w) => w.name), 'main-process', 'async-churn', 'packaged-app', 'ipc-contextbridge', 'network'];
+  let phaseNames = [
+    ...WORKLOADS.map((w) => w.name),
+    'main-process',
+    'async-churn',
+    'packaged-app',
+    'ipc-contextbridge',
+    'network'
+  ];
 
   if (process.env.PGO_WORKLOAD_FILTER) {
     const allowed = process.env.PGO_WORKLOAD_FILTER.split(',').map((s) => s.trim());

--- a/script/pgo/benchmark-app/main.js
+++ b/script/pgo/benchmark-app/main.js
@@ -140,6 +140,35 @@ async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// loadURL can hang forever: a wedged network service (observed on instrumented
+// builds - socket pool exhausted by stale keep-alive sockets that are never
+// reaped) leaves the navigation queued indefinitely, and the per-workload
+// timeout only starts counting AFTER the load resolves. Without this guard a
+// single wedged navigation hangs collection until the CI job timeout instead
+// of failing one workload and moving on.
+const NAVIGATION_TIMEOUT_MS = 2 * 60 * 1000;
+
+async function loadURLWithTimeout(win, url) {
+  const load = win.loadURL(url);
+  // If the timeout wins the race the eventual loadURL rejection has no
+  // listener; swallow it so it does not surface as an unhandled rejection.
+  load.catch(() => {});
+  let timer;
+  try {
+    await Promise.race([
+      load,
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`navigation to ${url.slice(0, 80)} timed out after ${NAVIGATION_TIMEOUT_MS / 1000}s`)),
+          NAVIGATION_TIMEOUT_MS
+        );
+      })
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Failure diagnostics
 //
@@ -244,7 +273,12 @@ async function runWorkload(win, workload, diag) {
   log(`starting workload: ${workload.name}`);
   if (diag) diag.reset();
   const startTime = Date.now();
-  await win.loadURL(workload.url);
+  try {
+    await loadURLWithTimeout(win, workload.url);
+  } catch (err) {
+    if (diag) await reportWorkloadFailure(win, workload.name, diag);
+    throw err;
+  }
 
   // Install page-side error capture for failure diagnostics. Benchmark
   // drivers swallow uncaught exceptions (window.onerror) silently; recording
@@ -583,13 +617,18 @@ async function runIpcBridgeWorkload(durationMs, maxCalls) {
       nodeIntegration: false
     }
   });
-  await win.loadURL('data:text/html,<html><body>pgo ipc workload</body></html>');
+  // This window spawns a fresh renderer; attach diagnostics so a crash during
+  // load reports its render-process-gone details instead of a bare ERR_FAILED.
+  const diag = attachDiagnostics(win);
+  let result;
+  try {
+    await loadURLWithTimeout(win, 'data:text/html,<html><body>pgo ipc workload</body></html>');
 
-  // The driver runs in the main world and calls across the bridge. Payload
-  // sizes cover the spectrum apps use: small control messages, medium JSON
-  // payloads, and large binary transfers.
-  const result = await win.webContents.executeJavaScript(
-    `(async () => {
+    // The driver runs in the main world and calls across the bridge. Payload
+    // sizes cover the spectrum apps use: small control messages, medium JSON
+    // payloads, and large binary transfers.
+    result = await win.webContents.executeJavaScript(
+      `(async () => {
     const small = { id: 1, type: 'msg', body: 'hello world' };
     const medium = { rows: Array.from({ length: 200 }, (_, i) => ({ i, name: 'row-' + i, values: [i, i * 2, i * 3] })) };
     const arr = Array.from({ length: 500 }, (_, i) => ({ i, label: 'item-' + i }));
@@ -621,11 +660,15 @@ async function runIpcBridgeWorkload(durationMs, maxCalls) {
     }
     return { bridgeCalls, ipcCalls };
   })()`,
-    true
-  );
-
-  win.destroy();
-  ipcMain.removeHandler('pgo-ping');
+      true
+    );
+  } catch (err) {
+    await reportWorkloadFailure(win, 'ipc-contextbridge', diag);
+    throw err;
+  } finally {
+    win.destroy();
+    ipcMain.removeHandler('pgo-ping');
+  }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
   log(
@@ -658,7 +701,7 @@ async function runNetworkWorkload(win, durationMs, maxRequests) {
   // Renderer: parallel fetches + WebSocket echo. Runs for the first half of
   // the budget; the Node-side loop runs for the second half.
   const rendererBudget = Math.floor(durationMs / 2);
-  await win.loadURL(`${BASE_URL}/speedometer/`);
+  await loadURLWithTimeout(win, `${BASE_URL}/speedometer/`);
   const rendererResult = await win.webContents.executeJavaScript(
     `(async () => {
     const deadline = Date.now() + ${rendererBudget};
@@ -789,7 +832,7 @@ app.whenReady().then(async () => {
     () => runIpcBridgeWorkload(IPC_BRIDGE_TIMEOUT_MS, IPC_BRIDGE_MAX_CALLS),
     () => runNetworkWorkload(win, NETWORK_TIMEOUT_MS, NETWORK_MAX_REQUESTS)
   ];
-  let phaseNames = [...WORKLOADS.map((w) => w.name), 'main-process', 'packaged-app', 'ipc-contextbridge', 'network'];
+  let phaseNames = [...WORKLOADS.map((w) => w.name), 'main-process', 'async-churn', 'packaged-app', 'ipc-contextbridge', 'network'];
 
   if (process.env.PGO_WORKLOAD_FILTER) {
     const allowed = process.env.PGO_WORKLOAD_FILTER.split(',').map((s) => s.trim());
@@ -798,12 +841,30 @@ app.whenReady().then(async () => {
     log(`workload filter active: ${phaseNames.join(', ')}`);
   }
 
+  // Transient child-process crashes (a renderer dying at spawn surfaces as a
+  // fast ERR_FAILED load) are retried once; profile counters are cumulative so
+  // a retried workload only adds coverage. Slow failures are NOT retried -
+  // they are timeouts, and rerunning a 30-45 minute workload risks blowing
+  // the job time limit for no new information.
+  const RETRY_IF_FAILED_WITHIN_MS = 5 * 60 * 1000;
   for (let i = 0; i < phases.length; i++) {
+    const attemptStart = Date.now();
     try {
       results.push(await phases[i]());
     } catch (err) {
       log(`ERROR: ${err.message}`);
-      results.push({ name: phaseNames[i], ok: false, error: err.message });
+      let failure = err;
+      if (Date.now() - attemptStart < RETRY_IF_FAILED_WITHIN_MS) {
+        log(`workload ${phaseNames[i]} failed quickly - retrying once`);
+        try {
+          results.push(await phases[i]());
+          continue;
+        } catch (retryErr) {
+          log(`ERROR (retry): ${retryErr.message}`);
+          failure = retryErr;
+        }
+      }
+      results.push({ name: phaseNames[i], ok: false, error: failure.message });
       // A failed workload reduces profile coverage but the data collected so
       // far is still valid - keep going and report partial failure.
       exitCode = 1;

--- a/script/pgo/serve-benchmarks.js
+++ b/script/pgo/serve-benchmarks.js
@@ -423,6 +423,19 @@ function startServer(workDir, port, opts = {}) {
     scheme = 'http';
   }
 
+  // Node closes idle keep-alive sockets after 5s by default. Instrumented
+  // Chromium builds intermittently fail to reap a socket the server closed
+  // while idle: it stays counted against the per-group connection pool limit
+  // (6), and once all six slots are held by dead sockets every later request
+  // to the origin queues forever - the next loadURL hangs indefinitely
+  // (reproduced locally; the renderer, browser, and network service all sit
+  // idle while the navigation waits for a pool slot). Benchmark workloads
+  // have idle gaps between phases, so keep sockets alive for far longer than
+  // any gap instead. headersTimeout must exceed keepAliveTimeout or node
+  // resets sockets mid-request.
+  server.keepAliveTimeout = 10 * 60 * 1000;
+  server.headersTimeout = 11 * 60 * 1000;
+
   attachWebSocketEcho(server);
 
   const host = opts.tls ? 'localhost' : '127.0.0.1';


### PR DESCRIPTION
## What

Makes PGO profile collection resilient to the intermittent instrumented-build failures that have been failing the `Generate PGO Profiles` workflow (e.g. [this run](https://github.com/electron/electron/actions/runs/26867762001/job/79239245142) and the one before it on `43-x-y`), and makes the failures that remain diagnosable.

## Why

Two consecutive `collect-macos-arm64` runs failed at different points with no usable detail in the log: one browser-process SIGTRAP 4 seconds in, one renderer crash spawning the IPC workload window (reported as a bare `ERR_FAILED (-2)`, and misattributed to the `network` workload by a phase-name bookkeeping bug).

Reproducing locally with the run's `generated_artifacts_darwin_arm64` artifact surfaced a third failure mode: a navigation that hangs forever. The benchmark server closes idle keep-alive sockets after node's default 5s, and the instrumented network service intermittently never reaps them - once all 6 per-group pool slots are held by dead sockets, the next `loadURL` queues indefinitely. `loadURL` had no timeout and the per-workload timeout only starts after the load resolves, so a wedged navigation runs the job into the 150-minute kill.

## Changes

- **Navigation timeout (2 min)** around every `loadURL` - a wedged navigation now fails one workload instead of hanging the job
- **Benchmark server keep-alive raised to 10 min** so idle gaps between workloads cannot strand the client's connection pool on closed sockets
- **Retry a workload once when it fails in under 5 minutes** - transient child-process crashes fail fast and profile counters are cumulative, so a retry only adds coverage; genuine timeouts are not retried
- **Crash diagnostics on the IPC workload window** (it spawns a fresh renderer but had no `render-process-gone` observer), plus `finally` cleanup of its window and IPC handler so a retry can re-register the handler
- **Fix `phaseNames`/`phases` mismatch** (`async-churn` was missing): failure rows now name the right workload, and `PGO_WORKLOAD_FILTER` selects the right phase instead of its neighbor
- **Upload macOS DiagnosticReports on failure** so the next SIGTRAP comes with a real stack instead of a one-line log message

## Verification

With the failing run's instrumented `darwin_arm64` artifact on an arm64 macOS host:

- the IPC workload passed 14/14 isolated runs
- one full CI-style collection reproduced the navigation hang (network service idle, 6 `CLOSED` sockets pinned in the pool)
- a full CI-style collection with these changes completed end-to-end: every workload green, exit 0, 30 profraw files written

Notes: none