### PR TITLE
test: use strict mode for TS smoke tests and improve typings

### DIFF
--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -31,7 +31,7 @@ import * as path from 'node:path';
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
-let mainWindow: Electron.BrowserWindow = null;
+let mainWindow: Electron.BrowserWindow | null = null;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
@@ -125,7 +125,7 @@ app.whenReady().then(() => {
   mainWindow.loadURL('https://github.com');
 
   mainWindow.webContents.on('did-finish-load', function () {
-    mainWindow.webContents.savePage('/tmp/test.html', 'HTMLComplete').then(() => {
+    mainWindow?.webContents.savePage('/tmp/test.html', 'HTMLComplete').then(() => {
       console.log('Page saved successfully');
     });
   });
@@ -140,10 +140,10 @@ app.whenReady().then(() => {
     console.log('Debugger detached due to : ', reason);
   });
 
-  mainWindow.webContents.debugger.on('message', function (event, method, params: any) {
+  mainWindow.webContents.debugger.on('message', function (event, method, params) {
     if (method === 'Network.requestWillBeSent') {
       if (params.request.url === 'https://www.github.com') {
-        mainWindow.webContents.debugger.detach();
+        mainWindow?.webContents.debugger.detach();
       }
     }
   });
@@ -160,7 +160,7 @@ app.whenReady().then(() => {
 app.commandLine.appendSwitch('enable-web-bluetooth');
 
 app.whenReady().then(() => {
-  mainWindow.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
+  mainWindow?.webContents.on('select-bluetooth-device', (event, deviceList, callback) => {
     event.preventDefault();
 
     const result = (() => {
@@ -188,21 +188,18 @@ app.getLocale();
 app.addRecentDocument('/Users/USERNAME/Desktop/work.type');
 app.clearRecentDocuments();
 const dockMenu = Menu.buildFromTemplate([
-  <Electron.MenuItemConstructorOptions>{
+  {
     label: 'New Window',
     click: () => {
       console.log('New Window');
     }
   },
-  <Electron.MenuItemConstructorOptions>{
+  {
     label: 'New Window with Settings',
-    submenu: [
-      <Electron.MenuItemConstructorOptions>{ label: 'Basic' },
-      <Electron.MenuItemConstructorOptions>{ label: 'Pro' }
-    ]
+    submenu: [{ label: 'Basic' }, { label: 'Pro' }]
   },
-  <Electron.MenuItemConstructorOptions>{ label: 'New Command...' },
-  <Electron.MenuItemConstructorOptions>{
+  { label: 'New Command...' },
+  {
     label: 'Edit',
     submenu: [
       {
@@ -240,13 +237,13 @@ const dockMenu = Menu.buildFromTemplate([
 app.dock?.setMenu(dockMenu);
 app.dock?.setBadge('foo');
 const dockid = app.dock?.bounce('informational');
-app.dock?.cancelBounce(dockid);
+if (dockid) app.dock?.cancelBounce(dockid);
 app.dock?.setIcon('/path/to/icon.png');
 
 app.setBadgeCount(app.getBadgeCount() + 1);
 
 app.setUserTasks([
-  <Electron.Task>{
+  {
     program: process.execPath,
     arguments: '--new-window',
     iconPath: process.execPath,
@@ -341,7 +338,7 @@ app.whenReady().then(() => {
 });
 app.on('accessibility-support-changed', (_, enabled) => console.log('accessibility: ' + enabled));
 
-ipcMain.on('online-status-changed', (event, status: any) => {
+ipcMain.on('online-status-changed', (event, status: string) => {
   console.log(status);
 });
 
@@ -483,7 +480,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDa
 // BrowserWindow
 // https://github.com/electron/electron/blob/main/docs/api/browser-window.md
 
-let win3 = new BrowserWindow({ width: 800, height: 600, show: false });
+let win3: BrowserWindow | null = new BrowserWindow({ width: 800, height: 600, show: false });
 win3.on('closed', () => {
   win3 = null;
 });
@@ -491,8 +488,8 @@ win3.on('closed', () => {
 win3.loadURL('https://github.com');
 win3.show();
 
-const toolbarRect = document.getElementById('toolbar').getBoundingClientRect();
-win3.setSheetOffset(toolbarRect.height);
+const toolbarRect = document.getElementById('toolbar')?.getBoundingClientRect();
+if (toolbarRect) win3.setSheetOffset(toolbarRect.height);
 
 let window = new BrowserWindow();
 window.setProgressBar(0.5);
@@ -596,17 +593,17 @@ globalShortcut.unregisterAll();
 // ipcMain
 // https://github.com/electron/electron/blob/main/docs/api/ipc-main.md
 
-ipcMain.handle('ping-pong', (event, arg: any) => {
+ipcMain.handle('ping-pong', (event, arg: string) => {
   console.log(arg); // prints "ping"
   return 'pong';
 });
 
-ipcMain.on('asynchronous-message', (event, arg: any) => {
+ipcMain.on('asynchronous-message', (event, arg: string) => {
   console.log(arg); // prints "ping"
   event.sender.send('asynchronous-reply', 'pong');
 });
 
-ipcMain.on('synchronous-message', (event, arg: any) => {
+ipcMain.on('synchronous-message', (event, arg: string) => {
   console.log(arg); // prints "ping"
   event.returnValue = 'pong';
 });
@@ -652,7 +649,7 @@ const pos = screen.getCursorScreenPoint();
 menu.popup({ x: pos.x, y: pos.y });
 
 // main.js
-const template = <Electron.MenuItemConstructorOptions[]>[
+const template: Electron.MenuItemConstructorOptions[] = [
   {
     label: 'Electron',
     submenu: [
@@ -679,7 +676,7 @@ const template = <Electron.MenuItemConstructorOptions[]>[
       {
         label: 'Hide Others',
         accelerator: 'Command+Shift+H',
-        role: 'hideothers'
+        role: 'hideOthers'
       },
       {
         label: 'Show All',
@@ -731,7 +728,7 @@ const template = <Electron.MenuItemConstructorOptions[]>[
       {
         label: 'Select All',
         accelerator: 'Command+A',
-        role: 'selectall'
+        role: 'selectAll'
       }
     ]
   },
@@ -994,7 +991,7 @@ app.whenReady().then(() => {
 // tray
 // https://github.com/electron/electron/blob/main/docs/api/tray.md
 
-let appIcon: Electron.Tray = null;
+let appIcon: Electron.Tray | null = null;
 app.whenReady().then(() => {
   appIcon = new Tray('/path/to/my/icon');
   const contextMenu = Menu.buildFromTemplate([
@@ -1121,7 +1118,7 @@ app.whenReady().then(() => {
 
 app.whenReady().then(() => {
   const displays = screen.getAllDisplays();
-  let externalDisplay: any = null;
+  let externalDisplay: Electron.Display | null = null;
   for (const i in displays) {
     if (displays[i].bounds.x > 0 || displays[i].bounds.y > 0) {
       externalDisplay = displays[i];
@@ -1301,7 +1298,7 @@ const filter = {
   urls: ['https://*.github.com/*', '*://electron.github.io']
 };
 
-session.defaultSession.webRequest.onBeforeSendHeaders(filter, function (details: any, callback: any) {
+session.defaultSession.webRequest.onBeforeSendHeaders(filter, function (details, callback) {
   details.requestHeaders['User-Agent'] = 'MyAgent';
   callback({ cancel: false, requestHeaders: details.requestHeaders });
 });
@@ -1366,4 +1363,4 @@ const touchBar = new TouchBar({
   items: [new TouchBar.TouchBarButton({ label: '' }), new TouchBar.TouchBarLabel({ label: '' })]
 });
 
-mainWindow.setTouchBar(touchBar);
+win4.setTouchBar(touchBar);

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -19,7 +19,7 @@ ipcRenderer.addListener('test', () => {});
 ipcRenderer.removeListener('test', () => {});
 ipcRenderer.removeAllListeners('test');
 
-ipcRenderer.on('asynchronous-reply', (event, arg: any) => {
+ipcRenderer.on('asynchronous-reply', (event, arg: string) => {
   console.log(arg); // prints "pong"
   event.sender.send('another-message', 'Hello World!');
 });
@@ -119,7 +119,7 @@ function getSources(options: Electron.SourcesOptions) {
 }
 
 function gotStream(stream: any) {
-  (document.querySelector('video') as HTMLVideoElement).src = URL.createObjectURL(stream);
+  document.querySelector('video')!.src = URL.createObjectURL(stream);
 }
 
 function getUserMediaError(error: Error) {

--- a/spec/ts-smoke/tsconfig.json
+++ b/spec/ts-smoke/tsconfig.json
@@ -6,9 +6,7 @@
           "dom"
       ],
       "typeRoots" : ["../../node_modules/@types"],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictNullChecks": false,
+      "strict": true,
       "noEmit": true,
       "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This fell out of looking into a smoke test false negative from #50659. We had `strictNullChecks` off when really we should be using strict mode overall to ensure we're really testing the typings accurately and not getting false negatives.

Fixed the handling of possible null values that came out of turning on strict mode and also cleaned up some other typings while I was in there. We had some explicit type assertions that were hiding some issues like the casing of `hideOthers` and `selectAll`. Removed as many explicit `any` types as I could, since that defeats the point of these smoke tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
