### PR TITLE
chore: cherry-pick 9 changes from chromium, v8

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -154,3 +154,11 @@ build_disable_llvm_unroll-add-parallel-reductions_on_apple_targets.patch
 feat_carry_embedder_startup_data_in_createnewwindowreply.patch
 feat_deliver_service_worker_preload_data_via_embeddedworkerstartparams.patch
 cherry-pick-2cdb07c74d06.patch
+cherry-pick-3f6678d31736.patch
+cherry-pick-409ec3ebc79c.patch
+cherry-pick-cd7201c2fce0.patch
+cherry-pick-c92de87bddf2.patch
+cherry-pick-db94c2cb8239.patch
+cherry-pick-b534033a6391.patch
+cherry-pick-36f6889ed145.patch
+cherry-pick-f9e6631b2ded.patch

--- a/patches/chromium/cherry-pick-36f6889ed145.patch
+++ b/patches/chromium/cherry-pick-36f6889ed145.patch
@@ -1,0 +1,228 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nidhi Jaju <nidhijaju@chromium.org>
+Date: Wed, 3 Jun 2026 02:36:11 -0700
+Subject: [M148] Fix context lifetime in ProxyResolverV8 callbacks
+
+Original change's description:
+> Fix context lifetime in ProxyResolverV8 callbacks
+>
+> Safeguard JS callback functions (like alert and dnsResolve) in the PAC
+> execution context. We now indirect the execution context pointer through
+> a GC-managed wrapper and add null checks for active bindings, ensuring
+> callbacks return safely if the context is no longer active.
+>
+> Bug: 518006379
+> Change-Id: Id0932b292b2ae1e09e6bccd8be07f613f64cfca0
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885520
+> Reviewed-by: Adam Rice <ricea@chromium.org>
+> Commit-Queue: Nidhi Jaju <nidhijaju@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640118}
+
+(cherry picked from commit 399cb31703ea6c6ce6456db6f450599dc0ae713f)
+
+Bug: 519444614,518006379
+Change-Id: Id0932b292b2ae1e09e6bccd8be07f613f64cfca0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7896940
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4218}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/services/proxy_resolver/proxy_resolver_v8.cc b/services/proxy_resolver/proxy_resolver_v8.cc
+index cd259358aaa49441d7471f2ab611ffb847c40068..51f00f060b61e76261abf74147ccee042188e601 100644
+--- a/services/proxy_resolver/proxy_resolver_v8.cc
++++ b/services/proxy_resolver/proxy_resolver_v8.cc
+@@ -453,7 +453,24 @@ class ProxyResolverV8::Context {
+           v8::ContextDependants::kNoDependants);
+     }
+ 
+-    v8_this_.Reset();
++    // ContextDisposedNotification only prunes dirty FinalizationRegistries; it
++    // does not cancel queued ResolveAsyncWaiterPromisesTask foreground tasks
++    // or flush the isolate's shared default MicrotaskQueue, both of which can
++    // still strongly root this v8::Context (and the v8::Functions whose
++    // v8::External data points at the holder). Neutralize the indirection while
++    // holding the v8::Locker so any later callback observes a null Context*
++    // instead of a dangling one.
++    if (holder_) {
++      holder_->context = nullptr;
++      if (!holder_->v8_this.IsEmpty()) {
++        // The v8::External is still alive, so release it. The V8 weak callback
++        // will delete it when the v8::External is garbage collected. If
++        // `v8_this` is empty, the v8::External was already garbage collected,
++        // so we can delete the holder.
++        holder_.release();
++      }
++    }
++
+     v8_context_.Reset();
+   }
+ 
+@@ -523,11 +540,13 @@ class ProxyResolverV8::Context {
+     v8::Isolate::Scope isolate_scope(isolate_);
+     v8::HandleScope scope(isolate_);
+ 
+-    v8_this_.Reset(
+-        isolate_,
+-        v8::External::New(isolate_, this, gin::kProxyResolverV8ContextTag));
+-    v8::Local<v8::External> v8_this =
+-        v8::Local<v8::External>::New(isolate_, v8_this_);
++    holder_ = std::make_unique<ContextHolder>();
++    holder_->context = this;
++    v8::Local<v8::External> v8_holder = v8::External::New(
++        isolate_, holder_.get(), gin::kProxyResolverV8ContextTag);
++    holder_->v8_this.Reset(isolate_, v8_holder);
++    holder_->v8_this.SetWeak(holder_.get(), OnExternalGC,
++                             v8::WeakCallbackType::kParameter);
+ 
+     v8_context_.Reset(isolate_, v8::Context::New(isolate_));
+ 
+@@ -539,25 +558,25 @@ class ProxyResolverV8::Context {
+     // Attach the javascript bindings.
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "alert"),
+-              v8::Function::New(context, &AlertCallback, v8_this, 0,
++              v8::Function::New(context, &AlertCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddress"),
+-              v8::Function::New(context, &MyIpAddressCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolve"),
+-              v8::Function::New(context, &DnsResolveCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isPlainHostName"),
+-              v8::Function::New(context, &IsPlainHostNameCallback, v8_this, 0,
++              v8::Function::New(context, &IsPlainHostNameCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -565,26 +584,26 @@ class ProxyResolverV8::Context {
+     // Microsoft's PAC extensions:
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolveEx"),
+-              v8::Function::New(context, &DnsResolveExCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddressEx"),
+-              v8::Function::New(context, &MyIpAddressExCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+ 
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "sortIpAddressList"),
+-              v8::Function::New(context, &SortIpAddressListCallback, v8_this, 0,
+-                                v8::ConstructorBehavior::kThrow)
++              v8::Function::New(context, &SortIpAddressListCallback, v8_holder,
++                                0, v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isInNetEx"),
+-              v8::Function::New(context, &IsInNetExCallback, v8_this, 0,
++              v8::Function::New(context, &IsInNetExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -693,9 +712,10 @@ class ProxyResolverV8::Context {
+ 
+   // V8 callback for when "alert()" is invoked by the PAC script.
+   static void AlertCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      return;
++    }
+ 
+     // Like firefox we assume "undefined" if no argument was specified, and
+     // disregard any arguments beyond the first.
+@@ -742,9 +762,26 @@ class ProxyResolverV8::Context {
+   static void DnsResolveCallbackHelper(
+       const v8::FunctionCallbackInfo<v8::Value>& args,
+       net::ProxyResolveDnsOperation op) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      // Each function handles resolution errors differently.
++      switch (op) {
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE:
++          args.GetReturnValue().SetNull();
++          return;
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS:
++          args.GetReturnValue().Set(
++              ASCIILiteralToV8String(args.GetIsolate(), "127.0.0.1"));
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++      }
++      NOTREACHED();
++    }
+ 
+     std::string hostname;
+ 
+@@ -860,10 +897,40 @@ class ProxyResolverV8::Context {
+     args.GetReturnValue().Set(IsPlainHostName(hostname_utf8));
+   }
+ 
++  // Indirection for the v8::External bound to the JS callback v8::Functions.
++  // The v8::External's value is immutable and the v8::Functions can outlive
++  // |this| (e.g. via Atomics.waitAsync reactions queued in the shared isolate
++  // MicrotaskQueue), so callbacks must go through a holder that ~Context()
++  // nulls under the v8::Locker. The holder is managed via a V8 weak persistent
++  // handle and is deleted in OnExternalGC once V8 has garbage-collected it.
++  struct ContextHolder {
++    // Nulled in ~Context(), so the raw_ptr never dangles.
++    raw_ptr<Context> context = nullptr;
++
++    // This is actually a weak persistent.
++    v8::Persistent<v8::External> v8_this;
++  };
++
++  static Context* ContextFromArgs(
++      const v8::FunctionCallbackInfo<v8::Value>& args) {
++    auto* holder = static_cast<ContextHolder*>(
++        v8::External::Cast(*args.Data())
++            ->Value(gin::kProxyResolverV8ContextTag));
++    return holder ? holder->context : nullptr;
++  }
++
++  static void OnExternalGC(const v8::WeakCallbackInfo<ContextHolder>& data) {
++    ContextHolder* holder = data.GetParameter();
++    holder->v8_this.Reset();
++    if (!holder->context) {
++      delete holder;
++    }
++  }
++
+   mutable base::Lock lock_;
+   raw_ptr<ProxyResolverV8::JSBindings> js_bindings_ = nullptr;
+   raw_ptr<v8::Isolate> isolate_;
+-  v8::Persistent<v8::External> v8_this_;
++  std::unique_ptr<ContextHolder> holder_;
+   v8::Persistent<v8::Context> v8_context_;
+ };
+ 

--- a/patches/chromium/cherry-pick-3f6678d31736.patch
+++ b/patches/chromium/cherry-pick-3f6678d31736.patch
@@ -1,0 +1,148 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Max Ihlenfeldt <max@igalia.com>
+Date: Wed, 3 Jun 2026 03:07:29 -0700
+Subject: [M148] wayland: Fix UAF/dangling ptr in
+ ReleasePressedPointerButtons()
+
+Original change's description:
+> wayland: Fix UAF/dangling ptr in ReleasePressedPointerButtons()
+>
+> Dispatching the event may destroy the window, and if we release multiple
+> buttons we use a freed/dangling pointer. Fix this by using a weak
+> pointer.
+>
+> Fixed: 516501794
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7880226
+> Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+> Commit-Queue: Max Ihlenfeldt <max@igalia.com>
+> Cr-Commit-Position: refs/heads/main@{#1639248}
+
+(cherry picked from commit edce928690cb0bbca49e411fc88b8293dcd9dc8a)
+
+Bug: 516501794
+Fixed: 519050940
+Change-Id: I8e293ee8eeaf41173a012ffee12c02eab44f1154
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7894925
+Reviewed-by: Raphael Kubo da Costa <kubo@igalia.com>
+Auto-Submit: Max Ihlenfeldt <max@igalia.com>
+Commit-Queue: Raphael Kubo da Costa <kubo@igalia.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4219}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.cc b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+index 41e82dc8bb95ef2b1ec74b5653d5c9e2d5e10ff0..059656b1b4fec6d0383b0bac0b3648392209d96e 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.cc
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+@@ -393,8 +393,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+     return;
+   }
+ 
+-  WaylandWindow* prev_focused_window =
+-      window_manager_->GetCurrentPointerFocusedWindow();
++  // Dispatching the event may delete the previously focused window.
++  base::WeakPtr<WaylandWindow> prev_focused_window =
++      window_manager_->GetCurrentPointerFocusedWindow()
++          ? window_manager_->GetCurrentPointerFocusedWindow()->AsWeakPtr()
++          : nullptr;
+   if (window) {
+     window_manager_->SetPointerFocusedWindow(window);
+   }
+@@ -432,10 +435,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+   }
+ }
+ 
+-void WaylandEventSource::OnPointerButtonEventInternal(WaylandWindow* window,
+-                                                      EventType type) {
++void WaylandEventSource::OnPointerButtonEventInternal(
++    base::WeakPtr<WaylandWindow> window,
++    EventType type) {
+   if (window) {
+-    window_manager_->SetPointerFocusedWindow(window);
++    window_manager_->SetPointerFocusedWindow(window.get());
+   }
+ }
+ 
+@@ -944,12 +948,16 @@ void WaylandEventSource::ReleasePressedPointerButtons(
+     return;
+   }
+ 
++  // Dispatching the event may delete the window.
++  base::WeakPtr<WaylandWindow> window_weak =
++      window ? window->AsWeakPtr() : nullptr;
+   for (const auto& [button, name] : kMouseButtonToStringMap) {
+     if (button & pointer_flags_) {
+       VLOG(1) << "Synthesizing pointer release for: " << name;
+       TRACE_EVENT_INSTANT("wayland.debug", "SynthesizePointerRelease", "button",
+                           name);
+-      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp, window,
++      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp,
++                           window_weak.get(),
+                            wl::EventDispatchPolicy::kImmediate,
+                            /*allow_release_of_unpressed_button=*/false,
+                            /*is_synthesized=*/true);
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.h b/ui/ozone/platform/wayland/host/wayland_event_source.h
+index f39137fef2ed59b4a798f347961455596e51302f..92182c78cc42131416d67e191ad383490cc292be 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.h
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.h
+@@ -237,7 +237,8 @@ class WaylandEventSource : public PlatformEventSource,
+   gfx::Vector2dF ComputeFlingVelocity();
+ 
+   // Wrap up method to support async pointer down/up event processing.
+-  void OnPointerButtonEventInternal(WaylandWindow* window, EventType type);
++  void OnPointerButtonEventInternal(base::WeakPtr<WaylandWindow> window,
++                                    EventType type);
+ 
+   // Wrap up method to support async touch release processing.
+   void OnTouchReleaseInternal(PointerId id);
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc b/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
+index aafab7df827be323ba11cbd40ec9d52dc7e41701..669b8bc9d782cdc922cba704ac419cc063376811 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
+@@ -280,6 +280,47 @@ TEST_P(WaylandEventSourceTest, ReleasesAllPressedPointerButtons) {
+       pointer_delegate_->IsPointerButtonPressed(EF_MIDDLE_MOUSE_BUTTON));
+ }
+ 
++// Check that if an event dispatched by ReleasePressedPointerButtons causes the
++// target window to be destroyed, we don't cause a UAF or dangling pointer.
++TEST_P(WaylandEventSourceTest, ReleasePressedPointerButtonsUAF) {
++  PostToServerAndWait([](wl::TestWaylandServerThread* server) {
++    wl_seat_send_capabilities(server->seat()->resource(),
++                              WL_SEAT_CAPABILITY_POINTER);
++  });
++  ASSERT_TRUE(connection_->seat()->pointer());
++
++  // Record two pressed buttons so ReleasePressedPointerButtons iterates twice.
++  EXPECT_CALL(delegate_, DispatchEvent(_)).Times(::testing::AnyNumber());
++  PostToServerAndWait([surface_id = window_->root_surface()->get_surface_id()](
++                          wl::TestWaylandServerThread* server) {
++    auto* const surface =
++        server->GetObject<wl::MockSurface>(surface_id)->resource();
++    auto* const pointer = server->seat()->pointer()->resource();
++    wl_pointer_send_enter(pointer, server->GetNextSerial(), surface, 0, 0);
++    wl_pointer_send_button(pointer, server->GetNextSerial(),
++                           server->GetNextTime(), BTN_LEFT,
++                           WL_POINTER_BUTTON_STATE_PRESSED);
++    wl_pointer_send_button(pointer, server->GetNextSerial(),
++                           server->GetNextTime(), BTN_RIGHT,
++                           WL_POINTER_BUTTON_STATE_PRESSED);
++    wl_pointer_send_frame(pointer);
++  });
++  ASSERT_TRUE(pointer_delegate_->IsPointerButtonPressed(EF_LEFT_MOUSE_BUTTON));
++  ASSERT_TRUE(pointer_delegate_->IsPointerButtonPressed(EF_RIGHT_MOUSE_BUTTON));
++
++  // Destroy the window on the first mouse release.
++  EXPECT_CALL(delegate_, DispatchEvent(_))
++      .WillOnce([&](Event* event) {
++        EXPECT_EQ(event->type(), EventType::kMouseReleased);
++        window_.reset();
++      })
++      .WillRepeatedly(::testing::Return());
++
++  // Release both pressed buttons.
++  pointer_delegate_->ReleasePressedPointerButtons(window_.get(),
++                                                  base::TimeTicks::Now());
++}
++
+ INSTANTIATE_TEST_SUITE_P(
+     EventsDispatchPolicyTest,
+     WaylandEventSourceTest,

--- a/patches/chromium/cherry-pick-409ec3ebc79c.patch
+++ b/patches/chromium/cherry-pick-409ec3ebc79c.patch
@@ -1,0 +1,192 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ming-Ying Chung <mych@chromium.org>
+Date: Fri, 5 Jun 2026 01:10:16 -0700
+Subject: [M148] [FSA] Fix UAF in ShowFilePickerOnUIThread.
+
+Original change's description:
+> [FSA] Fix UAF in ShowFilePickerOnUIThread.
+>
+> The `ShowFilePickerOnUIThread()` function in the browser process was
+> caching raw pointers to `RenderFrameHost` and `WebContents` which could
+> become dangling if the frame was destroyed during nested message loops
+> spun by intermediate operations like `CanShowFilePicker()` or
+> `ForSecurityDropFullscreen()`.
+>
+> Th CL re-resolves the RenderFrameHost and WebContents pointers from
+> the stored `GlobalRenderFrameHostId` after these operations and aborts
+> safely if they are no longer active or valid.
+>
+> Bug: 516677924
+> Change-Id: I50046d8f72f139f06f885309847b5179a32b7b37
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7871715
+> Reviewed-by: Fergal Daly <fergal@chromium.org>
+> Commit-Queue: Ming-Ying Chung <mych@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1637522}
+
+(cherry picked from commit eb0b9aba64dbe619399fb2e4e1be6a784524c809)
+
+Bug: 518966951,516677924
+Change-Id: I50046d8f72f139f06f885309847b5179a32b7b37
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7895216
+Commit-Queue: Ming-Ying Chung <mych@chromium.org>
+Reviewed-by: Mingyu Lei <leimy@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4244}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/file_system_access/file_system_access_manager_impl.cc b/content/browser/file_system_access/file_system_access_manager_impl.cc
+index 12dabdaf7e79de3dff17d2924856f1274b780b2e..35beeec3f6a888fe1c067131e84ffbefffdbecb6 100644
+--- a/content/browser/file_system_access/file_system_access_manager_impl.cc
++++ b/content/browser/file_system_access/file_system_access_manager_impl.cc
+@@ -19,6 +19,7 @@
+ #include "base/functional/bind.h"
+ #include "base/functional/callback_helpers.h"
+ #include "base/i18n/file_util_icu.h"
++#include "base/memory/raw_ptr.h"
+ #include "base/notreached.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/string_view_util.h"
+@@ -93,6 +94,40 @@ using HandleType = FileSystemAccessPermissionContext::HandleType;
+ 
+ namespace {
+ 
++// Holds resolved and validated frame objects. All pointers are guaranteed to be
++// non-null and active if this struct is returned.
++struct ResolvedFrame {
++  raw_ptr<RenderFrameHost> rfh;
++  raw_ptr<WebContents> web_contents;
++  raw_ptr<RenderFrameHost> outermost_rfh;
++};
++
++// Resolves `frame_id` to its corresponding `RenderFrameHost`, `WebContents`,
++// and outermost `RenderFrameHost`, and validates that they are all non-null
++// and active.
++// Returns a `ResolvedFrame` struct if ALL resolved objects are valid and
++// active, i.e. non-null; otherwise, returns `std::nullopt`.
++//
++// This check is critical because intermediate operations, like permission
++// checks or security prompts, can run nested message loops during which the
++// calling frame or WebContents can be destroyed or navigated.
++std::optional<ResolvedFrame> ResolveAndValidateFrame(
++    GlobalRenderFrameHostId frame_id) {
++  RenderFrameHost* rfh = RenderFrameHost::FromID(frame_id);
++  if (!rfh || !rfh->IsActive()) {
++    return std::nullopt;
++  }
++  WebContents* web_contents = WebContents::FromRenderFrameHost(rfh);
++  if (!web_contents) {
++    return std::nullopt;
++  }
++  RenderFrameHost* outermost_rfh = rfh->GetOutermostMainFrame();
++  if (!outermost_rfh || !outermost_rfh->IsActive()) {
++    return std::nullopt;
++  }
++  return ResolvedFrame{rfh, web_contents, outermost_rfh};
++}
++
+ #if BUILDFLAG(IS_ANDROID)
+ // Adaptor between FileSystemChooser::ResultCallback and FileSelectListener
+ // used when delegating file choosing to WebContentsDelegate.
+@@ -201,6 +236,18 @@ void ShowFilePickerOnUIThread(
+                           {});
+                       return;
+                     });
++    // `CanShowFilePicker()` runs nested message loops during which the frame
++    // could be destroyed or navigated. Re-resolve and re-validate the frame.
++    auto re_resolved = ResolveAndValidateFrame(frame_id);
++    if (!re_resolved) {
++      std::move(callback).Run(file_system_access_error::FromStatus(
++                                  FileSystemAccessStatus::kOperationAborted),
++                              {});
++      return;
++    }
++    rfh = re_resolved->rfh;
++    web_contents = re_resolved->web_contents;
++    outermost_rfh = re_resolved->outermost_rfh;
+   }
+ 
+ #if BUILDFLAG(IS_ANDROID)
+diff --git a/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc b/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
+index cd20481e32e030de5311d1bc9ad2478211bedc8e..a44a85b0eb5ad01aab5a650b813fa4b7df5ecae3 100644
+--- a/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
++++ b/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
+@@ -1588,6 +1588,80 @@ TEST_F(FileSystemAccessManagerImplTest, ChooseEntries_OpenFile) {
+   ASSERT_TRUE(future.Wait());
+ }
+ 
++// Covers the re-entrancy and lifetime safety of `RenderFrameHost` and
++// `WebContents` in `ShowFilePickerOnUIThread`. Specifically, it covers the
++// scenario where the frame is detached/destroyed during the
++// `CanShowFilePicker` permission check.
++//
++// Without the fix, this scenario triggers a crash when the code attempts to
++// access the destroyed `WebContents` to drop fullscreen
++// `web_contents->ForSecurityDropFullscreen(...)`.
++//
++// Note: If destruction occurred during the fullscreen exit loop instead, the
++// crash would occur in `FileSystemChooser::CreateAndShow()` when dereferencing
++// the dangling RenderFrameHost.
++TEST_F(FileSystemAccessManagerImplTest,
++       ChooseEntries_CanShowFilePickerDestroysFrameUAF) {
++  static_cast<TestRenderFrameHost*>(web_contents_->GetPrimaryMainFrame())
++      ->SimulateUserActivation();
++
++  mojo::Remote<blink::mojom::FileSystemAccessManager> manager_remote;
++  FileSystemAccessManagerImpl::BindingContext binding_context = {
++      kTestStorageKey, kTestURL,
++      web_contents_->GetPrimaryMainFrame()->GetGlobalId()};
++  manager_->BindReceiver(binding_context,
++                         manager_remote.BindNewPipeAndPassReceiver());
++
++  EXPECT_CALL(permission_context_,
++              CanObtainReadPermission(kTestStorageKey.origin()))
++      .WillOnce(testing::Return(true));
++
++  EXPECT_CALL(
++      permission_context_,
++      GetWellKnownDirectoryPath(blink::mojom::WellKnownDirectory::kDirDocuments,
++                                kTestStorageKey.origin()))
++      .WillOnce(testing::Return(base::FilePath()));
++  EXPECT_CALL(permission_context_,
++              GetLastPickedDirectory(kTestStorageKey.origin(), std::string()))
++      .WillOnce(testing::Return(PathInfo()));
++  EXPECT_CALL(permission_context_, GetPickerTitle(testing::_))
++      .WillOnce(testing::Return(std::u16string()));
++
++  // Mock CanShowFilePicker to synchronously destroy the WebContents, which
++  // destroys the RFH. This simulates the frame being detached/destroyed
++  // during the yielding permission check.
++  EXPECT_CALL(permission_context_, CanShowFilePicker(testing::_))
++      .WillOnce([&](content::RenderFrameHost* rfh) {
++        auto* temp_wc = web_contents_.get();
++        web_contents_ = nullptr;
++        web_contents_factory_.DestroyWebContents(temp_wc);
++        return base::ok();
++      });
++
++  auto open_file_picker_options = blink::mojom::OpenFilePickerOptions::New(
++      blink::mojom::AcceptsTypesInfo::New(
++          std::vector<blink::mojom::ChooseFileSystemEntryAcceptsOptionPtr>(),
++          /*include_accepts_all=*/true),
++      /*can_select_multiple_files=*/false);
++  auto picker_options = blink::mojom::FilePickerOptions::New(
++      blink::mojom::TypeSpecificFilePickerOptionsUnion::
++          NewOpenFilePickerOptions(std::move(open_file_picker_options)),
++      /*starting_directory_id=*/std::string(),
++      blink::mojom::FilePickerStartInOptionsUnionPtr());
++
++  base::test::TestFuture<blink::mojom::FileSystemAccessErrorPtr,
++                         std::vector<blink::mojom::FileSystemAccessEntryPtr>>
++      future;
++  manager_remote->ChooseEntries(std::move(picker_options),
++                                future.GetCallback());
++  ASSERT_TRUE(future.Wait());
++
++  // The call should be aborted gracefully since the frame was destroyed.
++  // Without the fix, this would have crashed during the picker call.
++  EXPECT_EQ(blink::mojom::FileSystemAccessStatus::kOperationAborted,
++            future.Get<0>()->status);
++}
++
+ TEST_F(FileSystemAccessManagerImplTest,
+        ChooseEntries_OpenFile_EnterpriseBlock) {
+   base::FilePath test_file = dir_.GetPath().AppendASCII("foo");

--- a/patches/chromium/cherry-pick-b534033a6391.patch
+++ b/patches/chromium/cherry-pick-b534033a6391.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Reynolds <mattreynolds@google.com>
+Date: Wed, 3 Jun 2026 17:33:55 -0700
+Subject: [M148] bluetooth: Avoid double invoking callback after failed winrt
+ call
+
+Original change's description:
+> bluetooth: Avoid double invoking callback after failed winrt call
+>
+> In OnGetGattServices and OnGetCharacteristics, if an API call fails while
+> iterating over a list then the callback is invoked twice: once to report
+> the failure and then again when RunCallbackIfDone is called after the
+> loop exits. This CL ensures these methods return after invoking the
+> callback the first time.
+>
+> Bug: 517418936
+> Change-Id: I6ed22b9a7d2aede6c807054b88f427d8564cf649
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7883805
+> Commit-Queue: Matt Reynolds <mattreynolds@chromium.org>
+> Reviewed-by: Alvin Ji <alvinji@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639876}
+
+(cherry picked from commit 4bb7a1ea296c757b7ce5a0ae7bedfc4226f15df2)
+
+Bug: 519444794,517418936
+Change-Id: I6ed22b9a7d2aede6c807054b88f427d8564cf649
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7893642
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4233}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc b/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
+index ae77850c02ed03f36991ea7351b385a14eee7f40..5f2c354bce8455e4f30f78ae54304c93710fc82e 100644
+--- a/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
++++ b/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
+@@ -302,6 +302,7 @@ void BluetoothGattDiscovererWinrt::OnGetGattServices(
+       BLUETOOTH_LOG(DEBUG) << "GattDeviceService::OpenAsync() failed: "
+                            << logging::SystemErrorCodeToString(hr);
+       std::move(callback_).Run(false);
++      return;
+     }
+ 
+     hr = base::win::PostAsyncResults(
+@@ -423,6 +424,7 @@ void BluetoothGattDiscovererWinrt::OnGetCharacteristics(
+       BLUETOOTH_LOG(DEBUG) << "PostAsyncResults failed: "
+                            << logging::SystemErrorCodeToString(hr);
+       std::move(callback_).Run(false);
++      return;
+     }
+   }
+ 

--- a/patches/chromium/cherry-pick-c92de87bddf2.patch
+++ b/patches/chromium/cherry-pick-c92de87bddf2.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maggie Chen <magchen@chromium.org>
+Date: Fri, 29 May 2026 16:05:48 -0700
+Subject: Fix GPU process lost race in DisplayLinkMacMojo
+
+DisplayLinkMacMojo manages objects like mojo::Remote, mojo::Receiver,
+and vsync callbacks that are bound to a dedicated VSync thread.
+Previously, OnGpuProcessLost attempts to recreate new objects on the
+main thread while destroying the old objects on the VSync thread, which
+can lead to race conditions or DCHECK failures.
+
+This CL serialize the destroy-then-recreate to ensures that these
+objects are cleaned up on the VSync thread before reconnecting the IPC
+on the main thread.
+
+Bug: 517227707
+Change-Id: Ie052347db9869d69e8de7beec2248a3241ff4b65
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7881564
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Commit-Queue: Maggie Chen <magchen@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1638792}
+
+diff --git a/ui/compositor/display_link_mac_mojo.h b/ui/compositor/display_link_mac_mojo.h
+index 8bdd487c126b79fb5d45cd69c1b577162ba55672..0efb961bc098364b1f5f712582f750d3d9250acf 100644
+--- a/ui/compositor/display_link_mac_mojo.h
++++ b/ui/compositor/display_link_mac_mojo.h
+@@ -5,6 +5,8 @@
+ #ifndef UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ #define UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ 
++#include <optional>
++
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/threading/thread.h"
+ #include "mojo/public/cpp/bindings/receiver.h"
+@@ -84,7 +86,8 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+  private:
+   // VSyncIpc is connected when DisplayLinkMacMojo is created, and it's
+   // reconnected after the GPU process is lost.
+-  void ConnectVSyncIpc(viz::HostFrameSinkManager* host_frame_sink_manager);
++  void ConnectVSyncIpcAndAddDisplayObserver(
++      viz::HostFrameSinkManager* host_frame_sink_manager);
+ 
+   void InitDisplaysOnVSyncThread();
+ 
+@@ -94,6 +97,31 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+ 
+   void DisplaysRemovedOnVSyncThread(std::vector<int64_t> display_ids);
+ 
++  // This sequence is called to prevent race conditions during GPU process loss.
++  // The flow is:
++  // OnGpuProcessLost() (Main thread) ->
++  // OnGpuProcessLostOnVSyncThread() (VSync thread) ->
++  // ContinueGpuProcessLostOnMainThread() (Main thread)
++  //
++  // Note: OnGpuProcessLostOnVSyncThread() must use base::Unretained(this) to
++  // ensure that thread-affine Mojo objects are always cleaned up on the VSync
++  // thread, even if this class is being destroyed. The recovery task
++  // (ContinueGpuProcessLostOnMainThread) uses a WeakPtr because recovery
++  // should only proceed if this instance has not been destroyed.
++  void ContinueGpuProcessLostOnMainThread(
++      viz::HostFrameSinkManager* host_frame_sink_manager);
++  void OnGpuProcessLostOnVSyncThread(
++      viz::HostFrameSinkManager* host_frame_sink_manager,
++      scoped_refptr<base::SingleThreadTaskRunner> main_task_runner,
++      base::WeakPtr<DisplayLinkMacMojo> weak_ptr);
++
++  void ResetStateOnVSyncThread();
++
++  // To prevent AddObserver from being called multiple times
++  std::optional<display::ScopedDisplayObserver> display_observer_;
++
++  int pending_gpu_lost_count_ = 0;
++
+   std::map<int64_t, scoped_refptr<DisplayLinkMac>> display_links_;
+   std::map<int64_t, std::unique_ptr<VSyncCallbackMac>> vsync_callbacks_;
+ 
+diff --git a/ui/compositor/display_link_mac_mojo.mm b/ui/compositor/display_link_mac_mojo.mm
+index 1ae10ef19ff89df3c03003061ceb6e706d28d2cd..22055f3340d6707b3e3612d574e35ce0737e1c54 100644
+--- a/ui/compositor/display_link_mac_mojo.mm
++++ b/ui/compositor/display_link_mac_mojo.mm
+@@ -6,6 +6,7 @@
+ 
+ #include <utility>
+ 
++#include "base/task/bind_post_task.h"
+ #include "components/viz/common/frame_sinks/begin_frame_args.h"
+ #include "components/viz/host/host_frame_sink_manager.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+@@ -32,11 +33,7 @@
+ 
+   // To ensure VSyncThread task_runner() is valid, StartWithOptions() must be
+   // called before ConnectVSyncIpc().
+-  ConnectVSyncIpc(host_frame_sink_manager);
+-
+-  // Display AddObserver can only be called on the browser main thread.
+-  DCHECK(display::Screen::HasScreen());
+-  display::Screen::Get()->AddObserver(this);
++  ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+ 
+   // Now |external_begin_frame_controller_| is valid after ConnectVSyncIpc(). We
+   // can start getting DisplayLinks for all displays.
+@@ -46,9 +43,7 @@
+ }
+ 
+ DisplayLinkMacMojo::~DisplayLinkMacMojo() {
+-  if (display::Screen::HasScreen()) {
+-    display::Screen::Get()->RemoveObserver(this);
+-  }
++  display_observer_.reset();
+ 
+   // Stop the VSync thread.
+   Stop();
+@@ -67,54 +62,79 @@
+ 
+ void DisplayLinkMacMojo::CleanUp() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++  ResetStateOnVSyncThread();
++}
++
++void DisplayLinkMacMojo::ResetStateOnVSyncThread() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
+ 
+   // Created on the VSync thread and must be destroyed on the same thread.
+   vsync_callbacks_.clear();
+   display_links_.clear();
+ 
+   // The remote and receiver are connected to IPC to issue and receive mojom
+-  // interrace calls on the VSync thread. These dtors are required to run on the
++  // interface calls on the VSync thread. These dtors are required to run on the
+   // same thread.
+   external_begin_frame_controller_.reset();
+   client_receiver_.reset();
+ }
+ 
+ // Called on the browser main thread.
++// OnGpuProcessLost can handle multiple GPU process losses occurring in rapid
++// succession.
+ void DisplayLinkMacMojo::OnGpuProcessLost(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+-  // Destroy all DisplayLinks on the VSyncThread.
+-  DCHECK(display::Screen::HasScreen());
+-  display::Screen::Get()->RemoveObserver(this);
++  pending_gpu_lost_count_++;
+ 
+-  if (!vsync_callbacks_.empty()) {
+-    task_runner()->PostTask(
+-        FROM_HERE, base::DoNothingWithBoundArgs(std::move(vsync_callbacks_)));
+-  }
+-  if (!display_links_.empty()) {
+-    task_runner()->PostTask(
+-        FROM_HERE, base::DoNothingWithBoundArgs(std::move(display_links_)));
+-  }
++  display_observer_.reset();
+ 
+-  // Reconnect IPC. Destory the old controller and the old receiver on the
+-  // VSyncThread first.
+-  if (external_begin_frame_controller_) {
+-    task_runner()->PostTask(FROM_HERE, base::DoNothingWithBoundArgs(std::move(
+-                                           external_begin_frame_controller_)));
+-  }
+-  if (client_receiver_) {
+-    task_runner()->DeleteSoon(FROM_HERE, std::move(client_receiver_));
++  // Ensure the WeakPtr are created and bound to the sequence on CrBrowserMain.
++  // The dereferencing (checking if the pointer is still valid) and invalidation
++  // happens on the Main thread only. A WeakPtr is passed to the VSync thread
++  // only to be used as an argument for the recovery task
++  // (ContinueGpuProcessLostOnMainThread).
++  task_runner()->PostTask(
++      FROM_HERE,
++      base::BindOnce(&DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread,
++                     base::Unretained(this), host_frame_sink_manager,
++                     base::SingleThreadTaskRunner::GetCurrentDefault(),
++                     weak_ptr_factory_.GetWeakPtr()));
++}
++
++// Called on the browser main thread.
++void DisplayLinkMacMojo::ContinueGpuProcessLostOnMainThread(
++    viz::HostFrameSinkManager* host_frame_sink_manager) {
++  pending_gpu_lost_count_--;
++  if (pending_gpu_lost_count_ > 0) {
++    return;
+   }
+ 
+-  ConnectVSyncIpc(host_frame_sink_manager);
++  ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+ 
+-  display::Screen::Get()->AddObserver(this);
+   task_runner()->PostTask(
+       FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+                                 base::Unretained(this)));
+ }
+ 
++void DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread(
++    viz::HostFrameSinkManager* host_frame_sink_manager,
++    scoped_refptr<base::SingleThreadTaskRunner> main_task_runner,
++    base::WeakPtr<DisplayLinkMacMojo> weak_ptr) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++
++  ResetStateOnVSyncThread();
++
++  // After destroying the old objects on the VSync thread, return to the main
++  // thread to continue the recovery process. We use a WeakPtr because recovery
++  // should only proceed if this instance has not been destroyed.
++  main_task_runner->PostTask(
++      FROM_HERE,
++      base::BindOnce(&DisplayLinkMacMojo::ContinueGpuProcessLostOnMainThread,
++                     weak_ptr, host_frame_sink_manager));
++}
++
+ // Called on the browser main thread
+-void DisplayLinkMacMojo::ConnectVSyncIpc(
++void DisplayLinkMacMojo::ConnectVSyncIpcAndAddDisplayObserver(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+   CHECK(host_frame_sink_manager);
+ 
+@@ -146,6 +166,10 @@
+   params->external_begin_frame_controller_client = std::move(remote_client);
+ 
+   host_frame_sink_manager->CreateCompositorDisplayLink(std::move(params));
++
++  // Display AddObserver can only be called on the browser main thread.
++  // Only add a observer after IPC is connected.
++  display_observer_.emplace(this);
+ }
+ 
+ // Called on the VSync thread directly from IPC.

--- a/patches/chromium/cherry-pick-cd7201c2fce0.patch
+++ b/patches/chromium/cherry-pick-cd7201c2fce0.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rob Pitkin <robpitkin@google.com>
+Date: Wed, 3 Jun 2026 15:53:55 -0700
+Subject: [M148] gamepad: Fix Use-After-Return in HidWriterWin
+
+Original change's description:
+> gamepad: Fix Use-After-Return in HidWriterWin
+>
+> HidWriterWin::WriteOutputReport uses a stack-allocated OVERLAPPED
+> structure for asynchronous writes. When a write operation times out, the
+> function calls CancelIo and then waits for either the file handle or the
+> event handle to be signaled using WaitForMultipleObjects with bWaitAll =
+> false.
+>
+> If the file handle was signaled by a previous operation,
+> WaitForMultipleObjects returns immediately, before the current operation
+> is fully cancelled. The function then returns, destroying the stack
+> frame and the OVERLAPPED structure. When the driver eventually completes
+> the cancellation, it writes status information back to the now-invalid
+> OVERLAPPED address, causing memory corruption.
+>
+> This CL fixes the issue by removing the WaitForMultipleObjects call and
+> instead calling GetOverlappedResult with `bWait = true` after
+> potentially cancelling the I/O. This ensures that the operation is fully
+> retired before the function returns and the stack frame is destroyed.
+>
+> Bug: 516975148
+> Change-Id: I92116cef7454e35de8d40ccb55b15819eddff79b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7892686
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Commit-Queue: Rob Pitkin <robpitkin@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640392}
+
+(cherry picked from commit a5e41fa34b2c37843ba3e82b51b7323f32b3763a)
+
+Bug: 519445263,516975148
+Change-Id: I92116cef7454e35de8d40ccb55b15819eddff79b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7893300
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4230}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/gamepad/hid_writer_win.cc b/device/gamepad/hid_writer_win.cc
+index 420f6372202d6650cbcc747bdf7849d6db3a0be1..7dc61c018703ce5d5b7f4b7fe2f6e8c6a5b8f700 100644
+--- a/device/gamepad/hid_writer_win.cc
++++ b/device/gamepad/hid_writer_win.cc
+@@ -57,19 +57,13 @@ size_t HidWriterWin::WriteOutputReport(base::span<const uint8_t> report) {
+       // Wait for the write to complete. This causes WriteOutputReport to behave
+       // synchronously.
+       DWORD wait_object = ::WaitForSingleObject(overlapped.hEvent, 100);
+-      if (wait_object == WAIT_OBJECT_0) {
+-        ::GetOverlappedResult(hid_handle_.Get(), &overlapped, &bytes_written,
+-                              true);
+-      } else {
+-        // Wait failed, or the timeout was exceeded before the write completed.
+-        // Cancel the write request.
+-        if (::CancelIo(hid_handle_.Get())) {
+-          HANDLE handles[2];
+-          handles[0] = hid_handle_.Get();
+-          handles[1] = overlapped.hEvent;
+-          ::WaitForMultipleObjects(2, handles, false, INFINITE);
+-        }
++      if (wait_object != WAIT_OBJECT_0) {
++        ::CancelIo(hid_handle_.Get());
+       }
++      // This blocks until the specific overlapped operation completes or
++      // aborts.
++      write_success = ::GetOverlappedResult(hid_handle_.Get(), &overlapped,
++                                            &bytes_written, true);
+     }
+   }
+   return write_success ? bytes_written : 0;

--- a/patches/chromium/cherry-pick-db94c2cb8239.patch
+++ b/patches/chromium/cherry-pick-db94c2cb8239.patch
@@ -1,0 +1,181 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maggie Chen <magchen@chromium.org>
+Date: Wed, 3 Jun 2026 12:18:30 -0700
+Subject: Assign DisplayLinkMacMojo mojo::Remote/Receiver on VSync thread
+
+Previously, in DisplayLinkMacMojo, the mojo::Remote
+|external_begin_frame_controller_| and the mojo::Receiver
+|client_receiver_| were assigned on the browser main thread (within
+ConnectVSyncIpcAndAddDisplayObserver) even though they were bound to the
+VSync thread's task runner.
+
+While the prior code ensured the remote and the receiver were not
+accessed on the VSync thread prior to assignment, assigning them on the
+main thread when they are used exclusively on the VSync thread sequence
+is conceptually unsafe.
+
+This CL resolves this by passing the mojo::Remote and the mojo::Receiver
+to InitDisplaysOnVSyncThread, moving and assigning them directly on the
+VSync thread where they are used.
+
+Also call GetAllDisplays() to get the current IDs only on the main
+thread.
+
+Bug: 517227707
+Change-Id: Icfe777e57503e50c2e4171762d4f0652e56baa71
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7897519
+Commit-Queue: Maggie Chen <magchen@chromium.org>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1641108}
+
+diff --git a/ui/compositor/display_link_mac_mojo.h b/ui/compositor/display_link_mac_mojo.h
+index 0efb961bc098364b1f5f712582f750d3d9250acf..767b1bad0b5d2acc712870c192c32fd5a085a0e5 100644
+--- a/ui/compositor/display_link_mac_mojo.h
++++ b/ui/compositor/display_link_mac_mojo.h
+@@ -5,7 +5,10 @@
+ #ifndef UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ #define UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ 
++#include <map>
++#include <memory>
+ #include <optional>
++#include <vector>
+ 
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/threading/thread.h"
+@@ -89,7 +92,13 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+   void ConnectVSyncIpcAndAddDisplayObserver(
+       viz::HostFrameSinkManager* host_frame_sink_manager);
+ 
+-  void InitDisplaysOnVSyncThread();
++  void InitDisplaysOnVSyncThread(
++      std::vector<int64_t> display_ids,
++      mojo::Remote<viz::mojom::ExternalBeginFrameController>
++          external_begin_frame_controller,
++      std::unique_ptr<
++          mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>
++          client_receiver);
+ 
+   void OnDisplayLinkVSyncCallback(int64_t display_id, VSyncParamsMac params);
+ 
+diff --git a/ui/compositor/display_link_mac_mojo.mm b/ui/compositor/display_link_mac_mojo.mm
+index 22055f3340d6707b3e3612d574e35ce0737e1c54..2a5e7f46a68b932d14d7a4fe2001e1dc5dff7989 100644
+--- a/ui/compositor/display_link_mac_mojo.mm
++++ b/ui/compositor/display_link_mac_mojo.mm
+@@ -32,14 +32,9 @@
+   StartWithOptions(base::Thread::Options(std::move(thread_options)));
+ 
+   // To ensure VSyncThread task_runner() is valid, StartWithOptions() must be
+-  // called before ConnectVSyncIpc().
++  // called before connecting the VSync IPC and adding the display observer,
++  // which are done on the browser main thread.
+   ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+-
+-  // Now |external_begin_frame_controller_| is valid after ConnectVSyncIpc(). We
+-  // can start getting DisplayLinks for all displays.
+-  task_runner()->PostTask(
+-      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+-                                base::Unretained(this)));
+ }
+ 
+ DisplayLinkMacMojo::~DisplayLinkMacMojo() {
+@@ -49,14 +44,20 @@
+   Stop();
+ }
+ 
+-void DisplayLinkMacMojo::InitDisplaysOnVSyncThread() {
++void DisplayLinkMacMojo::InitDisplaysOnVSyncThread(
++    std::vector<int64_t> display_ids,
++    mojo::Remote<viz::mojom::ExternalBeginFrameController>
++        external_begin_frame_controller,
++    std::unique_ptr<
++        mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>
++        client_receiver) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++  external_begin_frame_controller_ = std::move(external_begin_frame_controller);
++  client_receiver_ = std::move(client_receiver);
+ 
+   // Create CADisplayLink for all displays.
+-  const std::vector<display::Display>& displays =
+-      display::Screen::Get()->GetAllDisplays();
+-  for (const auto& display : displays) {
+-    DisplayAddedOnVSyncThread(display.id());
++  for (int64_t display_id : display_ids) {
++    DisplayAddedOnVSyncThread(display_id);
+   }
+ }
+ 
+@@ -80,8 +81,9 @@
+ }
+ 
+ // Called on the browser main thread.
+-// OnGpuProcessLost can handle multiple GPU process losses occurring in rapid
+-// succession.
++// Handles GPU process loss, even if multiple losses occur in rapid succession.
++// Resource destruction and recreation are serialized across both threads to
++// avoid races.
+ void DisplayLinkMacMojo::OnGpuProcessLost(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+   pending_gpu_lost_count_++;
+@@ -110,10 +112,6 @@
+   }
+ 
+   ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+-
+-  task_runner()->PostTask(
+-      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+-                                base::Unretained(this)));
+ }
+ 
+ void DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread(
+@@ -148,7 +146,6 @@
+   // Move pending receiver to params.
+   params->external_begin_frame_controller =
+       external_begin_frame_controller.BindNewPipeAndPassReceiver(task_runner());
+-  external_begin_frame_controller_ = std::move(external_begin_frame_controller);
+ 
+   // Set up ExternalBeginFrameControllerClient for Viz to call
+   // NeedsBeginFrameWithId() via IPC to request DisplayLinkMacMojo for VSync
+@@ -161,7 +158,7 @@
+   auto client_receiver = std::make_unique<
+       mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>(this);
+   client_receiver->Bind(std::move(pending_client_receiver), task_runner());
+-  client_receiver_ = std::move(client_receiver);
++
+   // Move pending remote to params.
+   params->external_begin_frame_controller_client = std::move(remote_client);
+ 
+@@ -170,6 +167,24 @@
+   // Display AddObserver can only be called on the browser main thread.
+   // Only add a observer after IPC is connected.
+   display_observer_.emplace(this);
++
++  std::vector<int64_t> display_ids;
++  // Screen GetAllDisplays() should be called on the main thread.
++  const std::vector<display::Display>& displays =
++      display::Screen::Get()->GetAllDisplays();
++  for (const display::Display& display : displays) {
++    display_ids.push_back(display.id());
++  }
++
++  // Since |external_begin_frame_controller_| and |client_receiver_| must be
++  // accessed exclusively on the VSync thread sequence, move the remote to the
++  // VSync thread and assign it there to maintain sequence safety. Now start
++  // getting DisplayLinks for all displays on the VSync thread.
++  task_runner()->PostTask(
++      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
++                                base::Unretained(this), std::move(display_ids),
++                                std::move(external_begin_frame_controller),
++                                std::move(client_receiver)));
+ }
+ 
+ // Called on the VSync thread directly from IPC.
+@@ -274,7 +289,7 @@
+ void DisplayLinkMacMojo::OnDisplaysRemoved(
+     const display::Displays& removed_displays) {
+   std::vector<int64_t> display_ids;
+-  for (auto& removed_display : removed_displays) {
++  for (const display::Display& removed_display : removed_displays) {
+     display_ids.push_back(removed_display.id());
+   }
+ 

--- a/patches/chromium/cherry-pick-f9e6631b2ded.patch
+++ b/patches/chromium/cherry-pick-f9e6631b2ded.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 3 Jun 2026 16:56:07 -0700
+Subject: [M148] Fix use-after-free in DesktopWindowTreeHostPlatform::Restore.
+
+> In DesktopWindowTreeHostPlatform::Restore(),
+> platform_window()->Restore() is called without a weak-pointer guard. On
+> Linux/X11, restoring a fullscreen window can trigger a synchronous
+> bounds change that notifies observers and may synchronously destroy the
+> host. If this occurs, subsequent execution of Show() on `this` causes a
+> use-after-free.
+>
+> This CL introduces a WeakPtr guard to check if the host has been
+> destroyed before proceeding to Show(), matching the pattern used by
+> Maximize() and SetFullscreen(). Also added a corresponding unit test to
+> prevent regression.
+>
+> Fixed: 518043597
+> Change-Id: I9bf4b2f79f37b6b9b22fde5d7292f30c326d4fca
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7889918
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639696}
+
+R=thestig
+
+Bug: 518043597
+Fixed: 519051392
+Change-Id: I0238ea58433abfc636ebc3e7deb09b35f03247de
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7899927
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4232}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+index e005cce1bce7ec4a13ae4ea851fdd15df395d4ea..c905168c4d4e8337f3c83f1d88d3ad701cee431b 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+@@ -656,7 +656,11 @@ void DesktopWindowTreeHostPlatform::Minimize() {
+ }
+ 
+ void DesktopWindowTreeHostPlatform::Restore() {
++  auto weak_ptr = weak_factory_.GetWeakPtr();
+   platform_window()->Restore();
++  if (!weak_ptr) {
++    return;
++  }
+   Show(ui::mojom::WindowShowState::kNormal, gfx::Rect());
+ }
+ 
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+index 950938b5ed8362519e3cd154f18383b0010884cc..be465b79b20631de934273fe631a33200c2e7c09 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+@@ -673,4 +673,85 @@ TEST_F(DesktopWindowTreeHostPlatformTest, ContentWindowShownOnce) {
+   host_platform->GetContentWindow()->RemoveObserver(&observer);
+ }
+ 
++#if !BUILDFLAG(IS_FUCHSIA)
++namespace {
++
++class CloseOnBoundsChangedWidgetObserver : public WidgetObserver {
++ public:
++  explicit CloseOnBoundsChangedWidgetObserver(Widget* widget) {
++    observation_.Observe(widget);
++  }
++  ~CloseOnBoundsChangedWidgetObserver() override = default;
++
++  void OnWidgetBoundsChanged(Widget* widget,
++                             const gfx::Rect& new_bounds) override {
++    observation_.Reset();
++    widget->CloseNow();
++  }
++
++ private:
++  base::ScopedObservation<Widget, WidgetObserver> observation_{this};
++};
++
++}  // namespace
++
++class RestoreBoundsChangeStubWindow : public ui::StubWindow {
++ public:
++  RestoreBoundsChangeStubWindow(ui::PlatformWindowDelegate* delegate,
++                                gfx::AcceleratedWidget widget,
++                                const gfx::Rect& bounds)
++      : StubWindow(delegate, false, bounds) {
++    InitDelegateWithWidget(delegate, widget);
++  }
++
++  void Restore() override {
++    delegate()->OnBoundsChanged({/*origin_changed=*/true});
++  }
++};
++
++class RestoreBoundsChangePlatformWindowFactoryDelegate
++    : public aura::WindowTreeHostPlatform::
++          PlatformWindowFactoryDelegateForTesting {
++ public:
++  RestoreBoundsChangePlatformWindowFactoryDelegate() {
++    aura::WindowTreeHostPlatform::SetPlatformWindowFactoryDelegateForTesting(
++        this);
++  }
++  RestoreBoundsChangePlatformWindowFactoryDelegate(
++      const RestoreBoundsChangePlatformWindowFactoryDelegate&) = delete;
++  RestoreBoundsChangePlatformWindowFactoryDelegate& operator=(
++      const RestoreBoundsChangePlatformWindowFactoryDelegate&) = delete;
++  ~RestoreBoundsChangePlatformWindowFactoryDelegate() override {
++    aura::WindowTreeHostPlatform::SetPlatformWindowFactoryDelegateForTesting(
++        nullptr);
++  }
++
++  std::unique_ptr<ui::PlatformWindow> Create(
++      aura::WindowTreeHostPlatform* host) override {
++    return std::make_unique<RestoreBoundsChangeStubWindow>(
++        host, ++last_accelerated_widget_, gfx::Rect(100, 100, 100, 100));
++  }
++
++  gfx::AcceleratedWidget last_accelerated_widget_ = gfx::kNullAcceleratedWidget;
++};
++
++TEST_F(DesktopWindowTreeHostPlatformTest,
++       RestoreSurvivesSynchronousCloseDuringBoundsChange) {
++  RestoreBoundsChangePlatformWindowFactoryDelegate
++      scoped_platform_window_factory_delegate;
++
++  std::unique_ptr<Widget> widget = CreateWidgetWithNativeWidget();
++  widget->Show();
++
++  auto* host_platform = DesktopWindowTreeHostPlatform::GetHostForWidget(
++      widget->GetNativeWindow()->GetHost()->GetAcceleratedWidget());
++  ASSERT_TRUE(host_platform);
++
++  CloseOnBoundsChangedWidgetObserver observer(widget.get());
++
++  // This should not crash or trigger UAF.
++  host_platform->Restore();
++}
++#endif  // !BUILDFLAG(IS_FUCHSIA)
++
+ }  // namespace views

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -2,3 +2,4 @@ chore_allow_customizing_microtask_policy_per_context.patch
 build_warn_instead_of_abort_on_builtin_pgo_profile_mismatch.patch
 cppgc_support_stackstartmarker_on_msvc.patch
 fastapi_store_v8_cfunction_pointer_directly_in.patch
+cherry-pick-c6bfbe7c4e84.patch

--- a/patches/v8/cherry-pick-c6bfbe7c4e84.patch
+++ b/patches/v8/cherry-pick-c6bfbe7c4e84.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Mon, 4 May 2026 12:27:58 +0200
+Subject: [M148] [objects] Abort TryFastAddDataProperty if map becomes slow
+
+Original change's description:
+> [objects] Abort TryFastAddDataProperty if map becomes slow
+>
+> When class fields are added to a constructor-created function object
+> when the class extends Function, TryFastAddDataProperty is invoked
+> to perform a fast transition. However, Map::PrepareForDataProperty may
+> instead normalize the map and return a slow dictionary map.
+>
+> This CL fixes the issue by aborting the fast transition in
+> TryFastAddDataProperty and returning false if
+> Map::PrepareForDataProperty returns a dictionary map, falling back
+> to the standard slow property addition path.
+>
+> TAG=agy
+> CONV=7233c224-ccbc-421c-88b3-34be1f425294
+>
+> Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+> Fixed: 506689381
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7807043
+> Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+> Reviewed-by: Igor Sheludko <ishell@chromium.org>
+> Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#107009}
+
+(cherry picked from commit 3c869652b039fc1fc9fbe035c6af879317e8b9f3)
+
+Bug: 514925552,506689381
+Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7874712
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/14.8@{#62}
+Cr-Branched-From: f9659283a5f8d42b3c09228cf5df606fcaf47a3d-refs/heads/14.8.178@{#1}
+Cr-Branched-From: 141232520dc4910401240c531db3af36910a0fd1-refs/heads/main@{#106240}
+
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index af6cdd90b7382960d4e230fd9357467d2d155249..fe16019d85257ba5bb32e3636ddd7e2a85596fa4 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -3702,6 +3702,7 @@ bool TryFastAddDataProperty(Isolate* isolate, DirectHandle<JSObject> object,
+   InternalIndex descriptor = new_map->LastAdded();
+   new_map = Map::PrepareForDataProperty(isolate, new_map, descriptor,
+                                         PropertyConstness::kConst, value);
++  if (new_map->is_dictionary_map()) return false;
+   JSObject::MigrateToMap(isolate, object, new_map);
+   // TODO(leszeks): Avoid re-loading the property details, which we already
+   // loaded in PrepareForDataProperty.
+diff --git a/test/mjsunit/regress/regress-crbug-506689381.js b/test/mjsunit/regress/regress-crbug-506689381.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ba2dc8e021e8ea2f7c2381d9ab9c6f88916479f
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-506689381.js
+@@ -0,0 +1,20 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++let key = 'AA';
++let value = 2;
++class C extends Function {
++  [key] = value;
++}
++
++// First object creation triggers transition MapA----(AA, kData, SMI)--->MapB
++let o1 = new C('\'use strict\'');
++
++value = 1.1;
++
++// Second object creation triggers TryFastAddDataProperty() which reconfigures
++// the property from Smi to Double. This reconfigures MapB in-place (or
++// normalizes it). TryFastAddDataProperty must not crash if the map is
++// normalized during preparation.
++let o2 = new C('\'use strict\'');


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`3f6678d31736`](https://chromium-review.googlesource.com/c/chromium/src/+/7894925) from chromium — wayland: Fix UAF/dangling ptr in ReleasePressedPointerButtons()
* [`409ec3ebc79c`](https://chromium-review.googlesource.com/c/chromium/src/+/7895216) from chromium — [FSA] Fix UAF in ShowFilePickerOnUIThread.
* [`cd7201c2fce0`](https://chromium-review.googlesource.com/c/chromium/src/+/7893300) from chromium — gamepad: Fix Use-After-Return in HidWriterWin
* [`c92de87bddf2`](https://chromium-review.googlesource.com/c/chromium/src/+/7881564) from chromium — Fix GPU process lost race in DisplayLinkMacMojo
* [`db94c2cb8239`](https://chromium-review.googlesource.com/c/chromium/src/+/7897519) from chromium — Assign DisplayLinkMacMojo mojo::Remote/Receiver on VSync thread
* [`b534033a6391`](https://chromium-review.googlesource.com/c/chromium/src/+/7893642) from chromium — bluetooth: Avoid double invoking callback after failed winrt call
* [`36f6889ed145`](https://chromium-review.googlesource.com/c/chromium/src/+/7896940) from chromium — Fix context lifetime in ProxyResolverV8 callbacks
* [`f9e6631b2ded`](https://chromium-review.googlesource.com/c/chromium/src/+/7899927) from chromium — Fix use-after-free in DesktopWindowTreeHostPlatform::Restore.
* [`c6bfbe7c4e84`](https://chromium-review.googlesource.com/c/v8/v8/+/7874712) from v8 — [objects] Abort TryFastAddDataProperty if map becomes slow

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium and V8.
