### PR TITLE
build: profile-pure PGO collection retries + automatic state-file update PRs

### DIFF
--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -602,19 +602,24 @@ jobs:
         if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Publish: OIDC upload to dev-cdn.electronjs.org/pgo/
+  # Publish: OIDC upload to dev-cdn.electronjs.org/pgo/ + state-file update PR
   # ---------------------------------------------------------------------------
 
   upload-profiles:
     name: Upload Profiles to dev-cdn
-    # builtins job in needs only for artifact availability; success not required.
-    needs: [merge-profiles, generate-v8-builtins-profiles]
-    if: ${{ !cancelled() && github.repository == 'electron/electron' && needs.merge-profiles.result == 'success' && inputs.upload-to-storage }}
+    # Every build, collection, and merge job must be green before anything is
+    # published: a partial profile set must never reach the CDN or the state
+    # files. Skipped jobs (the skip-* inputs) are allowed - intentionally
+    # regenerating a subset of platforms is fine; failures are not.
+    needs: [collect-linux-x64, collect-linux-arm, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64, generate-v8-builtins-profiles, merge-profiles]
+    if: ${{ !cancelled() && github.repository == 'electron/electron' && needs.merge-profiles.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && inputs.upload-to-storage }}
     runs-on: ubuntu-latest
     # Holds the Azure OIDC credentials; restricted to protected branches.
     environment: pgo-upload
     permissions:
-      contents: read
+      # write: GITHUB_TOKEN creates the profile-update branch (the app token
+      # below is restricted to single_file and cannot create refs).
+      contents: write
       id-token: write
     steps:
     - name: Download Merged Profiles
@@ -622,9 +627,10 @@ jobs:
       with:
         name: pgo-profiles
         path: profiles
-    # Optional - only exists if the builtins job succeeded.
+    # The job-level if guarantees the builtins job did not fail, but it is
+    # skipped entirely when skip-linux is set - only download when it ran.
     - name: Download V8 Builtins Profiles
-      continue-on-error: true
+      if: ${{ needs.generate-v8-builtins-profiles.result == 'success' }}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: pgo-v8-builtins-profiles
@@ -648,6 +654,83 @@ jobs:
         for f in profiles/*; do
           echo "- https://dev-cdn.electronjs.org/pgo/$(basename "$f")" >> $GITHUB_STEP_SUMMARY
         done
+    # Exchanges this job's OIDC token (scoped to the pgo-upload environment)
+    # for an electron-pgo-updater app token; the job's id-token: write
+    # permission covers both this and the Azure login above. Same pattern as
+    # update-website-docs.yml.
+    - name: Get GitHub App token
+      id: secret-service
+      uses: electron/secret-service-action@3476425e8b30555aac15b1b7096938e254b0e155 # v1.0.0
+    # The app token is narrowed to single_file: write on the state files and
+    # cannot create refs, so the branch comes from GITHUB_TOKEN.
+    - name: Create Profile Update Branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        BRANCH="pgo-update-${GITHUB_REF_NAME}-${GITHUB_RUN_ID}"
+        BASE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$GITHUB_REF_NAME" --jq .object.sha)
+        gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+          --field ref="refs/heads/$BRANCH" \
+          --field sha="$BASE_SHA" > /dev/null
+        echo "created $BRANCH at $BASE_SHA"
+    # The contents API is the only write path the single_file permission
+    # grants (the git data API needs contents: write), so the state files are
+    # committed one PUT at a time.
+    - name: Create Profile Update Pull Request
+      env:
+        GH_TOKEN: ${{ fromJSON(steps.secret-service.outputs.secrets).PGO_PROFILE_UPDATER_APP_TOKEN }}
+      run: |
+        BASE_BRANCH="$GITHUB_REF_NAME"
+        BRANCH="pgo-update-${BASE_BRANCH}-${GITHUB_RUN_ID}"
+
+        # Map every uploaded profile to its state file in build/pgo_profiles.
+        updated=0
+        for f in profiles/*; do
+          name=$(basename "$f")
+          case "$name" in
+            electron-v8-x64-*.profile)
+              state="build/pgo_profiles/v8-builtins.pgo.txt" ;;
+            electron-*.profdata)
+              target=$(echo "$name" | sed -E 's/^electron-//; s/-[0-9]+-[0-9a-f]+\.profdata$//')
+              state="build/pgo_profiles/${target}.pgo.txt" ;;
+            *)
+              echo "skipping unrecognized profile: $name"
+              continue ;;
+          esac
+          echo "$state <- $name"
+          args=(
+            --field message="build: update $(basename "$state" .pgo.txt) PGO profile"
+            --field content="$(printf '%s\n' "$name" | base64 -w0)"
+            --field branch="$BRANCH"
+          )
+          # Existing files need their current blob sha; absent ones (a state
+          # file new to this release line) are created by omitting it.
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/contents/$state?ref=$BRANCH" --jq .sha 2>/dev/null || true)
+          if [ -n "$sha" ]; then args+=(--field sha="$sha"); fi
+          gh api --method PUT "repos/$GITHUB_REPOSITORY/contents/$state" "${args[@]}" > /dev/null
+          updated=$((updated+1))
+        done
+        if [ "$updated" -eq 0 ]; then
+          echo "ERROR: no state files to update"
+          exit 1
+        fi
+
+        {
+          echo "Updates the PGO profile state files to the profiles generated and"
+          echo "uploaded by [this workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          echo ""
+          echo "Notes: none"
+        } > /tmp/pr-body.md
+        PR_URL=$(gh api "repos/$GITHUB_REPOSITORY/pulls" \
+          --field title="build: update PGO profiles" \
+          --field head="$BRANCH" \
+          --field base="$BASE_BRANCH" \
+          --field body="$(cat /tmp/pr-body.md)" --jq .html_url)
+        PR_NUMBER="${PR_URL##*/}"
+        gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+          --field "labels[]=semver/none" > /dev/null
+        echo "## Profile Update PR" >> $GITHUB_STEP_SUMMARY
+        echo "$PR_URL" >> $GITHUB_STEP_SUMMARY
 
   # Aggregate gate so a single status reflects the whole run.
   pgo-done:

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -667,7 +667,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        BRANCH="pgo-update-${GITHUB_REF_NAME}-${GITHUB_RUN_ID}"
+        BRANCH="pgo/update/${GITHUB_REF_NAME}-${GITHUB_RUN_ID}"
         BASE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$GITHUB_REF_NAME" --jq .object.sha)
         gh api "repos/$GITHUB_REPOSITORY/git/refs" \
           --field ref="refs/heads/$BRANCH" \
@@ -681,7 +681,7 @@ jobs:
         GH_TOKEN: ${{ fromJSON(steps.secret-service.outputs.secrets).PGO_PROFILE_UPDATER_APP_TOKEN }}
       run: |
         BASE_BRANCH="$GITHUB_REF_NAME"
-        BRANCH="pgo-update-${BASE_BRANCH}-${GITHUB_RUN_ID}"
+        BRANCH="pgo/update/${BASE_BRANCH}-${GITHUB_RUN_ID}"
 
         # Map every uploaded profile to its state file in build/pgo_profiles.
         updated=0

--- a/.github/workflows/pipeline-segment-pgo-collect.yml
+++ b/.github/workflows/pipeline-segment-pgo-collect.yml
@@ -103,7 +103,11 @@ jobs:
     # Raw .profraw output; merging happens in pgo-generation.yml's merge job.
     - name: Collect PGO Profile (linux)
       if: ${{ inputs.target-platform == 'linux' }}
-      timeout-minutes: 150
+      # Must exceed collect-profile.js's retry deadline (240 min, after which
+      # no new wipe-and-relaunch attempts start) by enough headroom for the
+      # in-flight attempt to finish and flush its counters - a step-timeout
+      # kill loses the exit-time profraw write.
+      timeout-minutes: 330
       run: |
         cd src
         xvfb-run -a -s "-screen 0 1280x1024x24" \
@@ -115,7 +119,11 @@ jobs:
             --no-merge
     - name: Collect PGO Profile (macos)
       if: ${{ inputs.target-platform == 'macos' }}
-      timeout-minutes: 150
+      # Must exceed collect-profile.js's retry deadline (240 min, after which
+      # no new wipe-and-relaunch attempts start) by enough headroom for the
+      # in-flight attempt to finish and flush its counters - a step-timeout
+      # kill loses the exit-time profraw write.
+      timeout-minutes: 330
       run: |
         cd src
         # --no-sandbox is safe and standard for profile collection: this is an
@@ -132,7 +140,11 @@ jobs:
           --no-merge
     - name: Collect PGO Profile (win)
       if: ${{ inputs.target-platform == 'win' }}
-      timeout-minutes: 150
+      # Must exceed collect-profile.js's retry deadline (240 min, after which
+      # no new wipe-and-relaunch attempts start) by enough headroom for the
+      # in-flight attempt to finish and flush its counters - a step-timeout
+      # kill loses the exit-time profraw write.
+      timeout-minutes: 330
       env:
         TARGET_ARCH: ${{ inputs.target-arch }}
       run: |

--- a/script/pgo/benchmark-app/main.js
+++ b/script/pgo/benchmark-app/main.js
@@ -55,6 +55,10 @@ const RESULTS_FILE = process.env.PGO_RESULTS_FILE || path.join(app.getPath('temp
 //   startExpr  - (optional) expression that starts the benchmark; it must
 //                return false (without side effects) until the page is ready
 //                to start, and true once the benchmark has been started.
+//   startFailExpr - (optional) expression that evaluates to true once the
+//                page can never become startable (e.g. the driver flagged a
+//                load error); fails the attempt immediately instead of
+//                waiting out the full start-polling window.
 //   doneExpr   - expression that evaluates to true when the run has ended
 //                (successfully or not).
 //   successExpr- (optional) evaluated after doneExpr fires; distinguishes a
@@ -111,6 +115,10 @@ const WORKLOADS = [
     // "Start Test" button. Calling start() before that point does nothing
     // useful, so gate on the button existing.
     startExpr: '!!document.querySelector("#status a.button") && (JetStream.start(), true)',
+    // The driver sets allIsGood = false (via window.onerror / a failed
+    // resource preload) and then refuses to run a partial suite, so the
+    // Start button will never appear.
+    startFailExpr: 'typeof allIsGood !== "undefined" && allIsGood === false',
     // On completion the driver adds the "done" class to #result-summary
     // (JetStreamDriver.js); there is no JetStream.done property.
     doneExpr: '!!document.querySelector("#result-summary.done")',
@@ -325,6 +333,15 @@ async function runWorkload(win, workload, diag) {
         started = await win.webContents.executeJavaScript(workload.startExpr, true);
       } catch {
         /* page busy - retry */
+      }
+      if (!started && workload.startFailExpr) {
+        let unstartable = false;
+        try {
+          unstartable = await win.webContents.executeJavaScript(workload.startFailExpr, true);
+        } catch {
+          /* page busy - keep polling */
+        }
+        if (unstartable) break;
       }
     }
     if (!started) {
@@ -848,33 +865,27 @@ app.whenReady().then(async () => {
     log(`workload filter active: ${phaseNames.join(', ')}`);
   }
 
-  // Transient child-process crashes (a renderer dying at spawn surfaces as a
-  // fast ERR_FAILED load) are retried once; profile counters are cumulative so
-  // a retried workload only adds coverage. Slow failures are NOT retried -
-  // they are timeouts, and rerunning a 30-45 minute workload risks blowing
-  // the job time limit for no new information.
-  const RETRY_IF_FAILED_WITHIN_MS = 5 * 60 * 1000;
+  // No in-app retry: a failed attempt's counters cannot be excised from
+  // already-running processes (continuous-mode counters in particular are
+  // app-lifetime cumulative), so retrying in-process would leave the failed
+  // attempt's mass in the profile. Failures are instead retried by
+  // collect-profile.js, which wipes the profraw dir and relaunches the whole
+  // app. When the orchestrator signals a relaunch is coming
+  // (PGO_ABORT_ON_FAILURE), bail on the first failure - finishing the
+  // remaining workloads is wasted work. On the final attempt the variable is
+  // unset and the run continues past failures so the partial profile keeps
+  // as much coverage as possible.
   for (let i = 0; i < phases.length; i++) {
-    const attemptStart = Date.now();
     try {
       results.push(await phases[i]());
     } catch (err) {
       log(`ERROR: ${err.message}`);
-      let failure = err;
-      if (Date.now() - attemptStart < RETRY_IF_FAILED_WITHIN_MS) {
-        log(`workload ${phaseNames[i]} failed quickly - retrying once`);
-        try {
-          results.push(await phases[i]());
-          continue;
-        } catch (retryErr) {
-          log(`ERROR (retry): ${retryErr.message}`);
-          failure = retryErr;
-        }
-      }
-      results.push({ name: phaseNames[i], ok: false, error: failure.message });
-      // A failed workload reduces profile coverage but the data collected so
-      // far is still valid - keep going and report partial failure.
+      results.push({ name: phaseNames[i], ok: false, error: err.message });
       exitCode = 1;
+      if (process.env.PGO_ABORT_ON_FAILURE) {
+        log('aborting remaining workloads; the orchestrator will wipe profiles and relaunch');
+        break;
+      }
     }
   }
 

--- a/script/pgo/collect-profile.js
+++ b/script/pgo/collect-profile.js
@@ -8,7 +8,7 @@
 //     --electron <path to instrumented electron binary> \
 //     --output <path to write merged .profdata> \
 //     [--work-dir <scratch dir>] [--port 8765] [--no-sandbox] [--no-merge]
-//     [--target-arch <arch>]
+//     [--target-arch <arch>] [--attempts <n>] [--retry-deadline-minutes <n>]
 //
 // --no-sandbox is required when running as root inside CI containers; the
 // sandbox setup paths are a negligible fraction of profile counters.
@@ -19,6 +19,10 @@
 // the Linux arm64 CI runners) - .profraw files are arch-independent data and
 // can be merged later on any machine with a matching llvm-profdata (see
 // fetch-llvm-profdata.js).
+//
+// Failed collections are retried (up to --attempts, default 5) by wiping the
+// profraw dir and relaunching the app from scratch, so a published profile
+// only ever contains counters from one fully-successful run.
 //
 // The flow mirrors Chromium's tools/pgo/generate_profile.py:
 //   1. Serve the benchmark workloads locally (Speedometer 3, JetStream 2,
@@ -300,10 +304,6 @@ async function main() {
   if (!fs.existsSync(electronBinary)) {
     throw new Error(`instrumented electron binary not found: ${electronBinary}`);
   }
-  // Stale pool files from a previous run would silently merge into this
-  // collection (%m pools append counters); always start clean.
-  fs.rmSync(profrawDir, { recursive: true, force: true });
-  fs.mkdirSync(profrawDir, { recursive: true });
   fs.mkdirSync(benchmarksDir, { recursive: true });
 
   // 1. Benchmarks, TLS material, and the local server.
@@ -368,48 +368,85 @@ async function main() {
   ];
   if (args['no-sandbox']) electronArgs.push('--no-sandbox');
 
-  const startTime = Date.now();
-  let exitCode = await new Promise((resolve, reject) => {
-    const child = spawn(electronBinary, electronArgs, {
-      env: {
-        ...process.env,
-        LLVM_PROFILE_FILE: profilePattern,
-        PGO_BENCHMARK_BASE_URL: baseUrl,
-        PGO_RESULTS_FILE: resultsFile,
-        PGO_ASAR_FIXTURE: asarFixture,
-        // Node's TLS stack (used by the main-process network workload) does
-        // not read the OS trust store; point it at the collection CA.
-        ...(caCertPath ? { NODE_EXTRA_CA_CERTS: caCertPath } : {})
-      },
-      stdio: 'inherit'
-    });
-    child.on('error', reject);
-    child.on('exit', (code, signal) => {
-      // A signal exit (code === null) usually means the OOM killer (SIGKILL)
-      // or a crash (SIGSEGV/SIGABRT) - log it so CI failures are diagnosable.
-      if (signal) log(`electron was killed by signal ${signal}`);
-      resolve(code ?? 1);
-    });
-  });
-  server.close();
-
-  const elapsedMin = ((Date.now() - startTime) / 60000).toFixed(1);
-  log(`instrumented run finished with exit code ${exitCode} in ${elapsedMin} minutes`);
-
-  // Electron's clean-shutdown path (app.quit()) always exits 0, so workload
-  // failures are reported through the results file rather than the exit code.
+  // A failed attempt's counters cannot be separated from good ones once they
+  // are on disk (and Darwin's %c continuous-mode counters accumulate for the
+  // whole app lifetime), so failures are retried by wiping the profraw dir
+  // and relaunching the app from scratch: a published profile only ever
+  // contains counters from one fully-successful run. Non-final attempts
+  // abort on the first workload failure (PGO_ABORT_ON_FAILURE) since their
+  // output is discarded anyway; the final attempt runs to completion so a
+  // persistent failure still yields a maximal partial profile.
+  const maxAttempts = parseInt(args.attempts || '5', 10);
+  // Attempts can be slow when a workload burns its own timeout before
+  // failing (jetstream2 alone allows 45 minutes), so the attempt count alone
+  // does not bound the step duration. Stop launching retries once this much
+  // wall clock has elapsed: the in-flight attempt must finish and cleanly
+  // flush its counters before the CI step timeout kills the process tree (a
+  // hard kill loses the exit-time profraw write entirely on Windows/Linux).
+  const retryDeadlineMs = parseInt(args['retry-deadline-minutes'] || '240', 10) * 60 * 1000;
+  const collectionStart = Date.now();
+  let exitCode = 1;
   let failedWorkloads = [];
-  if (fs.existsSync(resultsFile)) {
-    const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
-    log(`workload results:\n${JSON.stringify(results, null, 2)}`);
-    failedWorkloads = results.filter((r) => !r.ok);
-  } else {
-    log('WARNING: no results file was written - the app may have crashed');
-    failedWorkloads = [{ name: 'all', error: 'results file missing' }];
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const finalAttempt = attempt === maxAttempts;
+    // Always start clean: counters from a failed attempt (or stale %m pool
+    // files from a previous run, which append) must not merge into this one.
+    fs.rmSync(profrawDir, { recursive: true, force: true });
+    fs.mkdirSync(profrawDir, { recursive: true });
+    fs.rmSync(resultsFile, { force: true });
+
+    log(`collection attempt ${attempt}/${maxAttempts}`);
+    const startTime = Date.now();
+    exitCode = await new Promise((resolve, reject) => {
+      const child = spawn(electronBinary, electronArgs, {
+        env: {
+          ...process.env,
+          LLVM_PROFILE_FILE: profilePattern,
+          PGO_BENCHMARK_BASE_URL: baseUrl,
+          PGO_RESULTS_FILE: resultsFile,
+          PGO_ASAR_FIXTURE: asarFixture,
+          ...(finalAttempt ? {} : { PGO_ABORT_ON_FAILURE: '1' }),
+          // Node's TLS stack (used by the main-process network workload) does
+          // not read the OS trust store; point it at the collection CA.
+          ...(caCertPath ? { NODE_EXTRA_CA_CERTS: caCertPath } : {})
+        },
+        stdio: 'inherit'
+      });
+      child.on('error', reject);
+      child.on('exit', (code, signal) => {
+        // A signal exit (code === null) usually means the OOM killer (SIGKILL)
+        // or a crash (SIGSEGV/SIGABRT) - log it so CI failures are diagnosable.
+        if (signal) log(`electron was killed by signal ${signal}`);
+        resolve(code ?? 1);
+      });
+    });
+
+    const elapsedMin = ((Date.now() - startTime) / 60000).toFixed(1);
+    log(`instrumented run finished with exit code ${exitCode} in ${elapsedMin} minutes`);
+
+    // Electron's clean-shutdown path (app.quit()) always exits 0, so workload
+    // failures are reported through the results file rather than the exit code.
+    failedWorkloads = [];
+    if (fs.existsSync(resultsFile)) {
+      const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
+      log(`workload results:\n${JSON.stringify(results, null, 2)}`);
+      failedWorkloads = results.filter((r) => !r.ok);
+    } else {
+      log('WARNING: no results file was written - the app may have crashed');
+      failedWorkloads = [{ name: 'all', error: 'results file missing' }];
+    }
+    if (exitCode === 0 && failedWorkloads.length > 0) {
+      exitCode = 1;
+    }
+    if (exitCode === 0 || finalAttempt) break;
+    if (Date.now() - collectionStart > retryDeadlineMs) {
+      log(`retry deadline reached after attempt ${attempt} - keeping this attempt's partial output`);
+      break;
+    }
+    const reason = failedWorkloads.map((w) => w.name).join(', ') || `exit code ${exitCode}`;
+    log(`attempt ${attempt} failed (${reason}) - wiping profiles and retrying`);
   }
-  if (exitCode === 0 && failedWorkloads.length > 0) {
-    exitCode = 1;
-  }
+  server.close();
 
   // 3. Merge (or hand off the raw files for later merging).
   const profrawFiles = fs


### PR DESCRIPTION
Two improvements to the PGO generation pipeline, prompted by run 26933006860 where a jetstream2 startability failure on win-x86 could never be retried and blocked publishing.

### Profile-pure collection retries

The in-app retry from #51866 left the failed attempt's counters in the profile (continuous-mode counters are app-lifetime cumulative and cannot be excised). Replaced with wipe-and-relaunch retries in `collect-profile.js`:

- up to `--attempts` (default 5) full relaunches, each starting from an empty profraw dir and fresh processes, so a published profile only ever contains counters from one fully-successful run
- non-final attempts abort on the first workload failure (`PGO_ABORT_ON_FAILURE`); the final attempt runs to completion so a persistent failure still uploads a maximal partial profile
- retries stop launching past `--retry-deadline-minutes` (default 240) so the in-flight attempt finishes and flushes counters before the step timeout (a hard kill loses the exit-time profraw write); step timeout raised 150 → 330 to match
- jetstream2 fails in seconds instead of polling its 300s startability window when the driver flags a load error (`startFailExpr` on `allIsGood`), which is exactly the failure from the run above

### Publish gate + automatic state-file PR

- `upload-profiles` now requires every build/collect/merge job to be green (skipped platforms via the `skip-*` inputs remain allowed) - a partial profile set never reaches the CDN or the state files
- after the Azure upload, the job exchanges its OIDC token for an `electron-pgo-updater` app token via `electron/secret-service-action` (electron/secret-service#69) and opens a PR updating `build/pgo_profiles/*.pgo.txt` to the freshly uploaded profiles
- the app token is restricted to `single_file: write` on the nine state files and cannot create refs, so `GITHUB_TOKEN` creates the `pgo/update/*` branch and the app token commits each state file via the contents API (verified against the live installation)

Notes: none

