### PR TITLE
fix: invalidate sandboxed preload code cache when source changes without changing length

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2308,12 +2308,13 @@ void WebContents::MaybeSendRendererStartupData(
       preload = web_prefs->GetPreloadPath();
     if (preload && preload->IsAbsolute()) {
       auto ps = mojom::PreloadScriptData::New();
-      ps->id = "preload-" + preload->AsUTF8Unsafe();
+      ps->id = preload_code_cache::IdForWebPreferencesPreload(*preload);
       ps->file_path = preload->AsUTF8Unsafe();
       std::string contents;
       if (asar::ReadFileToString(*preload, &contents)) {
         ps->contents.assign(contents.begin(), contents.end());
-        std::vector<uint8_t> cache = preload_code_cache::Get(ps->id);
+        std::vector<uint8_t> cache =
+            preload_code_cache::Get(ps->id, ps->contents);
         if (!cache.empty())
           ps->code_cache = std::move(cache);
       } else {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -763,12 +763,13 @@ ElectronBrowserClient::GetExtraCreateNewWindowReplyData(
       preload = web_prefs->GetPreloadPath();
     if (preload && preload->IsAbsolute()) {
       auto ps = mojom::PreloadScriptData::New();
-      ps->id = "preload-" + preload->AsUTF8Unsafe();
+      ps->id = preload_code_cache::IdForWebPreferencesPreload(*preload);
       ps->file_path = preload->AsUTF8Unsafe();
       std::string contents;
       if (asar::ReadFileToString(*preload, &contents)) {
         ps->contents.assign(contents.begin(), contents.end());
-        std::vector<uint8_t> cache = preload_code_cache::Get(ps->id);
+        std::vector<uint8_t> cache =
+            preload_code_cache::Get(ps->id, ps->contents);
         if (!cache.empty())
           ps->code_cache = std::move(cache);
       } else {

--- a/shell/browser/electron_web_contents_utility_handler_impl.cc
+++ b/shell/browser/electron_web_contents_utility_handler_impl.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/electron_web_contents_utility_handler_impl.h"
 
+#include <algorithm>
+#include <optional>
 #include <utility>
 
 #include "content/public/browser/browser_context.h"
@@ -13,10 +15,42 @@
 #include "content/public/browser/render_process_host.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "shell/browser/preload_code_cache.h"
+#include "shell/browser/session_preferences.h"
 #include "shell/browser/web_contents_permission_helper.h"
+#include "shell/browser/web_contents_preferences.h"
 #include "third_party/blink/public/mojom/permissions/permission_status.mojom.h"
 
 namespace electron {
+
+namespace {
+
+// True if |id| names a preload script served to this frame — a renderer must
+// not be able to write cache entries for preloads it was never given.
+bool IsPreloadIdServedToFrame(content::RenderFrameHost* rfh,
+                              const std::string& id) {
+  if (!rfh)
+    return false;
+  auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+  if (auto* web_prefs = WebContentsPreferences::From(web_contents)) {
+    std::optional<base::FilePath> preload = web_prefs->GetPreloadPath();
+    if (preload &&
+        id == preload_code_cache::IdForWebPreferencesPreload(*preload)) {
+      return true;
+    }
+  }
+  auto* session_prefs =
+      SessionPreferences::FromBrowserContext(rfh->GetBrowserContext());
+  if (!session_prefs)
+    return false;
+  const auto& scripts = session_prefs->preload_scripts();
+  return std::ranges::any_of(scripts, [&id](const PreloadScript& script) {
+    return script.id == id &&
+           script.script_type == PreloadScript::ScriptType::kWebFrame;
+  });
+}
+
+}  // namespace
+
 ElectronWebContentsUtilityHandlerImpl::ElectronWebContentsUtilityHandlerImpl(
     content::RenderFrameHost* frame_host,
     mojo::PendingAssociatedReceiver<mojom::ElectronWebContentsUtility> receiver)
@@ -62,13 +96,16 @@ void ElectronWebContentsUtilityHandlerImpl::SetTemporaryZoomLevel(
 
 void ElectronWebContentsUtilityHandlerImpl::SetPreloadCodeCache(
     const std::string& id,
+    const std::vector<uint8_t>& source_hash,
     mojo_base::BigBuffer cache) {
   // Persist the freshly produced V8 code cache so subsequent navigations and
   // launches compile this preload from bytecode instead of re-parsing source.
-  // Renderer-supplied data: V8 validates the blob against the source + V8
-  // version + flags at consume time, so a malformed or stale blob just costs
-  // one rejected compile and is then overwritten.
-  preload_code_cache::Set(id, base::span<const uint8_t>(cache));
+  // |source_hash| must come from the renderer — only it knows which source
+  // the blob was compiled from; hashing the file here would race a
+  // concurrent preload change and pin a stale blob under the new hash.
+  if (!IsPreloadIdServedToFrame(GetRenderFrameHost(), id))
+    return;
+  preload_code_cache::Set(id, source_hash, base::span<const uint8_t>(cache));
 }
 
 void ElectronWebContentsUtilityHandlerImpl::CanAccessClipboardDeprecated(

--- a/shell/browser/electron_web_contents_utility_handler_impl.h
+++ b/shell/browser/electron_web_contents_utility_handler_impl.h
@@ -45,6 +45,7 @@ class ElectronWebContentsUtilityHandlerImpl
       const blink::LocalFrameToken& frame_token,
       CanAccessClipboardDeprecatedCallback callback) override;
   void SetPreloadCodeCache(const std::string& id,
+                           const std::vector<uint8_t>& source_hash,
                            mojo_base::BigBuffer cache) override;
 
   base::WeakPtr<ElectronWebContentsUtilityHandlerImpl> GetWeakPtr() {

--- a/shell/browser/preload_code_cache.cc
+++ b/shell/browser/preload_code_cache.cc
@@ -4,9 +4,13 @@
 
 #include "shell/browser/preload_code_cache.h"
 
+#include <algorithm>
+#include <array>
+#include <optional>
 #include <utility>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/span.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
@@ -22,12 +26,21 @@ namespace electron::preload_code_cache {
 
 namespace {
 
+// Disk format: kMagic + sha256(source) + blob. Pre-hash-format files fail
+// the magic check and read as a miss.
+constexpr std::array<uint8_t, 4> kMagic{'E', 'P', 'C', '1'};
+
+struct Entry {
+  std::array<uint8_t, crypto::hash::kSha256Size> source_hash;
+  std::vector<uint8_t> blob;
+};
+
 // In-memory tier. The optional<> memoizes a disk miss so it isn't re-tried
 // per navigation. UI-thread only: both Get() (from the navigation push paths)
 // and Set() (from the ElectronWebContentsUtility associated receiver on the
 // RenderFrameHost) are dispatched on the UI thread, so the map needs no lock
 // and concurrent SetPreloadCodeCache messages can't race it.
-using Cache = base::flat_map<std::string, std::optional<std::vector<uint8_t>>>;
+using Cache = base::flat_map<std::string, std::optional<Entry>>;
 Cache& GetMemoryCache() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   static base::NoDestructor<Cache> cache;
@@ -45,36 +58,57 @@ base::FilePath PathForId(const std::string& id) {
       .AppendASCII(digest + ".cache");
 }
 
-void WriteToDisk(const base::FilePath& path, std::vector<uint8_t> blob) {
+std::optional<Entry> ParseDiskEntry(const std::string& file_contents) {
+  base::span<const uint8_t> bytes = base::as_byte_span(file_contents);
+  if (bytes.size() <= kMagic.size() + crypto::hash::kSha256Size)
+    return std::nullopt;
+  if (bytes.first<kMagic.size()>() != base::span(kMagic))
+    return std::nullopt;
+  Entry entry;
+  base::span<const uint8_t> rest = bytes.subspan(kMagic.size());
+  std::ranges::copy(rest.first<crypto::hash::kSha256Size>(),
+                    entry.source_hash.begin());
+  base::span<const uint8_t> blob = rest.subspan(crypto::hash::kSha256Size);
+  entry.blob.assign(blob.begin(), blob.end());
+  return entry;
+}
+
+void WriteToDisk(const base::FilePath& path, std::vector<uint8_t> payload) {
   if (path.empty())
     return;
   base::CreateDirectory(path.DirName());
-  base::WriteFile(path, blob);
+  base::WriteFile(path, payload);
 }
 
 }  // namespace
 
-std::vector<uint8_t> Get(const std::string& id) {
-  auto& cache = GetMemoryCache();
-  auto it = cache.find(id);
-  if (it != cache.end())
-    return it->second.value_or(std::vector<uint8_t>());
-
-  // Cold lookup: read disk once and memoize (including misses).
-  std::optional<std::vector<uint8_t>> entry;
-  std::string contents;
-  base::FilePath path = PathForId(id);
-  if (!path.empty() && base::ReadFileToString(path, &contents) &&
-      !contents.empty()) {
-    entry = std::vector<uint8_t>(contents.begin(), contents.end());
-  }
-  std::vector<uint8_t> result = entry.value_or(std::vector<uint8_t>());
-  cache.insert_or_assign(id, std::move(entry));
-  return result;
+std::string IdForWebPreferencesPreload(const base::FilePath& path) {
+  return "preload-" + path.AsUTF8Unsafe();
 }
 
-void Set(const std::string& id, base::span<const uint8_t> blob) {
-  if (blob.empty())
+std::vector<uint8_t> Get(const std::string& id,
+                         base::span<const uint8_t> contents) {
+  auto& cache = GetMemoryCache();
+  auto it = cache.find(id);
+  if (it == cache.end()) {
+    // Cold lookup: read disk once and memoize (including misses).
+    std::optional<Entry> entry;
+    std::string file_contents;
+    base::FilePath path = PathForId(id);
+    if (!path.empty() && base::ReadFileToString(path, &file_contents))
+      entry = ParseDiskEntry(file_contents);
+    it = cache.insert_or_assign(it, id, std::move(entry));
+  }
+  const std::optional<Entry>& entry = it->second;
+  if (!entry || entry->source_hash != crypto::hash::Sha256(contents))
+    return {};
+  return entry->blob;
+}
+
+void Set(const std::string& id,
+         base::span<const uint8_t> source_hash,
+         base::span<const uint8_t> blob) {
+  if (blob.empty() || source_hash.size() != crypto::hash::kSha256Size)
     return;
   // No first-writer-wins guard: Set() must always overwrite. Get() memoizes
   // whatever is on disk *including a corrupt blob* (only V8 in the renderer
@@ -84,8 +118,17 @@ void Set(const std::string& id, base::span<const uint8_t> blob) {
   // duplicate-ship case (two renderers, same preload, first launch) just
   // writes identical bytes twice; harmless and rare, and Set() is UI-thread
   // serialized so it's not a data race.
-  std::vector<uint8_t> data(blob.begin(), blob.end());
-  GetMemoryCache().insert_or_assign(id, data);
+  Entry entry;
+  std::ranges::copy(source_hash, entry.source_hash.begin());
+  entry.blob.assign(blob.begin(), blob.end());
+
+  std::vector<uint8_t> payload;
+  payload.reserve(kMagic.size() + source_hash.size() + blob.size());
+  payload.insert(payload.end(), kMagic.begin(), kMagic.end());
+  payload.insert(payload.end(), source_hash.begin(), source_hash.end());
+  payload.insert(payload.end(), blob.begin(), blob.end());
+
+  GetMemoryCache().insert_or_assign(id, std::move(entry));
   // Fire-and-forget; a lost write just costs one cold compile next launch.
   // SKIP_ON_SHUTDOWN so an in-flight write finishes (no torn cache file)
   // rather than being abandoned mid-write during teardown.
@@ -93,7 +136,7 @@ void Set(const std::string& id, base::span<const uint8_t> blob) {
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
        base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&WriteToDisk, PathForId(id), std::move(data)));
+      base::BindOnce(&WriteToDisk, PathForId(id), std::move(payload)));
 }
 
 }  // namespace electron::preload_code_cache

--- a/shell/browser/preload_code_cache.h
+++ b/shell/browser/preload_code_cache.h
@@ -10,25 +10,33 @@
 
 #include "base/containers/span.h"
 
+namespace base {
+class FilePath;
+}
+
 namespace electron::preload_code_cache {
 
-// Returns the V8 code cache blob for the preload with the given |id|, or
-// empty if no cache exists. Checks an in-memory tier first, then disk
-// (userData/Code Cache/electron-preload/). Disk I/O is synchronous (call
-// behind a ScopedAllowBlocking) and happens at most once per id per session
-// — once read from (or absent on) disk, the result is cached in memory.
-//
-// Stale or corrupt blobs are not detected here. V8's CachedData validation
-// rejects blobs from a different V8 version, flag set, or source — the
-// renderer falls back to a normal compile and ships a fresh blob, which
-// overwrites the stale one.
-std::vector<uint8_t> Get(const std::string& id);
+// Cache id for a webPreferences.preload script (stable across launches).
+std::string IdForWebPreferencesPreload(const base::FilePath& path);
 
-// Stores a V8 code cache blob for the preload with the given |id|. The
-// in-memory tier is written immediately; the disk write is posted to the
-// thread pool (fire-and-forget — a lost write just means the next launch
-// pays one cold compile).
-void Set(const std::string& id, base::span<const uint8_t> blob);
+// Returns the V8 code cache blob recorded for |id| and these exact
+// |contents|, or empty. Checks an in-memory tier first, then disk
+// (userData/Code Cache/electron-preload/). Disk I/O is synchronous (call
+// behind a ScopedAllowBlocking) and happens at most once per id per session.
+//
+// Entries are bound to sha256(contents): V8's own CachedData source check
+// hashes only the source *length*, so without this a same-length source
+// change would execute stale bytecode. V8 still validates version/flags at
+// consume time.
+std::vector<uint8_t> Get(const std::string& id,
+                         base::span<const uint8_t> contents);
+
+// Stores a blob compiled from source whose sha256 is |source_hash| (32
+// bytes; other sizes are ignored). The in-memory tier is written
+// immediately; the disk write is fire-and-forget on the thread pool.
+void Set(const std::string& id,
+         base::span<const uint8_t> source_hash,
+         base::span<const uint8_t> blob);
 
 }  // namespace electron::preload_code_cache
 

--- a/shell/browser/renderer_startup_data.cc
+++ b/shell/browser/renderer_startup_data.cc
@@ -66,8 +66,8 @@ mojom::RendererStartupDataPtr Build(content::BrowserContext* browser_context,
       std::string contents;
       if (asar::ReadFileToString(script.file_path, &contents)) {
         ps->contents.assign(contents.begin(), contents.end());
-        // V8 validates the blob against source/version; no need to here.
-        std::vector<uint8_t> cache = preload_code_cache::Get(script.id);
+        std::vector<uint8_t> cache =
+            preload_code_cache::Get(script.id, ps->contents);
         if (!cache.empty())
           ps->code_cache = std::move(cache);
       } else {

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -17,8 +17,8 @@ struct PreloadScriptData {
   // Set if the file could not be read; surfaced via the 'preload-error' event.
   string? error;
   // V8 code cache, produced by the first renderer to compile this preload and
-  // persisted under userData/Code Cache/electron-preload/. V8's CachedData
-  // validation self-heals stale blobs.
+  // persisted under userData/Code Cache/electron-preload/. Only shipped when
+  // its recorded source hash matches |contents|.
   array<uint8>? code_cache;
 };
 

--- a/shell/common/web_contents_utility.mojom
+++ b/shell/common/web_contents_utility.mojom
@@ -21,9 +21,12 @@ interface ElectronWebContentsUtility {
       PermissionName name,
       blink.mojom.LocalFrameToken frame_token) => (blink.mojom.PermissionStatus status);
 
-  // Reports a V8 code cache produced by compiling a preload script. The
-  // browser persists it (in memory and on disk) keyed by sha256(id) so
-  // subsequent navigations / launches can compile this preload from bytecode
-  // instead of source. Sent off the FCP critical path, after the preload runs.
-  SetPreloadCodeCache(string id, mojo_base.mojom.BigBuffer cache);
+  // Reports a V8 code cache produced by compiling a preload script, plus the
+  // sha256 of the source that was compiled. The browser persists both and
+  // only ships the blob while the preload's contents still match (V8's own
+  // CachedData source check is length-only, so it cannot reject a
+  // same-length source change). Sent off the FCP critical path, after the
+  // preload runs.
+  SetPreloadCodeCache(string id, array<uint8, 32> source_hash,
+                      mojo_base.mojom.BigBuffer cache);
 };

--- a/shell/renderer/preload_utils.cc
+++ b/shell/renderer/preload_utils.cc
@@ -4,9 +4,11 @@
 
 #include "shell/renderer/preload_utils.h"
 
+#include <array>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "base/containers/span.h"
 #include "base/no_destructor.h"
@@ -15,6 +17,7 @@
 #include "base/strings/strcat.h"
 #include "chrome/common/chrome_version.h"
 #include "content/public/renderer/render_frame.h"
+#include "crypto/hash.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/electron_version.h"
 #include "mojo/public/cpp/base/big_buffer.h"
@@ -175,10 +178,15 @@ v8::Local<v8::Value> CreatePreloadScript(
     if (produced && produced->length > 0) {
       mojo::AssociatedRemote<mojom::ElectronWebContentsUtility> remote;
       render_frame->GetRemoteAssociatedInterfaces()->GetInterface(&remote);
+      // Hash of the exact source compiled — the browser only serves the
+      // blob back for matching contents.
+      std::array<uint8_t, crypto::hash::kSha256Size> source_hash =
+          crypto::hash::Sha256(contents);
       // SAFETY: produced->data points to produced->length contiguous bytes
       // owned by the CachedData.
       remote->SetPreloadCodeCache(
           script_id,
+          std::vector<uint8_t>(source_hash.begin(), source_hash.end()),
           mojo_base::BigBuffer(UNSAFE_BUFFERS(base::span(
               produced->data, base::checked_cast<size_t>(produced->length)))));
     }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4122,6 +4122,30 @@ describe('BrowserWindow module', () => {
         await waitFor(() => fs.statSync(cacheFile).size > 100, 'cache file to be overwritten');
         expect(fs.statSync(cacheFile).size).to.be.greaterThan(100);
       });
+
+      it('does not consume a cache produced from different source of the same length', async () => {
+        // V8's CachedData source check hashes only the source length, so the
+        // browser must invalidate by content.
+        const preloadSource = (marker: string) =>
+          `require('electron').ipcRenderer.send('preload-code-cache-marker', '${marker}');\n`;
+
+        fs.writeFileSync(preload, preloadSource('first-'));
+        const w1 = makeWindow();
+        const marker1 = once(ipcMain, 'preload-code-cache-marker');
+        await w1.loadFile(path.join(fixtures, 'api', 'blank.html'));
+        expect((await marker1)[1]).to.equal('first-');
+        await waitFor(() => fs.existsSync(cacheFile) && fs.statSync(cacheFile).size > 0, cacheFile);
+        w1.destroy();
+
+        const second = preloadSource('second');
+        expect(second.length).to.equal(preloadSource('first-').length);
+        fs.writeFileSync(preload, second);
+
+        const w2 = makeWindow();
+        const marker2 = once(ipcMain, 'preload-code-cache-marker');
+        await w2.loadFile(path.join(fixtures, 'api', 'blank.html'));
+        expect((await marker2)[1]).to.equal('second');
+      });
     });
 
     describe('window.open() popup preload', () => {


### PR DESCRIPTION
## Description

The sandboxed preload code cache (#51602) relied on V8's `CachedData` validation to reject stale blobs, but V8's source check hashes only the source *length*. Updating a preload without changing its byte length made renderers silently run the old version's bytecode.

Cache entries are now bound to the sha256 of the preload source: the renderer ships the hash of what it compiled with the produced blob, and the browser only serves a blob whose recorded hash matches the contents it just read. The browser also rejects cache writes for preload ids not served to the sending frame. Old-format cache files read as a miss and self-heal.

## Checklist

- [x] PR description included
- [x] `npm test` passes (preload code cache suite)
- [x] tests are added/updated

## Release Notes

Notes: Fixed sandboxed preload scripts running a stale cached version after the script was modified without its file size changing.
