### PR TITLE
refactor: use @electron-internal/extract-zip in the npm package

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -2,7 +2,7 @@
 
 const { downloadArtifact } = require('@electron/get');
 
-const extract = require('extract-zip');
+const { extract } = require('@electron-internal/extract-zip');
 
 const childProcess = require('child_process');
 const fs = require('fs');

--- a/npm/package.json
+++ b/npm/package.json
@@ -16,9 +16,9 @@
     "install.js"
   ],
   "dependencies": {
+    "@electron-internal/extract-zip": "^1.0.1",
     "@electron/get": "^5.0.0",
-    "@types/node": "^24.9.0",
-    "extract-zip": "^2.0.1"
+    "@types/node": "^24.9.0"
   },
   "engines": {
     "node": ">= 22.12.0"


### PR DESCRIPTION
## Description of Change

Closes https://github.com/electron/electron/issues/51619

Switches the published `electron` npm package from `extract-zip` to `@electron-internal/extract-zip`, a drop-in replacement maintained at [electron/extract-zip](https://github.com/electron/extract-zip) that uses prebuilt native bindings for extraction.

The package is ESM-only, so the `require()` in `install.js` now destructures the named `extract` export — supported on the Node versions the package already requires (`engines: >= 22.12.0`).

Verified locally on macOS arm64 by stamping the `npm/` folder as `electron@42.3.3` and running the full install flow: the zip downloads and extracts, `cli.js --version` launches the app, and the extracted output (file list, content hashes, symlinks, permissions) is byte-identical to what `extract-zip@2.0.1` produces.

## Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

## Release Notes

Notes: none