### PR TITLE
fix: lint not allowing merge commits

### DIFF
--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -15,6 +15,7 @@ const CL_REGEX =
 const ROLLER_BRANCH_PATTERN = /^roller\/chromium\/(.+)$/;
 const DEPS_BUMP_MSG_REGEX = /^chore: bump chromium in DEPS to (\S+)$/;
 const PATCHES_UPDATE_MSG = 'chore: update patches';
+const MERGE_COMMIT_MSG_REGEX = /^Merge (remote-tracking )?branch |^Merge commit /;
 
 function getCurrentBranch() {
   // In CI, use `GITHUB_HEAD_REF` since we checkout the PR branch in detached HEAD state
@@ -234,6 +235,12 @@ async function main() {
       continue;
     }
 
+    // Allow merge commits from the target branch
+    if (MERGE_COMMIT_MSG_REGEX.test(firstLine)) {
+      console.log(`  ✅ Merge commit`);
+      continue;
+    }
+
     // Validate Chromium version bump commits
     const parentVersion = getParentChromiumVersion(commit.sha);
     const commitVersion = getChromiumVersionForCommit(commit.sha);
@@ -339,7 +346,7 @@ async function main() {
     if (cls.length === 0) {
       console.error(`  ❌ Commit does not match any allowed pattern and references no CLs`);
       console.error(
-        `     Allowed: fixup! commit, "chore: bump chromium in DEPS to <version>", "${PATCHES_UPDATE_MSG}", or a commit referencing one or more CLs`
+        `     Allowed: fixup! commit, merge commit, "chore: bump chromium in DEPS to <version>", "${PATCHES_UPDATE_MSG}", or a commit referencing one or more CLs`
       );
       hasErrors = true;
       continue;


### PR DESCRIPTION
#### Description of Change

The roller lint script is not allowing merge commits -- blocking https://github.com/electron/electron/pull/51800

```
node script/lint-roller-chromium-changes.mjs
Linting roller branch: roller/chromium/main (target: main)
Chromium version range: 150.0.7863.0 -> 151.0.7873.0
Found 33 commits to check

Checking commit ba2e3a9: Merge remote-tracking branch 'origin/main' into roller/chromium/main
  ❌ Commit does not match any allowed pattern and references no CLs
     Allowed: fixup! commit, "chore: bump chromium in DEPS to <version>", "chore: update patches", or a commit referencing one or more CLs
```

This PR adds a pattern to allow them so lint will pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
