### PR TITLE
chore: cherry-pick 4 changes from chromium, v8

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -241,3 +241,6 @@ cherry-pick-6aa38f2d02b7.patch
 cherry-pick-926d3d259750.patch
 cherry-pick-2cdb07c74d06.patch
 cherry-pick-16dcbc3d1476.patch
+cherry-pick-40c4ee1326a2.patch
+cherry-pick-7c925f1f0941.patch
+cherry-pick-7b1403be9ec4.patch

--- a/patches/chromium/cherry-pick-40c4ee1326a2.patch
+++ b/patches/chromium/cherry-pick-40c4ee1326a2.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Max Ihlenfeldt <max@igalia.com>
+Date: Mon, 8 Jun 2026 20:27:52 -0700
+Subject: [M144-LTS] wayland: Fix UAF/dangling ptr in
+ ReleasePressedPointerButtons()
+
+Dispatching the event may destroy the window, and if we release multiple
+buttons we use a freed/dangling pointer. Fix this by using a weak
+pointer.
+
+(cherry picked from commit edce928690cb0bbca49e411fc88b8293dcd9dc8a)
+
+Fixed: 516501794
+Change-Id: I85b0ab643896cc80d9248f4ae18300125fa7167b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7880226
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Max Ihlenfeldt <max@igalia.com>
+Cr-Original-Commit-Position: refs/heads/main@{#1639248}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7898875
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Reviewed-by: Max Ihlenfeldt <max@igalia.com>
+Commit-Queue: Gyuyoung Kim (xWF) <qkim@google.com>
+Cr-Commit-Position: refs/branch-heads/7559@{#4972}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.cc b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+index 4e421ccbd36d4efebd43c9def5b575b7d8d5e336..7b04c1ef004fbe3041f4d3307c77d15a06fd5586 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.cc
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.cc
+@@ -391,8 +391,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+     return;
+   }
+ 
+-  WaylandWindow* prev_focused_window =
+-      window_manager_->GetCurrentPointerFocusedWindow();
++  // Dispatching the event may delete the previously focused window.
++  base::WeakPtr<WaylandWindow> prev_focused_window =
++      window_manager_->GetCurrentPointerFocusedWindow()
++          ? window_manager_->GetCurrentPointerFocusedWindow()->AsWeakPtr()
++          : nullptr;
+   if (window) {
+     window_manager_->SetPointerFocusedWindow(window);
+   }
+@@ -430,10 +433,11 @@ void WaylandEventSource::OnPointerButtonEvent(
+   }
+ }
+ 
+-void WaylandEventSource::OnPointerButtonEventInternal(WaylandWindow* window,
+-                                                      EventType type) {
++void WaylandEventSource::OnPointerButtonEventInternal(
++    base::WeakPtr<WaylandWindow> window,
++    EventType type) {
+   if (window) {
+-    window_manager_->SetPointerFocusedWindow(window);
++    window_manager_->SetPointerFocusedWindow(window.get());
+   }
+ }
+ 
+@@ -939,10 +943,14 @@ void WaylandEventSource::ReleasePressedPointerButtons(
+     return;
+   }
+ 
++  // Dispatching the event may delete the window.
++  base::WeakPtr<WaylandWindow> window_weak =
++      window ? window->AsWeakPtr() : nullptr;
+   for (const auto& [button, name] : kMouseButtonToStringMap) {
+     if (button & pointer_flags_) {
+       VLOG(1) << "Synthesizing pointer release for: " << name;
+-      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp, window,
++      OnPointerButtonEvent(EventType::kMouseReleased, button, timestamp,
++                           window_weak.get(),
+                            wl::EventDispatchPolicy::kImmediate,
+                            /*allow_release_of_unpressed_button=*/false,
+                            /*is_synthesized=*/true);
+diff --git a/ui/ozone/platform/wayland/host/wayland_event_source.h b/ui/ozone/platform/wayland/host/wayland_event_source.h
+index f39137fef2ed59b4a798f347961455596e51302f..92182c78cc42131416d67e191ad383490cc292be 100644
+--- a/ui/ozone/platform/wayland/host/wayland_event_source.h
++++ b/ui/ozone/platform/wayland/host/wayland_event_source.h
+@@ -237,7 +237,8 @@ class WaylandEventSource : public PlatformEventSource,
+   gfx::Vector2dF ComputeFlingVelocity();
+ 
+   // Wrap up method to support async pointer down/up event processing.
+-  void OnPointerButtonEventInternal(WaylandWindow* window, EventType type);
++  void OnPointerButtonEventInternal(base::WeakPtr<WaylandWindow> window,
++                                    EventType type);
+ 
+   // Wrap up method to support async touch release processing.
+   void OnTouchReleaseInternal(PointerId id);

--- a/patches/chromium/cherry-pick-7b1403be9ec4.patch
+++ b/patches/chromium/cherry-pick-7b1403be9ec4.patch
@@ -1,0 +1,223 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nidhi Jaju <nidhijaju@chromium.org>
+Date: Fri, 5 Jun 2026 11:05:47 -0700
+Subject: [M144-LTS] Fix context lifetime in ProxyResolverV8 callbacks
+
+Safeguard JS callback functions (like alert and dnsResolve) in the PAC
+execution context. We now indirect the execution context pointer through
+a GC-managed wrapper and add null checks for active bindings, ensuring
+callbacks return safely if the context is no longer active.
+
+(cherry picked from commit 399cb31703ea6c6ce6456db6f450599dc0ae713f)
+
+Bug: 518006379
+Change-Id: Id0932b292b2ae1e09e6bccd8be07f613f64cfca0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885520
+Reviewed-by: Adam Rice <ricea@chromium.org>
+Commit-Queue: Nidhi Jaju <nidhijaju@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1640118}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7901351
+Commit-Queue: Gyuyoung Kim (xWF) <qkim@google.com>
+Reviewed-by: Nidhi Jaju <nidhijaju@chromium.org>
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Cr-Commit-Position: refs/branch-heads/7559@{#4962}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/services/proxy_resolver/proxy_resolver_v8.cc b/services/proxy_resolver/proxy_resolver_v8.cc
+index afde3f8dec2c5f69c55232bd2b44f9125fca4f06..67063c951b4affb68f79c92974d1273822080949 100644
+--- a/services/proxy_resolver/proxy_resolver_v8.cc
++++ b/services/proxy_resolver/proxy_resolver_v8.cc
+@@ -447,7 +447,24 @@ class ProxyResolverV8::Context {
+     v8::Locker locked(isolate_);
+     v8::Isolate::Scope isolate_scope(isolate_);
+ 
+-    v8_this_.Reset();
++    // ContextDisposedNotification only prunes dirty FinalizationRegistries; it
++    // does not cancel queued ResolveAsyncWaiterPromisesTask foreground tasks
++    // or flush the isolate's shared default MicrotaskQueue, both of which can
++    // still strongly root this v8::Context (and the v8::Functions whose
++    // v8::External data points at the holder). Neutralize the indirection while
++    // holding the v8::Locker so any later callback observes a null Context*
++    // instead of a dangling one.
++    if (holder_) {
++      holder_->context = nullptr;
++      if (!holder_->v8_this.IsEmpty()) {
++        // The v8::External is still alive, so release it. The V8 weak callback
++        // will delete it when the v8::External is garbage collected. If
++        // `v8_this` is empty, the v8::External was already garbage collected,
++        // so we can delete the holder.
++        holder_.release();
++      }
++    }
++
+     v8_context_.Reset();
+   }
+ 
+@@ -517,11 +534,13 @@ class ProxyResolverV8::Context {
+     v8::Isolate::Scope isolate_scope(isolate_);
+     v8::HandleScope scope(isolate_);
+ 
+-    v8_this_.Reset(
+-        isolate_,
+-        v8::External::New(isolate_, this, gin::kProxyResolverV8ContextTag));
+-    v8::Local<v8::External> v8_this =
+-        v8::Local<v8::External>::New(isolate_, v8_this_);
++    holder_ = std::make_unique<ContextHolder>();
++    holder_->context = this;
++    v8::Local<v8::External> v8_holder = v8::External::New(
++        isolate_, holder_.get(), gin::kProxyResolverV8ContextTag);
++    holder_->v8_this.Reset(isolate_, v8_holder);
++    holder_->v8_this.SetWeak(holder_.get(), OnExternalGC,
++                             v8::WeakCallbackType::kParameter);
+ 
+     v8_context_.Reset(isolate_, v8::Context::New(isolate_));
+ 
+@@ -533,25 +552,25 @@ class ProxyResolverV8::Context {
+     // Attach the javascript bindings.
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "alert"),
+-              v8::Function::New(context, &AlertCallback, v8_this, 0,
++              v8::Function::New(context, &AlertCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddress"),
+-              v8::Function::New(context, &MyIpAddressCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolve"),
+-              v8::Function::New(context, &DnsResolveCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isPlainHostName"),
+-              v8::Function::New(context, &IsPlainHostNameCallback, v8_this, 0,
++              v8::Function::New(context, &IsPlainHostNameCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -559,26 +578,26 @@ class ProxyResolverV8::Context {
+     // Microsoft's PAC extensions:
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "dnsResolveEx"),
+-              v8::Function::New(context, &DnsResolveExCallback, v8_this, 0,
++              v8::Function::New(context, &DnsResolveExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "myIpAddressEx"),
+-              v8::Function::New(context, &MyIpAddressExCallback, v8_this, 0,
++              v8::Function::New(context, &MyIpAddressExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+ 
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "sortIpAddressList"),
+-              v8::Function::New(context, &SortIpAddressListCallback, v8_this, 0,
+-                                v8::ConstructorBehavior::kThrow)
++              v8::Function::New(context, &SortIpAddressListCallback, v8_holder,
++                                0, v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+     global
+         ->Set(context, ASCIILiteralToV8String(isolate_, "isInNetEx"),
+-              v8::Function::New(context, &IsInNetExCallback, v8_this, 0,
++              v8::Function::New(context, &IsInNetExCallback, v8_holder, 0,
+                                 v8::ConstructorBehavior::kThrow)
+                   .ToLocalChecked())
+         .Check();
+@@ -687,9 +706,10 @@ class ProxyResolverV8::Context {
+ 
+   // V8 callback for when "alert()" is invoked by the PAC script.
+   static void AlertCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      return;
++    }
+ 
+     // Like firefox we assume "undefined" if no argument was specified, and
+     // disregard any arguments beyond the first.
+@@ -736,9 +756,26 @@ class ProxyResolverV8::Context {
+   static void DnsResolveCallbackHelper(
+       const v8::FunctionCallbackInfo<v8::Value>& args,
+       net::ProxyResolveDnsOperation op) {
+-    Context* context =
+-        static_cast<Context*>(v8::External::Cast(*args.Data())
+-                                  ->Value(gin::kProxyResolverV8ContextTag));
++    Context* context = ContextFromArgs(args);
++    if (!context || !context->js_bindings()) {
++      // Each function handles resolution errors differently.
++      switch (op) {
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE:
++          args.GetReturnValue().SetNull();
++          return;
++        case net::ProxyResolveDnsOperation::DNS_RESOLVE_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS:
++          args.GetReturnValue().Set(
++              ASCIILiteralToV8String(args.GetIsolate(), "127.0.0.1"));
++          return;
++        case net::ProxyResolveDnsOperation::MY_IP_ADDRESS_EX:
++          args.GetReturnValue().SetEmptyString();
++          return;
++      }
++      NOTREACHED();
++    }
+ 
+     std::string hostname;
+ 
+@@ -854,10 +891,40 @@ class ProxyResolverV8::Context {
+     args.GetReturnValue().Set(IsPlainHostName(hostname_utf8));
+   }
+ 
++  // Indirection for the v8::External bound to the JS callback v8::Functions.
++  // The v8::External's value is immutable and the v8::Functions can outlive
++  // |this| (e.g. via Atomics.waitAsync reactions queued in the shared isolate
++  // MicrotaskQueue), so callbacks must go through a holder that ~Context()
++  // nulls under the v8::Locker. The holder is managed via a V8 weak persistent
++  // handle and is deleted in OnExternalGC once V8 has garbage-collected it.
++  struct ContextHolder {
++    // Nulled in ~Context(), so the raw_ptr never dangles.
++    raw_ptr<Context> context = nullptr;
++
++    // This is actually a weak persistent.
++    v8::Persistent<v8::External> v8_this;
++  };
++
++  static Context* ContextFromArgs(
++      const v8::FunctionCallbackInfo<v8::Value>& args) {
++    auto* holder = static_cast<ContextHolder*>(
++        v8::External::Cast(*args.Data())
++            ->Value(gin::kProxyResolverV8ContextTag));
++    return holder ? holder->context : nullptr;
++  }
++
++  static void OnExternalGC(const v8::WeakCallbackInfo<ContextHolder>& data) {
++    ContextHolder* holder = data.GetParameter();
++    holder->v8_this.Reset();
++    if (!holder->context) {
++      delete holder;
++    }
++  }
++
+   mutable base::Lock lock_;
+   raw_ptr<ProxyResolverV8::JSBindings> js_bindings_ = nullptr;
+   raw_ptr<v8::Isolate> isolate_;
+-  v8::Persistent<v8::External> v8_this_;
++  std::unique_ptr<ContextHolder> holder_;
+   v8::Persistent<v8::Context> v8_context_;
+ };
+ 

--- a/patches/chromium/cherry-pick-7c925f1f0941.patch
+++ b/patches/chromium/cherry-pick-7c925f1f0941.patch
@@ -1,0 +1,337 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Kvitek <kvitekp@chromium.org>
+Date: Tue, 2 Jun 2026 12:36:52 -0700
+Subject: [M144-LTS][headless][linux] Safeguard headless window code against
+ potential UAF
+
+ui::HeadlessWindow synchronously callsbacks delegate methods during state-changing operations. If an observer synchronously closes the widget during these callbacks, the associated ui::HeadlessWindow instance is deleted while its methods are still executing on the stack.
+
+This CL adds weak ptr checks to avoid ui::HeadlessWindow code execution after a delegate callback that invalidates 'this'.
+
+(cherry picked from commit 583fe61da24f865e1da49dc1ad1b297c7c9cf6d4)
+
+Bug: 516674532
+Change-Id: I788ba9b19c733c7af17010744bd66b25783ddf9c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7879467
+Commit-Queue: Peter Kvitek <kvitekp@chromium.org>
+Reviewed-by: Colin Blundell <blundell@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1637863}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885098
+Reviewed-by: Peter Kvitek <kvitekp@chromium.org>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Cr-Commit-Position: refs/branch-heads/7559@{#4941}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/ui/ozone/BUILD.gn b/ui/ozone/BUILD.gn
+index abb2ee9d82d291a82621cf449c391ce68ba86939..37904b1b3b7c433c55cebc2d96639fec8d1c6133 100644
+--- a/ui/ozone/BUILD.gn
++++ b/ui/ozone/BUILD.gn
+@@ -37,6 +37,7 @@ ozone_platform_interactive_ui_tests_sources =
+ if (ozone_platform_headless) {
+   ozone_platforms += [ "headless" ]
+   ozone_platform_deps += [ "platform/headless" ]
++  ozone_platform_test_deps += [ "platform/headless:headless_unittests" ]
+ }
+ 
+ if (ozone_platform_drm) {
+@@ -361,6 +362,7 @@ static_library("test_support") {
+   visibility = [
+     ":*",
+     "platform/flatland:flatland_unittests",
++    "platform/headless:headless_unittests",
+     "platform/wayland:test_support",
+     "platform/wayland:wayland_unittests",
+     "platform/x11:x11_unittests",
+diff --git a/ui/ozone/platform/headless/BUILD.gn b/ui/ozone/platform/headless/BUILD.gn
+index 650058400a2450255d8421ac449c5c47ae019f1b..dc07e2b6433d07f597c1558e85f031cb2e68dd89 100644
+--- a/ui/ozone/platform/headless/BUILD.gn
++++ b/ui/ozone/platform/headless/BUILD.gn
+@@ -59,3 +59,18 @@ source_set("headless") {
+     deps += [ "//gpu/vulkan" ]
+   }
+ }
++
++source_set("headless_unittests") {
++  testonly = true
++  sources = [ "headless_window_unittest.cc" ]
++  deps = [
++    ":headless",
++    "//base",
++    "//base/test:test_support",
++    "//testing/gtest",
++    "//ui/display:test_support",
++    "//ui/events:test_support",
++    "//ui/ozone:platform",
++    "//ui/ozone:test_support",
++  ]
++}
+diff --git a/ui/ozone/platform/headless/headless_window.cc b/ui/ozone/platform/headless/headless_window.cc
+index d11ccc52615c913c95f902f86079f1ce904c4560..a0061fa1697539d16f04860deb0bc1547460a268 100644
+--- a/ui/ozone/platform/headless/headless_window.cc
++++ b/ui/ozone/platform/headless/headless_window.cc
+@@ -78,18 +78,31 @@ void HeadlessWindow::SetFullscreen(bool fullscreen, int64_t target_display_id) {
+     return;
+   }
+ 
++  // PlatformWindowDelegate callbacks can destroy the window, invalidating
++  // `this`. Keep a weak pointer and check it after each callback, here and
++  // below.
++  auto weak_ptr = GetWeakPtr();
++
+   if (fullscreen) {
+     if (window_state_ != PlatformWindowState::kMaximized &&
+         window_state_ != PlatformWindowState::kFullScreen) {
+       restored_bounds_ = bounds_;
+     }
+     ZoomWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kFullScreen);
+   } else {
+     if (window_state_ != PlatformWindowState::kFullScreen) {
+       return;
+     }
+     RestoreWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kNormal);
+   }
+ }
+@@ -101,21 +114,37 @@ void HeadlessWindow::Maximize() {
+ 
+   if (window_state_ != PlatformWindowState::kMaximized &&
+       window_state_ != PlatformWindowState::kFullScreen) {
++    auto weak_ptr = GetWeakPtr();
++
+     restored_bounds_ = bounds_;
+     ZoomWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kMaximized);
+   }
+ }
+ 
+ void HeadlessWindow::Minimize() {
+   if (window_state_ != PlatformWindowState::kMinimized) {
++    auto weak_ptr = GetWeakPtr();
++
+     // Minimized window retains its size and position, however, it's made
+     // hidden by Aura.
+     if (window_state_ == PlatformWindowState::kMaximized ||
+         window_state_ == PlatformWindowState::kFullScreen) {
+       RestoreWindowBounds();
++      if (!weak_ptr) {
++        return;
++      }
+     }
++
+     UpdateWindowState(PlatformWindowState::kMinimized);
++    if (!weak_ptr) {
++      return;
++    }
++
+     // Minimized windows are inactive. Aura activates minimized windows
+     // when restoring. If we don't deactivate the window here, the subsequent
+     // activation will be optimized away, causing https://crbug.com/358998544.
+@@ -125,7 +154,13 @@ void HeadlessWindow::Minimize() {
+ 
+ void HeadlessWindow::Restore() {
+   if (window_state_ != PlatformWindowState::kNormal) {
++    auto weak_ptr = GetWeakPtr();
++
+     RestoreWindowBounds();
++    if (!weak_ptr) {
++      return;
++    }
++
+     UpdateWindowState(PlatformWindowState::kNormal);
+   }
+ }
+diff --git a/ui/ozone/platform/headless/headless_window.h b/ui/ozone/platform/headless/headless_window.h
+index 646e398135bfd51429272977a2471f17eb038290..a7dc0249fb00f5a2ebd0f0adaa10c8c83459888b 100644
+--- a/ui/ozone/platform/headless/headless_window.h
++++ b/ui/ozone/platform/headless/headless_window.h
+@@ -9,6 +9,7 @@
+ 
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/scoped_refptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "ui/gfx/geometry/point.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/image/image_skia.h"
+@@ -73,6 +74,10 @@ class HeadlessWindow : public PlatformWindow {
+  protected:
+   PlatformWindowDelegate* delegate() { return delegate_; }
+ 
++  base::WeakPtr<HeadlessWindow> GetWeakPtr() {
++    return weak_ptr_factory_.GetWeakPtr();
++  }
++
+  private:
+   enum class ActivationState {
+     kUnknown,
+@@ -90,6 +95,8 @@ class HeadlessWindow : public PlatformWindow {
+   std::optional<gfx::Rect> restored_bounds_;
+   PlatformWindowState window_state_ = PlatformWindowState::kUnknown;
+   ActivationState activation_state_ = ActivationState::kUnknown;
++
++  base::WeakPtrFactory<HeadlessWindow> weak_ptr_factory_{this};
+ };
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/headless/headless_window_unittest.cc b/ui/ozone/platform/headless/headless_window_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..0881a9841c2c2d9ca8d04d2ac63e396a70763af6
+--- /dev/null
++++ b/ui/ozone/platform/headless/headless_window_unittest.cc
+@@ -0,0 +1,143 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/headless/headless_window.h"
++
++#include <memory>
++
++#include "testing/gtest/include/gtest/gtest.h"
++#include "ui/display/test/test_screen.h"
++#include "ui/gfx/geometry/rect.h"
++#include "ui/ozone/platform/headless/headless_window_manager.h"
++#include "ui/platform_window/platform_window_delegate.h"
++
++namespace ui {
++namespace {
++
++// A PlatformWindowDelegate that simulates the production behaviour of
++// DesktopWindowTreeHostPlatform: when the platform window calls back into the
++// delegate (OnBoundsChanged / OnWindowStateChanged), an observer may
++// synchronously call Widget::CloseNow(), which ends up calling
++// HeadlessWindow::Close() -> delegate_->OnClosed() ->
++// DWTHP::OnClosed() -> SetPlatformWindow(nullptr) -> ~HeadlessWindow().
++//
++// This delegate models that by resetting its owned unique_ptr<PlatformWindow>
++// from inside the chosen callback.
++class DestroyingDelegate : public PlatformWindowDelegate {
++ public:
++  enum class DestroyOn {
++    kNone,
++    kBoundsChanged,
++    kWindowStateChanged,
++  };
++
++  explicit DestroyingDelegate(DestroyOn destroy_on) : destroy_on_(destroy_on) {}
++  ~DestroyingDelegate() override = default;
++
++  void set_destroy_on(DestroyOn destroy_on) { destroy_on_ = destroy_on; }
++
++  void SetWindow(std::unique_ptr<PlatformWindow> window) {
++    window_ = std::move(window);
++  }
++
++  // PlatformWindowDelegate:
++  void OnBoundsChanged(const BoundsChange& change) override {
++    if (destroy_on_ == DestroyOn::kBoundsChanged) {
++      window_.reset();
++    }
++  }
++  void OnDamageRect(const gfx::Rect& damaged_region) override {}
++  void DispatchEvent(Event* event) override {}
++  void OnCloseRequest() override {}
++  void OnClosed() override { window_.reset(); }
++  void OnWindowStateChanged(PlatformWindowState old_state,
++                            PlatformWindowState new_state) override {
++    if (destroy_on_ == DestroyOn::kWindowStateChanged) {
++      window_.reset();
++    }
++  }
++  void OnLostCapture() override {}
++  void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) override {}
++  void OnWillDestroyAcceleratedWidget() override {}
++  void OnAcceleratedWidgetDestroyed() override {}
++  void OnActivationChanged(bool active) override {}
++  void OnCursorUpdate() override {}
++  bool CanMaximize() const override { return true; }
++  bool CanFullscreen() const override { return true; }
++  gfx::Rect ConvertRectToPixels(const gfx::Rect& rect_in_dip) const override {
++    return rect_in_dip;
++  }
++  gfx::Rect ConvertRectToDIP(const gfx::Rect& rect_in_pixels) const override {
++    return rect_in_pixels;
++  }
++
++ private:
++  DestroyOn destroy_on_ = DestroyOn::kNone;
++  std::unique_ptr<PlatformWindow> window_;
++};
++
++class HeadlessWindowCrashTest : public ::testing::Test {
++ public:
++  HeadlessWindowCrashTest() = default;
++  ~HeadlessWindowCrashTest() override = default;
++
++ protected:
++  display::test::TestScreen test_screen_{/*create_display=*/true,
++                                         /*register_screen=*/true};
++  HeadlessWindowManager manager_;
++};
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInSetFullscreen) {
++  DestroyingDelegate delegate(DestroyingDelegate::DestroyOn::kBoundsChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->SetFullscreen(/*fullscreen=*/true,
++                                 /*target_display_id=*/-1);
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInMaximize) {
++  DestroyingDelegate delegate(
++      DestroyingDelegate::DestroyOn::kWindowStateChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Maximize();
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInMinimize) {
++  DestroyingDelegate delegate(
++      DestroyingDelegate::DestroyOn::kWindowStateChanged);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Minimize();
++}
++
++TEST_F(HeadlessWindowCrashTest, DestroyViaObserverInRestore) {
++  DestroyingDelegate delegate(DestroyingDelegate::DestroyOn::kNone);
++
++  auto window = std::make_unique<HeadlessWindow>(&delegate, &manager_,
++                                                 gfx::Rect(0, 0, 100, 100));
++  HeadlessWindow* headless_window = window.get();
++  delegate.SetWindow(std::move(window));
++
++  headless_window->Maximize();
++
++  delegate.set_destroy_on(DestroyingDelegate::DestroyOn::kBoundsChanged);
++
++  headless_window->Restore();
++}
++
++}  // namespace
++}  // namespace ui

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -14,3 +14,4 @@ cherry-pick-cl-7702700.patch
 cherry-pick-7758773.patch
 cherry-pick-7766691.patch
 cherry-pick-7789282.patch
+cherry-pick-c6bfbe7c4e84.patch

--- a/patches/v8/cherry-pick-c6bfbe7c4e84.patch
+++ b/patches/v8/cherry-pick-c6bfbe7c4e84.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Mon, 4 May 2026 12:27:58 +0200
+Subject: [M148] [objects] Abort TryFastAddDataProperty if map becomes slow
+
+Original change's description:
+> [objects] Abort TryFastAddDataProperty if map becomes slow
+>
+> When class fields are added to a constructor-created function object
+> when the class extends Function, TryFastAddDataProperty is invoked
+> to perform a fast transition. However, Map::PrepareForDataProperty may
+> instead normalize the map and return a slow dictionary map.
+>
+> This CL fixes the issue by aborting the fast transition in
+> TryFastAddDataProperty and returning false if
+> Map::PrepareForDataProperty returns a dictionary map, falling back
+> to the standard slow property addition path.
+>
+> TAG=agy
+> CONV=7233c224-ccbc-421c-88b3-34be1f425294
+>
+> Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+> Fixed: 506689381
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7807043
+> Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+> Reviewed-by: Igor Sheludko <ishell@chromium.org>
+> Auto-Submit: Leszek Swirski <leszeks@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#107009}
+
+(cherry picked from commit 3c869652b039fc1fc9fbe035c6af879317e8b9f3)
+
+Bug: 514925552,506689381
+Change-Id: If323afa0297782cd7a13efb02368e0dfdec00707
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7874712
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
+Reviewed-by: Leszek Swirski <leszeks@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/14.8@{#62}
+Cr-Branched-From: f9659283a5f8d42b3c09228cf5df606fcaf47a3d-refs/heads/14.8.178@{#1}
+Cr-Branched-From: 141232520dc4910401240c531db3af36910a0fd1-refs/heads/main@{#106240}
+
+diff --git a/src/objects/js-objects.cc b/src/objects/js-objects.cc
+index 26f429dd3481058ba04b5074b08bc11f88a7bae5..7e85b305626950189812cf0a1c879f10faed3aae 100644
+--- a/src/objects/js-objects.cc
++++ b/src/objects/js-objects.cc
+@@ -3655,6 +3655,7 @@ bool TryFastAddDataProperty(Isolate* isolate, DirectHandle<JSObject> object,
+   InternalIndex descriptor = new_map->LastAdded();
+   new_map = Map::PrepareForDataProperty(isolate, new_map, descriptor,
+                                         PropertyConstness::kConst, value);
++  if (new_map->is_dictionary_map()) return false;
+   JSObject::MigrateToMap(isolate, object, new_map);
+   // TODO(leszeks): Avoid re-loading the property details, which we already
+   // loaded in PrepareForDataProperty.
+diff --git a/test/mjsunit/regress/regress-crbug-506689381.js b/test/mjsunit/regress/regress-crbug-506689381.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ba2dc8e021e8ea2f7c2381d9ab9c6f88916479f
+--- /dev/null
++++ b/test/mjsunit/regress/regress-crbug-506689381.js
+@@ -0,0 +1,20 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++let key = 'AA';
++let value = 2;
++class C extends Function {
++  [key] = value;
++}
++
++// First object creation triggers transition MapA----(AA, kData, SMI)--->MapB
++let o1 = new C('\'use strict\'');
++
++value = 1.1;
++
++// Second object creation triggers TryFastAddDataProperty() which reconfigures
++// the property from Smi to Double. This reconfigures MapB in-place (or
++// normalizes it). TryFastAddDataProperty must not crash if the map is
++// normalized during preparation.
++let o2 = new C('\'use strict\'');


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`40c4ee1326a2`](https://chromium-review.googlesource.com/c/chromium/src/+/7898875) from chromium — wayland: Fix UAF/dangling ptr in ReleasePressedPointerButtons()
* [`7c925f1f0941`](https://chromium-review.googlesource.com/c/chromium/src/+/7885098) from chromium — [headless][linux] Safeguard headless window code against potential UAF
* [`7b1403be9ec4`](https://chromium-review.googlesource.com/c/chromium/src/+/7901351) from chromium — Fix context lifetime in ProxyResolverV8 callbacks
* [`c6bfbe7c4e84`](https://chromium-review.googlesource.com/c/v8/v8/+/7874712) from v8 — [objects] Abort TryFastAddDataProperty if map becomes slow

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium and V8.
