### PR TITLE
build: skip CI for PGO state-file-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,9 +152,12 @@ jobs:
         generate-sas-token: 'true'
         target-platform: macos
 
+  # No plain src gate here: the docs-only compile needs this checkout even
+  # when src is false. pgo-only changes have no consumer for it, so they
+  # skip it via the docs-only output instead.
   checkout-linux:
     needs: setup
-    if: ${{ !inputs.skip-linux}}
+    if: ${{ (needs.setup.outputs.src == 'true' || needs.setup.outputs.docs-only == 'true') && !inputs.skip-linux }}
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,15 @@ jobs:
         src: ${{ steps.filter.outputs.src }}
         build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
         docs-only: ${{ steps.set-output.outputs.docs-only }}
+        pgo-only: ${{ steps.set-output.outputs.pgo-only }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+    # The filters are evaluated per-pattern and OR'd together, so the src
+    # exclusions must live inside a single negated brace pattern - a second
+    # negated pattern would match (and re-include) every file the first one
+    # excluded.
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
@@ -75,8 +80,10 @@ jobs:
             - SECURITY.md
             - CONTRIBUTING.md
             - CODE_OF_CONDUCT.md
+          pgo:
+            - 'build/pgo_profiles/*.pgo.txt'
           src:
-            - '!{docs,.claude}/**'
+            - '!{docs/**,.claude/**,build/pgo_profiles/*.pgo.txt}'
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -86,11 +93,16 @@ jobs:
       id: set-output
       run: |
         echo "docs-only=${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.src == 'false' }}" >> "$GITHUB_OUTPUT"
+        echo "pgo-only=${{ steps.filter.outputs.pgo == 'true' && steps.filter.outputs.src == 'false' && steps.filter.outputs.docs == 'false' }}" >> "$GITHUB_OUTPUT"
 
   # Lint Jobs
+  # pgo-only changes skip lint too: the state files are machine-written
+  # single-line text files no linter covers, and skipping reports the
+  # required "lint / Lint" check as skipped, which branch protection treats
+  # as satisfied.
   lint:
     needs: setup
-    if: ${{ !inputs.skip-lint }}
+    if: ${{ !inputs.skip-lint && needs.setup.outputs.pgo-only != 'true' }}
     uses: ./.github/workflows/pipeline-electron-lint.yml
     permissions:
       contents: read


### PR DESCRIPTION
PRs and pushes that only touch `build/pgo_profiles/*.pgo.txt` now skip CI entirely and go green immediately. The state files are machine-written pointers to profiles on dev-cdn (soon written by the automated `pgo/update/*` PRs from #51881); no CI job exercises them and they cannot break a build, so a full build/test matrix on every profile roll is wasted compute.

- `src` filter excludes the state files, so all checkout/build/test/gn-check jobs skip; the exclusion lives inside the single negated brace pattern because paths-filter ORs patterns (a second negated pattern would re-include everything the first excluded - verified against the pinned action's picomatch matcher)
- new `pgo-only` setup output gates `lint`; the required `lint / Lint` check reports skipped, which branch protection treats as satisfied
- `checkout-linux` previously ran unconditionally to serve the docs-only compile; it is now gated on `src || docs-only` so pgo-only changes skip its 32-core sync too (every other consumer is already src-gated)
- `gha-done` already runs `always()` and goes green when all needs are skipped, so the required `GitHub Actions Completed` check passes
- anything else in `build/pgo_profiles/` (README, .gitignore) still counts as src and runs full CI, as does any PR mixing state files with other changes

Notes: none
