### PR TITLE
chore: cherry-pick 17 changes from angle, chromium, webrtc

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,5 @@ cherry-pick-7712217.patch
 cherry-pick-7722080.patch
 cherry-pick-d8ffa7447da0.patch
 cherry-pick-c0c3b52cec94.patch
+cherry-pick-86d64be7672e.patch
+cherry-pick-0323970550b9.patch

--- a/patches/angle/cherry-pick-0323970550b9.patch
+++ b/patches/angle/cherry-pick-0323970550b9.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenneth Russell <kbr@chromium.org>
+Date: Mon, 30 Mar 2026 18:13:36 -0700
+Subject: Metal: Fix pitch computation for compressed textures in PBOs.
+
+Correctly detect block formats and adjust the row and depth pitch
+computation. Inspiration taken from ANGLE's Vulkan backend.
+
+Authored with gemini-cli, with guidance from domain experts.
+
+Fixed: angleproject:489579953
+Change-Id: I5656b02bc235bbe068191a0fb2049afcea9a094e
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7699417
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+
+diff --git a/src/libANGLE/renderer/metal/TextureMtl.mm b/src/libANGLE/renderer/metal/TextureMtl.mm
+index 0dcbddd41f22928d1eafab3f6274b2b176899917..66118af260ce8262a3b5419fe25939dee0e1eadd 100644
+--- a/src/libANGLE/renderer/metal/TextureMtl.mm
++++ b/src/libANGLE/renderer/metal/TextureMtl.mm
+@@ -2471,7 +2471,29 @@ uint32_t height(GLuint glLevel) const
+                                                      ? imageFormat.textureLoadFunctions(type)
+                                                      : LoadImageFunctionInfo();
+         const angle::Format &dstFormat         = angle::Format::Get(imageFormat.actualFormatId);
+-        const size_t dstRowPitch               = dstFormat.pixelBytes * mtlArea.size.width;
++        size_t dstRowPitch;
++        size_t dstDepthPitch;
++        if (dstFormat.isBlock)
++        {
++            const gl::InternalFormat &dstFormatInfo =
++                gl::GetSizedInternalFormatInfo(dstFormat.glInternalFormat);
++            GLuint rowPitch;
++            ANGLE_CHECK_GL_MATH(contextMtl,
++                                dstFormatInfo.computeCompressedImageRowPitch(
++                                    static_cast<GLsizei>(mtlArea.size.width), &rowPitch));
++            dstRowPitch = rowPitch;
++
++            GLuint depthPitch;
++            ANGLE_CHECK_GL_MATH(contextMtl, dstFormatInfo.computeCompressedImageDepthPitch(
++                                                static_cast<GLsizei>(mtlArea.size.height),
++                                                static_cast<GLuint>(dstRowPitch), &depthPitch));
++            dstDepthPitch = depthPitch;
++        }
++        else
++        {
++            dstRowPitch   = dstFormat.pixelBytes * mtlArea.size.width;
++            dstDepthPitch = dstRowPitch * mtlArea.size.height;
++        }
+ 
+         // It is very important to avoid allocating a new buffer for each row during these
+         // uploads.
+@@ -2485,7 +2507,6 @@ uint32_t height(GLuint glLevel) const
+                 ASSERT(loadFunctionInfo.loadFunction);
+ 
+                 // Need to create a buffer to hold entire decompressed image.
+-                const size_t dstDepthPitch = dstRowPitch * mtlArea.size.height;
+                 angle::MemoryBuffer decompressBuf;
+                 ANGLE_CHECK_GL_ALLOC(contextMtl,
+                                      decompressBuf.resize(dstDepthPitch * mtlArea.size.depth));
+@@ -2509,7 +2530,6 @@ uint32_t height(GLuint glLevel) const
+                        static_cast<unsigned int>(imageDef.image->sizeAt0().width));
+                 ASSERT(mtlArea.size.height ==
+                        static_cast<unsigned int>(imageDef.image->sizeAt0().height));
+-                const size_t dstDepthPitch = dstRowPitch * mtlArea.size.height;
+                 ANGLE_TRY(UploadTextureContents(
+                     context, dstFormat, mtlArea, mtl::kZeroNativeMipLevel, slice, pixels,
+                     dstRowPitch, dstDepthPitch, kAvoidStagingBuffers, imageDef.image));
+diff --git a/src/tests/gl_tests/ETCTextureTest.cpp b/src/tests/gl_tests/ETCTextureTest.cpp
+index 319eb1c9ffe7a86b98a5cb98f98e1775bb9b0683..0d2f732676a47515693ad1e0255546f777b5e19d 100644
+--- a/src/tests/gl_tests/ETCTextureTest.cpp
++++ b/src/tests/gl_tests/ETCTextureTest.cpp
+@@ -12,6 +12,7 @@
+ #endif
+ 
+ #include "test_utils/ANGLETest.h"
++#include "test_utils/gl_raii.h"
+ 
+ #include "media/etc2bc_srgb8_alpha8.inc"
+ 
+@@ -309,6 +310,45 @@ TEST_P(ETCTextureTest, ETC2SRGB8A1Validation)
+     }
+ }
+ 
++// Tests that uploading compressed texture from a PBO with a misaligned offset doesn't crash.
++TEST_P(ETCTextureTest, PBOWithMisalignedOffset)
++{
++    // Need ES 3.0 for PBOs.
++    ANGLE_SKIP_TEST_IF(getClientMajorVersion() < 3);
++
++    // Check if ETC2 is supported. Not supported, for example, on ANGLE/OpenGL on macOS.
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_ANGLE_lossy_etc_decode") &&
++                       !IsGLExtensionEnabled("GL_OES_compressed_ETC2_RGB8_texture") &&
++                       !IsGLExtensionEnabled("GL_ANGLE_compressed_texture_etc"));
++
++    constexpr GLsizei kWidth  = 512;
++    constexpr GLsizei kHeight = 512;
++    constexpr GLsizei kBPB    = 8;  // 8 bytes per block
++    constexpr GLsizei kBW     = 4;
++    constexpr GLsizei kBH     = 4;
++
++    GLsizei blocksX        = kWidth / kBW;
++    GLsizei blocksY        = kHeight / kBH;
++    GLsizei compressedSize = blocksX * blocksY * kBPB;
++
++    glBindTexture(GL_TEXTURE_2D, mTexture);
++    // Use GL_COMPRESSED_RGB8_ETC2 which is core in ES 3.0
++    glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGB8_ETC2, kWidth, kHeight, 0,
++                           compressedSize, nullptr);
++
++    // Misaligned offset to trigger the fallback path in Metal backend
++    constexpr GLsizei kPBOOffset = 1;
++
++    GLBuffer pbo;
++    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
++    glBufferData(GL_PIXEL_UNPACK_BUFFER, kPBOOffset + compressedSize, nullptr, GL_STATIC_DRAW);
++    ASSERT_GL_NO_ERROR();
++
++    glCompressedTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, kWidth, kHeight, GL_COMPRESSED_RGB8_ETC2,
++                              compressedSize, reinterpret_cast<void *>(kPBOOffset));
++    EXPECT_GL_NO_ERROR();
++}
++
+ class ETCToBCTextureTest : public ANGLETest<>
+ {
+   protected:

--- a/patches/angle/cherry-pick-86d64be7672e.patch
+++ b/patches/angle/cherry-pick-86d64be7672e.patch
@@ -1,0 +1,159 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 23 Mar 2026 13:38:34 -0400
+Subject: Translator: Fix codegen of switch with empty last case
+
+... which is not actually allowed, except may be introduced to the AST
+by transformations that remove dead code.  The parser in this change
+makes sure the switch ends in some branch just in case.
+
+To pass the unit tests, PruneEmptyCases is improved to consider cases
+whose only code is "break" as empty.
+
+Bug: angleproject:488064108
+Change-Id: I728ee897b82a9a15d4c778839480969f3f743ace
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/7694532
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+
+diff --git a/src/compiler/translator/ParseContext.cpp b/src/compiler/translator/ParseContext.cpp
+index 462cef8228d0b9102c96d1a8c4a99eb9aaba364b..1f38e4484654255924a3d0b2c4aca3b1df8c2701 100644
+--- a/src/compiler/translator/ParseContext.cpp
++++ b/src/compiler/translator/ParseContext.cpp
+@@ -8248,6 +8248,19 @@ TIntermSwitch *TParseContext::addSwitch(TIntermTyped *init,
+         return nullptr;
+     }
+ 
++    // In case the last statement isn't already a branch, add |break| automatically.  Some AST
++    // transformations may dead-code-eliminate the contents of the last |case| and leave the switch
++    // statements ending in a case (which is what the check above forbids).  Most generators do not
++    // handle this unexpected situation.
++    //
++    // Note that a branch may be present inside a nested block, but that's ok, the extra branch
++    // added here gets eliminated in |PruneNoOps|.
++    if (statementCount > 0 &&
++        statementList->getChildNode(statementCount - 1)->getAsBranchNode() == nullptr)
++    {
++        statementList->appendStatement(new TIntermBranch(EOpBreak, nullptr));
++    }
++
+     mIRBuilder.endSwitch();
+ 
+     markStaticUseIfSymbol(init);
+diff --git a/src/compiler/translator/tree_ops/PruneEmptyCases.cpp b/src/compiler/translator/tree_ops/PruneEmptyCases.cpp
+index 276c8c98ed6d0312de096a1c5ec01eaf98fb9403..374438c0e4eaed7ef2f85e89e43f4896e913b13e 100644
+--- a/src/compiler/translator/tree_ops/PruneEmptyCases.cpp
++++ b/src/compiler/translator/tree_ops/PruneEmptyCases.cpp
+@@ -79,10 +79,18 @@ bool PruneEmptyCasesTraverser::visitSwitch(Visit visit, TIntermSwitch *node)
+     // blocks are marked for pruning.
+     size_t i                       = statements->size();
+     size_t lastNoOpInStatementList = i;
++
+     while (i > 0)
+     {
+         --i;
+         TIntermNode *statement = statements->at(i);
++
++        // Ignore the last |break| for the purposes of this pruning
++        if (i + 1 == statements->size() && statement->getAsBranchNode() != nullptr &&
++            statement->getAsBranchNode()->getFlowOp() == EOpBreak)
++        {
++            continue;
++        }
+         if (statement->getAsCaseNode() || IsEmptyBlock(statement))
+         {
+             lastNoOpInStatementList = i;
+@@ -111,7 +119,24 @@ bool PruneEmptyCasesTraverser::visitSwitch(Visit visit, TIntermSwitch *node)
+     }
+     if (lastNoOpInStatementList < statements->size())
+     {
+-        statements->erase(statements->begin() + lastNoOpInStatementList, statements->end());
++        // The extra cases can only be removed if there is no |default|, otherwise dropping them
++        // changes the cases that land in |default|.
++        bool hasDefault = false;
++        for (i = 0; i < lastNoOpInStatementList; ++i)
++        {
++            TIntermNode *statement = statements->at(i);
++            if (statement->getAsCaseNode() != nullptr &&
++                !statement->getAsCaseNode()->hasCondition())
++            {
++                hasDefault = true;
++                break;
++            }
++        }
++
++        if (!hasDefault)
++        {
++            statements->erase(statements->begin() + lastNoOpInStatementList, statements->end());
++        }
+     }
+ 
+     return true;
+diff --git a/src/tests/compiler_tests/PrunePureLiteralStatements_test.cpp b/src/tests/compiler_tests/PrunePureLiteralStatements_test.cpp
+index 910ccc519fa7a0f8673a3fdb18edb8f9eb344e53..a97651499ad9e8d162d6307f3e1d92382954b7ba 100644
+--- a/src/tests/compiler_tests/PrunePureLiteralStatements_test.cpp
++++ b/src/tests/compiler_tests/PrunePureLiteralStatements_test.cpp
+@@ -143,9 +143,10 @@ TEST_F(PrunePureLiteralStatementsTest, SwitchLiteralExpressionOnlyLastCase)
+         "    }\n"
+         "}\n";
+     compile(shaderString);
+-    ASSERT_TRUE(foundInCode("default"));
+-    ASSERT_TRUE(foundInCode("case"));
++    ASSERT_TRUE(notFoundInCode("default"));
++    ASSERT_TRUE(notFoundInCode("case"));
+     ASSERT_TRUE(notFoundInCode("42"));
++    ASSERT_TRUE(notFoundInCode("switch"));
+ }
+ 
+ // Test that the pruning correctly handles the pruning inside switch statements - pruning isn't
+diff --git a/src/tests/gl_tests/GLSLTest.cpp b/src/tests/gl_tests/GLSLTest.cpp
+index bfd75aedb62c39c6a3a5ae3e4038a357009fe390..30161c88c1379844d48279a2c758ab61b3a10e1d 100644
+--- a/src/tests/gl_tests/GLSLTest.cpp
++++ b/src/tests/gl_tests/GLSLTest.cpp
+@@ -22247,9 +22247,6 @@ void main()
+ // it is no-op.
+ TEST_P(GLSLTest_ES3, EmptyLastCaseInSwitch)
+ {
+-    // Incorrect translation before IR.
+-    ANGLE_SKIP_TEST_IF(!getEGLWindow()->isFeatureEnabled(Feature::UseIr));
+-
+     constexpr char kFS[] = R"(#version 300 es
+ uniform int ui;
+ out mediump vec4 color;
+@@ -22277,6 +22274,36 @@ void main(void)
+     ASSERT_GL_NO_ERROR();
+ }
+ 
++// Regression test for codegen errors when the last case of a switch is dead-code-eliminated.
++TEST_P(GLSLTest_ES3, EmptyLastCaseInSwitch2)
++{
++    constexpr char kFS[] = R"(#version 300 es
++precision mediump float;
++uniform int a, b;
++out vec4 color;
++void main() {
++    float r = 0.25;
++    switch(a) {
++        case 0:
++            switch(b) {
++                default:
++                    r = 0.75;
++                case 0:
++                    switch(b) { }
++            }
++            break;
++        default:
++            r = 0.5;
++    }
++    color = vec4(r, 0, 0, 1);
++})";
++
++    ANGLE_GL_PROGRAM(program, essl3_shaders::vs::Simple(), kFS);
++    drawQuad(program, essl3_shaders::PositionAttrib(), 0.5f);
++    EXPECT_PIXEL_COLOR_NEAR(0, 0, GLColor(63, 0, 0, 255), 1);
++    ASSERT_GL_NO_ERROR();
++}
++
+ // Test that if the uniform struct specifier is referenced by non-uniform variables, the
+ // sortUniforms() step does not reorder the uniform struct specifier and place it after where it is
+ // referenced.

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -215,3 +215,15 @@ cherry-pick-cd7556b9adf6.patch
 cherry-pick-a72c80884d88.patch
 cherry-pick-e5e651024478.patch
 build_disable_llvm_unroll-add-parallel-reductions_on_apple_targets.patch
+cherry-pick-d3ea06df9a4c.patch
+cherry-pick-1cd1e8607c8e.patch
+cherry-pick-7d0b7c526075.patch
+cherry-pick-b885cb0c8e97.patch
+cherry-pick-faada322153d.patch
+cherry-pick-e2b91876eb01.patch
+cherry-pick-7adec41c4fdc.patch
+cherry-pick-155b785d0e4f.patch
+cherry-pick-6aa38f2d02b7.patch
+cherry-pick-926d3d259750.patch
+cherry-pick-2cdb07c74d06.patch
+cherry-pick-16dcbc3d1476.patch

--- a/patches/chromium/cherry-pick-155b785d0e4f.patch
+++ b/patches/chromium/cherry-pick-155b785d0e4f.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Baron <dbaron@chromium.org>
+Date: Mon, 4 May 2026 18:23:42 -0700
+Subject: Add stronger (D)CHECK()s around batch setting of attributes.
+
+This adds additional CHECK()s and DCHECK()s around two Element functions
+(ParserSetAttributes and CloneAttributesFrom) that set attributes in
+batches and then do multiple AttributeChanged notifications.  This is
+only safe for newly-created elements for which this won't run script.
+
+This fixes one caller that would trigger these checks to not use
+CloneAttributesFrom.
+
+This also removes some code that is unnecessary given these checks.
+
+Bug: 496280532
+Change-Id: Ic8c44e3cfae20272f2ab480f5eb169c565298801
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7810037
+Reviewed-by: Joey Arhar <jarhar@chromium.org>
+Commit-Queue: David Baron <dbaron@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1625093}
+
+diff --git a/third_party/blink/renderer/core/dom/element.cc b/third_party/blink/renderer/core/dom/element.cc
+index dfcdef7c9382581f86a8112f2189d7d70d96391d..c183e27a276aaefc97a56f8cb08e25bd5532005b 100644
+--- a/third_party/blink/renderer/core/dom/element.cc
++++ b/third_party/blink/renderer/core/dom/element.cc
+@@ -1258,6 +1258,16 @@ void Element::removeAttribute(const QualifiedName& name) {
+   RemoveAttributeInternal(index, AttributeModificationReason::kDirectly);
+ }
+ 
++void Element::RemoveAllAttributes() {
++  while (hasAttributes()) {
++    const AttributeCollection& attributes = GetElementData()->Attributes();
++    // Use a reason of kByCloning since our caller is going to use the cloning
++    // process to restore a different set of attributes.
++    RemoveAttributeInternal(attributes.size() - 1,
++                            AttributeModificationReason::kByCloning);
++  }
++}
++
+ void Element::SetBooleanAttribute(const QualifiedName& name, bool value) {
+   if (value) {
+     setAttribute(name, g_empty_atom);
+@@ -4113,9 +4123,14 @@ void Element::StripScriptingAttributes(
+ 
+ void Element::ParserSetAttributes(
+     const Vector<Attribute, kAttributePrealloc>& attribute_vector) {
++  // We must start with a newly-created element.  If we don't, it would not be
++  // safe to batch the AttributeChanged notifications the way we do, since on
++  // elements that are not newly-created, AttributeChanged might run script.
+   DCHECK(!isConnected());
+   DCHECK(!parentNode());
+   DCHECK(!element_data_);
++  DCHECK(!HasChildren());
++  DCHECK_EQ(attribute_or_class_bloom_, 0u);
+ 
+   if (!attribute_vector.empty()) {
+     if (ElementDataCache* cache = GetDocument().GetElementDataCache()) {
+@@ -4126,15 +4141,9 @@ void Element::ParserSetAttributes(
+           ShareableElementData::CreateWithAttributes(attribute_vector);
+     }
+ 
+-    DCHECK_EQ(nullptr, ElementTraversal::FirstChild(*this));
+-
+-    // NOTE: AttributeChanged() will add back the class names (if any),
+-    // so it is safe to reset the filter here.
+-    attribute_or_class_bloom_ = 0;
+     for (const Attribute& attribute : attribute_vector) {
+       attribute_or_class_bloom_ |= FilterForAttribute(attribute.GetName());
+     }
+-    UpdateSubtreeBloomFilterAfterInsert();
+   }
+ 
+   ParserDidSetAttributes();
+@@ -11506,22 +11515,6 @@ void Element::DetachAttrNodeFromElementWithValue(Attr* attr_node,
+   }
+ }
+ 
+-void Element::DetachAllAttrNodesFromElement() {
+-  AttrNodeList* list = GetAttrNodeList();
+-  if (!list) {
+-    return;
+-  }
+-
+-  AttributeCollection attributes = GetElementData()->Attributes();
+-  for (const Attribute& attr : attributes) {
+-    if (Attr* attr_node = AttrIfExists(attr.GetName())) {
+-      attr_node->DetachFromElementWithValue(attr.Value());
+-    }
+-  }
+-
+-  RemoveAttrNodeList();
+-}
+-
+ void Element::WillRecalcStyle(const StyleRecalcChange) {
+   DCHECK(HasCustomStyleCallbacks());
+ }
+@@ -11541,9 +11534,16 @@ void Element::AdjustStyle(ComputedStyleBuilder&) {
+ }
+ 
+ void Element::CloneAttributesFrom(const Element& other) {
+-  if (RareData()) {
+-    DetachAllAttrNodesFromElement();
+-  }
++  // We must start with a newly-created element.  If we don't, it would not be
++  // safe to batch the AttributeChanged notifications the way we do, since on
++  // elements that are not newly-created, AttributeChanged might run script.
++  DCHECK(!isConnected());
++  DCHECK(!parentNode());
++  DCHECK(!element_data_);
++  DCHECK(!HasChildren());
++  CHECK_EQ(attribute_or_class_bloom_, 0u);
++  CHECK(!hasAttributes());
++  CHECK(!GetAttrNodeList());
+ 
+   other.SynchronizeAllAttributes();
+   if (!other.element_data_) {
+@@ -11595,19 +11595,6 @@ void Element::CloneAttributesFrom(const Element& other) {
+     element_data_ = other.element_data_->MakeUniqueCopy();
+   }
+ 
+-  // Since we're going through the list of attributes now, we use the
+-  // opportunity to recreate the Bloom filter; in particular, it may
+-  // be different from the source's Bloom filter if it came from a document
+-  // with different quirks mode setting.
+-  Element* first_child = ElementTraversal::FirstChild(*this);
+-  if (!first_child) {
+-    attribute_or_class_bloom_ = 0;
+-  } else if (!first_child->nextSibling()) {
+-    attribute_or_class_bloom_ = first_child->attribute_or_class_bloom_;
+-  } else {
+-    // Two or more children left; we don't consider it worth it
+-    // to try to reset the filter fully.
+-  }
+   for (wtf_size_t i = 0; i < element_data_->Attributes().size(); ++i) {
+     const Attribute& attr = element_data_->Attributes().at(i);
+     attribute_or_class_bloom_ |= FilterForAttribute(attr.GetName());
+@@ -11615,7 +11602,6 @@ void Element::CloneAttributesFrom(const Element& other) {
+         AttributeModificationParams(attr.GetName(), g_null_atom, attr.Value(),
+                                     AttributeModificationReason::kByCloning));
+   }
+-  UpdateSubtreeBloomFilterAfterInsert();
+ 
+   if (other.nonce() != g_null_atom) {
+     setNonce(other.nonce());
+diff --git a/third_party/blink/renderer/core/dom/element.h b/third_party/blink/renderer/core/dom/element.h
+index b416042ce00732c05061f6ae5c5310eb3f5ee260..fa5c95bab03975e6dbfa3b0a4c6b7d2eb374cdc3 100644
+--- a/third_party/blink/renderer/core/dom/element.h
++++ b/third_party/blink/renderer/core/dom/element.h
+@@ -646,6 +646,7 @@ class CORE_EXPORT Element : public ContainerNode {
+   }
+   void removeAttributeNS(const AtomicString& namespace_uri,
+                          const AtomicString& local_name);
++  void RemoveAllAttributes();
+ 
+   Attr* DetachAttribute(wtf_size_t index);
+ 
+@@ -2541,7 +2542,6 @@ class CORE_EXPORT Element : public ContainerNode {
+       ExceptionState&);
+ 
+   void RemoveAttrNodeList();
+-  void DetachAllAttrNodesFromElement();
+   void DetachAttrNodeFromElementWithValue(Attr*, const AtomicString& value);
+   void DetachAttrNodeAtIndex(Attr*, wtf_size_t index);
+ 
+diff --git a/third_party/blink/renderer/core/editing/commands/replace_node_with_span_command.cc b/third_party/blink/renderer/core/editing/commands/replace_node_with_span_command.cc
+index 23e9cd1b02a729507fa125e8f67f1174a218da4f..65ff217174686c71a931f2dab4575fa48cb70749 100644
+--- a/third_party/blink/renderer/core/editing/commands/replace_node_with_span_command.cc
++++ b/third_party/blink/renderer/core/editing/commands/replace_node_with_span_command.cc
+@@ -56,9 +56,14 @@ static void SwapInNodePreservingAttributesAndChildren(
+   for (const auto& child : children)
+     new_element->AppendChild(child);
+ 
+-  // FIXME: Fix this to send the proper MutationRecords when MutationObservers
+-  // are present.
+-  new_element->CloneAttributesFrom(element_to_replace);
++  new_element->RemoveAllAttributes();
++  // Make a copy of element_to_replace's attributes since setting attributes
++  // on new_element could run script and thus modify attributes on either
++  // element.
++  AttributeVector attributes(element_to_replace.Attributes());
++  for (const Attribute& attr : attributes) {
++    new_element->SetAttributeWithoutValidation(attr.GetName(), attr.Value());
++  }
+ 
+   parent_node->RemoveChild(&element_to_replace, ASSERT_NO_EXCEPTION);
+ }

--- a/patches/chromium/cherry-pick-16dcbc3d1476.patch
+++ b/patches/chromium/cherry-pick-16dcbc3d1476.patch
@@ -1,0 +1,114 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Bienvenu <davidbienvenu@chromium.org>
+Date: Wed, 13 May 2026 07:44:42 -0700
+Subject: win: Use static to keep track of in progress drags.
+
+Prevent multiple drags from different windows.
+
+Bug: 503551154
+Change-Id: I7bb052b88a7eb4fe06a827a55bbb05db2391e8f2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7841115
+Reviewed-by: Keren Zhu <kerenzhu@chromium.org>
+Commit-Queue: David Bienvenu <davidbienvenu@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1629961}
+
+diff --git a/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.cc b/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.cc
+index 19d18f27670febcb795deec24202eb22a2a1ad3a..a990686e7ce809b22111f13c06ad8c34b07a44ea 100644
+--- a/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.cc
++++ b/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <memory>
+ 
++#include "base/auto_reset.h"
+ #include "base/metrics/histogram_macros.h"
+ #include "base/notimplemented.h"
+ #include "base/scoped_observation.h"
+@@ -48,19 +49,21 @@ class SourceWindowObserver : public aura::WindowObserver {
+       scoped_observation_;
+ };
+ 
++bool g_is_dragging = false;
++
+ }  // namespace
+ 
+ DesktopDragDropClientWin::DesktopDragDropClientWin(
+     aura::Window* root_window,
+     HWND window,
+     DesktopWindowTreeHostWin* desktop_host)
+-    : drag_drop_in_progress_(false), desktop_host_(desktop_host) {
++    : desktop_host_(desktop_host) {
+   drop_target_ = new DesktopDropTargetWin(root_window);
+   drop_target_->Init(window);
+ }
+ 
+ DesktopDragDropClientWin::~DesktopDragDropClientWin() {
+-  if (drag_drop_in_progress_) {
++  if (g_is_dragging) {
+     DragCancel();
+   }
+ }
+@@ -72,6 +75,7 @@ ui::mojom::DragOperation DesktopDragDropClientWin::StartDragAndDrop(
+     const gfx::Point& screen_location,
+     int allowed_operations,
+     ui::mojom::DragEventSource source) {
++  CHECK(!g_is_dragging);
+   gfx::Point touch_screen_point;
+   if (source == ui::mojom::DragEventSource::kTouch) {
+     source_window->GetHost()->ConvertDIPToPixels(&touch_screen_point);
+@@ -97,7 +101,6 @@ ui::mojom::DragOperation DesktopDragDropClientWin::StartDragAndDrop(
+   SourceWindowObserver source_window_observer(source_window);
+   base::WeakPtr<DesktopDragDropClientWin> alive(weak_factory_.GetWeakPtr());
+ 
+-  drag_drop_in_progress_ = true;
+   drag_source_ = ui::DragSourceWin::Create();
+   Microsoft::WRL::ComPtr<ui::DragSourceWin> drag_source_copy = drag_source_;
+   drag_source_copy->set_data(data.get());
+@@ -105,6 +108,7 @@ ui::mojom::DragOperation DesktopDragDropClientWin::StartDragAndDrop(
+       true);
+ 
+   DWORD effect;
++  base::AutoReset<bool> drag_scoper(&g_is_dragging, true);
+ 
+   // Never consider the current scope as hung. The hang watching deadline (if
+   // any) is not valid since the user can take unbounded time to complete the
+@@ -128,10 +132,6 @@ ui::mojom::DragOperation DesktopDragDropClientWin::StartDragAndDrop(
+   }
+   drag_source_copy->set_data(nullptr);
+ 
+-  if (alive) {
+-    drag_drop_in_progress_ = false;
+-  }
+-
+   if (result != DRAGDROP_S_DROP) {
+     effect = DROPEFFECT_NONE;
+   }
+@@ -141,11 +141,13 @@ ui::mojom::DragOperation DesktopDragDropClientWin::StartDragAndDrop(
+ }
+ 
+ void DesktopDragDropClientWin::DragCancel() {
+-  drag_source_->CancelDrag();
++  if (drag_source_) {
++    drag_source_->CancelDrag();
++  }
+ }
+ 
+ bool DesktopDragDropClientWin::IsDragDropInProgress() {
+-  return drag_drop_in_progress_;
++  return g_is_dragging;
+ }
+ 
+ void DesktopDragDropClientWin::AddObserver(
+diff --git a/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.h b/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.h
+index 69bf4e0c30488893e6e4aa2245399b89958e62d0..374f7ba5a498cdc7094536728ab2c6849ef74928 100644
+--- a/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.h
++++ b/ui/views/widget/desktop_aura/desktop_drag_drop_client_win.h
+@@ -61,8 +61,6 @@ class VIEWS_EXPORT DesktopDragDropClientWin
+   }
+ 
+  private:
+-  bool drag_drop_in_progress_;
+-
+   Microsoft::WRL::ComPtr<ui::DragSourceWin> drag_source_;
+ 
+   scoped_refptr<DesktopDropTargetWin> drop_target_;

--- a/patches/chromium/cherry-pick-1cd1e8607c8e.patch
+++ b/patches/chromium/cherry-pick-1cd1e8607c8e.patch
@@ -1,0 +1,408 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yoshisto Yanagisawa <yyanagisawa@chromium.org>
+Date: Wed, 1 Apr 2026 18:14:48 -0700
+Subject: Block invalid responses for Static Router cache source
+
+This CL implements a security fix for the Service Worker Static Routing
+API. When a navigation request matches a 'cache' source and receives an
+opaque response, it is now blocked with net::ERR_FAILED if the new
+feature flag kServiceWorkerStaticRouterOpaqueCheck is enabled.
+This also follows https://fetch.spec.whatwg.org/#concept-http-fetch
+Step 3.5.6.
+
+This is implemented in both ServiceWorkerMainResourceLoader (browser)
+and ServiceWorkerSubresourceLoader (renderer) to ensure comprehensive
+coverage of requests.
+
+A new UMA ServiceWorker.StaticRouter.*.OpaqueResponse is
+added to track how often this case occurs in the wild.
+
+Bug: 495999481
+Change-Id: Icd72687e6d79fd98312e70d0d9a072f75f595e8e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7703459
+Reviewed-by: Shunya Shishido <sisidovski@chromium.org>
+Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1608913}
+
+diff --git a/content/browser/service_worker/service_worker_browsertest.cc b/content/browser/service_worker/service_worker_browsertest.cc
+index 5167c8c8c6a6685a8acc748cff7ce356049063ca..61d0142fb201a27786fe7f2d183b3e6d716a1830 100644
+--- a/content/browser/service_worker/service_worker_browsertest.cc
++++ b/content/browser/service_worker/service_worker_browsertest.cc
+@@ -35,6 +35,7 @@
+ #include "base/task/sequenced_task_runner.h"
+ #include "base/task/task_traits.h"
+ #include "base/test/bind.h"
++#include "base/test/metrics/histogram_tester.h"
+ #include "base/test/scoped_feature_list.h"
+ #include "base/test/with_feature_override.h"
+ #include "base/time/time.h"
+@@ -7482,6 +7483,13 @@ IN_PROC_BROWSER_TEST_F(ServiceWorkerStaticRouterBrowserTest,
+   // The result should be got from the cache, and no network access is
+   // expected.
+   EXPECT_EQ(0, GetRequestCount(relative_url));
++
++  // Sync histograms from the renderer process.
++  FetchHistogramsFromChildProcesses();
++
++  // Check UMA (success case should record true).
++  histogram_tester().ExpectBucketCount(
++      "ServiceWorker.StaticRouter.Subresource.ValidResponse", true, 1);
+ }
+ 
+ IN_PROC_BROWSER_TEST_F(ServiceWorkerStaticRouterBrowserTest,
+diff --git a/content/browser/service_worker/service_worker_main_resource_loader.cc b/content/browser/service_worker/service_worker_main_resource_loader.cc
+index 0aa8f0ef427ccc11589312e5d4c1dc0bbe5ac6af..63f683c703ca5f668e81a84e84c90ae38684bdc3 100644
+--- a/content/browser/service_worker/service_worker_main_resource_loader.cc
++++ b/content/browser/service_worker/service_worker_main_resource_loader.cc
+@@ -909,6 +909,17 @@ void ServiceWorkerMainResourceLoader::DidDispatchFetchEvent(
+         cache_matcher_->cache_lookup_start();
+     response_head_->service_worker_router_info->cache_lookup_time =
+         cache_matcher_->cache_lookup_duration();
++
++    // Block invalid responses from the static router.
++    if (response_head_->service_worker_router_info->matched_source_type ==
++        network::mojom::ServiceWorkerRouterSourceType::kCache) {
++      if (!IsValidStaticRouterResponse(resource_request_, response) &&
++          base::FeatureList::IsEnabled(
++              features::kServiceWorkerStaticRouterOpaqueCheck)) {
++        CommitCompleted(net::ERR_FAILED, "Invalid response from static router");
++        return;
++      }
++    }
+   }
+ 
+   // Record the timing of when the fetch event is dispatched on the worker
+diff --git a/content/common/features.cc b/content/common/features.cc
+index 7230b6bab9644325e32dca844261ce8565415a1d..6ef8a76f0967fa44ab8d7bda3d5a72323ea02e71 100644
+--- a/content/common/features.cc
++++ b/content/common/features.cc
+@@ -645,6 +645,12 @@ BASE_FEATURE(kServiceWorkerStaticRouterRaceRequestFix2,
+ BASE_FEATURE(kServiceWorkerStaticRouterConsolidateMainScriptResponse,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
++// crbug.com/495999481: When this is enabled, the navigation request should be
++// blocked when it receives an opaque response from the service worker static
++// router.
++BASE_FEATURE(kServiceWorkerStaticRouterOpaqueCheck,
++             base::FEATURE_DISABLED_BY_DEFAULT);
++
+ // (crbug.com/1371756): When enabled, the static routing API starts
+ // ServiceWorker when the routing result of a main resource request was network
+ // fallback.
+diff --git a/content/common/features.h b/content/common/features.h
+index 6c52c3c8608e437077ddb8311a7bb00e4f4a8b0b..15c8c015f18283044900b21dba10ad4ff9a28c08 100644
+--- a/content/common/features.h
++++ b/content/common/features.h
+@@ -202,6 +202,7 @@ CONTENT_EXPORT extern const base::FeatureParam<std::string>
+     kServiceWorkerBypassFetchHandlerBypassedHashStrings;
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerSrcdocSupport);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerStaticRouterRaceRequestFix2);
++CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerStaticRouterOpaqueCheck);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(
+     kServiceWorkerStaticRouterConsolidateMainScriptResponse);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(
+diff --git a/content/common/service_worker/service_worker_resource_loader.cc b/content/common/service_worker/service_worker_resource_loader.cc
+index 9c907e5e2c6773da307a00d8c7ef84c0d3bc82ed..b917f19c6035b2f5a45e77064e619a179da630cf 100644
+--- a/content/common/service_worker/service_worker_resource_loader.cc
++++ b/content/common/service_worker/service_worker_resource_loader.cc
+@@ -6,13 +6,77 @@
+ 
+ #include "base/check_op.h"
+ #include "base/feature_list.h"
++#include "base/metrics/histogram_functions.h"
+ #include "base/metrics/histogram_macros.h"
++#include "base/strings/strcat.h"
+ #include "base/trace_event/trace_event.h"
+ #include "content/public/common/content_features.h"
++#include "services/network/public/cpp/resource_request.h"
++#include "services/network/public/mojom/fetch_api.mojom.h"
+ #include "services/network/public/mojom/service_worker_router_info.mojom-shared.h"
++#include "third_party/blink/public/mojom/fetch/fetch_api_response.mojom.h"
+ #include "third_party/perfetto/include/perfetto/tracing/track_event_args.h"
+ 
+ namespace content {
++
++// static
++bool ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++    network::mojom::RequestMode request_mode,
++    network::mojom::RedirectMode redirect_mode,
++    const blink::mojom::FetchAPIResponsePtr& response) {
++  // This validation follows the Fetch spec.
++  // 4.4 HTTP fetch, Step 3.5.6.
++  // If one of the following is true
++  // - response’s type is "error"
++  // - request’s mode is "same-origin" and response’s type is "cors"
++  // - request’s mode is not "no-cors" and response’s type is "opaque"
++  // - request’s redirect mode is not "manual" and response’s type is
++  //   "opaqueredirect"
++  // - request’s redirect mode is not "follow" and response’s URL list has more
++  //   than one item
++  // then return a network error.
++  // Note: Existing validation functions do not fully follow the spec.
++  if (!response) {
++    return true;
++  }
++
++  if (response->response_type == network::mojom::FetchResponseType::kError) {
++    return false;
++  }
++  if (request_mode == network::mojom::RequestMode::kSameOrigin &&
++      response->response_type == network::mojom::FetchResponseType::kCors) {
++    return false;
++  }
++  if (request_mode != network::mojom::RequestMode::kNoCors &&
++      response->response_type == network::mojom::FetchResponseType::kOpaque) {
++    return false;
++  }
++  if (redirect_mode != network::mojom::RedirectMode::kManual &&
++      response->response_type ==
++          network::mojom::FetchResponseType::kOpaqueRedirect) {
++    return false;
++  }
++  if (redirect_mode != network::mojom::RedirectMode::kFollow &&
++      response->url_list.size() > 1) {
++    return false;
++  }
++
++  return true;
++}
++
++bool ServiceWorkerResourceLoader::IsValidStaticRouterResponse(
++    const network::ResourceRequest& resource_request,
++    const blink::mojom::FetchAPIResponsePtr& response) {
++  bool is_valid = IsValidServiceWorkerResponse(
++      resource_request.mode, resource_request.redirect_mode, response);
++  base::UmaHistogramBoolean(
++      base::StrCat({"ServiceWorker.StaticRouter.",
++                    IsMainResourceLoader() ? "MainResource" : "Subresource",
++                    ".ValidResponse"}),
++      is_valid);
++  return is_valid;
++}
++
+ ServiceWorkerResourceLoader::ServiceWorkerResourceLoader() = default;
+ ServiceWorkerResourceLoader::~ServiceWorkerResourceLoader() = default;
+ 
+diff --git a/content/common/service_worker/service_worker_resource_loader.h b/content/common/service_worker/service_worker_resource_loader.h
+index b74b9c7f5bf991c9fb48de7088ed59913ebcb937..d0ec8bd4d970d1faa566287e300e8074614ba397 100644
+--- a/content/common/service_worker/service_worker_resource_loader.h
++++ b/content/common/service_worker/service_worker_resource_loader.h
+@@ -9,9 +9,19 @@
+ 
+ #include "base/check_op.h"
+ #include "content/common/content_export.h"
++#include "mojo/public/cpp/base/big_buffer.h"
+ #include "services/network/public/mojom/service_worker_router_info.mojom-shared.h"
+ #include "services/network/public/mojom/url_loader.mojom.h"
+ #include "third_party/blink/public/common/service_worker/service_worker_router_rule.h"
++#include "third_party/blink/public/mojom/fetch/fetch_api_response.mojom-forward.h"
++
++namespace net {
++struct RedirectInfo;
++}  // namespace net
++
++namespace network {
++struct ResourceRequest;
++}  // namespace network
+ 
+ namespace content {
+ // A common interface in between:
+@@ -70,6 +80,19 @@ class CONTENT_EXPORT ServiceWorkerResourceLoader {
+     kAutoPreload,
+   };
+ 
++  // Static helper to validate the response from the Service Worker according
++  // to the Fetch spec (4.4 HTTP fetch, Step 3.5.6).
++  static bool IsValidServiceWorkerResponse(
++      network::mojom::RequestMode request_mode,
++      network::mojom::RedirectMode redirect_mode,
++      const blink::mojom::FetchAPIResponsePtr& response);
++
++  // Validates the response from the static router's cache source and records
++  // the result to UMA. Returns true if the response is valid.
++  bool IsValidStaticRouterResponse(
++      const network::ResourceRequest& resource_request,
++      const blink::mojom::FetchAPIResponsePtr& response);
++
+   ServiceWorkerResourceLoader();
+   virtual ~ServiceWorkerResourceLoader();
+ 
+diff --git a/content/common/service_worker/service_worker_resource_loader_unittest.cc b/content/common/service_worker/service_worker_resource_loader_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..1a4fe5c4424db80b7758506959dd8964ef4e375d
+--- /dev/null
++++ b/content/common/service_worker/service_worker_resource_loader_unittest.cc
+@@ -0,0 +1,102 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "content/common/service_worker/service_worker_resource_loader.h"
++
++#include "services/network/public/mojom/fetch_api.mojom.h"
++#include "testing/gtest/include/gtest/gtest.h"
++#include "third_party/blink/public/mojom/fetch/fetch_api_response.mojom.h"
++
++namespace content {
++
++TEST(ServiceWorkerResourceLoaderTest, IsValidServiceWorkerResponse) {
++  auto request_mode = network::mojom::RequestMode::kSameOrigin;
++  auto redirect_mode = network::mojom::RedirectMode::kFollow;
++
++  // Normal response.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kDefault;
++    EXPECT_TRUE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, redirect_mode, response));
++  }
++
++  // Error response.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kError;
++    EXPECT_FALSE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, redirect_mode, response));
++  }
++
++  // same-origin request and cors response.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kCors;
++    EXPECT_FALSE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        network::mojom::RequestMode::kSameOrigin, redirect_mode, response));
++  }
++
++  // cross-origin request (cors) and cors response (OK).
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kCors;
++    EXPECT_TRUE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        network::mojom::RequestMode::kCors, redirect_mode, response));
++  }
++
++  // cors request and opaque response.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kOpaque;
++    EXPECT_FALSE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        network::mojom::RequestMode::kCors, redirect_mode, response));
++  }
++
++  // no-cors request and opaque response (OK).
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type = network::mojom::FetchResponseType::kOpaque;
++    EXPECT_TRUE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        network::mojom::RequestMode::kNoCors, redirect_mode, response));
++  }
++
++  // opaqueredirect response and manual redirect mode (OK).
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type =
++        network::mojom::FetchResponseType::kOpaqueRedirect;
++    EXPECT_TRUE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, network::mojom::RedirectMode::kManual, response));
++  }
++
++  // opaqueredirect response and follow redirect mode.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->response_type =
++        network::mojom::FetchResponseType::kOpaqueRedirect;
++    EXPECT_FALSE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, network::mojom::RedirectMode::kFollow, response));
++  }
++
++  // multiple URLs in URL list and follow redirect mode (OK).
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->url_list.emplace_back("http://a.test/1");
++    response->url_list.emplace_back("http://a.test/2");
++    EXPECT_TRUE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, network::mojom::RedirectMode::kFollow, response));
++  }
++
++  // multiple URLs in URL list and manual redirect mode.
++  {
++    auto response = blink::mojom::FetchAPIResponse::New();
++    response->url_list.emplace_back("http://a.test/1");
++    response->url_list.emplace_back("http://a.test/2");
++    EXPECT_FALSE(ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
++        request_mode, network::mojom::RedirectMode::kManual, response));
++  }
++}
++
++}  // namespace content
+diff --git a/content/renderer/service_worker/service_worker_subresource_loader.cc b/content/renderer/service_worker/service_worker_subresource_loader.cc
+index e0c8b704cb4ea0693ae8aac3bb4ed914cb2ce654..9cabd3343980c13aaf7d4612111f23c3e44ce38f 100644
+--- a/content/renderer/service_worker/service_worker_subresource_loader.cc
++++ b/content/renderer/service_worker/service_worker_subresource_loader.cc
+@@ -36,6 +36,7 @@
+ #include "services/network/public/mojom/service_worker_router_info.mojom.h"
+ #include "services/network/public/mojom/url_response_head.mojom.h"
+ #include "third_party/blink/public/common/blob/blob_utils.h"
++#include "third_party/blink/public/common/loader/resource_type_util.h"
+ #include "third_party/blink/public/common/service_worker/service_worker_loader_helpers.h"
+ #include "third_party/blink/public/common/service_worker/service_worker_type_converters.h"
+ #include "third_party/blink/public/mojom/blob/blob.mojom.h"
+@@ -1517,6 +1518,19 @@ void ServiceWorkerSubresourceLoader::DidCacheStorageMatch(
+   // EagerResponse should be used only if `in_related_fetch_event` is set.
+   CHECK(result.value()->is_response());
+   auto& response = result.value()->get_response();
++
++  // Block invalid responses from the static router.
++  if (response_head_->service_worker_router_info &&
++      response_head_->service_worker_router_info->matched_source_type ==
++          network::mojom::ServiceWorkerRouterSourceType::kCache) {
++    if (!IsValidStaticRouterResponse(resource_request_, response) &&
++        base::FeatureList::IsEnabled(
++            features::kServiceWorkerStaticRouterOpaqueCheck)) {
++      CommitCompleted(net::ERR_FAILED, "Invalid response from static router");
++      return;
++    }
++  }
++
+   if (response->parsed_headers) {
+     // We intend to reset the parsed header. Or, invalid parsed headers
+     // should be set.
+diff --git a/content/test/BUILD.gn b/content/test/BUILD.gn
+index f5d72a89c7229bf8e897c90660feca482ac82594..663360b48ec307e99d700ce2c075201355e30349 100644
+--- a/content/test/BUILD.gn
++++ b/content/test/BUILD.gn
+@@ -3083,6 +3083,7 @@ test("content_unittests") {
+     "../common/service_worker/race_network_request_simple_buffer_manager_unittest.cc",
+     "../common/service_worker/race_network_request_url_loader_client_unittest.cc",
+     "../common/service_worker/race_network_request_write_buffer_manager_unittest.cc",
++    "../common/service_worker/service_worker_resource_loader_unittest.cc",
+     "../common/service_worker/service_worker_router_evaluator_unittest.cc",
+     "../common/url_utils_unittest.cc",
+     "../common/web_ui_loading_util_unittest.cc",
+diff --git a/tools/metrics/histograms/metadata/service/histograms.xml b/tools/metrics/histograms/metadata/service/histograms.xml
+index 261abb47e2bc436918a042af34ebfdaff6eb5580..abd096a6def89f20b89a1106440e97893cd5d379 100644
+--- a/tools/metrics/histograms/metadata/service/histograms.xml
++++ b/tools/metrics/histograms/metadata/service/histograms.xml
+@@ -1863,6 +1863,21 @@ chromium-metrics-reviews@google.com.
+   </token>
+ </histogram>
+ 
++<histogram name="ServiceWorker.StaticRouter.{Resource}.ValidResponse"
++    enum="Boolean" expires_after="2027-03-26">
++  <owner>yyanagisawa@chromium.org</owner>
++  <owner>chrome-worker@google.com</owner>
++  <summary>
++    Records whether a response from the ServiceWorker Static Routing API with
++    source: 'cache' is valid according to the Fetch spec (4.4 HTTP fetch, Step
++    3.5.6). If it's invalid, it is a security risk and should be blocked.
++  </summary>
++  <token key="Resource">
++    <variant name="MainResource" summary="main resource"/>
++    <variant name="Subresource" summary="subresource"/>
++  </token>
++</histogram>
++
+ <histogram name="ServiceWorker.Storage.DeleteAndStartOverResult"
+     enum="ServiceWorkerDeleteAndStartOverResult" expires_after="2024-08-04">
+   <owner>yyanagisawa@chromium.org</owner>

--- a/patches/chromium/cherry-pick-2cdb07c74d06.patch
+++ b/patches/chromium/cherry-pick-2cdb07c74d06.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yoshisto Yanagisawa <yyanagisawa@chromium.org>
+Date: Tue, 12 May 2026 09:17:51 -0700
+Subject: Enable ServiceWorkerStaticRouterCORPCheck and OpaqueCheck by default
+
+This CL enables kServiceWorkerStaticRouterCORPCheck and
+kServiceWorkerStaticRouterOpaqueCheck by default. We have confirmed
+that no significant issues occurred during the trial period.
+
+Bug: 495999481, 497436273
+Change-Id: I804191da030e03d67a846b781213d38e4ea8af9e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7838959
+Auto-Submit: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Reviewed-by: Charlie Reis <creis@chromium.org>
+Commit-Queue: Charlie Reis <creis@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1629375}
+
+diff --git a/content/common/features.cc b/content/common/features.cc
+index 8293f83f2fc67991ffae2d910dc83dc743b74b2c..02adbf32cd9540b8fdcf55a6ffa8310df7206883 100644
+--- a/content/common/features.cc
++++ b/content/common/features.cc
+@@ -647,13 +647,13 @@ BASE_FEATURE(kServiceWorkerStaticRouterConsolidateMainScriptResponse,
+ 
+ // Enforce CORP check for Service Worker Static Router's cache source.
+ BASE_FEATURE(kServiceWorkerStaticRouterCORPCheck,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // crbug.com/495999481: When this is enabled, the navigation request should be
+ // blocked when it receives an opaque response from the service worker static
+ // router.
+ BASE_FEATURE(kServiceWorkerStaticRouterOpaqueCheck,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // (crbug.com/1371756): When enabled, the static routing API starts
+ // ServiceWorker when the routing result of a main resource request was network

--- a/patches/chromium/cherry-pick-6aa38f2d02b7.patch
+++ b/patches/chromium/cherry-pick-6aa38f2d02b7.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Baron <dbaron@chromium.org>
+Date: Tue, 12 May 2026 10:27:24 -0700
+Subject: Add EventDispatchForbiddenScope for batch attribute notification.
+
+Bug: 496280532
+Change-Id: Ia8b477a5508490377b21bed6bbb8a78f8c2762bb
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7812905
+Reviewed-by: Joey Arhar <jarhar@chromium.org>
+Commit-Queue: David Baron <dbaron@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1629435}
+
+diff --git a/third_party/blink/renderer/core/dom/element.cc b/third_party/blink/renderer/core/dom/element.cc
+index c183e27a276aaefc97a56f8cb08e25bd5532005b..2a0470d6d18b52ceda7e0fc4043a7ddca34e2292 100644
+--- a/third_party/blink/renderer/core/dom/element.cc
++++ b/third_party/blink/renderer/core/dom/element.cc
+@@ -4131,6 +4131,7 @@ void Element::ParserSetAttributes(
+   DCHECK(!element_data_);
+   DCHECK(!HasChildren());
+   DCHECK_EQ(attribute_or_class_bloom_, 0u);
++  EventDispatchForbiddenScope assert_no_event_dispatch;
+ 
+   if (!attribute_vector.empty()) {
+     if (ElementDataCache* cache = GetDocument().GetElementDataCache()) {
+@@ -11544,6 +11545,7 @@ void Element::CloneAttributesFrom(const Element& other) {
+   CHECK_EQ(attribute_or_class_bloom_, 0u);
+   CHECK(!hasAttributes());
+   CHECK(!GetAttrNodeList());
++  EventDispatchForbiddenScope assert_no_event_dispatch;
+ 
+   other.SynchronizeAllAttributes();
+   if (!other.element_data_) {
+diff --git a/third_party/blink/renderer/core/html/forms/html_select_element.cc b/third_party/blink/renderer/core/html/forms/html_select_element.cc
+index bacaaa89f79d57853b692bf3acced25d95a2e501..e470c13eccf42e47199c5322fb63799960a9189d 100644
+--- a/third_party/blink/renderer/core/html/forms/html_select_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_select_element.cc
+@@ -394,7 +394,11 @@ void HTMLSelectElement::ParseAttribute(
+       ChangeRendering();
+       UpdateUserAgentShadowTree(*UserAgentShadowRoot());
+       UpdateMutationObserver();
+-      ResetToDefaultSelection();
++      // The selection can't change if there are no children; this is a
++      // common case during parsing.
++      if (hasChildren()) {
++        ResetToDefaultSelection();
++      }
+       select_type_->UpdateTextStyleAndContent();
+       select_type_->SaveListboxActiveSelection();
+     }

--- a/patches/chromium/cherry-pick-7adec41c4fdc.patch
+++ b/patches/chromium/cherry-pick-7adec41c4fdc.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brandon Jones <bajones@chromium.org>
+Date: Tue, 7 Apr 2026 11:21:13 -0700
+Subject: Remove GPU observer in XRRuntimeManager destructor
+
+Ensures that the XRRuntimeManager is removed as a GpuDataManager
+observer in the XRRuntimeManager destructor if it was ever registered as
+one. Normally it is removed when the GPU process restarts, but this is a
+safety precaution to prevent errors if the XRRuntimeManager is destroyed
+while the process is still restarting.
+
+Bug: 498702233
+Change-Id: Iaf27dee1eaad2e228e69c98d9434a2d4fe85a308
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7729684
+Reviewed-by: Brian Sheedy <bsheedy@chromium.org>
+Commit-Queue: Brandon Jones <bajones@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1610896}
+
+diff --git a/content/browser/xr/service/xr_runtime_manager_impl.cc b/content/browser/xr/service/xr_runtime_manager_impl.cc
+index caabfea55b309f86ce9db16d1752b19f01e76f57..e9da901867c0c6674241e0f60913e3824d26bd41 100644
+--- a/content/browser/xr/service/xr_runtime_manager_impl.cc
++++ b/content/browser/xr/service/xr_runtime_manager_impl.cc
+@@ -520,6 +520,11 @@ XRRuntimeManagerImpl::~XRRuntimeManagerImpl() {
+     base::CommandLine::ForCurrentProcess()->RemoveSwitch(
+         switches::kUseAdapterLuid);
+ 
++    // Ensure this object is no longer registered as a GpuDataManager observer,
++    // which may happen if MakeXrCompatible is called and the page is navigated
++    // before the GPU process restarts.
++    content::GpuDataManager::GetInstance()->RemoveObserver(this);
++
+ #if BUILDFLAG(IS_WIN)
+     // If we changed the GPU, revert it back to the default GPU. This is
+     // separate from xr_compatible_restarted_gpu_ because the GPU process may

--- a/patches/chromium/cherry-pick-7d0b7c526075.patch
+++ b/patches/chromium/cherry-pick-7d0b7c526075.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Takashi Sakamoto <tasak@google.com>
+Date: Sun, 29 Mar 2026 18:47:51 -0700
+Subject: Add AMSC macro to QuicProxyDatagramClientSocket
+
+Bug: 495798630
+Change-Id: I28ae57bb6fe11c62e3a6e6468c5a4639c15b6c0c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7706475
+Commit-Queue: Takashi Sakamoto <tasak@google.com>
+Reviewed-by: David Schinazi <dschinazi@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1606861}
+
+diff --git a/net/quic/quic_proxy_datagram_client_socket.h b/net/quic/quic_proxy_datagram_client_socket.h
+index 4c7fad91550fe2630ddb662bbfc5d15854ae8450..8afaa11e48429d8de4f0ea8ff5f7c9ceb91cd1ca 100644
+--- a/net/quic/quic_proxy_datagram_client_socket.h
++++ b/net/quic/quic_proxy_datagram_client_socket.h
+@@ -10,6 +10,7 @@
+ #include <queue>
+ #include <string_view>
+ 
++#include "base/memory/advanced_memory_safety_checks.h"
+ #include "net/base/completion_once_callback.h"
+ #include "net/base/ip_endpoint.h"
+ #include "net/base/net_export.h"
+@@ -37,6 +38,9 @@ class ProxyDelegate;
+ class NET_EXPORT_PRIVATE QuicProxyDatagramClientSocket
+     : public DatagramClientSocket,
+       public quic::QuicSpdyStream::Http3DatagramVisitor {
++  // TODO(crbug.com/495798630): Remove this macro once it gets fixed.
++  ADVANCED_MEMORY_SAFETY_CHECKS();
++
+  public:
+   // Initializes a QuicProxyDatagramClientSocket with the provided network
+   // log (source_net_log) and destination URL. The destination URL is

--- a/patches/chromium/cherry-pick-926d3d259750.patch
+++ b/patches/chromium/cherry-pick-926d3d259750.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Baron <dbaron@chromium.org>
+Date: Thu, 7 May 2026 09:40:50 -0700
+Subject: Avoid setting attribute in SliderThumbElement constructor.
+
+This moves the setting of the id attribute for the SliderThumbElement to
+CreateShadowSubtree, which is the normal pattern.  This avoids this
+attribute setting getting in the way of having better CHECK()s in
+CloneAttributesFrom.
+
+Fixed: 510011627
+Bug: 496280532
+Change-Id: I8d08ef039a49d7ad3d070a673aec68cefe43d045
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7822939
+Commit-Queue: David Baron <dbaron@chromium.org>
+Reviewed-by: Joey Arhar <jarhar@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1627001}
+
+diff --git a/third_party/blink/renderer/core/html/forms/range_input_type.cc b/third_party/blink/renderer/core/html/forms/range_input_type.cc
+index 8722fdda14a067cde6b814fbdde67c94da422871..4d09d487ebc5a957027ea0e1308a9c283049d3a1 100644
+--- a/third_party/blink/renderer/core/html/forms/range_input_type.cc
++++ b/third_party/blink/renderer/core/html/forms/range_input_type.cc
+@@ -278,7 +278,10 @@ void RangeInputType::CreateShadowSubtree() {
+   track->SetShadowPseudoId(shadow_element_names::kPseudoSliderTrack);
+   track->setAttribute(html_names::kIdAttr,
+                       shadow_element_names::kIdSliderTrack);
+-  track->AppendChild(MakeGarbageCollected<SliderThumbElement>(document));
++  auto* thumb = MakeGarbageCollected<SliderThumbElement>(document);
++  thumb->setAttribute(html_names::kIdAttr,
++                      shadow_element_names::kIdSliderThumb);
++  track->AppendChild(thumb);
+   auto* container = MakeGarbageCollected<SliderContainerElement>(document);
+   container->AppendChild(track);
+   GetElement().UserAgentShadowRoot()->AppendChild(container);
+diff --git a/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc b/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc
+index d3f41d71d024cc917047394cd724071d491ec673..5cef4ad6ae5f9e99c9d7aece249bf495b692d20f 100644
+--- a/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc
++++ b/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc
+@@ -53,7 +53,6 @@ namespace blink {
+ SliderThumbElement::SliderThumbElement(Document& document)
+     : HTMLDivElement(document), in_drag_mode_(false) {
+   SetHasCustomStyleCallbacks();
+-  setAttribute(html_names::kIdAttr, shadow_element_names::kIdSliderThumb);
+ }
+ 
+ void SliderThumbElement::SetPositionFromValue() {
+diff --git a/third_party/blink/web_tests/wpt_internal/html/semantics/forms/the-input-element/crashtests/range-clone-node.html b/third_party/blink/web_tests/wpt_internal/html/semantics/forms/the-input-element/crashtests/range-clone-node.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..49d6fab6725548eeb6c53db2924794ad62c667c9
+--- /dev/null
++++ b/third_party/blink/web_tests/wpt_internal/html/semantics/forms/the-input-element/crashtests/range-clone-node.html
+@@ -0,0 +1,5 @@
++<!DOCTYPE HTML>
++<input type=range id=e>
++<script>
++internals.shadowRoot(document.getElementById("e")).getElementById("thumb").cloneNode(false)
++</script>

--- a/patches/chromium/cherry-pick-b885cb0c8e97.patch
+++ b/patches/chromium/cherry-pick-b885cb0c8e97.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aman Verma <amanvr@google.com>
+Date: Mon, 30 Mar 2026 14:21:18 -0700
+Subject: input: Validate SetMouseCapture requests in the browser process
+
+Currently, a compromised or malicious renderer (such as an OOPIF or a
+Fenced Frame) can hijack mouse events intended for its embedder by
+sending a SetMouseCapture IPC message to the browser process. The
+browser process would previously accept this request regardless of
+whether a legitimate user interaction was ongoing.
+
+This CL adds validation to RenderWidgetHostInputEventRouter to ensure
+that a frame can only set mouse capture if it was the target of the
+most recent MouseDown event. We also ensure that this state is cleared
+when the mouse button is released (on MouseUp, or on subsequent events
+like MouseMove where no buttons are held down). This prevents frames
+from claiming capture after the user interaction has ended.
+
+Bug: 496375695
+Change-Id: I8b97b8c1693cd6bff7ff2adad342754f813f6f44
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7711973
+Commit-Queue: Jonathan Ross <jonross@chromium.org>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Auto-Submit: Aman Verma <amanvr@google.com>
+Cr-Commit-Position: refs/heads/main@{#1607373}
+
+diff --git a/components/input/render_widget_host_input_event_router.cc b/components/input/render_widget_host_input_event_router.cc
+index 256aac99045cf4b80c631bfae73960b72ecd0c50..4f2bf4867a8ae0628835a1d775d071d36200297b 100644
+--- a/components/input/render_widget_host_input_event_router.cc
++++ b/components/input/render_widget_host_input_event_router.cc
+@@ -640,32 +640,38 @@ void RenderWidgetHostInputEventRouter::DispatchMouseEvent(
+   // platforms where MouseUps are not received when the mouse cursor is off the
+   // browser window.
+   // Also, this is strictly necessary for touch emulation.
+-  if (mouse_capture_target_ &&
+-      (mouse_event.GetType() == blink::WebInputEvent::Type::kMouseUp ||
++  if (mouse_event.GetType() == blink::WebInputEvent::Type::kMouseUp ||
++      (mouse_event.GetType() != blink::WebInputEvent::Type::kMouseDown &&
+        !IsMouseButtonDown(mouse_event))) {
+-    mouse_capture_target_ = nullptr;
+-
+-    // Since capture is being lost it is possible that MouseMoves over a hit
+-    // test region might have been going to a different region, and now the
+-    // CursorManager might need to be notified that the view underneath the
+-    // cursor has changed, which could cause the display cursor to update.
+-    gfx::PointF transformed_point;
+-    auto hit_test_result =
+-        FindViewAtLocation(root_view, mouse_event.PositionInWidget(),
+-                           viz::EventSource::MOUSE, &transformed_point);
+-    // TODO(crbug.com/41419447): This is skipped if the HitTestResult is
+-    // requiring an asynchronous hit test to the renderer process, because it
+-    // might mean sending extra MouseMoves to renderers that don't need the
+-    // event updates which is a worse outcome than the cursor being delayed in
+-    // updating. An asynchronous hit test can be added here to fix the problem.
+-    if (hit_test_result.view != target && !hit_test_result.should_query_view) {
+-      SendMouseEnterOrLeaveEvents(
+-          mouse_event, hit_test_result.view, root_view,
+-          blink::WebInputEvent::Modifiers::kRelativeMotionEvent, true);
+-      if (root_view->GetCursorManager())
+-        root_view->GetCursorManager()->UpdateViewUnderCursor(
+-            hit_test_result.view);
++    if (mouse_capture_target_) {
++      mouse_capture_target_ = nullptr;
++
++      // Since capture is being lost it is possible that MouseMoves over a hit
++      // test region might have been going to a different region, and now the
++      // CursorManager might need to be notified that the view underneath the
++      // cursor has changed, which could cause the display cursor to update.
++      gfx::PointF transformed_point;
++      auto hit_test_result =
++          FindViewAtLocation(root_view, mouse_event.PositionInWidget(),
++                             viz::EventSource::MOUSE, &transformed_point);
++      // TODO(crbug.com/41419447): This is skipped if the HitTestResult is
++      // requiring an asynchronous hit test to the renderer process, because it
++      // might mean sending extra MouseMoves to renderers that don't need the
++      // event updates which is a worse outcome than the cursor being delayed in
++      // updating. An asynchronous hit test can be added here to fix the
++      // problem.
++      if (hit_test_result.view != target &&
++          !hit_test_result.should_query_view) {
++        SendMouseEnterOrLeaveEvents(
++            mouse_event, hit_test_result.view, root_view,
++            blink::WebInputEvent::Modifiers::kRelativeMotionEvent, true);
++        if (root_view->GetCursorManager()) {
++          root_view->GetCursorManager()->UpdateViewUnderCursor(
++              hit_test_result.view);
++        }
++      }
+     }
++    last_mouse_down_target_ = nullptr;
+   }
+ 
+   // When touch emulation is active, mouse events have to act like touch
+@@ -2143,6 +2149,12 @@ void RenderWidgetHostInputEventRouter::SetMouseCaptureTarget(
+   }
+ 
+   if (capture) {
++    // A frame should only be able to capture the mouse if it was the target of
++    // the last mouse down event. This prevents malicious frames (e.g. OOPIFs or
++    // Fenced Frames) from hijacking mouse events intended for other frames.
++    if (target != last_mouse_down_target_) {
++      return;
++    }
+     mouse_capture_target_ = target;
+     return;
+   }
+diff --git a/content/browser/renderer_host/render_widget_host_input_event_router_unittest.cc b/content/browser/renderer_host/render_widget_host_input_event_router_unittest.cc
+index 4ae1071e28e1430e0b290099ac098ef98e41b660..a30f26feb93fe807fd98f61dcc180c917d28da6b 100644
+--- a/content/browser/renderer_host/render_widget_host_input_event_router_unittest.cc
++++ b/content/browser/renderer_host/render_widget_host_input_event_router_unittest.cc
+@@ -204,6 +204,14 @@ class RenderWidgetHostInputEventRouterTest : public testing::Test {
+     return delegate_->GetInputEventRouter();
+   }
+ 
++  input::RenderWidgetHostViewInput* mouse_capture_target() {
++    return rwhier()->mouse_capture_target_;
++  }
++
++  input::RenderWidgetHostViewInput* last_mouse_down_target() {
++    return rwhier()->last_mouse_down_target_;
++  }
++
+   // testing::Test:
+   void SetUp() override {
+     browser_context_ = std::make_unique<TestBrowserContext>();
+@@ -1232,6 +1240,45 @@ TEST_F(RenderWidgetHostInputEventRouterTest,
+   EXPECT_FALSE(targeter->is_auto_scroll_in_progress());
+ }
+ 
++// Tests that SetMouseCaptureTarget only allows a frame to capture the mouse if
++// it was the target of the most recent MouseDown event.
++TEST_F(RenderWidgetHostInputEventRouterTest, SetMouseCaptureTargetValidation) {
++  ChildViewState child = MakeChildView(view_root_.get());
++
++  // 1. Request capture without a prior MouseDown. Should be rejected.
++  rwhier()->SetMouseCaptureTarget(child.view.get(), true);
++  EXPECT_EQ(nullptr, mouse_capture_target());
++
++  // 2. Simulate a MouseDown on the child view.
++  blink::WebMouseEvent mouse_down_event(
++      blink::WebInputEvent::Type::kMouseDown,
++      blink::WebInputEvent::kNoModifiers,
++      blink::WebInputEvent::GetStaticTimeStampForTests());
++  mouse_down_event.button = blink::WebPointerProperties::Button::kLeft;
++
++  view_root_->SetHittestResult(child.view.get(), false);
++  rwhier()->RouteMouseEvent(view_root_.get(), &mouse_down_event,
++                            ui::LatencyInfo());
++
++  // Verify the child is now the last mouse down target.
++  EXPECT_EQ(child.view.get(), last_mouse_down_target());
++
++  // 3. Request capture again. Should be accepted.
++  rwhier()->SetMouseCaptureTarget(child.view.get(), true);
++  EXPECT_EQ(child.view.get(), mouse_capture_target());
++
++  // 4. Simulate a MouseUp. The capture and last mouse down target should be
++  // cleared.
++  blink::WebMouseEvent mouse_up_event(
++      blink::WebInputEvent::Type::kMouseUp, blink::WebInputEvent::kNoModifiers,
++      blink::WebInputEvent::GetStaticTimeStampForTests());
++  mouse_up_event.button = blink::WebPointerProperties::Button::kLeft;
++  rwhier()->RouteMouseEvent(view_root_.get(), &mouse_up_event,
++                            ui::LatencyInfo());
++  EXPECT_EQ(nullptr, last_mouse_down_target());
++  EXPECT_EQ(nullptr, mouse_capture_target());
++}
++
+ TEST_F(RenderWidgetHostInputEventRouterTest, QueryResultAfterChildViewDead) {
+   ChildViewState child = MakeChildView(view_root_.get());
+ 

--- a/patches/chromium/cherry-pick-d3ea06df9a4c.patch
+++ b/patches/chromium/cherry-pick-d3ea06df9a4c.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mikt <mikt@google.com>
+Date: Fri, 27 Mar 2026 00:56:47 -0700
+Subject: Use index-based for in Element::CloneAttributesFrom
+
+We should not use range-based on if the vector can be updated in the
+loop.
+
+Bug: 496280532
+Change-Id: I0ff0b8d2039c184d7b40f4024dacb518834bd09f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7702091
+Reviewed-by: Kouhei Ueno <kouhei@chromium.org>
+Commit-Queue: Stephen Nusko <nuskos@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1606009}
+
+diff --git a/third_party/blink/renderer/core/dom/element.cc b/third_party/blink/renderer/core/dom/element.cc
+index b517acf0b70395b25ccd55e2a468ab367da14583..dfcdef7c9382581f86a8112f2189d7d70d96391d 100644
+--- a/third_party/blink/renderer/core/dom/element.cc
++++ b/third_party/blink/renderer/core/dom/element.cc
+@@ -11608,7 +11608,8 @@ void Element::CloneAttributesFrom(const Element& other) {
+     // Two or more children left; we don't consider it worth it
+     // to try to reset the filter fully.
+   }
+-  for (const Attribute& attr : element_data_->Attributes()) {
++  for (wtf_size_t i = 0; i < element_data_->Attributes().size(); ++i) {
++    const Attribute& attr = element_data_->Attributes().at(i);
+     attribute_or_class_bloom_ |= FilterForAttribute(attr.GetName());
+     AttributeChanged(
+         AttributeModificationParams(attr.GetName(), g_null_atom, attr.Value(),

--- a/patches/chromium/cherry-pick-e2b91876eb01.patch
+++ b/patches/chromium/cherry-pick-e2b91876eb01.patch
@@ -1,0 +1,1028 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yoshisto Yanagisawa <yyanagisawa@chromium.org>
+Date: Sun, 12 Apr 2026 19:16:13 -0700
+Subject: Enforce CORP for Static Router Cache Source
+
+This CL ensures that Cross-Origin Resource Policy (CORP) is correctly
+enforced and reported when using the Service Worker Static Routing API's
+cache source, gated by a feature flag.
+
+Key changes:
+1. Feature Flag: Introduced kServiceWorkerStaticRouterCORPCheck
+   to gate the new blocking behavior in content/common/features.h.
+2. UMA: Added ServiceWorker.StaticRouter.{Subresource|MainResource}.CORPCheckResult
+   to monitor policy violations in both enforcement and shadow modes.
+3. Reporting: Pass the client's COEP/DIP Reporters from the browser to
+   the renderer via ControllerServiceWorkerInfo, ensuring security
+   violations are properly reported.
+4. Unit Tests: Added comprehensive unit tests in
+   ServiceWorkerResourceLoaderTest to verify CORP blocking logic and
+   UMA recording across different scenarios.
+5. Testing Config: Added fieldtrial_testing_config.json entry to enable
+   the feature for automated testing.
+6. Refactoring: Encapsulated policy and reporter information into Mojo
+   structs (CrossOriginEmbedderPolicyInfo and
+   DocumentIsolationPolicyInfo) to ensure type safety and consistent
+   handling. Replaced acronyms with full names (e.g., coep ->
+   cross_origin_embedder_policy) for better readability.
+
+DanglingUntriaged-notes: In WebEmbeddedWorkerImplTest, the mock client
+holds a pointer to the proxy which can be destroyed first during
+termination tests. This is a known lifecycle pattern in this specific
+unit test environment.
+
+Bug: 497436273
+Change-Id: Iaf3b66daa02573637a196e26a54e0816cf7b87f6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7725522
+Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+Reviewed-by: Shunya Shishido <sisidovski@chromium.org>
+Commit-Queue: Yoshisato Yanagisawa <yyanagisawa@chromium.org>
+Reviewed-by: Hidehiko Abe <hidehiko@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1613472}
+
+diff --git a/content/browser/service_worker/service_worker_container_host.cc b/content/browser/service_worker/service_worker_container_host.cc
+index dfb38e8a8a1192e6a77e9e6b9266cad41a5549c8..88528b55fdbd82dbc433616b687840931d191f51 100644
+--- a/content/browser/service_worker/service_worker_container_host.cc
++++ b/content/browser/service_worker/service_worker_container_host.cc
+@@ -86,17 +86,19 @@ ServiceWorkerContainerHostForClient::ServiceWorkerContainerHostForClient(
+     blink::mojom::ServiceWorkerContainerInfoForClientPtr& container_info,
+     const PolicyContainerPolicies& policy_container_policies,
+     mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
+-        coep_reporter,
++        cross_origin_embedder_policy_reporter,
+     mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
+-        dip_reporter,
++        document_isolation_policy_reporter,
+     ukm::SourceId ukm_source_id)
+     : service_worker_client_(std::move(service_worker_client)),
+       container_(
+           container_info->client_receiver.InitWithNewEndpointAndPassRemote()),
+       ukm_source_id_(std::move(ukm_source_id)),
+       policy_container_policies_(policy_container_policies.Clone()),
+-      coep_reporter_(std::move(coep_reporter)),
+-      dip_reporter_(std::move(dip_reporter)) {
++      cross_origin_embedder_policy_reporter_(
++          std::move(cross_origin_embedder_policy_reporter)),
++      document_isolation_policy_reporter_(
++          std::move(document_isolation_policy_reporter)) {
+   CHECK(container_.is_bound());
+   CHECK(service_worker_client_);
+   CHECK(!service_worker_client_->is_response_committed());
+@@ -479,6 +481,11 @@ ServiceWorkerContainerHostForClient::CreateControllerServiceWorkerInfo() {
+       controller_info->router_data->initial_running_status =
+           controller()->running_status();
+     }
++
++    controller_info->cross_origin_embedder_policy =
++        CreateCrossOriginEmbedderPolicyInfo();
++    controller_info->document_isolation_policy =
++        CreateDocumentIsolationPolicyInfo();
+   }
+ 
+   // Note that |controller_info->remote_controller| is null if the controller
+@@ -705,26 +712,9 @@ ServiceWorkerContainerHostForClient::GetRemoteControllerServiceWorker() {
+ 
+ void ServiceWorkerContainerHostForClient::CloneControllerServiceWorker(
+     mojo::PendingReceiver<blink::mojom::ControllerServiceWorker> receiver) {
+-  mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
+-      coep_reporter_to_be_passed;
+-  mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
+-      dip_reporter_to_be_passed;
+-  if (coep_reporter_) {
+-    coep_reporter_->Clone(
+-        coep_reporter_to_be_passed.InitWithNewPipeAndPassReceiver());
+-  }
+-
+-  if (dip_reporter_) {
+-    dip_reporter_->Clone(
+-        dip_reporter_to_be_passed.InitWithNewPipeAndPassReceiver());
+-  }
+-
+-  controller()->controller()->Clone(
+-      std::move(receiver),
+-      policy_container_policies_.cross_origin_embedder_policy,
+-      std::move(coep_reporter_to_be_passed),
+-      policy_container_policies_.document_isolation_policy,
+-      std::move(dip_reporter_to_be_passed));
++  controller()->controller()->Clone(std::move(receiver),
++                                    CreateCrossOriginEmbedderPolicyInfo(),
++                                    CreateDocumentIsolationPolicyInfo());
+ }
+ 
+ bool ServiceWorkerContainerHostForClient::AllowServiceWorker(
+@@ -1391,4 +1381,28 @@ ServiceWorkerVersion* ServiceWorkerContainerHostForClient::controller() const {
+   return service_worker_client().controller();
+ }
+ 
++blink::mojom::CrossOriginEmbedderPolicyInfoPtr
++ServiceWorkerContainerHostForClient::CreateCrossOriginEmbedderPolicyInfo()
++    const {
++  auto info = blink::mojom::CrossOriginEmbedderPolicyInfo::New(
++      policy_container_policies_.cross_origin_embedder_policy,
++      mojo::NullRemote());
++  if (cross_origin_embedder_policy_reporter_) {
++    cross_origin_embedder_policy_reporter_->Clone(
++        info->reporter.InitWithNewPipeAndPassReceiver());
++  }
++  return info;
++}
++
++blink::mojom::DocumentIsolationPolicyInfoPtr
++ServiceWorkerContainerHostForClient::CreateDocumentIsolationPolicyInfo() const {
++  auto info = blink::mojom::DocumentIsolationPolicyInfo::New(
++      policy_container_policies_.document_isolation_policy, mojo::NullRemote());
++  if (document_isolation_policy_reporter_) {
++    document_isolation_policy_reporter_->Clone(
++        info->reporter.InitWithNewPipeAndPassReceiver());
++  }
++  return info;
++}
++
+ }  // namespace content
+diff --git a/content/browser/service_worker/service_worker_container_host.h b/content/browser/service_worker/service_worker_container_host.h
+index 7f857d80f65bc5e8826303710ca3be9e3edfd704..1b39ef850f7c06b49e29eeac60b0850b40620215 100644
+--- a/content/browser/service_worker/service_worker_container_host.h
++++ b/content/browser/service_worker/service_worker_container_host.h
+@@ -328,7 +328,25 @@ class CONTENT_EXPORT ServiceWorkerContainerHostForClient final
+   ukm::SourceId ukm_source_id() const { return ukm_source_id_; }
+   ServiceWorkerVersion* controller() const;
+ 
++  const mojo::Remote<network::mojom::CrossOriginEmbedderPolicyReporter>&
++  cross_origin_embedder_policy_reporter() const {
++    return cross_origin_embedder_policy_reporter_;
++  }
++  const mojo::Remote<network::mojom::DocumentIsolationPolicyReporter>&
++  document_isolation_policy_reporter() const {
++    return document_isolation_policy_reporter_;
++  }
++
++  const PolicyContainerPolicies& policy_container_policies() const {
++    return policy_container_policies_;
++  }
++
+  private:
++  blink::mojom::CrossOriginEmbedderPolicyInfoPtr
++  CreateCrossOriginEmbedderPolicyInfo() const;
++  blink::mojom::DocumentIsolationPolicyInfoPtr
++  CreateDocumentIsolationPolicyInfo() const;
++
+   // Callback for ServiceWorkerContextCore::RegisterServiceWorker().
+   void RegistrationComplete(const GURL& script_url,
+                             const GURL& scope,
+@@ -438,11 +456,12 @@ class CONTENT_EXPORT ServiceWorkerContainerHostForClient final
+   // An endpoint connected to the COEP reporter. A clone of this connection is
+   // passed to the service worker. Bound on response commit.
+   mojo::Remote<network::mojom::CrossOriginEmbedderPolicyReporter>
+-      coep_reporter_;
++      cross_origin_embedder_policy_reporter_;
+ 
+   // An endpoint connected to the DocumentIsolationPolicy reporter. A clone of
+   // this connection is passed to the service worker. Bound on response commit.
+-  mojo::Remote<network::mojom::DocumentIsolationPolicyReporter> dip_reporter_;
++  mojo::Remote<network::mojom::DocumentIsolationPolicyReporter>
++      document_isolation_policy_reporter_;
+ 
+   base::WeakPtrFactory<ServiceWorkerContainerHostForClient> weak_ptr_factory_{
+       this};
+diff --git a/content/browser/service_worker/service_worker_main_resource_loader.cc b/content/browser/service_worker/service_worker_main_resource_loader.cc
+index 63f683c703ca5f668e81a84e84c90ae38684bdc3..29bbdcbdf9173cd3ff0655152ce087699688d74b 100644
+--- a/content/browser/service_worker/service_worker_main_resource_loader.cc
++++ b/content/browser/service_worker/service_worker_main_resource_loader.cc
+@@ -25,7 +25,9 @@
+ #include "base/trace_event/trace_event.h"
+ #include "content/browser/loader/navigation_url_loader.h"
+ #include "content/browser/loader/response_head_update_params.h"
++#include "content/browser/renderer_host/policy_container_host.h"
+ #include "content/browser/service_worker/service_worker_client.h"
++#include "content/browser/service_worker/service_worker_container_host.h"
+ #include "content/browser/service_worker/service_worker_context_core.h"
+ #include "content/browser/service_worker/service_worker_context_wrapper.h"
+ #include "content/browser/service_worker/service_worker_loader_helpers.h"
+@@ -44,6 +46,8 @@
+ #include "net/base/load_timing_info.h"
+ #include "net/http/http_request_headers.h"
+ #include "net/http/http_status_code.h"
++#include "services/network/public/cpp/cross_origin_embedder_policy.h"
++#include "services/network/public/cpp/document_isolation_policy.h"
+ #include "services/network/public/cpp/features.h"
+ #include "services/network/public/cpp/timing_allow_origin_parser.h"
+ #include "services/network/public/mojom/fetch_api.mojom.h"
+@@ -913,11 +917,23 @@ void ServiceWorkerMainResourceLoader::DidDispatchFetchEvent(
+     // Block invalid responses from the static router.
+     if (response_head_->service_worker_router_info->matched_source_type ==
+         network::mojom::ServiceWorkerRouterSourceType::kCache) {
+-      if (!IsValidStaticRouterResponse(resource_request_, response) &&
+-          base::FeatureList::IsEnabled(
+-              features::kServiceWorkerStaticRouterOpaqueCheck)) {
+-        CommitCompleted(net::ERR_FAILED, "Invalid response from static router");
+-        return;
++      if (service_worker_client_ && service_worker_client_->container_host()) {
++        ServiceWorkerContainerHostForClient* container_host =
++            service_worker_client_->container_host();
++        if (!IsValidStaticRouterResponse(
++                resource_request_, response,
++                container_host->policy_container_policies()
++                    .cross_origin_embedder_policy,
++                container_host->cross_origin_embedder_policy_reporter().get(),
++                container_host->policy_container_policies()
++                    .document_isolation_policy,
++                container_host->document_isolation_policy_reporter().get()) &&
++            base::FeatureList::IsEnabled(
++                features::kServiceWorkerStaticRouterOpaqueCheck)) {
++          CommitCompleted(net::ERR_FAILED,
++                          "Invalid response from static router");
++          return;
++        }
+       }
+     }
+   }
+diff --git a/content/common/features.cc b/content/common/features.cc
+index 6ef8a76f0967fa44ab8d7bda3d5a72323ea02e71..8293f83f2fc67991ffae2d910dc83dc743b74b2c 100644
+--- a/content/common/features.cc
++++ b/content/common/features.cc
+@@ -645,6 +645,10 @@ BASE_FEATURE(kServiceWorkerStaticRouterRaceRequestFix2,
+ BASE_FEATURE(kServiceWorkerStaticRouterConsolidateMainScriptResponse,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
++// Enforce CORP check for Service Worker Static Router's cache source.
++BASE_FEATURE(kServiceWorkerStaticRouterCORPCheck,
++             base::FEATURE_DISABLED_BY_DEFAULT);
++
+ // crbug.com/495999481: When this is enabled, the navigation request should be
+ // blocked when it receives an opaque response from the service worker static
+ // router.
+diff --git a/content/common/features.h b/content/common/features.h
+index 15c8c015f18283044900b21dba10ad4ff9a28c08..d288ea49f5baa0dd1961a894465e9b89fd214ad4 100644
+--- a/content/common/features.h
++++ b/content/common/features.h
+@@ -202,6 +202,7 @@ CONTENT_EXPORT extern const base::FeatureParam<std::string>
+     kServiceWorkerBypassFetchHandlerBypassedHashStrings;
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerSrcdocSupport);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerStaticRouterRaceRequestFix2);
++CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerStaticRouterCORPCheck);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(kServiceWorkerStaticRouterOpaqueCheck);
+ CONTENT_EXPORT BASE_DECLARE_FEATURE(
+     kServiceWorkerStaticRouterConsolidateMainScriptResponse);
+diff --git a/content/common/service_worker/service_worker_resource_loader.cc b/content/common/service_worker/service_worker_resource_loader.cc
+index b917f19c6035b2f5a45e77064e619a179da630cf..98429284b9e6bca812cea9cac97d4dea8186b547 100644
+--- a/content/common/service_worker/service_worker_resource_loader.cc
++++ b/content/common/service_worker/service_worker_resource_loader.cc
+@@ -10,8 +10,13 @@
+ #include "base/metrics/histogram_macros.h"
+ #include "base/strings/strcat.h"
+ #include "base/trace_event/trace_event.h"
++#include "content/common/features.h"
+ #include "content/public/common/content_features.h"
++#include "services/network/public/cpp/cross_origin_embedder_policy.h"
++#include "services/network/public/cpp/cross_origin_resource_policy.h"
++#include "services/network/public/cpp/document_isolation_policy.h"
+ #include "services/network/public/cpp/resource_request.h"
++#include "services/network/public/mojom/cross_origin_embedder_policy.mojom.h"
+ #include "services/network/public/mojom/fetch_api.mojom.h"
+ #include "services/network/public/mojom/service_worker_router_info.mojom-shared.h"
+ #include "third_party/blink/public/mojom/fetch/fetch_api_response.mojom.h"
+@@ -66,9 +71,53 @@ bool ServiceWorkerResourceLoader::IsValidServiceWorkerResponse(
+ 
+ bool ServiceWorkerResourceLoader::IsValidStaticRouterResponse(
+     const network::ResourceRequest& resource_request,
+-    const blink::mojom::FetchAPIResponsePtr& response) {
++    const blink::mojom::FetchAPIResponsePtr& response,
++    const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
++    network::mojom::CrossOriginEmbedderPolicyReporter*
++        cross_origin_embedder_policy_reporter,
++    const network::DocumentIsolationPolicy& document_isolation_policy,
++    network::mojom::DocumentIsolationPolicyReporter*
++        document_isolation_policy_reporter) {
+   bool is_valid = IsValidServiceWorkerResponse(
+       resource_request.mode, resource_request.redirect_mode, response);
++
++  if (is_valid && response) {
++    std::optional<std::string> corp_header_value;
++    auto it =
++        response->headers.find(network::CrossOriginResourcePolicy::kHeaderName);
++    if (it != response->headers.end()) {
++      corp_header_value = it->second;
++    }
++
++    // Since the static router's cache source is handled by the browser process
++    // on behalf of the service worker, we should perform the CORP check
++    // here to ensure the security.
++    // The check is performed against the client's COEP and DIP.
++    CORPCheckResult result = CORPCheckResult::kSuccess;
++    bool is_enabled = base::FeatureList::IsEnabled(
++        features::kServiceWorkerStaticRouterCORPCheck);
++    if (network::CrossOriginResourcePolicy::IsBlockedByHeaderValue(
++            resource_request.url, resource_request.url,
++            resource_request.request_initiator, corp_header_value,
++            resource_request.mode, resource_request.destination,
++            response->request_include_credentials, cross_origin_embedder_policy,
++            is_enabled ? cross_origin_embedder_policy_reporter : nullptr,
++            document_isolation_policy,
++            is_enabled ? document_isolation_policy_reporter : nullptr)) {
++      if (is_enabled) {
++        is_valid = false;
++        result = CORPCheckResult::kBlocked;
++      } else {
++        result = CORPCheckResult::kViolation;
++      }
++    }
++    base::UmaHistogramEnumeration(
++        base::StrCat({"ServiceWorker.StaticRouter.",
++                      IsMainResourceLoader() ? "MainResource" : "Subresource",
++                      ".CORPCheckResult"}),
++        result);
++  }
++
+   base::UmaHistogramBoolean(
+       base::StrCat({"ServiceWorker.StaticRouter.",
+                     IsMainResourceLoader() ? "MainResource" : "Subresource",
+diff --git a/content/common/service_worker/service_worker_resource_loader.h b/content/common/service_worker/service_worker_resource_loader.h
+index d0ec8bd4d970d1faa566287e300e8074614ba397..b1b5b3c60127841e17d6a527a62ccea05212494a 100644
+--- a/content/common/service_worker/service_worker_resource_loader.h
++++ b/content/common/service_worker/service_worker_resource_loader.h
+@@ -10,6 +10,10 @@
+ #include "base/check_op.h"
+ #include "content/common/content_export.h"
+ #include "mojo/public/cpp/base/big_buffer.h"
++#include "services/network/public/cpp/cross_origin_embedder_policy.h"
++#include "services/network/public/cpp/document_isolation_policy.h"
++#include "services/network/public/mojom/cross_origin_embedder_policy.mojom-forward.h"
++#include "services/network/public/mojom/document_isolation_policy.mojom-forward.h"
+ #include "services/network/public/mojom/service_worker_router_info.mojom-shared.h"
+ #include "services/network/public/mojom/url_loader.mojom.h"
+ #include "third_party/blink/public/common/service_worker/service_worker_router_rule.h"
+@@ -80,6 +84,16 @@ class CONTENT_EXPORT ServiceWorkerResourceLoader {
+     kAutoPreload,
+   };
+ 
++  // Results of the CORP check for the static router's cache source.
++  // These values are persisted to logs. Entries should not be renumbered and
++  // numeric values should never be reused.
++  enum class CORPCheckResult {
++    kSuccess = 0,    // Not blocked by policy.
++    kBlocked = 1,    // Blocked by policy, and feature flag enabled.
++    kViolation = 2,  // Blocked by policy, but feature flag disabled.
++    kMaxValue = kViolation,
++  };
++
+   // Static helper to validate the response from the Service Worker according
+   // to the Fetch spec (4.4 HTTP fetch, Step 3.5.6).
+   static bool IsValidServiceWorkerResponse(
+@@ -91,7 +105,13 @@ class CONTENT_EXPORT ServiceWorkerResourceLoader {
+   // the result to UMA. Returns true if the response is valid.
+   bool IsValidStaticRouterResponse(
+       const network::ResourceRequest& resource_request,
+-      const blink::mojom::FetchAPIResponsePtr& response);
++      const blink::mojom::FetchAPIResponsePtr& response,
++      const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
++      network::mojom::CrossOriginEmbedderPolicyReporter*
++          cross_origin_embedder_policy_reporter,
++      const network::DocumentIsolationPolicy& document_isolation_policy,
++      network::mojom::DocumentIsolationPolicyReporter*
++          document_isolation_policy_reporter);
+ 
+   ServiceWorkerResourceLoader();
+   virtual ~ServiceWorkerResourceLoader();
+diff --git a/content/common/service_worker/service_worker_resource_loader_unittest.cc b/content/common/service_worker/service_worker_resource_loader_unittest.cc
+index 1a4fe5c4424db80b7758506959dd8964ef4e375d..fd2f13214155dc10775bad530c817ddf77ee78c9 100644
+--- a/content/common/service_worker/service_worker_resource_loader_unittest.cc
++++ b/content/common/service_worker/service_worker_resource_loader_unittest.cc
+@@ -4,12 +4,46 @@
+ 
+ #include "content/common/service_worker/service_worker_resource_loader.h"
+ 
++#include "base/test/metrics/histogram_tester.h"
++#include "base/test/scoped_feature_list.h"
++#include "content/common/features.h"
++#include "content/public/common/content_features.h"
++#include "services/network/public/cpp/resource_request.h"
+ #include "services/network/public/mojom/fetch_api.mojom.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "third_party/blink/public/mojom/fetch/fetch_api_response.mojom.h"
+ 
+ namespace content {
+ 
++namespace {
++
++class TestServiceWorkerResourceLoader : public ServiceWorkerResourceLoader {
++ public:
++  explicit TestServiceWorkerResourceLoader(bool is_main_resource)
++      : is_main_resource_(is_main_resource) {}
++  ~TestServiceWorkerResourceLoader() override = default;
++
++  bool IsMainResourceLoader() override { return is_main_resource_; }
++
++  void CommitResponseBody(
++      const network::mojom::URLResponseHeadPtr& response_head,
++      mojo::ScopedDataPipeConsumerHandle response_body,
++      std::optional<mojo_base::BigBuffer> cached_metadata) override {}
++
++  void CommitEmptyResponseAndComplete() override {}
++
++  void CommitCompleted(int error_code, const char* reason) override {}
++
++  void HandleRedirect(
++      const net::RedirectInfo& redirect_info,
++      const network::mojom::URLResponseHeadPtr& response_head) override {}
++
++ private:
++  bool is_main_resource_;
++};
++
++}  // namespace
++
+ TEST(ServiceWorkerResourceLoaderTest, IsValidServiceWorkerResponse) {
+   auto request_mode = network::mojom::RequestMode::kSameOrigin;
+   auto redirect_mode = network::mojom::RedirectMode::kFollow;
+@@ -99,4 +133,80 @@ TEST(ServiceWorkerResourceLoaderTest, IsValidServiceWorkerResponse) {
+   }
+ }
+ 
++TEST(ServiceWorkerResourceLoaderTest, IsValidStaticRouterResponse) {
++  TestServiceWorkerResourceLoader loader(/*is_main_resource=*/false);
++  base::HistogramTester histogram_tester;
++
++  network::ResourceRequest request;
++  request.url = GURL("https://b.test/resource");
++  request.request_initiator = url::Origin::Create(GURL("https://a.test/"));
++  request.mode = network::mojom::RequestMode::kNoCors;
++  request.destination = network::mojom::RequestDestination::kImage;
++
++  auto response = blink::mojom::FetchAPIResponse::New();
++  response->response_type = network::mojom::FetchResponseType::kOpaque;
++
++  network::CrossOriginEmbedderPolicy coep;
++  coep.value = network::mojom::CrossOriginEmbedderPolicyValue::kRequireCorp;
++  network::DocumentIsolationPolicy dip;
++
++  // Case 1: Same-origin request should be valid even without CORP.
++  {
++    network::ResourceRequest same_origin_request;
++    same_origin_request.url = GURL("https://a.test/resource");
++    same_origin_request.request_initiator =
++        url::Origin::Create(GURL("https://a.test/"));
++    same_origin_request.mode = network::mojom::RequestMode::kNoCors;
++
++    EXPECT_TRUE(loader.IsValidStaticRouterResponse(
++        same_origin_request, response, coep, nullptr, dip, nullptr));
++    histogram_tester.ExpectBucketCount(
++        "ServiceWorker.StaticRouter.Subresource.CORPCheckResult",
++        ServiceWorkerResourceLoader::CORPCheckResult::kSuccess, 1);
++  }
++
++  // Case 2: Cross-origin request without CORP, flag OFF.
++  {
++    base::test::ScopedFeatureList scoped_feature_list;
++    scoped_feature_list.InitAndDisableFeature(
++        features::kServiceWorkerStaticRouterCORPCheck);
++
++    EXPECT_TRUE(loader.IsValidStaticRouterResponse(request, response, coep,
++                                                   nullptr, dip, nullptr));
++    histogram_tester.ExpectBucketCount(
++        "ServiceWorker.StaticRouter.Subresource.CORPCheckResult",
++        ServiceWorkerResourceLoader::CORPCheckResult::kViolation, 1);
++  }
++
++  // Case 3: Cross-origin request without CORP, flag ON.
++  {
++    base::test::ScopedFeatureList scoped_feature_list;
++    scoped_feature_list.InitAndEnableFeature(
++        features::kServiceWorkerStaticRouterCORPCheck);
++
++    EXPECT_FALSE(loader.IsValidStaticRouterResponse(request, response, coep,
++                                                    nullptr, dip, nullptr));
++    histogram_tester.ExpectBucketCount(
++        "ServiceWorker.StaticRouter.Subresource.CORPCheckResult",
++        ServiceWorkerResourceLoader::CORPCheckResult::kBlocked, 1);
++  }
++
++  // Case 4: Cross-origin request WITH CORP, flag ON.
++  {
++    base::test::ScopedFeatureList scoped_feature_list;
++    scoped_feature_list.InitAndEnableFeature(
++        features::kServiceWorkerStaticRouterCORPCheck);
++
++    auto corp_response = blink::mojom::FetchAPIResponse::New();
++    corp_response->response_type = network::mojom::FetchResponseType::kOpaque;
++    corp_response->headers["Cross-Origin-Resource-Policy"] = "cross-origin";
++
++    EXPECT_TRUE(loader.IsValidStaticRouterResponse(request, corp_response, coep,
++                                                   nullptr, dip, nullptr));
++    histogram_tester.ExpectBucketCount(
++        "ServiceWorker.StaticRouter.Subresource.CORPCheckResult",
++        ServiceWorkerResourceLoader::CORPCheckResult::kSuccess, 2);
++  }
++}
++
+ }  // namespace content
+diff --git a/content/renderer/renderer_blink_platform_impl.cc b/content/renderer/renderer_blink_platform_impl.cc
+index 222286e1606e82823494de18f5d33dc2ce2dc80e..d076bcb8f55fd36d23979dce5873b004ca337ef5 100644
+--- a/content/renderer/renderer_blink_platform_impl.cc
++++ b/content/renderer/renderer_blink_platform_impl.cc
+@@ -998,7 +998,11 @@ void RendererBlinkPlatformImpl::CreateServiceWorkerSubresourceLoaderFactory(
+           /*remote_controller=*/mojo::NullRemote(),
+           /*remote_cache_storage=*/mojo::NullRemote(), client_id.Utf8(),
+           blink::mojom::ServiceWorkerFetchHandlerBypassOption::kDefault,
+-          /*router_rules=*/std::nullopt, blink::EmbeddedWorkerStatus::kStopped,
++          /*router_rules=*/std::nullopt, network::CrossOriginEmbedderPolicy(),
++          mojo::NullRemote() /*coep_reporter*/,
++          network::DocumentIsolationPolicy(),
++          mojo::NullRemote() /*dip_reporter*/,
++          blink::EmbeddedWorkerStatus::kStopped,
+           /*running_status_receiver=*/mojo::NullReceiver()),
+       network::SharedURLLoaderFactory::Create(std::move(fallback_factory)),
+       std::move(receiver), std::move(task_runner));
+diff --git a/content/renderer/service_worker/controller_service_worker_connector.cc b/content/renderer/service_worker/controller_service_worker_connector.cc
+index 74f72e53784f218664c36ccaabc9d55236f6a87e..3ec959f02c704737b36deaba86d734fc3b081a44 100644
+--- a/content/renderer/service_worker/controller_service_worker_connector.cc
++++ b/content/renderer/service_worker/controller_service_worker_connector.cc
+@@ -24,13 +24,29 @@ ControllerServiceWorkerConnector::ControllerServiceWorkerConnector(
+     blink::mojom::ServiceWorkerFetchHandlerBypassOption
+         fetch_handler_bypass_option,
+     std::optional<blink::ServiceWorkerRouterRules> router_rules,
++    const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
++    mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
++        cross_origin_embedder_policy_reporter,
++    const network::DocumentIsolationPolicy& document_isolation_policy,
++    mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
++        document_isolation_policy_reporter,
+     std::optional<blink::EmbeddedWorkerStatus> initial_running_status,
+     mojo::PendingReceiver<blink::mojom::ServiceWorkerRunningStatusCallback>
+         running_status_receiver)
+-    : client_id_(client_id),
++    : cross_origin_embedder_policy_(cross_origin_embedder_policy),
++      document_isolation_policy_(document_isolation_policy),
++      client_id_(client_id),
+       fetch_handler_bypass_option_(fetch_handler_bypass_option),
+       running_status_(initial_running_status),
+       running_status_receiver_(this) {
++  if (cross_origin_embedder_policy_reporter) {
++    cross_origin_embedder_policy_reporter_.Bind(
++        std::move(cross_origin_embedder_policy_reporter));
++  }
++  if (document_isolation_policy_reporter) {
++    document_isolation_policy_reporter_.Bind(
++        std::move(document_isolation_policy_reporter));
++  }
+   container_host_.Bind(std::move(remote_container_host));
+   container_host_.set_disconnect_handler(base::BindOnce(
+       &ControllerServiceWorkerConnector::OnContainerHostConnectionClosed,
+diff --git a/content/renderer/service_worker/controller_service_worker_connector.h b/content/renderer/service_worker/controller_service_worker_connector.h
+index 4a4d4e1aa1c17222ec728ae765c92ff04a09e0b8..6fc60a3d501a01af4d8810b8fff1296e817fcf69 100644
+--- a/content/renderer/service_worker/controller_service_worker_connector.h
++++ b/content/renderer/service_worker/controller_service_worker_connector.h
+@@ -14,6 +14,10 @@
+ #include "mojo/public/cpp/bindings/pending_remote.h"
+ #include "mojo/public/cpp/bindings/receiver_set.h"
+ #include "mojo/public/cpp/bindings/remote.h"
++#include "services/network/public/cpp/cross_origin_embedder_policy.h"
++#include "services/network/public/cpp/document_isolation_policy.h"
++#include "services/network/public/mojom/cross_origin_embedder_policy.mojom.h"
++#include "services/network/public/mojom/document_isolation_policy.mojom.h"
+ #include "third_party/blink/public/common/service_worker/embedded_worker_status.h"
+ #include "third_party/blink/public/mojom/cache_storage/cache_storage.mojom.h"
+ #include "third_party/blink/public/mojom/service_worker/controller_service_worker.mojom.h"
+@@ -83,6 +87,12 @@ class CONTENT_EXPORT ControllerServiceWorkerConnector
+       blink::mojom::ServiceWorkerFetchHandlerBypassOption
+           fetch_handler_bypass_option,
+       std::optional<blink::ServiceWorkerRouterRules> router_rules,
++      const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
++      mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
++          cross_origin_embedder_policy_reporter,
++      const network::DocumentIsolationPolicy& document_isolation_policy,
++      mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
++          document_isolation_policy_reporter,
+       std::optional<blink::EmbeddedWorkerStatus> initial_running_status,
+       mojo::PendingReceiver<blink::mojom::ServiceWorkerRunningStatusCallback>
+           running_status_receiver);
+@@ -131,6 +141,29 @@ class CONTENT_EXPORT ControllerServiceWorkerConnector
+     return router_evaluator_.get();
+   }
+ 
++  const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy()
++      const {
++    return cross_origin_embedder_policy_;
++  }
++
++  const network::DocumentIsolationPolicy& document_isolation_policy() const {
++    return document_isolation_policy_;
++  }
++
++  network::mojom::CrossOriginEmbedderPolicyReporter*
++  cross_origin_embedder_policy_reporter() const {
++    return cross_origin_embedder_policy_reporter_
++               ? cross_origin_embedder_policy_reporter_.get()
++               : nullptr;
++  }
++
++  network::mojom::DocumentIsolationPolicyReporter*
++  document_isolation_policy_reporter() const {
++    return document_isolation_policy_reporter_
++               ? document_isolation_policy_reporter_.get()
++               : nullptr;
++  }
++
+   // Returns recent ServiceWorker's running status.
+   //
+   // The ServiceWorkerVersion status change callback will send an IPC to update
+@@ -167,6 +200,13 @@ class CONTENT_EXPORT ControllerServiceWorkerConnector
+   // Connection to the cache storage.
+   mojo::Remote<blink::mojom::CacheStorage> cache_storage_;
+ 
++  network::CrossOriginEmbedderPolicy cross_origin_embedder_policy_;
++  mojo::Remote<network::mojom::CrossOriginEmbedderPolicyReporter>
++      cross_origin_embedder_policy_reporter_;
++  network::DocumentIsolationPolicy document_isolation_policy_;
++  mojo::Remote<network::mojom::DocumentIsolationPolicyReporter>
++      document_isolation_policy_reporter_;
++
+   base::ObserverList<Observer>::Unchecked observer_list_;
+ 
+   // The web-exposed client id, used for FetchEvent#clientId (i.e.,
+diff --git a/content/renderer/service_worker/service_worker_provider_context.cc b/content/renderer/service_worker/service_worker_provider_context.cc
+index 694035f994b5f1d4a7382eaa9912b37a7fd06f99..a6ed175b9d9e8623c3f566f2555c828b9dd661af 100644
+--- a/content/renderer/service_worker/service_worker_provider_context.cc
++++ b/content/renderer/service_worker/service_worker_provider_context.cc
+@@ -56,6 +56,12 @@ void CreateSubresourceLoaderFactoryForProviderContext(
+     blink::mojom::ServiceWorkerFetchHandlerBypassOption
+         fetch_handler_bypass_option,
+     std::optional<blink::ServiceWorkerRouterRules> router_rules,
++    const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
++    mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
++        cross_origin_embedder_policy_reporter,
++    const network::DocumentIsolationPolicy& document_isolation_policy,
++    mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
++        document_isolation_policy_reporter,
+     std::optional<blink::EmbeddedWorkerStatus> initial_running_status,
+     mojo::PendingReceiver<blink::mojom::ServiceWorkerRunningStatusCallback>
+         running_status_receiver,
+@@ -68,7 +74,10 @@ void CreateSubresourceLoaderFactoryForProviderContext(
+   auto connector = base::MakeRefCounted<ControllerServiceWorkerConnector>(
+       std::move(remote_container_host), std::move(remote_controller),
+       std::move(remote_cache_storage), client_id, fetch_handler_bypass_option,
+-      router_rules, initial_running_status, std::move(running_status_receiver));
++      router_rules, cross_origin_embedder_policy,
++      std::move(cross_origin_embedder_policy_reporter),
++      document_isolation_policy, std::move(document_isolation_policy_reporter),
++      initial_running_status, std::move(running_status_receiver));
+   connector->AddBinding(std::move(connector_receiver));
+   ServiceWorkerSubresourceLoaderFactory::Create(
+       std::move(connector),
+@@ -168,6 +177,20 @@ ServiceWorkerProviderContext::GetSubresourceLoaderFactoryInternal() {
+     // extra contention on the main thread.
+     auto task_runner = base::ThreadPool::CreateSequencedTaskRunner(
+         {base::MayBlock(), base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
++    mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>
++        cross_origin_embedder_policy_reporter;
++    if (cross_origin_embedder_policy_reporter_) {
++      cross_origin_embedder_policy_reporter_->Clone(
++          cross_origin_embedder_policy_reporter
++              .InitWithNewPipeAndPassReceiver());
++    }
++    mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>
++        document_isolation_policy_reporter;
++    if (document_isolation_policy_reporter_) {
++      document_isolation_policy_reporter_->Clone(
++          document_isolation_policy_reporter.InitWithNewPipeAndPassReceiver());
++    }
++
+     task_runner->PostTask(
+         FROM_HERE,
+         base::BindOnce(
+@@ -175,6 +198,10 @@ ServiceWorkerProviderContext::GetSubresourceLoaderFactoryInternal() {
+             std::move(remote_container_host), std::move(remote_controller_),
+             std::move(remote_cache_storage_), client_id_,
+             fetch_handler_bypass_option_, router_rules_,
++            cross_origin_embedder_policy_,
++            std::move(cross_origin_embedder_policy_reporter),
++            document_isolation_policy_,
++            std::move(document_isolation_policy_reporter),
+             initial_running_status_, std::move(running_status_receiver_),
+             fallback_loader_factory_->Clone(),
+             controller_connector_.BindNewPipeAndPassReceiver(),
+@@ -434,6 +461,29 @@ void ServiceWorkerProviderContext::SetController(
+   remote_controller_ = std::move(controller_info->remote_controller);
+   fetch_handler_bypass_option_ = controller_info->fetch_handler_bypass_option;
+   sha256_script_checksum_ = controller_info->sha256_script_checksum;
++
++  cross_origin_embedder_policy_ = network::CrossOriginEmbedderPolicy();
++  cross_origin_embedder_policy_reporter_.reset();
++  if (controller_info->cross_origin_embedder_policy) {
++    cross_origin_embedder_policy_ =
++        controller_info->cross_origin_embedder_policy->value;
++    if (controller_info->cross_origin_embedder_policy->reporter) {
++      cross_origin_embedder_policy_reporter_.Bind(
++          std::move(controller_info->cross_origin_embedder_policy->reporter));
++    }
++  }
++
++  document_isolation_policy_ = network::DocumentIsolationPolicy();
++  document_isolation_policy_reporter_.reset();
++  if (controller_info->document_isolation_policy) {
++    document_isolation_policy_ =
++        controller_info->document_isolation_policy->value;
++    if (controller_info->document_isolation_policy->reporter) {
++      document_isolation_policy_reporter_.Bind(
++          std::move(controller_info->document_isolation_policy->reporter));
++    }
++  }
++
+   if (controller_info->router_data) {
+     router_rules_ = controller_info->router_data->router_rules;
+     initial_running_status_ =
+diff --git a/content/renderer/service_worker/service_worker_provider_context.h b/content/renderer/service_worker/service_worker_provider_context.h
+index f860c4a46da0a79f5aaf0f72420b3790eea7cf3f..7681217fce3db1434df757838992aaebdccab434 100644
+--- a/content/renderer/service_worker/service_worker_provider_context.h
++++ b/content/renderer/service_worker/service_worker_provider_context.h
+@@ -22,6 +22,10 @@
+ #include "mojo/public/cpp/bindings/pending_remote.h"
+ #include "mojo/public/cpp/bindings/receiver_set.h"
+ #include "mojo/public/cpp/bindings/remote.h"
++#include "services/network/public/cpp/cross_origin_embedder_policy.h"
++#include "services/network/public/cpp/document_isolation_policy.h"
++#include "services/network/public/mojom/cross_origin_embedder_policy.mojom.h"
++#include "services/network/public/mojom/document_isolation_policy.mojom.h"
+ #include "services/network/public/mojom/url_loader_factory.mojom.h"
+ #include "third_party/blink/public/mojom/service_worker/controller_service_worker.mojom.h"
+ #include "third_party/blink/public/mojom/service_worker/service_worker_container.mojom.h"
+@@ -338,6 +342,12 @@ class CONTENT_EXPORT ServiceWorkerProviderContext
+ 
+   // Tracks feature usage for UseCounter.
+   std::set<blink::mojom::WebFeature> used_features_;
++  network::CrossOriginEmbedderPolicy cross_origin_embedder_policy_;
++  mojo::Remote<network::mojom::CrossOriginEmbedderPolicyReporter>
++      cross_origin_embedder_policy_reporter_;
++  network::DocumentIsolationPolicy document_isolation_policy_;
++  mojo::Remote<network::mojom::DocumentIsolationPolicyReporter>
++      document_isolation_policy_reporter_;
+ 
+   // Corresponds to this context's ServiceWorkerContainer. May be null when not
+   // yet created, when already destroyed, or when this client is not a Document
+diff --git a/content/renderer/service_worker/service_worker_provider_context_unittest.cc b/content/renderer/service_worker/service_worker_provider_context_unittest.cc
+index f533cd03f4ea382002c897e2587fdbfac1275ebb..69f072666266702b7b926c8878f44fe37ed3fe77 100644
+--- a/content/renderer/service_worker/service_worker_provider_context_unittest.cc
++++ b/content/renderer/service_worker/service_worker_provider_context_unittest.cc
+@@ -206,11 +206,8 @@ class FakeControllerServiceWorker
+   }
+   void Clone(
+       mojo::PendingReceiver<blink::mojom::ControllerServiceWorker> receiver,
+-      const network::CrossOriginEmbedderPolicy&,
+-      mojo::PendingRemote<network::mojom::CrossOriginEmbedderPolicyReporter>,
+-      const network::DocumentIsolationPolicy&,
+-      mojo::PendingRemote<network::mojom::DocumentIsolationPolicyReporter>)
+-      override {
++      blink::mojom::CrossOriginEmbedderPolicyInfoPtr,
++      blink::mojom::DocumentIsolationPolicyInfoPtr) override {
+     receivers_.Add(this, std::move(receiver));
+   }
+ 
+@@ -480,9 +477,7 @@ TEST_F(ServiceWorkerProviderContextTest, SetControllerServiceWorker) {
+   auto controller_info1 = blink::mojom::ControllerServiceWorkerInfo::New();
+   mojo::Remote<blink::mojom::ControllerServiceWorker> remote_controller1;
+   fake_controller1.Clone(remote_controller1.BindNewPipeAndPassReceiver(),
+-                         network::CrossOriginEmbedderPolicy(),
+-                         mojo::NullRemote(), network::DocumentIsolationPolicy(),
+-                         mojo::NullRemote());
++                         nullptr, nullptr);
+   controller_info1->mode =
+       blink::mojom::ControllerServiceWorkerMode::kControlled;
+   controller_info1->fetch_handler_type =
+@@ -528,9 +523,7 @@ TEST_F(ServiceWorkerProviderContextTest, SetControllerServiceWorker) {
+   auto controller_info2 = blink::mojom::ControllerServiceWorkerInfo::New();
+   mojo::Remote<blink::mojom::ControllerServiceWorker> remote_controller2;
+   fake_controller2.Clone(remote_controller2.BindNewPipeAndPassReceiver(),
+-                         network::CrossOriginEmbedderPolicy(),
+-                         mojo::NullRemote(), network::DocumentIsolationPolicy(),
+-                         mojo::NullRemote());
++                         nullptr, nullptr);
+   controller_info2->mode =
+       blink::mojom::ControllerServiceWorkerMode::kControlled;
+   controller_info2->fetch_handler_type =
+@@ -622,9 +615,7 @@ TEST_F(ServiceWorkerProviderContextTest, SetControllerServiceWorker) {
+   auto controller_info4 = blink::mojom::ControllerServiceWorkerInfo::New();
+   mojo::Remote<blink::mojom::ControllerServiceWorker> remote_controller4;
+   fake_controller4.Clone(remote_controller4.BindNewPipeAndPassReceiver(),
+-                         network::CrossOriginEmbedderPolicy(),
+-                         mojo::NullRemote(), network::DocumentIsolationPolicy(),
+-                         mojo::NullRemote());
++                         nullptr, nullptr);
+   controller_info4->mode =
+       blink::mojom::ControllerServiceWorkerMode::kControlled;
+   controller_info4->fetch_handler_type =
+@@ -781,10 +772,8 @@ TEST_F(ServiceWorkerProviderContextTest, OnNetworkProviderDestroyed) {
+   FakeControllerServiceWorker fake_controller;
+   auto controller_info = blink::mojom::ControllerServiceWorkerInfo::New();
+   mojo::Remote<blink::mojom::ControllerServiceWorker> remote_controller;
+-  fake_controller.Clone(remote_controller.BindNewPipeAndPassReceiver(),
+-                        network::CrossOriginEmbedderPolicy(),
+-                        mojo::NullRemote(), network::DocumentIsolationPolicy(),
+-                        mojo::NullRemote());
++  fake_controller.Clone(remote_controller.BindNewPipeAndPassReceiver(), nullptr,
++                        nullptr);
+   controller_info->mode =
+       blink::mojom::ControllerServiceWorkerMode::kControlled;
+   controller_info->fetch_handler_type =
+@@ -832,10 +821,8 @@ TEST_F(ServiceWorkerProviderContextTest,
+   FakeControllerServiceWorker fake_controller;
+   auto controller_info = blink::mojom::ControllerServiceWorkerInfo::New();
+   mojo::Remote<blink::mojom::ControllerServiceWorker> remote_controller;
+-  fake_controller.Clone(remote_controller.BindNewPipeAndPassReceiver(),
+-                        network::CrossOriginEmbedderPolicy(),
+-                        mojo::NullRemote(), network::DocumentIsolationPolicy(),
+-                        mojo::NullRemote());
++  fake_controller.Clone(remote_controller.BindNewPipeAndPassReceiver(), nullptr,
++                        nullptr);
+   controller_info->mode =
+       blink::mojom::ControllerServiceWorkerMode::kControlled;
+   controller_info->fetch_handler_type =
+diff --git a/content/renderer/service_worker/service_worker_subresource_loader.cc b/content/renderer/service_worker/service_worker_subresource_loader.cc
+index 9cabd3343980c13aaf7d4612111f23c3e44ce38f..82e8fe1132bdf7af1b7ccec66b3a2c47f93dbc6b 100644
+--- a/content/renderer/service_worker/service_worker_subresource_loader.cc
++++ b/content/renderer/service_worker/service_worker_subresource_loader.cc
+@@ -1523,7 +1523,12 @@ void ServiceWorkerSubresourceLoader::DidCacheStorageMatch(
+   if (response_head_->service_worker_router_info &&
+       response_head_->service_worker_router_info->matched_source_type ==
+           network::mojom::ServiceWorkerRouterSourceType::kCache) {
+-    if (!IsValidStaticRouterResponse(resource_request_, response) &&
++    if (!IsValidStaticRouterResponse(
++            resource_request_, response,
++            controller_connector_->cross_origin_embedder_policy(),
++            controller_connector_->cross_origin_embedder_policy_reporter(),
++            controller_connector_->document_isolation_policy(),
++            controller_connector_->document_isolation_policy_reporter()) &&
+         base::FeatureList::IsEnabled(
+             features::kServiceWorkerStaticRouterOpaqueCheck)) {
+       CommitCompleted(net::ERR_FAILED, "Invalid response from static router");
+diff --git a/third_party/blink/public/mojom/service_worker/controller_service_worker.mojom b/third_party/blink/public/mojom/service_worker/controller_service_worker.mojom
+index 2063c9d3417391610aeb54ab2c557134fc7c8034..853d2304a7c643cddf67ada1154f399df0847f28 100644
+--- a/third_party/blink/public/mojom/service_worker/controller_service_worker.mojom
++++ b/third_party/blink/public/mojom/service_worker/controller_service_worker.mojom
+@@ -53,16 +53,21 @@ interface ControllerServiceWorker {
+   // Connects a new pipe to this controller instance.
+   // |cross_origin_embedder_policy| is the policy for the client which uses the
+   // counterpart of |receiver|.
+-  // |coep_reporter| is the endpoint to report the error raised by the CORP
+-  // validation based on |cross_origin_embedder_policy|. This can be null when
+-  // it's not supported yet.
+   Clone(pending_receiver<ControllerServiceWorker> receiver,
+-        network.mojom.CrossOriginEmbedderPolicy cross_origin_embedder_policy,
+-        pending_remote<network.mojom.CrossOriginEmbedderPolicyReporter>?
+-            coep_reporter,
+-        network.mojom.DocumentIsolationPolicy document_isolation_policy,
+-        pending_remote<network.mojom.DocumentIsolationPolicyReporter>?
+-            dip_reporter);
++        CrossOriginEmbedderPolicyInfo? cross_origin_embedder_policy,
++        DocumentIsolationPolicyInfo? document_isolation_policy);
++};
++
++// Struct to represent Cross-Origin-Embedder-Policy and its reporter.
++struct CrossOriginEmbedderPolicyInfo {
++  network.mojom.CrossOriginEmbedderPolicy value;
++  pending_remote<network.mojom.CrossOriginEmbedderPolicyReporter>? reporter;
++};
++
++// Struct to represent Document-Isolation-Policy and its reporter.
++struct DocumentIsolationPolicyInfo {
++  network.mojom.DocumentIsolationPolicy value;
++  pending_remote<network.mojom.DocumentIsolationPolicyReporter>? reporter;
+ };
+ 
+ // A convenient struct to keep ServiceWorker static routing API data.
+@@ -142,6 +147,10 @@ struct ControllerServiceWorkerInfo {
+ 
+   // The set of features the controller has used, for UseCounter purposes.
+   array<WebFeature> used_features;
++
++  // The security policies of the client being controlled.
++  CrossOriginEmbedderPolicyInfo? cross_origin_embedder_policy;
++  DocumentIsolationPolicyInfo? document_isolation_policy;
+ };
+ 
+ // A renderer-side interface for talking across threads. The main thread
+diff --git a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
+index ef0e8418b987f9751c7e2cb0d0a01a1a69dd3289..4bd6bdb2f386736f8cb56b375d3ee1b802d6ffc6 100644
+--- a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
++++ b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
+@@ -1637,16 +1637,33 @@ void ServiceWorkerGlobalScope::DispatchFetchEventForSubresource(
+ 
+ void ServiceWorkerGlobalScope::Clone(
+     mojo::PendingReceiver<mojom::blink::ControllerServiceWorker> receiver,
+-    const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
+-    mojo::PendingRemote<
+-        network::mojom::blink::CrossOriginEmbedderPolicyReporter> coep_reporter,
+-    const network::DocumentIsolationPolicy& document_isolation_policy,
+-    mojo::PendingRemote<network::mojom::blink::DocumentIsolationPolicyReporter>
+-        dip_reporter) {
+-  DCHECK(IsContextThread());
++    mojom::blink::CrossOriginEmbedderPolicyInfoPtr
++        cross_origin_embedder_policy_info,
++    mojom::blink::DocumentIsolationPolicyInfoPtr
++        document_isolation_policy_info) {
++  DCHECK(IsContextThread());
++  network::CrossOriginEmbedderPolicy cross_origin_embedder_policy;
++  mojo::PendingRemote<network::mojom::blink::CrossOriginEmbedderPolicyReporter>
++      cross_origin_embedder_policy_reporter;
++  if (cross_origin_embedder_policy_info) {
++    cross_origin_embedder_policy = cross_origin_embedder_policy_info->value;
++    cross_origin_embedder_policy_reporter =
++        std::move(cross_origin_embedder_policy_info->reporter);
++  }
++
++  network::DocumentIsolationPolicy document_isolation_policy;
++  mojo::PendingRemote<network::mojom::blink::DocumentIsolationPolicyReporter>
++      document_isolation_policy_reporter;
++  if (document_isolation_policy_info) {
++    document_isolation_policy = document_isolation_policy_info->value;
++    document_isolation_policy_reporter =
++        std::move(document_isolation_policy_info->reporter);
++  }
++
+   auto checker = std::make_unique<CrossOriginResourcePolicyChecker>(
+-      cross_origin_embedder_policy, std::move(coep_reporter),
+-      document_isolation_policy, std::move(dip_reporter));
++      cross_origin_embedder_policy,
++      std::move(cross_origin_embedder_policy_reporter),
++      document_isolation_policy, std::move(document_isolation_policy_reporter));
+ 
+   controller_receivers_.Add(
+       std::move(receiver), std::move(checker),
+diff --git a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.h b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.h
+index 97c569a0ba81fc955d57801c6e134c97bfa4a7d8..1588b2afea2dc40cc768c59b162f37dcf401ba28 100644
+--- a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.h
++++ b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.h
+@@ -451,14 +451,10 @@ class MODULES_EXPORT ServiceWorkerGlobalScope final
+       DispatchFetchEventForSubresourceCallback callback) override;
+   void Clone(
+       mojo::PendingReceiver<mojom::blink::ControllerServiceWorker> receiver,
+-      const network::CrossOriginEmbedderPolicy& cross_origin_embedder_policy,
+-      mojo::PendingRemote<
+-          network::mojom::blink::CrossOriginEmbedderPolicyReporter>
+-          coep_reporter,
+-      const network::DocumentIsolationPolicy& document_isolation_policy,
+-      mojo::PendingRemote<
+-          network::mojom::blink::DocumentIsolationPolicyReporter> dip_reporter)
+-      override;
++      mojom::blink::CrossOriginEmbedderPolicyInfoPtr
++          cross_origin_embedder_policy_info,
++      mojom::blink::DocumentIsolationPolicyInfoPtr
++          document_isolation_policy_info) override;
+ 
+   // Implements mojom::blink::ServiceWorker.
+   void InitializeGlobalScope(
+diff --git a/third_party/blink/renderer/modules/service_worker/web_embedded_worker_impl_test.cc b/third_party/blink/renderer/modules/service_worker/web_embedded_worker_impl_test.cc
+index e656c3a68265f88c83371db15b375c33ba3000fd..b3e73b0ea07a4670fa5328c014808769b308894f 100644
+--- a/third_party/blink/renderer/modules/service_worker/web_embedded_worker_impl_test.cc
++++ b/third_party/blink/renderer/modules/service_worker/web_embedded_worker_impl_test.cc
+@@ -399,6 +399,7 @@ class MockServiceWorkerContextClient final
+   void WorkerContextStarted(
+       WebServiceWorkerContextProxy* proxy,
+       scoped_refptr<base::SequencedTaskRunner> worker_task_runner) override {
++    proxy_ = proxy;
+     worker_task_runner_ = std::move(worker_task_runner);
+     mojo::PendingAssociatedRemote<mojom::blink::ServiceWorkerHost> host_remote;
+     auto host_receiver = host_remote.InitWithNewEndpointAndPassReceiver();
+@@ -458,18 +459,6 @@ class MockServiceWorkerContextClient final
+         mock_policy_container_host.BindNewEndpointAndPassDedicatedRemote();
+     web_policy_container_ = nullptr;
+ 
+-    // ControllerServiceWorker requires Clone to ensure
+-    // CrossOriginResourcePolicyChecker. See
+-    // ServiceWorkerGlobalScope::DispatchFetchEventForSubresource().
+-    mojo::Remote<mojom::blink::ControllerServiceWorker>
+-        stub_controller_service_worker;
+-    proxy->BindControllerServiceWorker(
+-        stub_controller_service_worker.BindNewPipeAndPassReceiver());
+-    stub_controller_service_worker->Clone(
+-        controller_service_worker_.BindNewPipeAndPassReceiver(),
+-        network::CrossOriginEmbedderPolicy(), mojo::NullRemote(),
+-        network::DocumentIsolationPolicy(), mojo::NullRemote());
+-
+     // To make the other side callable.
+     host_receiver.EnableUnassociatedUsage();
+     associated_interfaces_recevier_from_browser.EnableUnassociatedUsage();
+@@ -534,6 +523,17 @@ class MockServiceWorkerContextClient final
+     test_data_uploader_ = std::make_unique<TestDataUploader>(upload_contents);
+     ResourceRequestBody src(test_data_uploader_->BindNewPipeAndPassRemote());
+     request->body = std::move(src);
++
++    if (!controller_service_worker_.is_bound()) {
++      mojo::Remote<mojom::blink::ControllerServiceWorker>
++          stub_controller_service_worker;
++      proxy_->BindControllerServiceWorker(
++          stub_controller_service_worker.BindNewPipeAndPassReceiver());
++      stub_controller_service_worker->Clone(
++          controller_service_worker_.BindNewPipeAndPassReceiver(), nullptr,
++          nullptr);
++    }
++
+     auto params = mojom::blink::DispatchFetchEventParams::New();
+     params->request = std::move(request);
+     params->client_id = "foo";
+@@ -582,6 +582,7 @@ class MockServiceWorkerContextClient final
+   base::WaitableEvent classic_script_load_failure_event_;
+ 
+   scoped_refptr<base::SequencedTaskRunner> worker_task_runner_;
++  raw_ptr<WebServiceWorkerContextProxy, DanglingUntriaged> proxy_ = nullptr;
+   mojo::Remote<mojom::blink::ControllerServiceWorker>
+       controller_service_worker_;
+   std::unique_ptr<TestDataUploader> test_data_uploader_;

--- a/patches/chromium/cherry-pick-faada322153d.patch
+++ b/patches/chromium/cherry-pick-faada322153d.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergio Solano <sergiosolano@google.com>
+Date: Mon, 6 Apr 2026 09:15:42 -0700
+Subject: [media/gpu] Enforce safe range for NativePixmapPlane construction
+
+This is a quick fix for a potential security issue where internal
+calculations for strides or offsets could lead to sign-extension or
+truncation vulnerabilities in the NativePixmapPlane constructor.
+
+By using base::checked_cast<int> at call sites, we ensure that any
+out-of-range values trigger a safe crash instead of silent corruption.
+We also use base::strict_cast<uint64_t> for plane sizes and correct
+literal types (e.g., 0u) to satisfy reviewer feedback and improve
+overall type correctness.
+
+For further reference: (Internal only) go/code-terracotta-review-explainer
+
+Project: Project-Fortify
+Bug: b:497542537
+Change-Id: I82647b3c8a94368e9e6273e341e0976d8648a4d7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7724047
+Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
+Reviewed-by: Stephen Nusko <nuskos@chromium.org>
+Commit-Queue: Sergio Solano <sergiosolano@google.com>
+Reviewed-by: Tom Sepez <tsepez@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1610319}
+
+diff --git a/chromeos/ash/experiences/arc/video_accelerator/protected_buffer_manager.cc b/chromeos/ash/experiences/arc/video_accelerator/protected_buffer_manager.cc
+index 719f270f86e6b83b61eddc609216afad6e2f940a..5f9f4518051cf87fb8090776bd9fb192be0f47f5 100644
+--- a/chromeos/ash/experiences/arc/video_accelerator/protected_buffer_manager.cc
++++ b/chromeos/ash/experiences/arc/video_accelerator/protected_buffer_manager.cc
+@@ -505,7 +505,7 @@ scoped_refptr<gfx::NativePixmap> ProtectedBufferManager::ImportDummyFd(
+   // also on failure.
+   gfx::NativePixmapHandle pixmap_handle;
+   pixmap_handle.planes.emplace_back(
+-      gfx::NativePixmapPlane(0, 0, 0, std::move(dummy_fd)));
++      gfx::NativePixmapPlane(0, 0, 0u, std::move(dummy_fd)));
+   ui::OzonePlatform* platform = ui::OzonePlatform::GetInstance();
+   ui::SurfaceFactoryOzone* factory = platform->GetSurfaceFactoryOzone();
+   scoped_refptr<gfx::NativePixmap> pixmap =
+diff --git a/media/gpu/chromeos/mock_native_pixmap_dmabuf.cc b/media/gpu/chromeos/mock_native_pixmap_dmabuf.cc
+index 02baece099cd95d5734173cb354429bec0eb4203..12fe2ab8225dfb2100e2ef3e495a552a252f7ef1 100644
+--- a/media/gpu/chromeos/mock_native_pixmap_dmabuf.cc
++++ b/media/gpu/chromeos/mock_native_pixmap_dmabuf.cc
+@@ -59,7 +59,9 @@ scoped_refptr<const gfx::NativePixmapDmaBuf> CreateMockNativePixmapDmaBuf(
+       LOG(ERROR) << "Failed to open a file";
+       return nullptr;
+     }
+-    handle.planes.emplace_back(plane.stride, plane.offset, plane.size,
++    handle.planes.emplace_back(base::checked_cast<int>(plane.stride),
++                               base::checked_cast<int>(plane.offset),
++                               base::strict_cast<uint64_t>(plane.size),
+                                base::ScopedFD(file.TakePlatformFile()));
+   }
+   handle.modifier = modifier;
+diff --git a/media/gpu/chromeos/native_pixmap_frame_resource.cc b/media/gpu/chromeos/native_pixmap_frame_resource.cc
+index 7ead2a7dc0f58a01d9e4fc04e6437566ccd495c2..3deb700e85b2321fe708447b274fdb22235cb1ec 100644
+--- a/media/gpu/chromeos/native_pixmap_frame_resource.cc
++++ b/media/gpu/chromeos/native_pixmap_frame_resource.cc
+@@ -125,7 +125,9 @@ scoped_refptr<NativePixmapFrameResource> NativePixmapFrameResource::Create(
+   handle.planes.reserve(num_planes);
+   for (size_t i = 0; i < num_planes; ++i) {
+     const auto& plane = layout.planes()[i];
+-    handle.planes.emplace_back(plane.stride, plane.offset, plane.size,
++    handle.planes.emplace_back(base::checked_cast<int>(plane.stride),
++                               base::checked_cast<int>(plane.offset),
++                               base::strict_cast<uint64_t>(plane.size),
+                                std::move(dmabuf_fds[i]));
+   }
+   handle.modifier = layout.modifier();
+diff --git a/media/gpu/chromeos/platform_video_frame_utils.cc b/media/gpu/chromeos/platform_video_frame_utils.cc
+index 18764111d918e4aad9cdbab03b12e626ec4a9609..fe6a43cd10d4e58362c4edfcca4d33287bf65695 100644
+--- a/media/gpu/chromeos/platform_video_frame_utils.cc
++++ b/media/gpu/chromeos/platform_video_frame_utils.cc
+@@ -516,7 +516,9 @@ gfx::GpuMemoryBufferHandle CreateGpuMemoryBufferHandle(
+       for (size_t i = 0; i < num_planes; ++i) {
+         const auto& plane = video_frame->layout().planes()[i];
+         native_pixmap_handle.planes.emplace_back(
+-            plane.stride, plane.offset, plane.size, std::move(duped_fds[i]));
++            base::checked_cast<int>(plane.stride),
++            base::checked_cast<int>(plane.offset),
++            base::strict_cast<uint64_t>(plane.size), std::move(duped_fds[i]));
+       }
+       handle = gfx::GpuMemoryBufferHandle(std::move(native_pixmap_handle));
+     } break;
+diff --git a/media/gpu/test/test_gbm_buffer_manager.cc b/media/gpu/test/test_gbm_buffer_manager.cc
+index c7c87e7d5cfb5b05251f2dbba70d155a14e34ea9..ee71fed2813efd9c37c60840bbc61e325b5c4a01 100644
+--- a/media/gpu/test/test_gbm_buffer_manager.cc
++++ b/media/gpu/test/test_gbm_buffer_manager.cc
+@@ -104,9 +104,9 @@ TestGbmBuffer::TestGbmBuffer(gbm_bo* buffer_object)
+   for (size_t i = 0;
+        i < static_cast<size_t>(gbm_bo_get_plane_count(buffer_object)); ++i) {
+     native_pixmap_handle.planes.push_back(gfx::NativePixmapPlane(
+-        gbm_bo_get_stride_for_plane(buffer_object, i),
+-        gbm_bo_get_offset(buffer_object, i),
+-        gbm_bo_get_plane_size(buffer_object, i),
++        base::checked_cast<int>(gbm_bo_get_stride_for_plane(buffer_object, i)),
++        base::checked_cast<int>(gbm_bo_get_offset(buffer_object, i)),
++        base::strict_cast<uint64_t>(gbm_bo_get_plane_size(buffer_object, i)),
+         base::ScopedFD(gbm_bo_get_plane_fd(buffer_object, i))));
+   }
+   handle_ = gfx::GpuMemoryBufferHandle(std::move(native_pixmap_handle));

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,1 +1,4 @@
 fix_handle_pipewire_capturer_initialization_and_management.patch
+cherry-pick-21d9744bd599.patch
+cherry-pick-458a75ec3e37.patch
+cherry-pick-12cce13db567.patch

--- a/patches/webrtc/cherry-pick-12cce13db567.patch
+++ b/patches/webrtc/cherry-pick-12cce13db567.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "mark a. foltz" <mfoltz@chromium.org>
+Date: Mon, 20 Apr 2026 15:16:47 -0700
+Subject: [M146] [Pipewire] Fix mouse cursor data race.
+
+Original change's description:
+> [Pipewire] Fix mouse cursor data race.
+>
+> This addresses a potential data race when the mouse cursor is updated
+> on the Pipewire thread and read by the capture thread.
+>
+> Bug: chromium:504551032
+> Change-Id: I1afb9febe8bb41ce62c63872e2cb5514e908dd38
+> Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/465440
+> Reviewed-by: Tomas Gunnarsson <tommi@webrtc.org>
+> Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+> Auto-Submit: Mark Foltz <mfoltz@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#47502}
+
+(cherry picked from commit 90b22181ec922900e26de71463b8e0ed47a5c2dd)
+
+Bug: chromium:505447120,chromium:504551032
+Change-Id: I1afb9febe8bb41ce62c63872e2cb5514e908dd38
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/468120
+Auto-Submit: Chrome Cherry Picker <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7680@{#9}
+Cr-Branched-From: d1972add2a63b2a528a6471d447f82e0010b5215-refs/heads/main@{#46853}
+
+diff --git a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index f420038f090030274e46acf1d310cce16552cf99..ffe6bfde5c211e4d41c50040caf188658e62497d 100644
+--- a/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -124,8 +124,9 @@ class SharedScreenCastStreamPrivate {
+   Mutex latest_frame_lock_ RTC_ACQUIRED_AFTER(queue_lock_);
+   SharedDesktopFrame* latest_available_frame_
+       RTC_GUARDED_BY(&latest_frame_lock_) = nullptr;
+-  std::unique_ptr<MouseCursor> mouse_cursor_;
+-  DesktopVector mouse_cursor_position_ = DesktopVector(-1, -1);
++  std::unique_ptr<MouseCursor> mouse_cursor_ RTC_GUARDED_BY(&latest_frame_lock_);
++  DesktopVector mouse_cursor_position_ RTC_GUARDED_BY(&latest_frame_lock_) =
++      DesktopVector(-1, -1);
+ 
+   int64_t modifier_;
+   std::unique_ptr<EglDmaBuf> egl_dmabuf_;
+@@ -690,6 +691,7 @@ SharedScreenCastStreamPrivate::CaptureFrame() {
+ }
+ 
+ std::unique_ptr<MouseCursor> SharedScreenCastStreamPrivate::CaptureCursor() {
++  MutexLock latest_frame_lock(&latest_frame_lock_);
+   if (!mouse_cursor_) {
+     return nullptr;
+   }
+@@ -698,6 +700,7 @@ std::unique_ptr<MouseCursor> SharedScreenCastStreamPrivate::CaptureCursor() {
+ }
+ 
+ DesktopVector SharedScreenCastStreamPrivate::CaptureCursorPosition() {
++  MutexLock latest_frame_lock(&latest_frame_lock_);
+   return mouse_cursor_position_;
+ }
+ 
+@@ -769,20 +772,28 @@ void SharedScreenCastStreamPrivate::ProcessBuffer(pw_buffer* buffer) {
+           mouse_frame->CopyPixelsFrom(
+               bitmap_data, bitmap->stride,
+               DesktopRect::MakeWH(bitmap->size.width, bitmap->size.height));
+-          mouse_cursor_ = std::make_unique<MouseCursor>(
+-              mouse_frame, DesktopVector(cursor->hotspot.x, cursor->hotspot.y));
++          {
++            MutexLock latest_frame_lock(&latest_frame_lock_);
++            mouse_cursor_ = std::make_unique<MouseCursor>(
++                mouse_frame,
++                DesktopVector(cursor->hotspot.x, cursor->hotspot.y));
++          }
+ 
+           if (observer_) {
+             observer_->OnCursorShapeChanged();
+           }
+         }
+-        mouse_cursor_position_.set(cursor->position.x, cursor->position.y);
++        {
++          MutexLock latest_frame_lock(&latest_frame_lock_);
++          mouse_cursor_position_.set(cursor->position.x, cursor->position.y);
++        }
+ 
+         if (observer_) {
+           observer_->OnCursorPositionChanged();
+         }
+       } else {
+         // Indicate an invalid cursor
++        MutexLock latest_frame_lock(&latest_frame_lock_);
+         mouse_cursor_position_.set(-1, -1);
+       }
+     }

--- a/patches/webrtc/cherry-pick-21d9744bd599.patch
+++ b/patches/webrtc/cherry-pick-21d9744bd599.patch
@@ -1,0 +1,149 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Erik=20Spr=C3=A5ng?= <sprang@webrtc.org>
+Date: Tue, 21 Apr 2026 13:16:27 +0200
+Subject: Always release VideoEncoders before destruction.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without a `Release()` call there is a potential for race conditions
+between asynchronous encoder callbacks and the destructor sequence.
+
+Bug: chromium:504620824
+Change-Id: I1fba23ef3a4a238503cdf8d2ea5831e815d7b902
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/465582
+Auto-Submit: Erik Språng <sprang@webrtc.org>
+Reviewed-by: Sergey Silkin <ssilkin@webrtc.org>
+Commit-Queue: Sergey Silkin <ssilkin@webrtc.org>
+Commit-Queue: Erik Språng <sprang@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#47495}
+
+diff --git a/video/video_stream_encoder.cc b/video/video_stream_encoder.cc
+index eea90cad3bb5753bf013c469ab97073cbdcdeaf0..6711a8d081d25b0a645877bbf79f72c00e58b77a 100644
+--- a/video/video_stream_encoder.cc
++++ b/video/video_stream_encoder.cc
+@@ -1074,6 +1074,7 @@ void VideoStreamEncoder::ReconfigureEncoder() {
+     // Destroy existing encoder instance before creating a new one. Otherwise
+     // attempt to create another instance will fail if encoder factory
+     // supports only single instance of encoder of given type.
++    ReleaseEncoder();
+     encoder_.reset();
+ 
+     encoder_ = MaybeCreateFrameDumpingEncoderWrapper(
+diff --git a/video/video_stream_encoder_unittest.cc b/video/video_stream_encoder_unittest.cc
+index 154716d0b49b396489071db2a03c097743c08871..11d586e9929d348def67ec676f9d411a2439fd1f 100644
+--- a/video/video_stream_encoder_unittest.cc
++++ b/video/video_stream_encoder_unittest.cc
+@@ -28,6 +28,7 @@
+ #include "api/array_view.h"
+ #include "api/environment/environment.h"
+ #include "api/environment/environment_factory.h"
++#include "api/fec_controller_override.h"
+ #include "api/field_trials.h"
+ #include "api/field_trials_view.h"
+ #include "api/location.h"
+@@ -42,6 +43,7 @@
+ #include "api/test/mock_video_encoder_factory.h"
+ #include "api/test/rtc_error_matchers.h"
+ #include "api/test/time_controller.h"
++#include "api/test/video/function_video_encoder_factory.h"
+ #include "api/units/data_rate.h"
+ #include "api/units/time_delta.h"
+ #include "api/units/timestamp.h"
+@@ -2186,6 +2188,96 @@ TEST_F(VideoStreamEncoderTest,
+   video_stream_encoder_->Stop();
+ }
+ 
++TEST_F(VideoStreamEncoderTest,
++       EncoderReleasedBeforeDestructionOnReconfiguration) {
++  class ReleaseCheckEncoderProxy : public VideoEncoder {
++   public:
++    ReleaseCheckEncoderProxy(VideoEncoder* encoder, bool& released)
++        : encoder_(encoder), released_(released) {}
++    ~ReleaseCheckEncoderProxy() override = default;
++
++    int32_t Encode(const VideoFrame& input_image,
++                   const std::vector<VideoFrameType>* frame_types) override {
++      return encoder_->Encode(input_image, frame_types);
++    }
++
++    int32_t InitEncode(const VideoCodec* config,
++                       const Settings& settings) override {
++      return encoder_->InitEncode(config, settings);
++    }
++
++    int32_t RegisterEncodeCompleteCallback(
++        EncodedImageCallback* callback) override {
++      return encoder_->RegisterEncodeCompleteCallback(callback);
++    }
++
++    int32_t Release() override {
++      released_ = true;
++      return encoder_->Release();
++    }
++
++    void SetRates(const RateControlParameters& parameters) override {
++      encoder_->SetRates(parameters);
++    }
++
++    VideoEncoder::EncoderInfo GetEncoderInfo() const override {
++      return encoder_->GetEncoderInfo();
++    }
++
++    void SetFecControllerOverride(
++        FecControllerOverride* fec_controller_override) override {
++      encoder_->SetFecControllerOverride(fec_controller_override);
++    }
++
++   private:
++    VideoEncoder* const encoder_;
++    bool& released_;
++  };
++
++  bool released[2] = {false, false};
++  int instance_count = 0;
++
++  test::FunctionVideoEncoderFactory factory(
++      [this, &instance_count, &released](const Environment& env,
++                                         const SdpVideoFormat& format) {
++        RTC_CHECK_LT(instance_count, 2);
++        bool& r = released[instance_count++];
++        return std::make_unique<ReleaseCheckEncoderProxy>(&fake_encoder_, r);
++      });
++
++  video_send_config_.encoder_settings.encoder_factory = &factory;
++  ConfigureEncoder(video_encoder_config_.Copy());
++
++  video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
++      kTargetBitrate, kTargetBitrate, 0, 0, 0);
++
++  // Capture a frame and wait for it to synchronize with the encoder thread.
++  video_source_.IncomingCapturedFrame(CreateFrame(1, nullptr));
++  WaitForEncodedFrame(1);
++
++  EXPECT_EQ(instance_count, 1);
++  EXPECT_FALSE(released[0]);
++
++  VideoEncoderConfig video_encoder_config = video_encoder_config_.Copy();
++  // Changing the max payload data length recreates encoder.
++  video_stream_encoder_->ConfigureEncoder(std::move(video_encoder_config),
++                                          kMaxPayloadLength / 2);
++
++  // Capture a frame and wait for it to synchronize with the encoder thread.
++  video_source_.IncomingCapturedFrame(CreateFrame(2, nullptr));
++  WaitForEncodedFrame(2);
++
++  // We expect that two encoders were created.
++  EXPECT_EQ(instance_count, 2);
++  // The first encoder should have been released before destruction.
++  EXPECT_TRUE(released[0]);
++
++  video_stream_encoder_->Stop();
++
++  // The second encoder should also be released after Stop().
++  EXPECT_TRUE(released[1]);
++}
++
+ TEST_F(VideoStreamEncoderTest, BitrateLimitsChangeReconfigureRateAllocator) {
+   video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+       kTargetBitrate, kTargetBitrate, 0, 0, 0);

--- a/patches/webrtc/cherry-pick-458a75ec3e37.patch
+++ b/patches/webrtc/cherry-pick-458a75ec3e37.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Erik=20Spr=C3=A5ng?= <sprang@webrtc.org>
+Date: Tue, 21 Apr 2026 13:50:05 +0200
+Subject: Call Release in SimulcastEncoderAdapter destructor if inited.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This check should be superflous once
+https://webrtc-review.git.corp.google.com/c/src/+/465582 has landed,
+but just to be safe make sure we always call Release() in the destructor
+if it hasn't already been called.
+
+Bug: chromium:504620824
+Change-Id: I70323b1a71fd9830f0d7af62ebeced05dd833d54
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/465600
+Auto-Submit: Erik Språng <sprang@webrtc.org>
+Commit-Queue: Sergey Silkin <ssilkin@webrtc.org>
+Reviewed-by: Sergey Silkin <ssilkin@webrtc.org>
+Commit-Queue: Erik Språng <sprang@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#47496}
+
+diff --git a/media/engine/simulcast_encoder_adapter.cc b/media/engine/simulcast_encoder_adapter.cc
+index c55919c114dade332f4c5cf7fccf58dda614193f..1b8d205124734137e6499f9c988c851ea398862e 100644
+--- a/media/engine/simulcast_encoder_adapter.cc
++++ b/media/engine/simulcast_encoder_adapter.cc
+@@ -326,7 +326,9 @@ SimulcastEncoderAdapter::SimulcastEncoderAdapter(
+ 
+ SimulcastEncoderAdapter::~SimulcastEncoderAdapter() {
+   RTC_DCHECK_RUN_ON(&encoder_queue_checker_);
+-  RTC_DCHECK(!Initialized());
++  if (Initialized()) {
++    Release();
++  }
+   DestroyStoredEncoders();
+ }
+ 
+diff --git a/media/engine/simulcast_encoder_adapter_unittest.cc b/media/engine/simulcast_encoder_adapter_unittest.cc
+index 68c0b820c2d5e9247f751d0d1320f513e8e53fb6..aba2079b3b1e62ee74a6f840783750a505a8f221 100644
+--- a/media/engine/simulcast_encoder_adapter_unittest.cc
++++ b/media/engine/simulcast_encoder_adapter_unittest.cc
+@@ -729,6 +729,18 @@ TEST_F(TestSimulcastEncoderAdapterFake, ReleaseWithoutInitEncode) {
+   EXPECT_EQ(0, adapter_->Release());
+ }
+ 
++TEST_F(TestSimulcastEncoderAdapterFake, DestructorCallsReleaseIfInitialized) {
++  SetupCodec();
++  std::vector<MockVideoEncoder*> encoders = helper_->factory()->encoders();
++  ASSERT_EQ(3u, encoders.size());
++
++  for (auto* encoder : encoders) {
++    EXPECT_CALL(*encoder, ReleaseMock()).WillOnce(testing::Return(0));
++  }
++
++  adapter_.reset();
++}
++
+ TEST_F(TestSimulcastEncoderAdapterFake, Reinit) {
+   SetupCodec();
+   EXPECT_EQ(0, adapter_->Release());


### PR DESCRIPTION
Backports the following changes:

* [`16dcbc3d1476`](https://chromium-review.googlesource.com/c/chromium/src/+/7841115) from chromium — win: Use static to keep track of in progress drags ([503551154](https://crbug.com/503551154), CVE-2026-9110)
* [`12cce13db567`](https://webrtc-review.googlesource.com/c/src/+/468120) from webrtc — [M146] [Pipewire] Fix mouse cursor data race ([504551032](https://crbug.com/504551032), CVE-2026-9111)
* [`7d0b7c526075`](https://chromium-review.googlesource.com/c/chromium/src/+/7706475) from chromium — Add AMSC macro to QuicProxyDatagramClientSocket ([495798630](https://crbug.com/495798630), CVE-2026-9114 — hardening mitigation; see note below)
* [`1cd1e8607c8e`](https://chromium-review.googlesource.com/c/chromium/src/+/7703459) from chromium — Block invalid responses for Static Router cache source ([495999481](https://crbug.com/495999481), CVE-2026-9115)
* [`e2b91876eb01`](https://chromium-review.googlesource.com/c/chromium/src/+/7725522) from chromium — Enforce CORP for Static Router Cache Source ([497436273](https://crbug.com/497436273), CVE-2026-9116)
* [`2cdb07c74d06`](https://chromium-review.googlesource.com/c/chromium/src/+/7838959) from chromium — Enable ServiceWorkerStaticRouterCORPCheck and OpaqueCheck by default ([495999481](https://crbug.com/495999481) / [497436273](https://crbug.com/497436273), CVE-2026-9115 / CVE-2026-9116)
* [`faada322153d`](https://chromium-review.googlesource.com/c/chromium/src/+/7724047) from chromium — [media/gpu] Enforce safe range for NativePixmapPlane construction ([497542537](https://crbug.com/497542537), CVE-2026-9117)
* [`7adec41c4fdc`](https://chromium-review.googlesource.com/c/chromium/src/+/7729684) from chromium — Remove GPU observer in XRRuntimeManager destructor ([498702233](https://crbug.com/498702233), CVE-2026-9118)
* [`21d9744bd599`](https://webrtc-review.googlesource.com/c/src/+/465582) from webrtc — Always release VideoEncoders before destruction ([504620824](https://crbug.com/504620824), CVE-2026-9120)
* [`458a75ec3e37`](https://webrtc-review.googlesource.com/c/src/+/465600) from webrtc — Call Release in SimulcastEncoderAdapter destructor if inited ([504620824](https://crbug.com/504620824), CVE-2026-9120)
* [`86d64be7672e`](https://chromium-review.googlesource.com/c/angle/angle/+/7694532) from angle — Translator: Fix codegen of switch with empty last case ([488064108](https://crbug.com/488064108), CVE-2026-9121)
* [`0323970550b9`](https://chromium-review.googlesource.com/c/angle/angle/+/7699417) from angle — Metal: Fix pitch computation for compressed textures in PBOs ([489579953](https://crbug.com/489579953), CVE-2026-9122)
* [`b885cb0c8e97`](https://chromium-review.googlesource.com/c/chromium/src/+/7711973) from chromium — input: Validate SetMouseCapture requests in the browser process ([496375695](https://crbug.com/496375695), CVE-2026-9124)
* [`d3ea06df9a4c`](https://chromium-review.googlesource.com/c/chromium/src/+/7702091) from chromium — Use index-based for in Element::CloneAttributesFrom ([496280532](https://crbug.com/496280532), CVE-2026-9126)
* [`155b785d0e4f`](https://chromium-review.googlesource.com/c/chromium/src/+/7810037) from chromium — Add stronger (D)CHECK()s around batch setting of attributes ([496280532](https://crbug.com/496280532), CVE-2026-9126)
* [`6aa38f2d02b7`](https://chromium-review.googlesource.com/c/chromium/src/+/7812905) from chromium — Add EventDispatchForbiddenScope for batch attribute notification ([496280532](https://crbug.com/496280532), CVE-2026-9126)
* [`926d3d259750`](https://chromium-review.googlesource.com/c/chromium/src/+/7822939) from chromium — Avoid setting attribute in SliderThumbElement constructor ([496280532](https://crbug.com/496280532), CVE-2026-9126)

Covers the security fixes from the [Chrome 148.0.7778.178 stable release](https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_0841193308.html) that were missing from the 41-x-y tree (Chromium 146.0.7680.216). Already in-tree and therefore not included: CVE-2026-9112, CVE-2026-9113 (ANGLE M146 merges), CVE-2026-9119 (WebRTC M146 merge).

For CVE-2026-9114 (QUIC use-after-free), the cherry-pick is the same hardening mitigation Chrome shipped on stable (`ADVANCED_MEMORY_SAFETY_CHECKS()` on the vulnerable class); the actual fix ([7900197](https://chromium-review.googlesource.com/c/chromium/src/+/7900197)) landed on Chromium main on 2026-06-04 and has not shipped in any Chrome stable channel yet.

Intentionally not backported: `7765503` (CVE-2026-9123) touches only `chromecast/media/`, which Electron does not compile.

Notes: Security: backported fixes for CVE-2026-9110, CVE-2026-9111, CVE-2026-9114, CVE-2026-9115, CVE-2026-9116, CVE-2026-9117, CVE-2026-9118, CVE-2026-9120, CVE-2026-9121, CVE-2026-9122, CVE-2026-9124, CVE-2026-9126.
