### PR TITLE
test: don't import from ../lib in API tests

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -349,6 +349,20 @@
     },
     {
       "files": [
+        "spec/**/api-*.ts",
+        "spec/**/api-*.js",
+        "spec/**/api-*.mjs"
+      ],
+      "rules": {
+        "no-restricted-imports": ["error", {
+          "patterns": [{
+            "regex": "^\\.\\./"
+          }]
+        }]
+      }
+    },
+    {
+      "files": [
         "**/*.d.ts"
       ],
       "rules": {

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -12,12 +12,28 @@ import { expect } from 'chai';
 
 import { once } from 'node:events';
 
-import { roleList, execute } from '../lib/browser/api/menu-item-roles';
+/* oxlint-disable-next-line no-restricted-imports */
+import { roleList } from '../lib/browser/api/menu-item-roles';
 import { ifit, ifdescribe } from './lib/spec-helpers';
 import { closeAllWindows, cleanupWebContents } from './lib/window-helpers';
 
 function keys<Key extends string, Value>(record: Record<Key, Value>) {
   return Object.keys(record) as Key[];
+}
+
+// Helper to execute a menu item by its role
+function executeByRole(role: MenuItemConstructorOptions['role'], win: BaseWindow, wc: Electron.WebContents) {
+  let handledByRole = true;
+  const menu = Menu.buildFromTemplate([
+    {
+      role,
+      click: () => {
+        handledByRole = false;
+      }
+    }
+  ]);
+  menu.items[0].click({}, win, wc);
+  return handledByRole;
 }
 
 describe('MenuItems', () => {
@@ -264,7 +280,7 @@ describe('MenuItems', () => {
       const win = new BrowserWindow({ show: false, width: 200, height: 200 });
       const item = new MenuItem({ role: 'asdfghjkl' as any });
 
-      const canExecute = execute(item.role as any, win, win.webContents);
+      const canExecute = executeByRole(item.role as any, win, win.webContents);
       expect(canExecute).to.be.false('can execute');
     });
 
@@ -272,7 +288,7 @@ describe('MenuItems', () => {
       const win = new BrowserWindow({ show: false, width: 200, height: 200 });
       const item = new MenuItem({ role: 'reload' });
 
-      const canExecute = execute(item.role as any, win, win.webContents);
+      const canExecute = executeByRole(item.role as any, win, win.webContents);
       expect(canExecute).to.be.true('can execute');
     });
 
@@ -280,7 +296,7 @@ describe('MenuItems', () => {
       const win = new BrowserWindow({ show: false, width: 200, height: 200 });
       const item = new MenuItem({ role: 'resetZoom' });
 
-      const canExecute = execute(item.role as any, win, win.webContents);
+      const canExecute = executeByRole(item.role as any, win, win.webContents);
       expect(canExecute).to.be.true('can execute');
     });
 
@@ -527,12 +543,12 @@ describe('MenuItems', () => {
       await wcv.webContents.loadURL('about:blank');
 
       const opened = once(wcv.webContents, 'devtools-opened');
-      expect(execute('toggledevtools', w, wcv.webContents)).to.be.true();
+      expect(executeByRole('toggleDevTools', w, wcv.webContents)).to.be.true();
       await opened;
       expect(wcv.webContents.isDevToolsOpened()).to.be.true();
 
       const closed = once(wcv.webContents, 'devtools-closed');
-      execute('toggledevtools', w, wcv.webContents);
+      executeByRole('toggleDevTools', w, wcv.webContents);
       await closed;
       expect(wcv.webContents.isDevToolsOpened()).to.be.false();
     });
@@ -552,7 +568,7 @@ describe('MenuItems', () => {
       expect(devToolsWc).to.not.be.null();
 
       const closed = once(wcv.webContents, 'devtools-closed');
-      expect(execute('toggledevtools', w, devToolsWc)).to.be.true();
+      expect(executeByRole('toggleDevTools', w, devToolsWc)).to.be.true();
       await closed;
       expect(wcv.webContents.isDevToolsOpened()).to.be.false();
     });

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -7,7 +7,6 @@ import { once } from 'node:events';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-import { sortMenuItems } from '../lib/browser/api/menu-utils';
 import { singleModifierCombinations } from './lib/accelerator-helpers';
 import { ifit } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';
@@ -102,7 +101,7 @@ describe('Menu module', function () {
     describe('Menu sorting and building', () => {
       describe('sorts groups', () => {
         it('does a simple sort', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               label: 'two',
               id: '2',
@@ -113,22 +112,27 @@ describe('Menu module', function () {
               id: '1',
               label: 'one'
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
               label: 'two',
-              afterGroupContaining: ['1']
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it('does a simple sort with MenuItems', () => {
@@ -140,14 +144,14 @@ describe('Menu module', function () {
           });
           const sep = new MenuItem({ type: 'separator' });
 
-          const items = [secondItem, sep, firstItem];
+          const menu = Menu.buildFromTemplate([secondItem, sep, firstItem]);
           const expected = [firstItem, sep, secondItem];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items).to.deep.equal(expected);
         });
 
         it('resolves cycles by ignoring things that conflict', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '2',
               label: 'two',
@@ -159,27 +163,31 @@ describe('Menu module', function () {
               label: 'one',
               afterGroupContaining: ['2']
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
               label: 'one',
-              afterGroupContaining: ['2']
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
               label: 'two',
-              afterGroupContaining: ['1']
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it('ignores references to commands that do not exist', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -190,26 +198,31 @@ describe('Menu module', function () {
               label: 'two',
               afterGroupContaining: ['does-not-exist']
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
               label: 'two',
-              afterGroupContaining: ['does-not-exist']
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -230,38 +243,48 @@ describe('Menu module', function () {
               id: '2',
               label: 'two'
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '3',
               label: 'three',
-              beforeGroupContaining: ['1']
+              type: 'normal'
             },
             {
               id: '4',
               label: 'four',
-              afterGroupContaining: ['2']
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
-              label: 'two'
+              label: 'two',
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
       });
 
       describe('moves an item to a different group by merging groups', () => {
         it('can move a group of one item', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -278,30 +301,36 @@ describe('Menu module', function () {
               after: ['1']
             },
             { type: 'separator' }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
             {
               id: '3',
               label: 'three',
-              after: ['1']
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
-              label: 'two'
+              label: 'two',
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it("moves all items in the moving item's group", () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -322,34 +351,41 @@ describe('Menu module', function () {
               label: 'four'
             },
             { type: 'separator' }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
             {
               id: '3',
               label: 'three',
-              after: ['1']
+              type: 'normal'
             },
             {
               id: '4',
-              label: 'four'
+              label: 'four',
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
-              label: 'two'
+              label: 'two',
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it("ignores positions relative to commands that don't exist", () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -371,35 +407,41 @@ describe('Menu module', function () {
               after: ['1']
             },
             { type: 'separator' }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
-              label: 'one'
+              label: 'one',
+              type: 'normal'
             },
             {
               id: '3',
               label: 'three',
-              after: ['does-not-exist']
+              type: 'normal'
             },
             {
               id: '4',
               label: 'four',
-              after: ['1']
+              type: 'normal'
             },
-            { type: 'separator' },
+            {
+              id: undefined,
+              label: '',
+              type: 'separator'
+            },
             {
               id: '2',
-              label: 'two'
+              label: 'two',
+              type: 'normal'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label, type }) => ({ id, label, type }))).to.deep.equal(expected);
         });
 
         it('can handle recursive group merging', () => {
-          const items = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one',
@@ -414,30 +456,28 @@ describe('Menu module', function () {
               id: '3',
               label: 'three'
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '3',
               label: 'three'
             },
             {
               id: '2',
-              label: 'two',
-              before: ['1']
+              label: 'two'
             },
             {
               id: '1',
-              label: 'one',
-              after: ['3']
+              label: 'one'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label }) => ({ id, label }))).to.deep.equal(expected);
         });
 
         it('can merge multiple groups when given a list of before/after commands', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -453,9 +493,9 @@ describe('Menu module', function () {
               label: 'three',
               after: ['1', '2']
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '2',
               label: 'two'
@@ -466,16 +506,15 @@ describe('Menu module', function () {
             },
             {
               id: '3',
-              label: 'three',
-              after: ['1', '2']
+              label: 'three'
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label }) => ({ id, label }))).to.deep.equal(expected);
         });
 
         it('can merge multiple groups based on both before/after commands', () => {
-          const items: Electron.MenuItemConstructorOptions[] = [
+          const menu = Menu.buildFromTemplate([
             {
               id: '1',
               label: 'one'
@@ -492,18 +531,16 @@ describe('Menu module', function () {
               after: ['1'],
               before: ['2']
             }
-          ];
+          ]);
 
-          const expected = [
+          const expected: Electron.MenuItemConstructorOptions[] = [
             {
               id: '1',
               label: 'one'
             },
             {
               id: '3',
-              label: 'three',
-              after: ['1'],
-              before: ['2']
+              label: 'three'
             },
             {
               id: '2',
@@ -511,7 +548,7 @@ describe('Menu module', function () {
             }
           ];
 
-          expect(sortMenuItems(items)).to.deep.equal(expected);
+          expect(menu.items.map(({ id, label }) => ({ id, label }))).to.deep.equal(expected);
         });
       });
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We shouldn't be reaching into `../lib/` during API tests as we want to be writing integration tests, not testing implementation details. Sets an oxlint rule (`no-restricted-imports`) to enforce this and cleans up the few violations we had. There's still one violation but I disabled the rule for that specific case (importing `roleList`) as there wasn't a clear clean up for that one.

Limiting this to just API tests since we have a handful of useful test coverage that's providing unit test level coverage for a few internal functions in other test files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
