### PR TITLE
chore: cherry-pick 14 changes from chromium, v8

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -227,3 +227,16 @@ cherry-pick-6aa38f2d02b7.patch
 cherry-pick-926d3d259750.patch
 cherry-pick-2cdb07c74d06.patch
 cherry-pick-16dcbc3d1476.patch
+cherry-pick-3f6678d31736.patch
+cherry-pick-ba3e2c142b89.patch
+cherry-pick-409ec3ebc79c.patch
+cherry-pick-a3fe69a65a6d.patch
+cherry-pick-74a45c11c791.patch
+cherry-pick-cd7201c2fce0.patch
+cherry-pick-ddbffa721d7c.patch
+cherry-pick-136880de7a91.patch
+cherry-pick-c92de87bddf2.patch
+cherry-pick-db94c2cb8239.patch
+cherry-pick-b534033a6391.patch
+cherry-pick-36f6889ed145.patch
+cherry-pick-f9e6631b2ded.patch

--- a/patches/chromium/cherry-pick-136880de7a91.patch
+++ b/patches/chromium/cherry-pick-136880de7a91.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bryan Oltman <bryanoltman@google.com>
+Date: Mon, 1 Jun 2026 08:12:20 -0700
+Subject: [M148] [macOS] Prevent UAF during fullscreen controller transition
+ complete
+
+Original change's description:
+> [macOS] Prevent UAF during fullscreen controller transition complete
+>
+> Closing a window while transitioning out of fullscreen can cause a
+> use-after-free crash if a modal sheet animation is run. This CL checks
+> if the NativeWidgetNSWindowBridge was destroyed during child window
+> ordering and aborts completion if so.
+>
+> Fixed: 517040438
+> Change-Id: I89b979cbf716202036f6484059bec002b3779064
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7881662
+> Commit-Queue: Bryan Oltman <bryanoltman@google.com>
+> Reviewed-by: Keren Zhu <kerenzhu@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1637915}
+
+(cherry picked from commit d698fc88d0d073cf6be985297e6cf41a13225c2d)
+
+Bug: 517794411,517040438
+Change-Id: I89b979cbf716202036f6484059bec002b3779064
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7888516
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4152}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+index 672d90ed9bf76ba4c66d83d3f0ccd9970b0bb1b3..80716959470b5984f939b416b215a2d1994a2e53 100644
+--- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
++++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+@@ -1552,7 +1552,14 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+   UpdateWindowDisplay();
+ 
+   // Add any children that were skipped during the fullscreen transition.
++  // A weak pointer is needed because OrderChildren() can synchronously run a
++  // modal sheet animation (ShowAsModalSheet), entering a nested run-loop during
++  // which this bridge may be destroyed.
++  base::WeakPtr<NativeWidgetNSWindowBridge> weak_ptr = factory_.GetWeakPtr();
+   OrderChildren();
++  if (!weak_ptr) {
++    return;
++  }
+ 
+   host_->OnWindowFullscreenTransitionComplete(is_fullscreen);
+   if (is_fullscreen && immersive_mode_controller_) {

--- a/patches/chromium/cherry-pick-36f6889ed145.patch
+++ b/patches/chromium/cherry-pick-36f6889ed145.patch
@@ -1,0 +1,228 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nidhi Jaju <nidhijaju@chromium.org>
+Date: Wed, 3 Jun 2026 02:36:11 -0700
+Subject: [M148] Fix context lifetime in ProxyResolverV8 callbacks
+
+Original change's description:
+> Fix context lifetime in ProxyResolverV8 callbacks
+>
+> Safeguard JS callback functions (like alert and dnsResolve) in the PAC
+> execution context. We now indirect the execution context pointer through
+> a GC-managed wrapper and add null checks for active bindings, ensuring
+> callbacks return safely if the context is no longer active.
+>
+> Bug: 518006379
+> Change-Id: Id0932b292b2ae1e09e6bccd8be07f613f64cfca0
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885520
+> Reviewed-by: Adam Rice <ricea@chromium.org>
+> Commit-Queue: Nidhi Jaju <nidhijaju@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640118}
+
+(cherry picked from commit 399cb31703ea6c6ce6456db6f450599dc0ae713f)
+
+Bug: 519444614,518006379
+Change-Id: Id0932b292b2ae1e09e6bccd8be07f613f64cfca0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7896940
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4218}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/services/proxy_resolver/proxy_resolver_v8.cc b/services/proxy_resolver/proxy_resolver_v8.cc
+index 6e931d7259ac69c00e9c96156cf4acba48d50589..42f64032c1ec510bde787f2083ed83aaa27ae54a 100644
+--- a/services/proxy_resolver/proxy_resolver_v8.cc
++++ b/services/proxy_resolver/proxy_resolver_v8.cc
+@@ -445,7 +445,24 @@ class ProxyResolverV8::Context {
+     v8::Locker locked(isolate_);
+     v8::Isolate::Scope isolate_scope(isolate_);
+ 
+-    v8_this_.Reset();
++    // ContextDisposedNotification only prunes dirty FinalizationRegistries; it
++    // does not cancel queued ResolveAsyncWaiterPromisesTask foreground tasks
++    // or flush the isolate's shared default MicrotaskQueue, both of which can
++    // still strongly root this v8::Context (and the v8::Functions whose
++    // v8::External data points at the holder). Neutralize the indirection while
++    // holding the v8::Locker so any later callback observes a null Context*
++    // instead of a dangling one.
++    if (holder_) {
++      holder_->context = nullptr;
++      if (!holder_->v8_this.IsEmpty()) {
++        // The v8::External is still alive, so release it. The V8 weak callback
++        // will delete it when the v8::External is garbage collected. If
++        // `v8_this` is empty, the v8::External was already garbage collected,
++        // so we can delete the holder.
++        holder_.release();
++      }
++    }
++
+     v8_context_.Reset();
+   }
+ 
+@@ -515,11 +532,13 @@ class ProxyResolverV8::Context {
+     v8::Isolate::Scope isolate_scope(isolate_);
+     v8::HandleScope scope(isolate_);
+ 
+-    v8_this_.Reset(
+-        isolate_,
+-        v8::External::New(isolate_, this, gin::kProxyResolverV8ContextTag));
+-    v8::Local<v8::External> v8_this =
+-        v8::Local<v8::External>::New(isolate_, v8_this_);
++    holder_ = std::make_unique<ContextHolder>();
++    holder_->context = this;
++    v8::Local<v8::External> v8_holder = v8::External::New(
++        isolate_, holder_.get(), gin::kProxyResolverV8ContextTag);
++    holder_->v8_this.Reset(isolate_, v8_holder);
++    holder_->v8_this.SetWeak(holder_.get(), OnExternalGC,
++                             v8::WeakCallbackType::kParameter);
+ 
+     v8_context_.Reset(isolate_, v8::Context::New(isolate_));
+ 
+@@ -531,25 +550,25 @@ class ProxyResolverV8::Context {
+     // Attach the javascript bindings.
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "alert"),
+-              v8::Function::New(context, &AlertCallback, v8_this, 0,
++              v8::Function::New(context, &AlertCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddress"),
+-              v8::Function::New(context, &MyIpAddressCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolve"),
+-              v8::Function::New(context, &DnsResolveCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isPlainHostName"),
+-              v8::Function::New(context, &IsPlainHostNameCallback, v8_this, 0,
++              v8::Function::New(context, &IsPlainHostNameCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -557,26 +576,26 @@ class ProxyResolverV8::Context {
+     // Microsoft's PAC extensions:
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolveEx"),
+-              v8::Function::New(context, &DnsResolveExCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddressEx"),
+-              v8::Function::New(context, &MyIpAddressExCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+ 
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "sortIpAddressList"),
+-              v8::Function::New(context, &SortIpAddressListCallback, v8_this, 0,
+-                                v8::ConstructorBehavior::kThrow)
++              v8::Function::New(context, &SortIpAddressListCallback, v8_holder,
++                                0, v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isInNetEx"),
+-              v8::Function::New(context, &IsInNetExCallback, v8_this, 0,
++              v8::Function::New(context, &IsInNetExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -685,9 +704,10 @@ class ProxyResolverV8::Context {
+ 
+   // V8 callback for when "alert()" is invoked by the PAC script.
+   static void AlertCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      return;
++    }
+ 
+     // Like firefox we assume "undefined" if no argument was specified, and
+     // disregard any arguments beyond the first.
+@@ -734,9 +754,26 @@ class ProxyResolverV8::Context {
+   static void DnsResolveCallbackHelper(
+       const v8::FunctionCallbackInfo<v8::Value>& args,
+       net::ProxyResolveDnsOperation op) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      // Each function handles resolution errors differently.
++      switch (op) {
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE:
++          args.GetReturnValue().SetNull();
++          return;
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS:
++          args.GetReturnValue().Set(
++              ASCIILiteralToV8String(args.GetIsolate(), "127.0.0.1"));
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++      }
++      NOTREACHED();
++    }
+ 
+     std::string hostname;
+ 
+@@ -852,10 +889,40 @@ class ProxyResolverV8::Context {
+     args.GetReturnValue().Set(IsPlainHostName(hostname_utf8));
+   }
+ 
++  // Indirection for the v8::External bound to the JS callback v8::Functions.
++  // The v8::External's value is immutable and the v8::Functions can outlive
++  // |this| (e.g. via Atomics.waitAsync reactions queued in the shared isolate
++  // MicrotaskQueue), so callbacks must go through a holder that ~Context()
++  // nulls under the v8::Locker. The holder is managed via a V8 weak persistent
++  // handle and is deleted in OnExternalGC once V8 has garbage-collected it.
++  struct ContextHolder {
++    // Nulled in ~Context(), so the raw_ptr never dangles.
++    raw_ptr<Context> context = nullptr;
++
++    // This is actually a weak persistent.
++    v8::Persistent<v8::External> v8_this;
++  };
++
++  static Context* ContextFromArgs(
++      const v8::FunctionCallbackInfo<v8::Value>& args) {
++    auto* holder = static_cast<ContextHolder*>(
++        v8::External::Cast(*args.Data())
++            ->Value(gin::kProxyResolverV8ContextTag));
++    return holder ? holder->context : nullptr;
++  }
++
++  static void OnExternalGC(const v8::WeakCallbackInfo<ContextHolder>& data) {
++    ContextHolder* holder = data.GetParameter();
++    holder->v8_this.Reset();
++    if (!holder->context) {
++      delete holder;
++    }
++  }
++
+   mutable base::Lock lock_;
+   raw_ptr<ProxyResolverV8::JSBindings> js_bindings_ = nullptr;
+   raw_ptr<v8::Isolate> isolate_;
+-  v8::Persistent<v8::External> v8_this_;
++  std::unique_ptr<ContextHolder> holder_;
+   v8::Persistent<v8::Context> v8_context_;
+ };
+ 

--- a/patches/chromium/cherry-pick-3f6678d31736.patch
+++ b/patches/chromium/cherry-pick-3f6678d31736.patch
@@ -1,0 +1,146 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Max Ihlenfeldt <max@igalia.com>
+Date: Wed, 3 Jun 2026 03:07:29 -0700
+Subject: [M148] wayland: Fix UAF/dangling ptr in
+ ReleasePressedPointerButtons()
+
+Original change's description:
+> wayland: Fix UAF/dangling ptr in ReleasePressedPointerButtons()
+>
+> Dispatching the event may destroy the window, and if we release multiple
+> buttons we use a freed/dangling pointer. Fix this by using a weak
+> pointer.
+>
+> Fixed: 516501794
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7880226
+> Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+> Commit-Queue: Max Ihlenfeldt <max@igalia.com>
+> Cr-Commit-Position: refs/heads/main@{#1639248}
+
+(cherry picked from commit edce928690cb0bbca49e411fc88b8293dcd9dc8a)
+
+Bug: 516501794
+Fixed: 519050940
+Change-Id: I8e293ee8eeaf41173a012ffee12c02eab44f1154
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7894925
+Reviewed-by: Raphael Kubo da Costa <kubo@igalia.com>
+Auto-Submit: Max Ihlenfeldt <max@igalia.com>
+Commit-Queue: Raphael Kubo da Costa <kubo@igalia.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4219}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.cc b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+index 6b026aa411000ecd70d06065f6b2c2e9f474c315..c8ed95757d837e8d9bf23ef87d2c04ccae186b5a 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.cc
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+@@ -392,8 +392,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+     return;
+   }
+ 
+-  WaylandWindow* prev_focused_window =
+-      window_manager_->GetCurrentPointerFocusedWindow();
++  // Dispatching the event may delete the previously focused window.
++  base::WeakPtr<WaylandWindow> prev_focused_window =
++      window_manager_->GetCurrentPointerFocusedWindow()
++          ? window_manager_->GetCurrentPointerFocusedWindow()->AsWeakPtr()
++          : nullptr;
+   if (window) {
+     window_manager_->SetPointerFocusedWindow(window);
+   }
+@@ -431,10 +434,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+   }
+ }
+ 
+-void WaylandEventSource::OnPointerButtonEventInternal(WaylandWindow* window,
+-                                                      EventType type) {
++void WaylandEventSource::OnPointerButtonEventInternal(
++    base::WeakPtr<WaylandWindow> window,
++    EventType type) {
+   if (window) {
+-    window_manager_->SetPointerFocusedWindow(window);
++    window_manager_->SetPointerFocusedWindow(window.get());
+   }
+ }
+ 
+@@ -940,10 +944,14 @@ void WaylandEventSource::ReleasePressedPointerButtons(
+     return;
+   }
+ 
++  // Dispatching the event may delete the window.
++  base::WeakPtr<WaylandWindow> window_weak =
++      window ? window->AsWeakPtr() : nullptr;
+   for (const auto& [button, name] : kMouseButtonToStringMap) {
+     if (button & pointer_flags_) {
+       VLOG(1) << "Synthesizing pointer release for: " << name;
+-      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp, window,
++      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp,
++                           window_weak.get(),
+                            wl::EventDispatchPolicy::kImmediate,
+                            /*allow_release_of_unpressed_button=*/false,
+                            /*is_synthesized=*/true);
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.h b/ui/ozone/platform/wayland/host/wayland_event_source.h
+index f39137fef2ed59b4a798f347961455596e51302f..92182c78cc42131416d67e191ad383490cc292be 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.h
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.h
+@@ -237,7 +237,8 @@ class WaylandEventSource : public PlatformEventSource,
+   gfx::Vector2dF ComputeFlingVelocity();
+ 
+   // Wrap up method to support async pointer down/up event processing.
+-  void OnPointerButtonEventInternal(WaylandWindow* window, EventType type);
++  void OnPointerButtonEventInternal(base::WeakPtr<WaylandWindow> window,
++                                    EventType type);
+ 
+   // Wrap up method to support async touch release processing.
+   void OnTouchReleaseInternal(PointerId id);
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc b/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
+index aafab7df827be323ba11cbd40ec9d52dc7e41701..669b8bc9d782cdc922cba704ac419cc063376811 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_event_source_unittest.cc
+@@ -280,6 +280,47 @@ TEST_P(WaylandEventSourceTest, ReleasesAllPressedPointerButtons) {
+       pointer_delegate_->IsPointerButtonPressed(EF_MIDDLE_MOUSE_BUTTON));
+ }
+ 
++// Check that if an event dispatched by ReleasePressedPointerButtons causes the
++// target window to be destroyed, we don't cause a UAF or dangling pointer.
++TEST_P(WaylandEventSourceTest, ReleasePressedPointerButtonsUAF) {
++  PostToServerAndWait([](wl::TestWaylandServerThread* server) {
++    wl_seat_send_capabilities(server->seat()->resource(),
++                              WL_SEAT_CAPABILITY_POINTER);
++  });
++  ASSERT_TRUE(connection_->seat()->pointer());
++
++  // Record two pressed buttons so ReleasePressedPointerButtons iterates twice.
++  EXPECT_CALL(delegate_, DispatchEvent(_)).Times(::testing::AnyNumber());
++  PostToServerAndWait([surface_id = window_->root_surface()->get_surface_id()](
++                          wl::TestWaylandServerThread* server) {
++    auto* const surface =
++        server->GetObject<wl::MockSurface>(surface_id)->resource();
++    auto* const pointer = server->seat()->pointer()->resource();
++    wl_pointer_send_enter(pointer, server->GetNextSerial(), surface, 0, 0);
++    wl_pointer_send_button(pointer, server->GetNextSerial(),
++                           server->GetNextTime(), BTN_LEFT,
++                           WL_POINTER_BUTTON_STATE_PRESSED);
++    wl_pointer_send_button(pointer, server->GetNextSerial(),
++                           server->GetNextTime(), BTN_RIGHT,
++                           WL_POINTER_BUTTON_STATE_PRESSED);
++    wl_pointer_send_frame(pointer);
++  });
++  ASSERT_TRUE(pointer_delegate_->IsPointerButtonPressed(EF_LEFT_MOUSE_BUTTON));
++  ASSERT_TRUE(pointer_delegate_->IsPointerButtonPressed(EF_RIGHT_MOUSE_BUTTON));
++
++  // Destroy the window on the first mouse release.
++  EXPECT_CALL(delegate_, DispatchEvent(_))
++      .WillOnce([&](Event* event) {
++        EXPECT_EQ(event->type(), EventType::kMouseReleased);
++        window_.reset();
++      })
++      .WillRepeatedly(::testing::Return());
++
++  // Release both pressed buttons.
++  pointer_delegate_->ReleasePressedPointerButtons(window_.get(),
++                                                  base::TimeTicks::Now());
++}
++
+ INSTANTIATE_TEST_SUITE_P(
+     EventsDispatchPolicyTest,
+     WaylandEventSourceTest,

--- a/patches/chromium/cherry-pick-409ec3ebc79c.patch
+++ b/patches/chromium/cherry-pick-409ec3ebc79c.patch
@@ -1,0 +1,192 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ming-Ying Chung <mych@chromium.org>
+Date: Fri, 5 Jun 2026 01:10:16 -0700
+Subject: [M148] [FSA] Fix UAF in ShowFilePickerOnUIThread.
+
+Original change's description:
+> [FSA] Fix UAF in ShowFilePickerOnUIThread.
+>
+> The `ShowFilePickerOnUIThread()` function in the browser process was
+> caching raw pointers to `RenderFrameHost` and `WebContents` which could
+> become dangling if the frame was destroyed during nested message loops
+> spun by intermediate operations like `CanShowFilePicker()` or
+> `ForSecurityDropFullscreen()`.
+>
+> Th CL re-resolves the RenderFrameHost and WebContents pointers from
+> the stored `GlobalRenderFrameHostId` after these operations and aborts
+> safely if they are no longer active or valid.
+>
+> Bug: 516677924
+> Change-Id: I50046d8f72f139f06f885309847b5179a32b7b37
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7871715
+> Reviewed-by: Fergal Daly <fergal@chromium.org>
+> Commit-Queue: Ming-Ying Chung <mych@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1637522}
+
+(cherry picked from commit eb0b9aba64dbe619399fb2e4e1be6a784524c809)
+
+Bug: 518966951,516677924
+Change-Id: I50046d8f72f139f06f885309847b5179a32b7b37
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7895216
+Commit-Queue: Ming-Ying Chung <mych@chromium.org>
+Reviewed-by: Mingyu Lei <leimy@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4244}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/file_system_access/file_system_access_manager_impl.cc b/content/browser/file_system_access/file_system_access_manager_impl.cc
+index b9ecd894b422b59689cd18f4e46f00c4d7206e1b..797d4802c1d461b78a5a67eb460ba8338db2bea3 100644
+--- a/content/browser/file_system_access/file_system_access_manager_impl.cc
++++ b/content/browser/file_system_access/file_system_access_manager_impl.cc
+@@ -19,6 +19,7 @@
+ #include "base/functional/bind.h"
+ #include "base/functional/callback_helpers.h"
+ #include "base/i18n/file_util_icu.h"
++#include "base/memory/raw_ptr.h"
+ #include "base/notreached.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+@@ -92,6 +93,40 @@ using HandleType = FileSystemAccessPermissionContext::HandleType;
+ 
+ namespace {
+ 
++// Holds resolved and validated frame objects. All pointers are guaranteed to be
++// non-null and active if this struct is returned.
++struct ResolvedFrame {
++  raw_ptr<RenderFrameHost> rfh;
++  raw_ptr<WebContents> web_contents;
++  raw_ptr<RenderFrameHost> outermost_rfh;
++};
++
++// Resolves `frame_id` to its corresponding `RenderFrameHost`, `WebContents`,
++// and outermost `RenderFrameHost`, and validates that they are all non-null
++// and active.
++// Returns a `ResolvedFrame` struct if ALL resolved objects are valid and
++// active, i.e. non-null; otherwise, returns `std::nullopt`.
++//
++// This check is critical because intermediate operations, like permission
++// checks or security prompts, can run nested message loops during which the
++// calling frame or WebContents can be destroyed or navigated.
++std::optional<ResolvedFrame> ResolveAndValidateFrame(
++    GlobalRenderFrameHostId frame_id) {
++  RenderFrameHost* rfh = RenderFrameHost::FromID(frame_id);
++  if (!rfh || !rfh->IsActive()) {
++    return std::nullopt;
++  }
++  WebContents* web_contents = WebContents::FromRenderFrameHost(rfh);
++  if (!web_contents) {
++    return std::nullopt;
++  }
++  RenderFrameHost* outermost_rfh = rfh->GetOutermostMainFrame();
++  if (!outermost_rfh || !outermost_rfh->IsActive()) {
++    return std::nullopt;
++  }
++  return ResolvedFrame{rfh, web_contents, outermost_rfh};
++}
++
+ #if BUILDFLAG(IS_ANDROID)
+ // Adaptor between FileSystemChooser::ResultCallback and FileSelectListener
+ // used when delegating file choosing to WebContentsDelegate.
+@@ -200,6 +235,18 @@ void ShowFilePickerOnUIThread(
+                           {});
+                       return;
+                     });
++    // `CanShowFilePicker()` runs nested message loops during which the frame
++    // could be destroyed or navigated. Re-resolve and re-validate the frame.
++    auto re_resolved = ResolveAndValidateFrame(frame_id);
++    if (!re_resolved) {
++      std::move(callback).Run(file_system_access_error::FromStatus(
++                                  FileSystemAccessStatus::kOperationAborted),
++                              {});
++      return;
++    }
++    rfh = re_resolved->rfh;
++    web_contents = re_resolved->web_contents;
++    outermost_rfh = re_resolved->outermost_rfh;
+   }
+ 
+ #if BUILDFLAG(IS_ANDROID)
+diff --git a/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc b/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
+index cd20481e32e030de5311d1bc9ad2478211bedc8e..a44a85b0eb5ad01aab5a650b813fa4b7df5ecae3 100644
+--- a/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
++++ b/content/browser/file_system_access/file_system_access_manager_impl_unittest.cc
+@@ -1588,6 +1588,80 @@ TEST_F(FileSystemAccessManagerImplTest, ChooseEntries_OpenFile) {
+   ASSERT_TRUE(future.Wait());
+ }
+ 
++// Covers the re-entrancy and lifetime safety of `RenderFrameHost` and
++// `WebContents` in `ShowFilePickerOnUIThread`. Specifically, it covers the
++// scenario where the frame is detached/destroyed during the
++// `CanShowFilePicker` permission check.
++//
++// Without the fix, this scenario triggers a crash when the code attempts to
++// access the destroyed `WebContents` to drop fullscreen
++// `web_contents->ForSecurityDropFullscreen(...)`.
++//
++// Note: If destruction occurred during the fullscreen exit loop instead, the
++// crash would occur in `FileSystemChooser::CreateAndShow()` when dereferencing
++// the dangling RenderFrameHost.
++TEST_F(FileSystemAccessManagerImplTest,
++       ChooseEntries_CanShowFilePickerDestroysFrameUAF) {
++  static_cast<TestRenderFrameHost*>(web_contents_->GetPrimaryMainFrame())
++      ->SimulateUserActivation();
++
++  mojo::Remote<blink::mojom::FileSystemAccessManager> manager_remote;
++  FileSystemAccessManagerImpl::BindingContext binding_context = {
++      kTestStorageKey, kTestURL,
++      web_contents_->GetPrimaryMainFrame()->GetGlobalId()};
++  manager_->BindReceiver(binding_context,
++                         manager_remote.BindNewPipeAndPassReceiver());
++
++  EXPECT_CALL(permission_context_,
++              CanObtainReadPermission(kTestStorageKey.origin()))
++      .WillOnce(testing::Return(true));
++
++  EXPECT_CALL(
++      permission_context_,
++      GetWellKnownDirectoryPath(blink::mojom::WellKnownDirectory::kDirDocuments,
++                                kTestStorageKey.origin()))
++      .WillOnce(testing::Return(base::FilePath()));
++  EXPECT_CALL(permission_context_,
++              GetLastPickedDirectory(kTestStorageKey.origin(), std::string()))
++      .WillOnce(testing::Return(PathInfo()));
++  EXPECT_CALL(permission_context_, GetPickerTitle(testing::_))
++      .WillOnce(testing::Return(std::u16string()));
++
++  // Mock CanShowFilePicker to synchronously destroy the WebContents, which
++  // destroys the RFH. This simulates the frame being detached/destroyed
++  // during the yielding permission check.
++  EXPECT_CALL(permission_context_, CanShowFilePicker(testing::_))
++      .WillOnce([&](content::RenderFrameHost* rfh) {
++        auto* temp_wc = web_contents_.get();
++        web_contents_ = nullptr;
++        web_contents_factory_.DestroyWebContents(temp_wc);
++        return base::ok();
++      });
++
++  auto open_file_picker_options = blink::mojom::OpenFilePickerOptions::New(
++      blink::mojom::AcceptsTypesInfo::New(
++          std::vector<blink::mojom::ChooseFileSystemEntryAcceptsOptionPtr>(),
++          /*include_accepts_all=*/true),
++      /*can_select_multiple_files=*/false);
++  auto picker_options = blink::mojom::FilePickerOptions::New(
++      blink::mojom::TypeSpecificFilePickerOptionsUnion::
++          NewOpenFilePickerOptions(std::move(open_file_picker_options)),
++      /*starting_directory_id=*/std::string(),
++      blink::mojom::FilePickerStartInOptionsUnionPtr());
++
++  base::test::TestFuture<blink::mojom::FileSystemAccessErrorPtr,
++                         std::vector<blink::mojom::FileSystemAccessEntryPtr>>
++      future;
++  manager_remote->ChooseEntries(std::move(picker_options),
++                                future.GetCallback());
++  ASSERT_TRUE(future.Wait());
++
++  // The call should be aborted gracefully since the frame was destroyed.
++  // Without the fix, this would have crashed during the picker call.
++  EXPECT_EQ(blink::mojom::FileSystemAccessStatus::kOperationAborted,
++            future.Get<0>()->status);
++}
++
+ TEST_F(FileSystemAccessManagerImplTest,
+        ChooseEntries_OpenFile_EnterpriseBlock) {
+   base::FilePath test_file = dir_.GetPath().AppendASCII("foo");

--- a/patches/chromium/cherry-pick-74a45c11c791.patch
+++ b/patches/chromium/cherry-pick-74a45c11c791.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Sun, 31 May 2026 20:55:50 -0700
+Subject: [M148] bluetooth: Fix potential UAF in Bluetooth Classic channel
+ delegates on macOS
+
+Original change's description:
+> bluetooth: Fix potential UAF in Bluetooth Classic channel delegates on macOS
+>
+> Clears the native channel's delegate and extends the delegate's lifetime
+> across one run-loop turn during channel destruction.
+>
+> On macOS, the classic Bluetooth channel delegates only self-retain on
+> successful open. On connection failure or timeout, destroying the C++
+> wrapper deallocates the delegate while the OS still holds an unsafe
+> reference, causing a UAF during subsequent async callbacks.
+>
+> Bug: 516963272
+> Change-Id: Ice878214b875039e6eff06b0b4101a7c4ea433f6
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7884206
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1638776}
+
+(cherry picked from commit 3da0d899cbbe299ec3ba36bb842b0b6215915b63)
+
+Bug: 518123692,516963272
+Change-Id: Ice878214b875039e6eff06b0b4101a7c4ea433f6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7884252
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4123}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_l2cap_channel_mac.mm b/device/bluetooth/bluetooth_l2cap_channel_mac.mm
+index 5bcbde969ab86151f013999b7d13c8b82c9b6eca..66db9baae58b4d6d05570c11323c5256d9ca035b 100644
+--- a/device/bluetooth/bluetooth_l2cap_channel_mac.mm
++++ b/device/bluetooth/bluetooth_l2cap_channel_mac.mm
+@@ -110,7 +110,16 @@ - (void)resetOwner {
+   // delegate's reference to this object so the delegate will not notify us
+   // for events that occur after our destruction.
+   [delegate_ resetOwner];
++  [channel_ setDelegate:nil];
+   [channel_ closeChannel];
++  // `delegate_`'s self-retain (`_strongSelf`) is only armed after a successful
++  // open. If we are destroyed during a pending or failed open, keep the
++  // delegate alive across one main-run-loop turn so any already-enqueued
++  // IOBluetooth callbacks hit a live receiver. See FB13705522.
++  BluetoothL2capChannelDelegate* __strong delegate = delegate_;
++  dispatch_async(dispatch_get_main_queue(), ^{
++    (void)delegate;
++  });
+ }
+ 
+ // static
+diff --git a/device/bluetooth/bluetooth_rfcomm_channel_mac.mm b/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
+index ebc668426afd4cdb6641f0fc2169bf5c0255ec6d..fd75d89437ffa394e4b86b25cc5013c5c438c6cf 100644
+--- a/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
++++ b/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
+@@ -117,7 +117,16 @@ - (void)setRfcommChannel:(IOBluetoothRFCOMMChannel*)rfcommChannel {
+   // delegate's reference to this object so the delegate will not notify us
+   // for events that occur after our destruction.
+   [delegate_ resetOwner];
++  [channel_ setDelegate:nil];
+   [channel_ closeChannel];
++  // `delegate_`'s self-retain (`_strongSelf`) is only armed after a successful
++  // open. If we are destroyed during a pending or failed open, keep the
++  // delegate alive across one main-run-loop turn so any already-enqueued
++  // IOBluetooth callbacks hit a live receiver. See FB13705522.
++  BluetoothRfcommChannelDelegate* __strong delegate = delegate_;
++  dispatch_async(dispatch_get_main_queue(), ^{
++    (void)delegate;
++  });
+ }
+ 
+ // static

--- a/patches/chromium/cherry-pick-a3fe69a65a6d.patch
+++ b/patches/chromium/cherry-pick-a3fe69a65a6d.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kartar Singh <kartarsingh@google.com>
+Date: Fri, 29 May 2026 08:27:37 -0700
+Subject: [M148] Prevent Use-After-Free in
+ RenderWidgetHostViewAura::ShowWithVisibility.
+
+Original change's description:
+> Prevent Use-After-Free in RenderWidgetHostViewAura::ShowWithVisibility.
+>
+> Use base::WeakPtr to guard against view destruction during ShowImpl
+> on Windows builds.
+>
+> Bug: 516691130
+> Change-Id: I857c1900ab55f6b0d26e54db35652df4d14d32b8
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7883318
+> Reviewed-by: Jonathan Ross <jonross@chromium.org>
+> Commit-Queue: Kartar Singh <kartarsingh@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1637761}
+
+(cherry picked from commit d86edd3226e233b4556c7fc7022042824806e3d9)
+
+Bug: 517793286,516691130
+Change-Id: I857c1900ab55f6b0d26e54db35652df4d14d32b8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7881333
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#3971}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/renderer_host/render_widget_host_view_aura.cc b/content/browser/renderer_host/render_widget_host_view_aura.cc
+index 2ae3a467ca4be802cd53b5823f23bf0224c3a761..9205e9f6decbb4fcae4881e0d51dde9eabe853ce 100644
+--- a/content/browser/renderer_host/render_widget_host_view_aura.cc
++++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
+@@ -1018,8 +1018,15 @@ void RenderWidgetHostViewAura::ShowWithVisibility(
+   }
+ 
+   window_->Show();
++
++  base::WeakPtr<RenderWidgetHostViewAura> weak_this(
++      weak_ptr_factory_.GetWeakPtr());
++
+   ShowImpl(page_visibility);
+ #if BUILDFLAG(IS_WIN)
++  if (!weak_this) {
++    return;
++  }
+   if (page_visibility != PageVisibilityState::kVisible &&
+       legacy_render_widget_host_HWND_) {
+     legacy_render_widget_host_HWND_->Hide();

--- a/patches/chromium/cherry-pick-b534033a6391.patch
+++ b/patches/chromium/cherry-pick-b534033a6391.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Reynolds <mattreynolds@google.com>
+Date: Wed, 3 Jun 2026 17:33:55 -0700
+Subject: [M148] bluetooth: Avoid double invoking callback after failed winrt
+ call
+
+Original change's description:
+> bluetooth: Avoid double invoking callback after failed winrt call
+>
+> In OnGetGattServices and OnGetCharacteristics, if an API call fails while
+> iterating over a list then the callback is invoked twice: once to report
+> the failure and then again when RunCallbackIfDone is called after the
+> loop exits. This CL ensures these methods return after invoking the
+> callback the first time.
+>
+> Bug: 517418936
+> Change-Id: I6ed22b9a7d2aede6c807054b88f427d8564cf649
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7883805
+> Commit-Queue: Matt Reynolds <mattreynolds@chromium.org>
+> Reviewed-by: Alvin Ji <alvinji@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639876}
+
+(cherry picked from commit 4bb7a1ea296c757b7ce5a0ae7bedfc4226f15df2)
+
+Bug: 519444794,517418936
+Change-Id: I6ed22b9a7d2aede6c807054b88f427d8564cf649
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7893642
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4233}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc b/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
+index ae77850c02ed03f36991ea7351b385a14eee7f40..5f2c354bce8455e4f30f78ae54304c93710fc82e 100644
+--- a/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
++++ b/device/bluetooth/bluetooth_gatt_discoverer_winrt.cc
+@@ -302,6 +302,7 @@ void BluetoothGattDiscovererWinrt::OnGetGattServices(
+       BLUETOOTH_LOG(DEBUG) << "GattDeviceService::OpenAsync() failed: "
+                            << logging::SystemErrorCodeToString(hr);
+       std::move(callback_).Run(false);
++      return;
+     }
+ 
+     hr = base::win::PostAsyncResults(
+@@ -423,6 +424,7 @@ void BluetoothGattDiscovererWinrt::OnGetCharacteristics(
+       BLUETOOTH_LOG(DEBUG) << "PostAsyncResults failed: "
+                            << logging::SystemErrorCodeToString(hr);
+       std::move(callback_).Run(false);
++      return;
+     }
+   }
+ 

--- a/patches/chromium/cherry-pick-ba3e2c142b89.patch
+++ b/patches/chromium/cherry-pick-ba3e2c142b89.patch
@@ -1,0 +1,343 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Kvitek <kvitekp@chromium.org>
+Date: Fri, 29 May 2026 13:50:35 -0700
+Subject: [M148] [headless][linux] Safeguard headless window code against
+ potential UAF
+
+Original change's description:
+> [headless][linux] Safeguard headless window code against potential UAF
+>
+> ui::HeadlessWindow synchronously callsbacks delegate methods during state-changing operations. If an observer synchronously closes the widget during these callbacks, the associated ui::HeadlessWindow instance is deleted while its methods are still executing on the stack.
+>
+> This CL adds weak ptr checks to avoid ui::HeadlessWindow code execution after a delegate callback that invalidates 'this'.
+>
+> Bug: 516674532
+> Change-Id: I788ba9b19c733c7af17010744bd66b25783ddf9c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7879467
+> Commit-Queue: Peter Kvitek <kvitekp@chromium.org>
+> Reviewed-by: Colin Blundell <blundell@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1637863}
+
+(cherry picked from commit 583fe61da24f865e1da49dc1ad1b297c7c9cf6d4)
+
+Bug: 517793482,516674532
+Change-Id: I788ba9b19c733c7af17010744bd66b25783ddf9c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7884242
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#3984}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/ozone/BUILD.gn b/ui/ozone/BUILD.gn
+index 7bf64c40e9f14c86fdca8d1c438061432a0e9dd6..0bd2b4e80e3bbe421dafe6c538e113fa665d4365 100644
+--- a/ui/ozone/BUILD.gn
++++ b/ui/ozone/BUILD.gn
+@@ -37,6 +37,7 @@ ozone_platform_interactive_ui_tests_sources =
+ if (ozone_platform_headless) {
+   ozone_platforms += [ "headless" ]
+   ozone_platform_deps += [ "platform/headless" ]
++  ozone_platform_test_deps += [ "platform/headless:headless_unittests" ]
+ }
+ 
+ if (ozone_platform_drm) {
+@@ -356,6 +357,7 @@ static_library("test_support") {
+   visibility = [
+     ":*",
+     "platform/flatland:flatland_unittests",
++    "platform/headless:headless_unittests",
+     "platform/wayland:test_support",
+     "platform/wayland:wayland_unittests",
+     "platform/x11:x11_unittests",
+diff --git a/ui/ozone/platform/headless/BUILD.gn b/ui/ozone/platform/headless/BUILD.gn
+index 650058400a2450255d8421ac449c5c47ae019f1b..dc07e2b6433d07f597c1558e85f031cb2e68dd89 100644
+--- a/ui/ozone/platform/headless/BUILD.gn
++++ b/ui/ozone/platform/headless/BUILD.gn
+@@ -59,3 +59,18 @@ source_set("headless") {
+     deps += [ "//gpu/vulkan" ]
+   }
+ }
++
++source_set("headless_unittests") {
++  testonly = true
++  sources = [ "headless_window_unittest.cc" ]
++  deps = [
++    ":headless",
++    "//base",
++    "//base/test:test_support",
++    "//testing/gtest",
++    "//ui/display:test_support",
++    "//ui/events:test_support",
++    "//ui/ozone:platform",
++    "//ui/ozone:test_support",
++  ]
++}
+diff --git a/ui/ozone/platform/headless/headless_window.cc b/ui/ozone/platform/headless/headless_window.cc
+index d11ccc52615c913c95f902f86079f1ce904c4560..a0061fa1697539d16f04860deb0bc1547460a268 100644
+--- a/ui/ozone/platform/headless/headless_window.cc
++++ b/ui/ozone/platform/headless/headless_window.cc
+@@ -78,18 +78,31 @@ void HeadlessWindow::SetFullscreen(bool fullscreen, int64_t target_display_id) {
+     return;
+   }
+ 
++  // PlatformWindowDelegate callbacks can destroy the window, invalidating
++  // `this`. Keep a weak pointer and check it after each callback, here and
++  // below.
++  auto weak_ptr = GetWeakPtr();
++
+   if (fullscreen) {
+     if (window_state_ != PlatformWindowState::kMaximized &&
+         window_state_ != PlatformWindowState::kFullScreen) {
+       restored_bounds_ = bounds_;
+     }
+     ZoomWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kFullScreen);
+   } else {
+     if (window_state_ != PlatformWindowState::kFullScreen) {
+       return;
+     }
+     RestoreWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kNormal);
+   }
+ }
+@@ -101,21 +114,37 @@ void HeadlessWindow::Maximize() {
+ 
+   if (window_state_ != PlatformWindowState::kMaximized &&
+       window_state_ != PlatformWindowState::kFullScreen) {
++    auto weak_ptr = GetWeakPtr();
++
+     restored_bounds_ = bounds_;
+     ZoomWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kMaximized);
+   }
+ }
+ 
+ void HeadlessWindow::Minimize() {
+   if (window_state_ != PlatformWindowState::kMinimized) {
++    auto weak_ptr = GetWeakPtr();
++
+     // Minimized window retains its size and position, however, it's made
+     // hidden by Aura.
+     if (window_state_ == PlatformWindowState::kMaximized ||
+         window_state_ == PlatformWindowState::kFullScreen) {
+       RestoreWindowBounds();
++      if (!weak_ptr) {
++        return;
++      }
+     }
++
+     UpdateWindowState(PlatformWindowState::kMinimized);
++    if (!weak_ptr) {
++      return;
++    }
++
+     // Minimized windows are inactive. Aura activates minimized windows
+     // when restoring. If we don't deactivate the window here, the subsequent
+     // activation will be optimized away, causing https://crbug.com/358998544.
+@@ -125,7 +154,13 @@ void HeadlessWindow::Minimize() {
+ 
+ void HeadlessWindow::Restore() {
+   if (window_state_ != PlatformWindowState::kNormal) {
++    auto weak_ptr = GetWeakPtr();
++
+     RestoreWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kNormal);
+   }
+ }
+diff --git a/ui/ozone/platform/headless/headless_window.h b/ui/ozone/platform/headless/headless_window.h
+index 646e398135bfd51429272977a2471f17eb038290..a7dc0249fb00f5a2ebd0f0adaa10c8c83459888b 100644
+--- a/ui/ozone/platform/headless/headless_window.h
++++ b/ui/ozone/platform/headless/headless_window.h
+@@ -9,6 +9,7 @@
+ 
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/scoped_refptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "ui/gfx/geometry/point.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/image/image_skia.h"
+@@ -73,6 +74,10 @@ class HeadlessWindow : public PlatformWindow {
+  protected:
+   PlatformWindowDelegate* delegate() { return delegate_; }
+ 
++  base::WeakPtr<HeadlessWindow> GetWeakPtr() {
++    return weak_ptr_factory_.GetWeakPtr();
++  }
++
+  private:
+   enum class ActivationState {
+     kUnknown,
+@@ -90,6 +95,8 @@ class HeadlessWindow : public PlatformWindow {
+   std::optional<gfx::Rect> restored_bounds_;
+   PlatformWindowState window_state_ = PlatformWindowState::kUnknown;
+   ActivationState activation_state_ = ActivationState::kUnknown;
++
++  base::WeakPtrFactory<HeadlessWindow> weak_ptr_factory_{this};
+ };
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/headless/headless_window_unittest.cc b/ui/ozone/platform/headless/headless_window_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..0881a9841c2c2d9ca8d04d2ac63e396a70763af6
+--- /dev/null
++++ b/ui/ozone/platform/headless/headless_window_unittest.cc
+@@ -0,0 +1,143 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/headless/headless_window.h"
++
++#include <memory>
++
++#include "testing/gtest/include/gtest/gtest.h"
++#include "ui/display/test/test_screen.h"
++#include "ui/gfx/geometry/rect.h"
++#include "ui/ozone/platform/headless/headless_window_manager.h"
++#include "ui/platform_window/platform_window_delegate.h"
++
++namespace ui {
++namespace {
++
++// A PlatformWindowDelegate that simulates the production behaviour of
++// DesktopWindowTreeHostPlatform: when the platform window calls back into the
++// delegate (OnBoundsChanged / OnWindowStateChanged), an observer may
++// synchronously call Widget::CloseNow(), which ends up calling
++// HeadlessWindow::Close() -> delegate_->OnClosed() ->
++// DWTHP::OnClosed() -> SetPlatformWindow(nullptr) -> ~HeadlessWindow().
++//
++// This delegate models that by resetting its owned unique_ptr<PlatformWindow>
++// from inside the chosen callback.
++class DestroyingDelegate : public PlatformWindowDelegate {
++ public:
++  enum class DestroyOn {
++    kNone,
++    kBoundsChanged,
++    kWindowStateChanged,
++  };
++
++  explicit DestroyingDelegate(DestroyOn destroy_on) : destroy_on_(destroy_on) {}
++  ~DestroyingDelegate() override = default;
++
++  void set_destroy_on(DestroyOn destroy_on) { destroy_on_ = destroy_on; }
++
++  void SetWindow(std::unique_ptr<PlatformWindow> window) {
++    window_ = std::move(window);
++  }
++
++  // PlatformWindowDelegate:
++  void OnBoundsChanged(const BoundsChange& change) override {
++    if (destroy_on_ == DestroyOn::kBoundsChanged) {
++      window_.reset();
++    }
++  }
++  void OnDamageRect(const gfx::Rect& damaged_region) override {}
++  void DispatchEvent(Event* event) override {}
++  void OnCloseRequest() override {}
++  void OnClosed() override { window_.reset(); }
++  void OnWindowStateChanged(PlatformWindowState old_state,
++                            PlatformWindowState new_state) override {
++    if (destroy_on_ == DestroyOn::kWindowStateChanged) {
++      window_.reset();
++    }
++  }
++  void OnLostCapture() override {}
++  void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) override {}
++  void OnWillDestroyAcceleratedWidget() override {}
++  void OnAcceleratedWidgetDestroyed() override {}
++  void OnActivationChanged(bool active) override {}
++  void OnCursorUpdate() override {}
++  bool CanMaximize() const override { return true; }
++  bool CanFullscreen() const override { return true; }
++  gfx::Rect ConvertRectToPixels(const gfx::Rect& rect_in_dip) const override {
++    return rect_in_dip;
++  }
++  gfx::Rect ConvertRectToDIP(const gfx::Rect& rect_in_pixels) const override {
++    return rect_in_pixels;
++  }
++
++ private:
++  DestroyOn destroy_on_ = DestroyOn::kNone;
++  std::unique_ptr<PlatformWindow> window_;
++};
++
++class HeadlessWindowCrashTest : public ::testing::Test {
++ public:
++  HeadlessWindowCrashTest() = default;
++  ~HeadlessWindowCrashTest() override = default;
++
++ protected:
++  display::test::TestScreen test_screen_{/*create_display=*/true,
++                                         /*register_screen=*/true};
++  HeadlessWindowManager manager_;
++};
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInSetFullscreen) {
++  DestroyingDelegate delegate(DestroyingDelegate::DestroyOn::kBoundsChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->SetFullscreen(/*fullscreen=*/true,
++                                 /*target_display_id=*/-1);
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInMaximize) {
++  DestroyingDelegate delegate(
++      DestroyingDelegate::DestroyOn::kWindowStateChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Maximize();
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInMinimize) {
++  DestroyingDelegate delegate(
++      DestroyingDelegate::DestroyOn::kWindowStateChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Minimize();
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInRestore) {
++  DestroyingDelegate delegate(DestroyingDelegate::DestroyOn::kNone);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Maximize();
++
++  delegate.set_destroy_on(DestroyingDelegate::DestroyOn::kBoundsChanged);
++
++  headless_window->Restore();
++}
++
++}  // namespace
++}  // namespace ui

--- a/patches/chromium/cherry-pick-c92de87bddf2.patch
+++ b/patches/chromium/cherry-pick-c92de87bddf2.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maggie Chen <magchen@chromium.org>
+Date: Fri, 29 May 2026 16:05:48 -0700
+Subject: Fix GPU process lost race in DisplayLinkMacMojo
+
+DisplayLinkMacMojo manages objects like mojo::Remote, mojo::Receiver,
+and vsync callbacks that are bound to a dedicated VSync thread.
+Previously, OnGpuProcessLost attempts to recreate new objects on the
+main thread while destroying the old objects on the VSync thread, which
+can lead to race conditions or DCHECK failures.
+
+This CL serialize the destroy-then-recreate to ensures that these
+objects are cleaned up on the VSync thread before reconnecting the IPC
+on the main thread.
+
+Bug: 517227707
+Change-Id: Ie052347db9869d69e8de7beec2248a3241ff4b65
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7881564
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Commit-Queue: Maggie Chen <magchen@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1638792}
+
+diff --git a/ui/compositor/display_link_mac_mojo.h b/ui/compositor/display_link_mac_mojo.h
+index 8bdd487c126b79fb5d45cd69c1b577162ba55672..0efb961bc098364b1f5f712582f750d3d9250acf 100644
+--- a/ui/compositor/display_link_mac_mojo.h
++++ b/ui/compositor/display_link_mac_mojo.h
+@@ -5,6 +5,8 @@
+ #ifndef UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ #define UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ 
++#include <optional>
++
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/threading/thread.h"
+ #include "mojo/public/cpp/bindings/receiver.h"
+@@ -84,7 +86,8 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+  private:
+   // VSyncIpc is connected when DisplayLinkMacMojo is created, and it's
+   // reconnected after the GPU process is lost.
+-  void ConnectVSyncIpc(viz::HostFrameSinkManager* host_frame_sink_manager);
++  void ConnectVSyncIpcAndAddDisplayObserver(
++      viz::HostFrameSinkManager* host_frame_sink_manager);
+ 
+   void InitDisplaysOnVSyncThread();
+ 
+@@ -94,6 +97,31 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+ 
+   void DisplaysRemovedOnVSyncThread(std::vector<int64_t> display_ids);
+ 
++  // This sequence is called to prevent race conditions during GPU process loss.
++  // The flow is:
++  // OnGpuProcessLost() (Main thread) ->
++  // OnGpuProcessLostOnVSyncThread() (VSync thread) ->
++  // ContinueGpuProcessLostOnMainThread() (Main thread)
++  //
++  // Note: OnGpuProcessLostOnVSyncThread() must use base::Unretained(this) to
++  // ensure that thread-affine Mojo objects are always cleaned up on the VSync
++  // thread, even if this class is being destroyed. The recovery task
++  // (ContinueGpuProcessLostOnMainThread) uses a WeakPtr because recovery
++  // should only proceed if this instance has not been destroyed.
++  void ContinueGpuProcessLostOnMainThread(
++      viz::HostFrameSinkManager* host_frame_sink_manager);
++  void OnGpuProcessLostOnVSyncThread(
++      viz::HostFrameSinkManager* host_frame_sink_manager,
++      scoped_refptr<base::SingleThreadTaskRunner> main_task_runner,
++      base::WeakPtr<DisplayLinkMacMojo> weak_ptr);
++
++  void ResetStateOnVSyncThread();
++
++  // To prevent AddObserver from being called multiple times
++  std::optional<display::ScopedDisplayObserver> display_observer_;
++
++  int pending_gpu_lost_count_ = 0;
++
+   std::map<int64_t, scoped_refptr<DisplayLinkMac>> display_links_;
+   std::map<int64_t, std::unique_ptr<VSyncCallbackMac>> vsync_callbacks_;
+ 
+diff --git a/ui/compositor/display_link_mac_mojo.mm b/ui/compositor/display_link_mac_mojo.mm
+index 0fd296b3c3272ffada6cc896af6c1b9e9d1eb0b4..28fafba7b74c547c0091e2450214ea4078fc6d37 100644
+--- a/ui/compositor/display_link_mac_mojo.mm
++++ b/ui/compositor/display_link_mac_mojo.mm
+@@ -6,6 +6,7 @@
+ 
+ #include <utility>
+ 
++#include "base/task/bind_post_task.h"
+ #include "components/viz/common/frame_sinks/begin_frame_args.h"
+ #include "components/viz/host/host_frame_sink_manager.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+@@ -32,11 +33,7 @@
+ 
+   // To ensure VSyncThread task_runner() is valid, StartWithOptions() must be
+   // called before ConnectVSyncIpc().
+-  ConnectVSyncIpc(host_frame_sink_manager);
+-
+-  // Display AddObserver can only be called on the browser main thread.
+-  DCHECK(display::Screen::HasScreen());
+-  display::Screen::Get()->AddObserver(this);
++  ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+ 
+   // Now |external_begin_frame_controller_| is valid after ConnectVSyncIpc(). We
+   // can start getting DisplayLinks for all displays.
+@@ -46,9 +43,7 @@
+ }
+ 
+ DisplayLinkMacMojo::~DisplayLinkMacMojo() {
+-  if (display::Screen::HasScreen()) {
+-    display::Screen::Get()->RemoveObserver(this);
+-  }
++  display_observer_.reset();
+ 
+   // Stop the VSync thread.
+   Stop();
+@@ -67,54 +62,79 @@
+ 
+ void DisplayLinkMacMojo::CleanUp() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++  ResetStateOnVSyncThread();
++}
++
++void DisplayLinkMacMojo::ResetStateOnVSyncThread() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
+ 
+   // Created on the VSync thread and must be destroyed on the same thread.
+   vsync_callbacks_.clear();
+   display_links_.clear();
+ 
+   // The remote and receiver are connected to IPC to issue and receive mojom
+-  // interrace calls on the VSync thread. These dtors are required to run on the
++  // interface calls on the VSync thread. These dtors are required to run on the
+   // same thread.
+   external_begin_frame_controller_.reset();
+   client_receiver_.reset();
+ }
+ 
+ // Called on the browser main thread.
++// OnGpuProcessLost can handle multiple GPU process losses occurring in rapid
++// succession.
+ void DisplayLinkMacMojo::OnGpuProcessLost(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+-  // Destroy all DisplayLinks on the VSyncThread.
+-  DCHECK(display::Screen::HasScreen());
+-  display::Screen::Get()->RemoveObserver(this);
++  pending_gpu_lost_count_++;
+ 
+-  if (!vsync_callbacks_.empty()) {
+-    task_runner()->PostTask(
+-        FROM_HERE, base::DoNothingWithBoundArgs(std::move(vsync_callbacks_)));
+-  }
+-  if (!display_links_.empty()) {
+-    task_runner()->PostTask(
+-        FROM_HERE, base::DoNothingWithBoundArgs(std::move(display_links_)));
+-  }
++  display_observer_.reset();
+ 
+-  // Reconnect IPC. Destory the old controller and the old receiver on the
+-  // VSyncThread first.
+-  if (external_begin_frame_controller_) {
+-    task_runner()->PostTask(FROM_HERE, base::DoNothingWithBoundArgs(std::move(
+-                                           external_begin_frame_controller_)));
+-  }
+-  if (client_receiver_) {
+-    task_runner()->DeleteSoon(FROM_HERE, std::move(client_receiver_));
++  // Ensure the WeakPtr are created and bound to the sequence on CrBrowserMain.
++  // The dereferencing (checking if the pointer is still valid) and invalidation
++  // happens on the Main thread only. A WeakPtr is passed to the VSync thread
++  // only to be used as an argument for the recovery task
++  // (ContinueGpuProcessLostOnMainThread).
++  task_runner()->PostTask(
++      FROM_HERE,
++      base::BindOnce(&DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread,
++                     base::Unretained(this), host_frame_sink_manager,
++                     base::SingleThreadTaskRunner::GetCurrentDefault(),
++                     weak_ptr_factory_.GetWeakPtr()));
++}
++
++// Called on the browser main thread.
++void DisplayLinkMacMojo::ContinueGpuProcessLostOnMainThread(
++    viz::HostFrameSinkManager* host_frame_sink_manager) {
++  pending_gpu_lost_count_--;
++  if (pending_gpu_lost_count_ > 0) {
++    return;
+   }
+ 
+-  ConnectVSyncIpc(host_frame_sink_manager);
++  ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+ 
+-  display::Screen::Get()->AddObserver(this);
+   task_runner()->PostTask(
+       FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+                                 base::Unretained(this)));
+ }
+ 
++void DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread(
++    viz::HostFrameSinkManager* host_frame_sink_manager,
++    scoped_refptr<base::SingleThreadTaskRunner> main_task_runner,
++    base::WeakPtr<DisplayLinkMacMojo> weak_ptr) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++
++  ResetStateOnVSyncThread();
++
++  // After destroying the old objects on the VSync thread, return to the main
++  // thread to continue the recovery process. We use a WeakPtr because recovery
++  // should only proceed if this instance has not been destroyed.
++  main_task_runner->PostTask(
++      FROM_HERE,
++      base::BindOnce(&DisplayLinkMacMojo::ContinueGpuProcessLostOnMainThread,
++                     weak_ptr, host_frame_sink_manager));
++}
++
+ // Called on the browser main thread
+-void DisplayLinkMacMojo::ConnectVSyncIpc(
++void DisplayLinkMacMojo::ConnectVSyncIpcAndAddDisplayObserver(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+   CHECK(host_frame_sink_manager);
+ 
+@@ -146,6 +166,10 @@
+   params->external_begin_frame_controller_client = std::move(remote_client);
+ 
+   host_frame_sink_manager->CreateCompositorDisplayLink(std::move(params));
++
++  // Display AddObserver can only be called on the browser main thread.
++  // Only add a observer after IPC is connected.
++  display_observer_.emplace(this);
+ }
+ 
+ // Called on the VSync thread directly from IPC.

--- a/patches/chromium/cherry-pick-cd7201c2fce0.patch
+++ b/patches/chromium/cherry-pick-cd7201c2fce0.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rob Pitkin <robpitkin@google.com>
+Date: Wed, 3 Jun 2026 15:53:55 -0700
+Subject: [M148] gamepad: Fix Use-After-Return in HidWriterWin
+
+Original change's description:
+> gamepad: Fix Use-After-Return in HidWriterWin
+>
+> HidWriterWin::WriteOutputReport uses a stack-allocated OVERLAPPED
+> structure for asynchronous writes. When a write operation times out, the
+> function calls CancelIo and then waits for either the file handle or the
+> event handle to be signaled using WaitForMultipleObjects with bWaitAll =
+> false.
+>
+> If the file handle was signaled by a previous operation,
+> WaitForMultipleObjects returns immediately, before the current operation
+> is fully cancelled. The function then returns, destroying the stack
+> frame and the OVERLAPPED structure. When the driver eventually completes
+> the cancellation, it writes status information back to the now-invalid
+> OVERLAPPED address, causing memory corruption.
+>
+> This CL fixes the issue by removing the WaitForMultipleObjects call and
+> instead calling GetOverlappedResult with `bWait = true` after
+> potentially cancelling the I/O. This ensures that the operation is fully
+> retired before the function returns and the stack frame is destroyed.
+>
+> Bug: 516975148
+> Change-Id: I92116cef7454e35de8d40ccb55b15819eddff79b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7892686
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Commit-Queue: Rob Pitkin <robpitkin@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640392}
+
+(cherry picked from commit a5e41fa34b2c37843ba3e82b51b7323f32b3763a)
+
+Bug: 519445263,516975148
+Change-Id: I92116cef7454e35de8d40ccb55b15819eddff79b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7893300
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4230}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/gamepad/hid_writer_win.cc b/device/gamepad/hid_writer_win.cc
+index 420f6372202d6650cbcc747bdf7849d6db3a0be1..7dc61c018703ce5d5b7f4b7fe2f6e8c6a5b8f700 100644
+--- a/device/gamepad/hid_writer_win.cc
++++ b/device/gamepad/hid_writer_win.cc
+@@ -57,19 +57,13 @@ size_t HidWriterWin::WriteOutputReport(base::span<const uint8_t> report) {
+       // Wait for the write to complete. This causes WriteOutputReport to behave
+       // synchronously.
+       DWORD wait_object = ::WaitForSingleObject(overlapped.hEvent, 100);
+-      if (wait_object == WAIT_OBJECT_0) {
+-        ::GetOverlappedResult(hid_handle_.Get(), &overlapped, &bytes_written,
+-                              true);
+-      } else {
+-        // Wait failed, or the timeout was exceeded before the write completed.
+-        // Cancel the write request.
+-        if (::CancelIo(hid_handle_.Get())) {
+-          HANDLE handles[2];
+-          handles[0] = hid_handle_.Get();
+-          handles[1] = overlapped.hEvent;
+-          ::WaitForMultipleObjects(2, handles, false, INFINITE);
+-        }
++      if (wait_object != WAIT_OBJECT_0) {
++        ::CancelIo(hid_handle_.Get());
+       }
++      // This blocks until the specific overlapped operation completes or
++      // aborts.
++      write_success = ::GetOverlappedResult(hid_handle_.Get(), &overlapped,
++                                            &bytes_written, true);
+     }
+   }
+   return write_success ? bytes_written : 0;

--- a/patches/chromium/cherry-pick-db94c2cb8239.patch
+++ b/patches/chromium/cherry-pick-db94c2cb8239.patch
@@ -1,0 +1,181 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maggie Chen <magchen@chromium.org>
+Date: Wed, 3 Jun 2026 12:18:30 -0700
+Subject: Assign DisplayLinkMacMojo mojo::Remote/Receiver on VSync thread
+
+Previously, in DisplayLinkMacMojo, the mojo::Remote
+|external_begin_frame_controller_| and the mojo::Receiver
+|client_receiver_| were assigned on the browser main thread (within
+ConnectVSyncIpcAndAddDisplayObserver) even though they were bound to the
+VSync thread's task runner.
+
+While the prior code ensured the remote and the receiver were not
+accessed on the VSync thread prior to assignment, assigning them on the
+main thread when they are used exclusively on the VSync thread sequence
+is conceptually unsafe.
+
+This CL resolves this by passing the mojo::Remote and the mojo::Receiver
+to InitDisplaysOnVSyncThread, moving and assigning them directly on the
+VSync thread where they are used.
+
+Also call GetAllDisplays() to get the current IDs only on the main
+thread.
+
+Bug: 517227707
+Change-Id: Icfe777e57503e50c2e4171762d4f0652e56baa71
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7897519
+Commit-Queue: Maggie Chen <magchen@chromium.org>
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1641108}
+
+diff --git a/ui/compositor/display_link_mac_mojo.h b/ui/compositor/display_link_mac_mojo.h
+index 0efb961bc098364b1f5f712582f750d3d9250acf..767b1bad0b5d2acc712870c192c32fd5a085a0e5 100644
+--- a/ui/compositor/display_link_mac_mojo.h
++++ b/ui/compositor/display_link_mac_mojo.h
+@@ -5,7 +5,10 @@
+ #ifndef UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ #define UI_COMPOSITOR_DISPLAY_LINK_MAC_MOJO_H_
+ 
++#include <map>
++#include <memory>
+ #include <optional>
++#include <vector>
+ 
+ #include "base/task/single_thread_task_runner.h"
+ #include "base/threading/thread.h"
+@@ -89,7 +92,13 @@ class COMPOSITOR_EXPORT DisplayLinkMacMojo
+   void ConnectVSyncIpcAndAddDisplayObserver(
+       viz::HostFrameSinkManager* host_frame_sink_manager);
+ 
+-  void InitDisplaysOnVSyncThread();
++  void InitDisplaysOnVSyncThread(
++      std::vector<int64_t> display_ids,
++      mojo::Remote<viz::mojom::ExternalBeginFrameController>
++          external_begin_frame_controller,
++      std::unique_ptr<
++          mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>
++          client_receiver);
+ 
+   void OnDisplayLinkVSyncCallback(int64_t display_id, VSyncParamsMac params);
+ 
+diff --git a/ui/compositor/display_link_mac_mojo.mm b/ui/compositor/display_link_mac_mojo.mm
+index 28fafba7b74c547c0091e2450214ea4078fc6d37..88722c6212c70dec2667b403325f218598adea3c 100644
+--- a/ui/compositor/display_link_mac_mojo.mm
++++ b/ui/compositor/display_link_mac_mojo.mm
+@@ -32,14 +32,9 @@
+   StartWithOptions(base::Thread::Options(std::move(thread_options)));
+ 
+   // To ensure VSyncThread task_runner() is valid, StartWithOptions() must be
+-  // called before ConnectVSyncIpc().
++  // called before connecting the VSync IPC and adding the display observer,
++  // which are done on the browser main thread.
+   ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+-
+-  // Now |external_begin_frame_controller_| is valid after ConnectVSyncIpc(). We
+-  // can start getting DisplayLinks for all displays.
+-  task_runner()->PostTask(
+-      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+-                                base::Unretained(this)));
+ }
+ 
+ DisplayLinkMacMojo::~DisplayLinkMacMojo() {
+@@ -49,14 +44,20 @@
+   Stop();
+ }
+ 
+-void DisplayLinkMacMojo::InitDisplaysOnVSyncThread() {
++void DisplayLinkMacMojo::InitDisplaysOnVSyncThread(
++    std::vector<int64_t> display_ids,
++    mojo::Remote<viz::mojom::ExternalBeginFrameController>
++        external_begin_frame_controller,
++    std::unique_ptr<
++        mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>
++        client_receiver) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(vsync_thread_sequence_checker_);
++  external_begin_frame_controller_ = std::move(external_begin_frame_controller);
++  client_receiver_ = std::move(client_receiver);
+ 
+   // Create CADisplayLink for all displays.
+-  const std::vector<display::Display>& displays =
+-      display::Screen::Get()->GetAllDisplays();
+-  for (const auto& display : displays) {
+-    DisplayAddedOnVSyncThread(display.id());
++  for (int64_t display_id : display_ids) {
++    DisplayAddedOnVSyncThread(display_id);
+   }
+ }
+ 
+@@ -80,8 +81,9 @@
+ }
+ 
+ // Called on the browser main thread.
+-// OnGpuProcessLost can handle multiple GPU process losses occurring in rapid
+-// succession.
++// Handles GPU process loss, even if multiple losses occur in rapid succession.
++// Resource destruction and recreation are serialized across both threads to
++// avoid races.
+ void DisplayLinkMacMojo::OnGpuProcessLost(
+     viz::HostFrameSinkManager* host_frame_sink_manager) {
+   pending_gpu_lost_count_++;
+@@ -110,10 +112,6 @@
+   }
+ 
+   ConnectVSyncIpcAndAddDisplayObserver(host_frame_sink_manager);
+-
+-  task_runner()->PostTask(
+-      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
+-                                base::Unretained(this)));
+ }
+ 
+ void DisplayLinkMacMojo::OnGpuProcessLostOnVSyncThread(
+@@ -148,7 +146,6 @@
+   // Move pending receiver to params.
+   params->external_begin_frame_controller =
+       external_begin_frame_controller.BindNewPipeAndPassReceiver(task_runner());
+-  external_begin_frame_controller_ = std::move(external_begin_frame_controller);
+ 
+   // Set up ExternalBeginFrameControllerClient for Viz to call
+   // NeedsBeginFrameWithId() via IPC to request DisplayLinkMacMojo for VSync
+@@ -161,7 +158,7 @@
+   auto client_receiver = std::make_unique<
+       mojo::Receiver<viz::mojom::ExternalBeginFrameControllerClient>>(this);
+   client_receiver->Bind(std::move(pending_client_receiver), task_runner());
+-  client_receiver_ = std::move(client_receiver);
++
+   // Move pending remote to params.
+   params->external_begin_frame_controller_client = std::move(remote_client);
+ 
+@@ -170,6 +167,24 @@
+   // Display AddObserver can only be called on the browser main thread.
+   // Only add a observer after IPC is connected.
+   display_observer_.emplace(this);
++
++  std::vector<int64_t> display_ids;
++  // Screen GetAllDisplays() should be called on the main thread.
++  const std::vector<display::Display>& displays =
++      display::Screen::Get()->GetAllDisplays();
++  for (const display::Display& display : displays) {
++    display_ids.push_back(display.id());
++  }
++
++  // Since |external_begin_frame_controller_| and |client_receiver_| must be
++  // accessed exclusively on the VSync thread sequence, move the remote to the
++  // VSync thread and assign it there to maintain sequence safety. Now start
++  // getting DisplayLinks for all displays on the VSync thread.
++  task_runner()->PostTask(
++      FROM_HERE, base::BindOnce(&DisplayLinkMacMojo::InitDisplaysOnVSyncThread,
++                                base::Unretained(this), std::move(display_ids),
++                                std::move(external_begin_frame_controller),
++                                std::move(client_receiver)));
+ }
+ 
+ // Called on the VSync thread directly from IPC.
+@@ -273,7 +288,7 @@
+ void DisplayLinkMacMojo::OnDisplaysRemoved(
+     const display::Displays& removed_displays) {
+   std::vector<int64_t> display_ids;
+-  for (auto& removed_display : removed_displays) {
++  for (const display::Display& removed_display : removed_displays) {
+     display_ids.push_back(removed_display.id());
+   }
+ 

--- a/patches/chromium/cherry-pick-ddbffa721d7c.patch
+++ b/patches/chromium/cherry-pick-ddbffa721d7c.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Sun, 31 May 2026 20:29:35 -0700
+Subject: [M148] bluetooth: Prevent UAF in macOS Bluetooth listeners
+
+Original change's description:
+> bluetooth: Prevent UAF in macOS Bluetooth listeners
+>
+> Implement the FB13705522 workaround for BluetoothDevicesConnectListener
+> and BluetoothDeviceDisconnectListener on macOS. This ensures that these
+> listeners stay alive past any already-enqueued notifications on the main
+> run loop, preventing Use-After-Free (UAF) when the C++ owner is
+> destroyed.
+>
+> Bug: 516987814
+> Change-Id: I542200f213f499370dc89a7cf68dde9fc6299285
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7884382
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1638719}
+
+(cherry picked from commit 75b964de97d2781d1f8329f2fb754862dc212c63)
+
+Bug: 518122985,516987814
+Change-Id: I542200f213f499370dc89a7cf68dde9fc6299285
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7886959
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4121}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_adapter_mac.mm b/device/bluetooth/bluetooth_adapter_mac.mm
+index 4ff5277d550485cd79c5b5316d89c730ba709254..6defe5e0ccd0dc20bee280b1951735e4f5ec961f 100644
+--- a/device/bluetooth/bluetooth_adapter_mac.mm
++++ b/device/bluetooth/bluetooth_adapter_mac.mm
+@@ -103,6 +103,9 @@ - (instancetype)initWithAdapter:
+ 
+ - (void)deviceConnected:(IOBluetoothUserNotification*)notification
+                  device:(IOBluetoothDevice*)device {
++  if (!_ui_task_runner) {
++    return;
++  }
+   _ui_task_runner->PostTask(
+       FROM_HERE,
+       base::BindOnce(&device::BluetoothAdapterMac::OnConnectNotification,
+@@ -111,6 +114,17 @@ - (void)deviceConnected:(IOBluetoothUserNotification*)notification
+ 
+ - (void)stopListening {
+   [_connectNotification unregister];
++  _ui_task_runner = nullptr;
++  _adapter = nullptr;
++
++  // Keep self alive for a brief period to allow any already-enqueued
++  // notifications on the main run loop to fire safely (and become no-ops
++  // since _ui_task_runner is now null) rather than hitting a deallocated
++  // object. See FB13705522.
++  __strong auto strongSelf = self;
++  dispatch_async(dispatch_get_main_queue(), ^{
++    (void)strongSelf;
++  });
+ }
+ 
+ @end
+diff --git a/device/bluetooth/bluetooth_classic_device_mac.mm b/device/bluetooth/bluetooth_classic_device_mac.mm
+index 47ce0ba52e98407460f6e0a8b36baf1d9ddc590b..7c366c95a1bfc18ed1e527276de775f7bbe64b0b 100644
+--- a/device/bluetooth/bluetooth_classic_device_mac.mm
++++ b/device/bluetooth/bluetooth_classic_device_mac.mm
+@@ -86,6 +86,15 @@ - (void)stopListening {
+   // destruction will see a null |_device| and become a no-op instead of
+   // dereferencing a freed object.
+   _device = nullptr;
++
++  // Keep self alive for a brief period to allow any already-enqueued
++  // notifications on the main run loop to fire safely (and become no-ops
++  // since _device is now null) rather than hitting a deallocated object.
++  // See FB13705522.
++  __strong auto strongSelf = self;
++  dispatch_async(dispatch_get_main_queue(), ^{
++    (void)strongSelf;
++  });
+ }
+ 
+ @end

--- a/patches/chromium/cherry-pick-f9e6631b2ded.patch
+++ b/patches/chromium/cherry-pick-f9e6631b2ded.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 3 Jun 2026 16:56:07 -0700
+Subject: [M148] Fix use-after-free in DesktopWindowTreeHostPlatform::Restore.
+
+> In DesktopWindowTreeHostPlatform::Restore(),
+> platform_window()->Restore() is called without a weak-pointer guard. On
+> Linux/X11, restoring a fullscreen window can trigger a synchronous
+> bounds change that notifies observers and may synchronously destroy the
+> host. If this occurs, subsequent execution of Show() on `this` causes a
+> use-after-free.
+>
+> This CL introduces a WeakPtr guard to check if the host has been
+> destroyed before proceeding to Show(), matching the pattern used by
+> Maximize() and SetFullscreen(). Also added a corresponding unit test to
+> prevent regression.
+>
+> Fixed: 518043597
+> Change-Id: I9bf4b2f79f37b6b9b22fde5d7292f30c326d4fca
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7889918
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639696}
+
+R=thestig
+
+Bug: 518043597
+Fixed: 519051392
+Change-Id: I0238ea58433abfc636ebc3e7deb09b35f03247de
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7899927
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4232}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+index 92787957bb72802d5b8af9ee6fdedfd7fc7d702f..aff7a479cebcadbaf2070ed0e8f71390a3862d46 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+@@ -636,7 +636,11 @@ void DesktopWindowTreeHostPlatform::Minimize() {
+ }
+ 
+ void DesktopWindowTreeHostPlatform::Restore() {
++  auto weak_ptr = weak_factory_.GetWeakPtr();
+   platform_window()->Restore();
++  if (!weak_ptr) {
++    return;
++  }
+   Show(ui::mojom::WindowShowState::kNormal, gfx::Rect());
+ }
+ 
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+index 950938b5ed8362519e3cd154f18383b0010884cc..be465b79b20631de934273fe631a33200c2e7c09 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform_unittest.cc
+@@ -673,4 +673,85 @@ TEST_F(DesktopWindowTreeHostPlatformTest, ContentWindowShownOnce) {
+   host_platform->GetContentWindow()->RemoveObserver(&observer);
+ }
+ 
++#if !BUILDFLAG(IS_FUCHSIA)
++namespace {
++
++class CloseOnBoundsChangedWidgetObserver : public WidgetObserver {
++ public:
++  explicit CloseOnBoundsChangedWidgetObserver(Widget* widget) {
++    observation_.Observe(widget);
++  }
++  ~CloseOnBoundsChangedWidgetObserver() override = default;
++
++  void OnWidgetBoundsChanged(Widget* widget,
++                             const gfx::Rect& new_bounds) override {
++    observation_.Reset();
++    widget->CloseNow();
++  }
++
++ private:
++  base::ScopedObservation<Widget, WidgetObserver> observation_{this};
++};
++
++}  // namespace
++
++class RestoreBoundsChangeStubWindow : public ui::StubWindow {
++ public:
++  RestoreBoundsChangeStubWindow(ui::PlatformWindowDelegate* delegate,
++                                gfx::AcceleratedWidget widget,
++                                const gfx::Rect& bounds)
++      : StubWindow(delegate, false, bounds) {
++    InitDelegateWithWidget(delegate, widget);
++  }
++
++  void Restore() override {
++    delegate()->OnBoundsChanged({/*origin_changed=*/true});
++  }
++};
++
++class RestoreBoundsChangePlatformWindowFactoryDelegate
++    : public aura::WindowTreeHostPlatform::
++          PlatformWindowFactoryDelegateForTesting {
++ public:
++  RestoreBoundsChangePlatformWindowFactoryDelegate() {
++    aura::WindowTreeHostPlatform::SetPlatformWindowFactoryDelegateForTesting(
++        this);
++  }
++  RestoreBoundsChangePlatformWindowFactoryDelegate(
++      const RestoreBoundsChangePlatformWindowFactoryDelegate&) = delete;
++  RestoreBoundsChangePlatformWindowFactoryDelegate& operator=(
++      const RestoreBoundsChangePlatformWindowFactoryDelegate&) = delete;
++  ~RestoreBoundsChangePlatformWindowFactoryDelegate() override {
++    aura::WindowTreeHostPlatform::SetPlatformWindowFactoryDelegateForTesting(
++        nullptr);
++  }
++
++  std::unique_ptr<ui::PlatformWindow> Create(
++      aura::WindowTreeHostPlatform* host) override {
++    return std::make_unique<RestoreBoundsChangeStubWindow>(
++        host, ++last_accelerated_widget_, gfx::Rect(100, 100, 100, 100));
++  }
++
++  gfx::AcceleratedWidget last_accelerated_widget_ = gfx::kNullAcceleratedWidget;
++};
++
++TEST_F(DesktopWindowTreeHostPlatformTest,
++       RestoreSurvivesSynchronousCloseDuringBoundsChange) {
++  RestoreBoundsChangePlatformWindowFactoryDelegate
++      scoped_platform_window_factory_delegate;
++
++  std::unique_ptr<Widget> widget = CreateWidgetWithNativeWidget();
++  widget->Show();
++
++  auto* host_platform = DesktopWindowTreeHostPlatform::GetHostForWidget(
++      widget->GetNativeWindow()->GetHost()->GetAcceleratedWidget());
++  ASSERT_TRUE(host_platform);
++
++  CloseOnBoundsChangedWidgetObserver observer(widget.get());
++
++  // This should not crash or trigger UAF.
++  host_platform->Restore();
++}
++#endif  // !BUILDFLAG(IS_FUCHSIA)
++
+ }  // namespace views

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -8,3 +8,4 @@ cherry-pick-a068030f5179.patch
 cherry-pick-7758773.patch
 cherry-pick-7766691.patch
 cherry-pick-7789282.patch
+cherry-pick-c6bfbe7c4e84.patch

--- a/patches/v8/cherry-pick-c6bfbe7c4e84.patch
+++ b/patches/v8/cherry-pick-c6bfbe7c4e84.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Mon, 4 May 2026 12:27:58 +0200
+Subject: [M148] [objects] Abort TryFastAddDataProperty if map becomes slow
+
+Original change's description:
+> [objects] Abort TryFastAddDataProperty if map becomes slow
+>
+> When class fields are added to a constructor-created function object
+> when the class extends Function, TryFastAddDataProperty is invoked
+> to perform a fast transition. However, Map::PrepareForDataProperty may
+> instead normalize the map and return a slow dictionary map.
+>
+> This CL fixes the issue by aborting the fast transition in
+> TryFastAddDataProperty and returning false if
+> Map::PrepareForDataProperty returns a dictionary map, falling back
+> to the standard slow property addition path.
+>
+> TAG=agy
+> CONV=7233c224-ccbc-421c-88b3-34be1f425294
+>
+> Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+> Fixed: 506689381
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7807043
+> Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+> Reviewed-by: Igor Sheludko <ishell@chromium.org>
+> Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#107009}
+
+(cherry picked from commit 3c869652b039fc1fc9fbe035c6af879317e8b9f3)
+
+Bug: 514925552,506689381
+Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7874712
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/14.8@{#62}
+Cr-Branched-From: f9659283a5f8d42b3c09228cf5df606fcaf47a3d-refs/heads/14.8.178@{#1}
+Cr-Branched-From: 141232520dc4910401240c531db3af36910a0fd1-refs/heads/main@{#106240}
+
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index 8e18b4fe6602dbdec9154c166d12e01b09cb0dd6..8591fc76bdd1bbf8bb3c85b331f103eeaa3a6c93 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -3674,6 +3674,7 @@ bool TryFastAddDataProperty(Isolate* isolate, DirectHandle<JSObject> object,
+   InternalIndex descriptor = new_map->LastAdded();
+   new_map = Map::PrepareForDataProperty(isolate, new_map, descriptor,
+                                         PropertyConstness::kConst, value);
++  if (new_map->is_dictionary_map()) return false;
+   JSObject::MigrateToMap(isolate, object, new_map);
+   // TODO(leszeks): Avoid re-loading the property details, which we already
+   // loaded in PrepareForDataProperty.
+diff --git a/test/mjsunit/regress/regress-crbug-506689381.js b/test/mjsunit/regress/regress-crbug-506689381.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ba2dc8e021e8ea2f7c2381d9ab9c6f88916479f
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-506689381.js
+@@ -0,0 +1,20 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++let key = 'AA';
++let value = 2;
++class C extends Function {
++  [key] = value;
++}
++
++// First object creation triggers transition MapA----(AA, kData, SMI)--->MapB
++let o1 = new C('\'use strict\'');
++
++value = 1.1;
++
++// Second object creation triggers TryFastAddDataProperty() which reconfigures
++// the property from Smi to Double. This reconfigures MapB in-place (or
++// normalizes it). TryFastAddDataProperty must not crash if the map is
++// normalized during preparation.
++let o2 = new C('\'use strict\'');


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`3f6678d31736`](https://chromium-review.googlesource.com/c/chromium/src/+/7894925) from chromium — wayland: Fix UAF/dangling ptr in ReleasePressedPointerButtons()
* [`ba3e2c142b89`](https://chromium-review.googlesource.com/c/chromium/src/+/7884242) from chromium — [headless][linux] Safeguard headless window code against potential UAF
* [`409ec3ebc79c`](https://chromium-review.googlesource.com/c/chromium/src/+/7895216) from chromium — [FSA] Fix UAF in ShowFilePickerOnUIThread.
* [`a3fe69a65a6d`](https://chromium-review.googlesource.com/c/chromium/src/+/7881333) from chromium — Prevent Use-After-Free in RenderWidgetHostViewAura::ShowWithVisibility.
* [`74a45c11c791`](https://chromium-review.googlesource.com/c/chromium/src/+/7884252) from chromium — bluetooth: Fix potential UAF in Bluetooth Classic channel delegates on macOS
* [`cd7201c2fce0`](https://chromium-review.googlesource.com/c/chromium/src/+/7893300) from chromium — gamepad: Fix Use-After-Return in HidWriterWin
* [`ddbffa721d7c`](https://chromium-review.googlesource.com/c/chromium/src/+/7886959) from chromium — bluetooth: Prevent UAF in macOS Bluetooth listeners
* [`136880de7a91`](https://chromium-review.googlesource.com/c/chromium/src/+/7888516) from chromium — [macOS] Prevent UAF during fullscreen controller transition complete
* [`c92de87bddf2`](https://chromium-review.googlesource.com/c/chromium/src/+/7881564) from chromium — Fix GPU process lost race in DisplayLinkMacMojo
* [`db94c2cb8239`](https://chromium-review.googlesource.com/c/chromium/src/+/7897519) from chromium — Assign DisplayLinkMacMojo mojo::Remote/Receiver on VSync thread
* [`b534033a6391`](https://chromium-review.googlesource.com/c/chromium/src/+/7893642) from chromium — bluetooth: Avoid double invoking callback after failed winrt call
* [`36f6889ed145`](https://chromium-review.googlesource.com/c/chromium/src/+/7896940) from chromium — Fix context lifetime in ProxyResolverV8 callbacks
* [`f9e6631b2ded`](https://chromium-review.googlesource.com/c/chromium/src/+/7899927) from chromium — Fix use-after-free in DesktopWindowTreeHostPlatform::Restore.
* [`c6bfbe7c4e84`](https://chromium-review.googlesource.com/c/v8/v8/+/7874712) from v8 — [objects] Abort TryFastAddDataProperty if map becomes slow

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium and V8.
