### PR TITLE
fix: lazily initialize safeStorage async encryptor

### DIFF
--- a/docs/api/safe-storage.md
+++ b/docs/api/safe-storage.md
@@ -59,7 +59,12 @@ On Windows, returns true once the app has emitted the `ready` event.
 
 ### `safeStorage.isAsyncEncryptionAvailable()`
 
-Returns `Promise<Boolean>` - Whether encryption is available for asynchronous safeStorage operations.
+Returns `Promise<boolean>` - Resolves with whether encryption is available for
+asynchronous safeStorage operations.
+
+The asynchronous encryptor is initialized lazily the first time this method,
+`encryptStringAsync`, or `decryptStringAsync` is called after the app is ready.
+The returned promise resolves once initialization completes.
 
 ### `safeStorage.encryptString(plainText)`
 

--- a/shell/browser/api/electron_api_safe_storage.cc
+++ b/shell/browser/api/electron_api_safe_storage.cc
@@ -54,17 +54,9 @@ gin_helper::Handle<SafeStorage> SafeStorage::Create(v8::Isolate* isolate) {
   return gin_helper::CreateHandle(isolate, new SafeStorage(isolate));
 }
 
-SafeStorage::SafeStorage(v8::Isolate* isolate) {
-  if (electron::Browser::Get()->is_ready()) {
-    OnFinishLaunching({});
-  } else {
-    Browser::Get()->AddObserver(this);
-  }
-}
+SafeStorage::SafeStorage(v8::Isolate* isolate) {}
 
-SafeStorage::~SafeStorage() {
-  Browser::Get()->RemoveObserver(this);
-}
+SafeStorage::~SafeStorage() = default;
 
 gin::ObjectTemplateBuilder SafeStorage::GetObjectTemplateBuilder(
     v8::Isolate* isolate) {
@@ -85,7 +77,11 @@ gin::ObjectTemplateBuilder SafeStorage::GetObjectTemplateBuilder(
       ;
 }
 
-void SafeStorage::OnFinishLaunching(base::DictValue launch_info) {
+void SafeStorage::EnsureAsyncEncryptorRequested() {
+  DCHECK(electron::Browser::Get()->is_ready());
+  if (encryptor_requested_)
+    return;
+  encryptor_requested_ = true;
   g_browser_process->os_crypt_async()->GetInstance(
       base::BindOnce(&SafeStorage::OnOsCryptReady, base::Unretained(this)),
       os_crypt_async::Encryptor::Option::kEncryptSyncCompat);
@@ -95,13 +91,21 @@ void SafeStorage::OnOsCryptReady(os_crypt_async::Encryptor encryptor) {
   encryptor_ = std::move(encryptor);
   is_available_ = true;
 
+  // This callback may fire from a posted task without an active V8 scope.
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  for (auto& pending : pending_availability_checks_) {
+    pending.Resolve(true);
+  }
+  pending_availability_checks_.clear();
+
   for (auto& pending : pending_encrypts_) {
     std::string ciphertext;
     bool encrypted = encryptor_->EncryptString(pending.plaintext, &ciphertext);
     if (encrypted) {
       pending.promise.Resolve(
-          electron::Buffer::Copy(pending.promise.isolate(), ciphertext)
-              .ToLocalChecked());
+          electron::Buffer::Copy(isolate, ciphertext).ToLocalChecked());
     } else {
       pending.promise.RejectWithErrorMessage(
           "Error while encrypting the text provided to "
@@ -117,8 +121,6 @@ void SafeStorage::OnOsCryptReady(os_crypt_async::Encryptor encryptor) {
         encryptor_->DecryptString(pending.ciphertext, &plaintext, &flags);
 
     if (decrypted) {
-      v8::Isolate* isolate = pending.promise.isolate();
-      v8::HandleScope handle_scope(isolate);
       auto dict = gin_helper::Dictionary::CreateEmpty(isolate);
 
       dict.Set("shouldReEncrypt", flags.should_reencrypt);
@@ -155,16 +157,33 @@ bool SafeStorage::IsEncryptionAvailable() {
 #endif
 }
 
-bool SafeStorage::IsAsyncEncryptionAvailable() {
-  if (!electron::Browser::Get()->is_ready())
-    return false;
+v8::Local<v8::Promise> SafeStorage::IsAsyncEncryptionAvailable(
+    v8::Isolate* isolate) {
+  gin_helper::Promise<bool> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  if (!electron::Browser::Get()->is_ready()) {
+    promise.Resolve(false);
+    return handle;
+  }
+
 #if BUILDFLAG(IS_LINUX)
-  return is_available_ || (use_password_v10_ &&
-                           static_cast<BrowserProcessImpl*>(g_browser_process)
-                                   ->linux_storage_backend() == "basic_text");
-#else
-  return is_available_;
+  if (use_password_v10_ && static_cast<BrowserProcessImpl*>(g_browser_process)
+                                   ->linux_storage_backend() == "basic_text") {
+    promise.Resolve(true);
+    return handle;
+  }
 #endif
+
+  EnsureAsyncEncryptorRequested();
+
+  if (is_available_) {
+    promise.Resolve(true);
+    return handle;
+  }
+
+  pending_availability_checks_.push_back(std::move(promise));
+  return handle;
 }
 
 void SafeStorage::SetUsePasswordV10(bool use) {
@@ -270,6 +289,8 @@ v8::Local<v8::Promise> SafeStorage::encryptStringAsync(
     return handle;
   }
 
+  EnsureAsyncEncryptorRequested();
+
   if (is_available_) {
     std::string ciphertext;
     bool encrypted = encryptor_->EncryptString(plaintext, &ciphertext);
@@ -317,6 +338,8 @@ v8::Local<v8::Promise> SafeStorage::decryptStringAsync(
     promise.Resolve(dict);
     return handle;
   }
+
+  EnsureAsyncEncryptorRequested();
 
   if (is_available_) {
     std::string plaintext;

--- a/shell/browser/api/electron_api_safe_storage.h
+++ b/shell/browser/api/electron_api_safe_storage.h
@@ -10,7 +10,6 @@
 
 #include "build/build_config.h"
 #include "components/os_crypt/async/common/encryptor.h"
-#include "shell/browser/browser_observer.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/wrappable.h"
@@ -35,8 +34,7 @@ class Handle;
 
 namespace electron::api {
 
-class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
-                          private BrowserObserver {
+class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage> {
  public:
   static gin_helper::Handle<SafeStorage> Create(v8::Isolate* isolate);
 
@@ -55,14 +53,16 @@ class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
   ~SafeStorage() override;
 
  private:
-  // BrowserObserver:
-  void OnFinishLaunching(base::DictValue launch_info) override;
+  // Lazily request the async encryptor on first use. ESM named imports
+  // eagerly evaluate all electron module getters, so requesting in the
+  // constructor would touch the OS keychain even when safeStorage is unused.
+  void EnsureAsyncEncryptorRequested();
 
   void OnOsCryptReady(os_crypt_async::Encryptor encryptor);
 
   bool IsEncryptionAvailable();
 
-  bool IsAsyncEncryptionAvailable();
+  v8::Local<v8::Promise> IsAsyncEncryptionAvailable(v8::Isolate* isolate);
 
   void SetUsePasswordV10(bool use);
 
@@ -83,6 +83,7 @@ class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
 
   bool use_password_v10_ = false;
 
+  bool encryptor_requested_ = false;
   bool is_available_ = false;
 
   std::optional<os_crypt_async::Encryptor> encryptor_;
@@ -112,6 +113,8 @@ class SafeStorage final : public gin_helper::DeprecatedWrappable<SafeStorage>,
     std::string ciphertext;
   };
   std::vector<PendingDecrypt> pending_decrypts_;
+
+  std::vector<gin_helper::Promise<bool>> pending_availability_checks_;
 };
 
 }  // namespace electron::api

--- a/spec/api-safe-storage-spec.ts
+++ b/spec/api-safe-storage-spec.ts
@@ -81,8 +81,8 @@ describe('safeStorage module', () => {
   });
 
   describe('SafeStorage.isAsyncEncryptionAvailable()', () => {
-    it('should return true when async encryption is available', () => {
-      expect(safeStorage.isAsyncEncryptionAvailable()).to.equal(true);
+    it('should resolve true when async encryption is available', async () => {
+      expect(await safeStorage.isAsyncEncryptionAvailable()).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Backport of #50419

See that PR for details.

Fixes #51759.

On 42-x-y, the `SafeStorage` constructor registers a browser observer that requests the async encryptor on app-ready, and `isAsyncEncryptionAvailable()` synchronously returns `is_available_`. Because the encryptor arrives via an asynchronous keychain round-trip, calling `isAsyncEncryptionAvailable()` shortly after `ready` returns `false`, and any `encryptStringAsync()`/`decryptStringAsync()` call queued before the encryptor arrives crashes the process — `OnOsCryptReady` fires from a posted task without a V8 `HandleScope` and the pending-encrypt path creates handles (`Buffer::Copy`, `Promise::Resolve`).

Verified: the repro from #51759 reproduces the `false` + SIGSEGV on v42.2.0 and passes on v43.0.0-beta.1, which contains this change.

Notes: Fixed `safeStorage.isAsyncEncryptionAvailable()` incorrectly reporting `false` shortly after the app `ready` event, and a crash when calling `safeStorage.encryptStringAsync()` or `safeStorage.decryptStringAsync()` before async encryption initialization completed. `safeStorage.isAsyncEncryptionAvailable()` now returns a Promise as documented.
