### PR TITLE
chore: bump simple-git to 3.36.0 and basic-ftp to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
     "abstract-socket": "patch:abstract-socket@npm%3A2.0.0#~/.yarn/patches/abstract-socket-npm-2.0.0-b025d8ca5a.patch",
     "minimist@npm:~0.0.1": "0.2.4",
     "put": "npm:@nornagon/put@0.0.8",
-    "get-intrinsic": "^1.3.0"
+    "get-intrinsic": "^1.3.0",
+    "simple-git": "3.36.0"
   },
   "packageManager": "yarn@4.12.0",
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/args-pathspec@npm:1.0.3"
+  checksum: 10c0/91bfc99daa956df28e4efd683cd799f60c6d169fce6adf71a9efa80a6b5938fed4b03e55fa929cfd51aed64f3ada5c1e4edad45a3872dbd94d11924b3258b5bc
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@simple-git/argv-parser@npm:1.1.1"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+  checksum: 10c0/2c21166f1bb7c4373e7b4e52bd0c7f333e58ea0ff5ac0b6c2d305835f4a2bcad1ef4bcce3cff63312ac55655ea7be3aba4c7c0c41e3ebcb8bee343f65bb92f5e
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.48
   resolution: "@sinclair/typebox@npm:0.34.48"
@@ -3215,9 +3231,9 @@ __metadata:
   linkType: hard
 
 "basic-ftp@npm:^5.0.2":
-  version: 5.3.0
-  resolution: "basic-ftp@npm:5.3.0"
-  checksum: 10c0/307ebc0635d06e671729d348e45e6eaec5f926713f93de535b268e17ae675942cd6903a84196cece948b54e04b24591431be3df79b2824551a0d5ed150555fb2
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
   languageName: node
   linkType: hard
 
@@ -10477,14 +10493,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:3.33.0, simple-git@npm:^3.5.0":
-  version: 3.33.0
-  resolution: "simple-git@npm:3.33.0"
+"simple-git@npm:3.36.0":
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
     debug: "npm:^4.4.0"
-  checksum: 10c0/463e91f3ee04b7fc445284c64502a4ee3d607f626f18c8bcc036815a30fe178d2216976e683c6368edd7b3093801d6e534deeb8e700a4863a76ef23f881a0712
+  checksum: 10c0/4c22e57107535168f354e5abbbf6e618a7b39d76491ca225c70588520fbe86891f3b9a5c4f8a3fc0137e669aad2f0e11f6c6e677bfec07169cd18f29bf23cb77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps two transitive dependencies whose lockfile-pinned versions have known vulnerabilities:

- **simple-git 3.33.0 → 3.36.0** ([GHSA-hffm-xvc3-vprc](https://github.com/advisories/GHSA-hffm-xvc3-vprc)) — pinned exactly by `@datadog/datadog-ci`, which still pins the vulnerable version in its latest release (5.12.0), so this adds a root `resolutions` override.
- **basic-ftp 5.3.0 → 5.3.1** ([GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89)) — transitive via `get-uri@^5.0.2`, re-resolved within the existing range.

Both are devDependencies of the repo tooling; nothing ships to users. `yarn install` verified clean after the bump.

Notes: none
