### PR TITLE
chore: cherry-pick 15 changes from chromium, skia, dawn

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -162,3 +162,15 @@ cherry-pick-db94c2cb8239.patch
 cherry-pick-b534033a6391.patch
 cherry-pick-36f6889ed145.patch
 cherry-pick-f9e6631b2ded.patch
+cherry-pick-12de7ea26453.patch
+cherry-pick-df3780d115a3.patch
+cherry-pick-8ed77b6a0d7a.patch
+cherry-pick-18ce72db3063.patch
+cherry-pick-44d6bf109100.patch
+cherry-pick-b46a51655dd6.patch
+cherry-pick-8db4874bd3ff.patch
+cherry-pick-c6c60af71b11.patch
+cherry-pick-e819a80f8ff8.patch
+cherry-pick-22e4bb302a14.patch
+cherry-pick-17f11eae14fd.patch
+cherry-pick-3f57fbc717d7.patch

--- a/patches/chromium/cherry-pick-12de7ea26453.patch
+++ b/patches/chromium/cherry-pick-12de7ea26453.patch
@@ -1,0 +1,176 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrea Orru <andreaorru@chromium.org>
+Date: Thu, 4 Jun 2026 08:19:47 -0700
+Subject: [M148] [Extensions] Fix Site Isolation bypass in WebRequest API via
+ EventRouter
+
+Original change's description:
+> [Extensions] Fix Site Isolation bypass in WebRequest API via EventRouter
+>
+> When kWebRequestPersistFilteredEventsViaEventRouter is enabled, active
+> webRequest listeners are registered via the mojom::EventRouter
+> interface. EventRouter::AddFilteredListenerForMainThread permits
+> registrations from renderers that have executed a content script for the
+> extension. However, WebRequestAPI::OnListenerAdded does not verify
+> whether the registering process was a privileged extension process
+> rather than a content script web process before establishing active
+> listeners that receive sensitive cross-origin network data.
+>
+> This change adds a process authorization check in
+> WebRequestAPI::OnListenerAdded using ProcessMap::Contains. If an
+> unauthorized process attempts to register a webRequest listener, the
+> registration is rejected and the renderer process is terminated with the
+> new bad message reason WRA_INVALID_EXTENSION_ID_FOR_PROCESS.
+>
+> Bug: 513321171
+> Change-Id: Iad4aca0a303cc64cec5f280bc12a21c3b03cc799
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7867503
+> Reviewed-by: Tim <tjudkins@chromium.org>
+> Reviewed-by: Kelvin Jiang <kelvinjiang@chromium.org>
+> Reviewed-by: Luc Nguyen <lucnguyen@google.com>
+> Commit-Queue: Andrea Orru <andreaorru@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1636336}
+
+(cherry picked from commit 572cfa5066cece423fd070de5d61395bf947630b)
+
+Bug: 517794297,513321171
+Change-Id: Iad4aca0a303cc64cec5f280bc12a21c3b03cc799
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7886775
+Reviewed-by: Devlin Cronin <rdevlin.cronin@chromium.org>
+Commit-Queue: Andrea Orru <andreaorru@chromium.org>
+Reviewed-by: Luc Nguyen <lucnguyen@google.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4238}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/chrome/browser/extensions/extension_security_exploit_browsertest.cc b/chrome/browser/extensions/extension_security_exploit_browsertest.cc
+index 9c620f723c6504981d686baf65b4d09965fd7e54..8f8660cc3fe96311253b8451f63949205b15ba37 100644
+--- a/chrome/browser/extensions/extension_security_exploit_browsertest.cc
++++ b/chrome/browser/extensions/extension_security_exploit_browsertest.cc
+@@ -11,6 +11,8 @@
+ #include "base/memory/weak_ptr.h"
+ #include "base/strings/stringprintf.h"
+ #include "base/test/bind.h"
++#include "base/test/values_test_util.h"
++#include "base/values.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/chrome_content_browser_client.h"
+ #include "chrome/browser/extensions/api/messaging/native_messaging_test_util.h"
+@@ -761,6 +763,17 @@ class EventRouterExploitTest : public ExtensionSecurityExploitBrowserTest {
+     // access to do things, while `spoofed_extension()` should not.
+     InstallTestExtensions();
+   }
++
++  // Binds the EventRouter interface as though `process` were the renderer
++  // sending the message.
++  mojo::AssociatedRemote<mojom::EventRouter> BindEventRouterForProcess(
++      content::RenderProcessHost* process) {
++    mojo::AssociatedRemote<mojom::EventRouter> event_router;
++    EventRouter::BindForRenderer(
++        process->GetID(),
++        event_router.BindNewEndpointAndPassDedicatedReceiver());
++    return event_router;
++  }
+ };
+ 
+ // Tests that attempting to add a main thread listener for the process of a
+@@ -1114,4 +1127,39 @@ IN_PROC_BROWSER_TEST_F(
+   }
+ }
+ 
++// Tests that a web page process that ran a content script cannot register an
++// active webRequest listener for that extension.
++IN_PROC_BROWSER_TEST_F(
++    EventRouterExploitTest,
++    AddFilteredListenerForMainThread_WebRequestFromContentScriptProcess) {
++  // Navigate to a web page where active_extension() has host permissions.
++  GURL test_page_url =
++      embedded_test_server()->GetURL("foo.com", "/title1.html");
++  auto* web_contents = GetActiveWebContents();
++  EXPECT_TRUE(NavigateToURL(web_contents, test_page_url));
++
++  // Execute a content script so ScriptInjectionTracker authorizes this process
++  // for main thread listeners.
++  ASSERT_TRUE(ExecuteProgrammaticContentScript(
++      web_contents, active_extension_id(), "document.body.bgColor = 'red';"));
++
++  content::RenderProcessHost* main_frame_process =
++      web_contents->GetPrimaryMainFrame()->GetProcess();
++  mojo::AssociatedRemote<mojom::EventRouter> event_router =
++      BindEventRouterForProcess(main_frame_process);
++
++  RenderProcessHostBadIpcMessageWaiter kill_waiter(main_frame_process);
++
++  base::DictValue filter =
++      base::test::ParseJsonDict(R"({"urls": ["http://*/*"]})");
++
++  event_router->AddFilteredListenerForMainThread(
++      mojom::EventListenerOwner::NewExtensionId(active_extension_id()),
++      "webRequest.onBeforeRequest", std::move(filter),
++      /*add_lazy_listener=*/false);
++
++  EXPECT_EQ(bad_message::WRA_INVALID_EXTENSION_ID_FOR_PROCESS,
++            kill_waiter.Wait());
++}
++
+ }  // namespace extensions
+diff --git a/extensions/browser/api/web_request/web_request_api.cc b/extensions/browser/api/web_request/web_request_api.cc
+index 4902e390115cb0a92abfcafa04f0999dbe7e6ad6..cdc89a73e21b81af67d15bef14155f27bc5c98e2 100644
+--- a/extensions/browser/api/web_request/web_request_api.cc
++++ b/extensions/browser/api/web_request/web_request_api.cc
+@@ -41,6 +41,7 @@
+ #include "extensions/browser/api/web_request/web_request_proxying_url_loader_factory.h"
+ #include "extensions/browser/api/web_request/web_request_proxying_websocket.h"
+ #include "extensions/browser/api/web_request/web_request_proxying_webtransport.h"
++#include "extensions/browser/bad_message.h"
+ #include "extensions/browser/browser_frame_context_data.h"
+ #include "extensions/browser/browser_process_context_data.h"
+ #include "extensions/browser/event_router.h"
+@@ -464,6 +465,20 @@ void WebRequestAPI::OnListenerAdded(const EventListenerInfo& details) {
+   std::string sub_event_name = details.event_name;
+   auto* process = content::RenderProcessHost::FromID(details.render_process_id);
+ 
++  // Active webRequest listeners owned by an extension must only be registered
++  // by processes authorized to host that extension.
++  // `AddFilteredListenerForMainThread` also accepts registrations from web
++  // processes that have executed content or user scripts for the extension, so
++  // enforce the stronger `ProcessMap` check here. Lazy listeners are exempt
++  // since they are not bound to a specific process. See crbug.com/513321171.
++  if (extension && !details.is_lazy && process &&
++      !ProcessMap::Get(details.browser_context)
++           ->Contains(extension->id(), process->GetDeprecatedID())) {
++    bad_message::ReceivedBadMessage(
++        process, bad_message::WRA_INVALID_EXTENSION_ID_FOR_PROCESS);
++    return;
++  }
++
+   if (extra_info_spec & ExtraInfoSpec::SECURITY_INFO) {
+     // Security info should not be available in Chrome Apps and
+     // non-controlled frame, non-extension contexts.
+diff --git a/extensions/browser/bad_message.h b/extensions/browser/bad_message.h
+index cb78b91132fbf2e8572c9bb2eea8ea443d24d0f6..276ff421b5f5fd8a61f0b4f7789d047c66cd20e0 100644
+--- a/extensions/browser/bad_message.h
++++ b/extensions/browser/bad_message.h
+@@ -74,6 +74,9 @@ enum BadMessageReason {
+   SWH_BAD_WORKER_THREAD_ID = 34,
+   ER_INVALID_EXTENSION_ID_FOR_PROCESS = 35,
+   CEFH_INVALID_EXTENSION_ID_FOR_SCRIPT_INJECT_REQUEST = 36,
++  SWH_INVALID_SERVICE_WORKER_SCOPE = 37,
++  EMF_INVALID_MESSAGE_FROM_SANDBOXED_PROCESS = 38,
++  WRA_INVALID_EXTENSION_ID_FOR_PROCESS = 39,
+   // Please add new elements here. The naming convention is abbreviated class
+   // name (e.g. ExtensionHost becomes EH) plus a unique description of the
+   // reason. After making changes, you MUST update histograms.xml by running:
+diff --git a/tools/metrics/histograms/metadata/stability/enums.xml b/tools/metrics/histograms/metadata/stability/enums.xml
+index a2f8bd64e3ddf62680675ad08587ee10f3975a14..f53a0da3c1d92280354c9e873e82a68b546f09ac 100644
+--- a/tools/metrics/histograms/metadata/stability/enums.xml
++++ b/tools/metrics/histograms/metadata/stability/enums.xml
+@@ -552,6 +552,9 @@ Called by update_bad_message_reasons.py.-->
+   <int value="34" label="SWH_BAD_WORKER_THREAD_ID"/>
+   <int value="35" label="ER_INVALID_EXTENSION_ID_FOR_PROCESS"/>
+   <int value="36" label="CEFH_INVALID_EXTENSION_ID_FOR_SCRIPT_INJECT_REQUEST"/>
++  <int value="37" label="SWH_INVALID_SERVICE_WORKER_SCOPE"/>
++  <int value="38" label="EMF_INVALID_MESSAGE_FROM_SANDBOXED_PROCESS"/>
++  <int value="39" label="WRA_INVALID_EXTENSION_ID_FOR_PROCESS"/>
+ </enum>
+ 
+ <enum name="BadMessageReasonGuestView">

--- a/patches/chromium/cherry-pick-17f11eae14fd.patch
+++ b/patches/chromium/cherry-pick-17f11eae14fd.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Wed, 3 Jun 2026 14:29:13 -0700
+Subject: [M148] Fix UAF in BluetoothRfcommChannelMac and
+ BluetoothL2capChannelMac delegates on macOS
+
+Original change's description:
+> Fix UAF in BluetoothRfcommChannelMac and BluetoothL2capChannelMac delegates on macOS
+>
+> When a Bluetooth channel is closed, the C++ wrapper class synchronously
+> releases its strong reference to its Objective-C delegate class while
+> the delegate's own closed-callback method is still active on the call
+> stack. This results in the delegate being immediately deallocated,
+> causing UAF reads and writes upon method return.
+>
+> This CL fixes the issue by holding a strong local reference to the
+> delegate (self) at the beginning of rfcommChannelClosed: and l2capChannelClosed: to ensure it survives the callback execution.
+>
+> Bug: 518235412
+> Change-Id: Ie29e7a96cb36f3673a56d2a8d3834409c5007efb
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7892775
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640409}
+
+(cherry picked from commit 407929b2c76b20b7d2e291ffd5cdea7c2c383380)
+
+Bug: 519444377,518235412
+Change-Id: Ie29e7a96cb36f3673a56d2a8d3834409c5007efb
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7899243
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4228}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_l2cap_channel_mac.mm b/device/bluetooth/bluetooth_l2cap_channel_mac.mm
+index 1792d66a3f4cc89b96efd2d9e7cc00e2276a6692..5843679590638daecc92162de61809d933479bfc 100644
+--- a/device/bluetooth/bluetooth_l2cap_channel_mac.mm
++++ b/device/bluetooth/bluetooth_l2cap_channel_mac.mm
+@@ -78,6 +78,13 @@ - (void)l2capChannelData:(IOBluetoothL2CAPChannel*)l2capChannel
+ - (void)l2capChannelClosed:(IOBluetoothL2CAPChannel*)l2capChannel {
+   [_l2capChannel setDelegate:nil];
+ 
++  // Maintain a strong local reference to ensure the delegate survives the
++  // callback. This is necessary for incoming connections or failed outgoing
++  // connections where `_strongSelf` is never armed, leaving `delegate_` in
++  // C++ as the only strong reference keeping this object alive.
++  [[maybe_unused]] NS_VALID_UNTIL_END_OF_SCOPE BluetoothL2capChannelDelegate*
++      keepAlive = self;
++
+   // If `_channel` still exists, notify it that the channel was closed so it
+   // can release its strong references to `l2capChannel` and the channel
+   // delegate (this object). In the typical case we expect `_channel` has
+diff --git a/device/bluetooth/bluetooth_rfcomm_channel_mac.mm b/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
+index a2411754cf4d0726f6a3c39058a9861259163a01..2354bade665bb36f9a16c98faeb05cc0f5838e56 100644
+--- a/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
++++ b/device/bluetooth/bluetooth_rfcomm_channel_mac.mm
+@@ -78,6 +78,13 @@ - (void)rfcommChannelData:(IOBluetoothRFCOMMChannel*)rfcommChannel
+ - (void)rfcommChannelClosed:(IOBluetoothRFCOMMChannel*)rfcommChannel {
+   [_rfcommChannel setDelegate:nil];
+ 
++  // Maintain a strong local reference to ensure the delegate survives the
++  // callback. This is necessary for incoming connections or failed outgoing
++  // connections where `_strongSelf` is never armed, leaving `delegate_` in
++  // C++ as the only strong reference keeping this object alive.
++  [[maybe_unused]] NS_VALID_UNTIL_END_OF_SCOPE BluetoothRfcommChannelDelegate*
++      keepAlive = self;
++
+   // If `_channel` still exists, notify it that the channel was closed so it
+   // can release its strong references to `rfcommChannel` and the channel
+   // delegate (this object). In the typical case we expect `_channel` has

--- a/patches/chromium/cherry-pick-18ce72db3063.patch
+++ b/patches/chromium/cherry-pick-18ce72db3063.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenichi Ishibashi <bashi@chromium.org>
+Date: Thu, 4 Jun 2026 17:42:11 -0700
+Subject: [M148] Improve temporary file creation and error handling in
+ SimpleURLLoader
+
+Original change's description:
+> Improve temporary file creation and error handling in SimpleURLLoader
+>
+> This CL updates SimpleURLLoader to use
+> base::CreateAndOpenTemporaryFileInDir() when downloading to a temporary
+> file. This atomically creates and opens the file, retaining the file
+> descriptor directly and avoiding the previous pattern of closing and
+> re-opening the file by path.
+>
+> Additionally, it improves error reporting on initialization failure by
+> explicitly mapping base::File::error_details() to a net::Error via
+> net::FileErrorToNetError().
+>
+> Bug: 516979551
+> Change-Id: I353bac993212cbee76cb8a1c3c086e73ff4e6369
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885361
+> Reviewed-by: mmenke <mmenke@chromium.org>
+> Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640681}
+
+(cherry picked from commit 037c5ddb3336e88e3215f9e2cb903282d032b653)
+
+Bug: 519857795,516979551
+Change-Id: I353bac993212cbee76cb8a1c3c086e73ff4e6369
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7902751
+Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Kenichi Ishibashi <bashi@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4242}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/services/network/public/cpp/simple_url_loader.cc b/services/network/public/cpp/simple_url_loader.cc
+index 0ebecf46d2c20007c4e47b22338b9e50e3105ebd..3cfc70a84e9d0c57d20c153067181db1b7b44303 100644
+--- a/services/network/public/cpp/simple_url_loader.cc
++++ b/services/network/public/cpp/simple_url_loader.cc
+@@ -1020,28 +1020,28 @@ class SaveToFileBodyHandler : public BodyHandler {
+       DCHECK(!file_.IsValid());
+       DCHECK(!body_reader_);
+ 
+-      bool have_path = !create_temp_file_;
+-      if (!have_path) {
+-        DCHECK(create_temp_file_);
+-        have_path = base::CreateTemporaryFile(&path_);
+-        // CreateTemporaryFile() creates an empty file.
+-        if (have_path)
+-          owns_file_ = true;
+-      }
+-
+-      if (have_path) {
+-        // Try to initialize |file_|, creating the file if needed.
++      if (create_temp_file_) {
++        base::FilePath temp_dir;
++        if (base::GetTempDir(&temp_dir)) {
++          file_ = base::CreateAndOpenTemporaryFileInDir(temp_dir, &path_);
++        }
++      } else {
+         file_.Initialize(
+             path_, base::File::FLAG_WRITE | base::File::FLAG_CREATE_ALWAYS);
+       }
+ 
+       // If CreateTemporaryFile() or File::Initialize() failed, report failure.
+       if (!file_.IsValid()) {
++        net::Error net_error = net::FileErrorToNetError(file_.error_details());
++        if (net_error == net::OK) {
++          net_error = net::MapSystemError(logging::GetLastSystemErrorCode());
++          if (net_error == net::OK) {
++            net_error = net::ERR_FILE_NOT_FOUND;
++          }
++        }
+         body_handler_task_runner_->PostTask(
+-            FROM_HERE, base::BindOnce(std::move(on_done_callback),
+-                                      net::MapSystemError(
+-                                          logging::GetLastSystemErrorCode()),
+-                                      0, base::FilePath()));
++            FROM_HERE, base::BindOnce(std::move(on_done_callback), net_error, 0,
++                                      base::FilePath()));
+         return;
+       }
+ 

--- a/patches/chromium/cherry-pick-22e4bb302a14.patch
+++ b/patches/chromium/cherry-pick-22e4bb302a14.patch
@@ -1,0 +1,123 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Tue, 2 Jun 2026 11:44:04 -0700
+Subject: [M148] Add validation to cursor theme name to prevent path traversal.
+
+Original change's description:
+> Add validation to cursor theme name to prevent path traversal.
+>
+> On Linux Ozone/X11 platforms, a compromised GPU process could
+> potentially exploit its cloned X11 connection to hijack the XSETTINGS
+> selection, supplying a malicious cursor theme name.
+>
+> This CL remediates the issue by sanitizing and validating any cursor
+> theme name retrieved from GetCursorThemeName() or recursive inherits
+> parsing during the cursor loading process, rejecting absolute paths,
+> relative parent references, and paths with multiple components.
+>
+> Fixed: 518105731
+> Change-Id: Ia0f9eb7b433dc1d7a200485dfb70e1ec67e68910
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7890525
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639694}
+
+(cherry picked from commit 633de441a4c8d326e1575eef15167d9e38e4cdb1)
+
+Bug: 519051210,518105731
+Change-Id: Ia0f9eb7b433dc1d7a200485dfb70e1ec67e68910
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7895318
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4211}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/ui/base/x/x11_cursor_loader.cc b/ui/base/x/x11_cursor_loader.cc
+index 04365d8b5bd5f6f95b9517e5aba9e8a2eb6ae6ae..150a4f1b5b1dfa8df9153489f55b970faa1ef76c 100644
+--- a/ui/base/x/x11_cursor_loader.cc
++++ b/ui/base/x/x11_cursor_loader.cc
+@@ -151,12 +151,22 @@ base::FilePath CanonicalizePath(base::FilePath path) {
+   return path;
+ }
+ 
++bool IsValidCursorThemeName(const std::string& theme) {
++  base::FilePath theme_path(theme);
++  return !theme.empty() && theme != "." && !theme_path.IsAbsolute() &&
++         !theme_path.ReferencesParent() && theme_path.BaseName() == theme_path;
++}
++
+ scoped_refptr<base::RefCountedMemory> ReadCursorFromThemeImpl(
+     const std::string& theme,
+     const std::string& cursor_name,
+     base::flat_set<ThemeAndCursorName>* parent_theme_and_cursor_names,
+     base::flat_map<ThemeAndCursorName, scoped_refptr<base::RefCountedMemory>>*
+         cache) {
++  if (!IsValidCursorThemeName(theme)) {
++    return nullptr;
++  }
++
+   constexpr const char kCursorDir[] = "cursors";
+   constexpr const char kThemeInfo[] = "index.theme";
+ 
+@@ -266,6 +276,10 @@ std::vector<XCursorLoader::Image> ReadCursorImages(
+ 
+ }  // namespace
+ 
++bool IsValidCursorThemeNameForTesting(const std::string& theme) {
++  return IsValidCursorThemeName(theme);
++}
++
+ XCursorLoader::XCursorLoader(x11::Connection* connection,
+                              base::RepeatingClosure on_cursor_config_changed)
+     : connection_(connection),
+diff --git a/ui/base/x/x11_cursor_loader.h b/ui/base/x/x11_cursor_loader.h
+index 94d08728c76385d20a5d389d88eb75d4ca6d5265..570a70ce957ac9aae1c59c2adb584b6944daa301 100644
+--- a/ui/base/x/x11_cursor_loader.h
++++ b/ui/base/x/x11_cursor_loader.h
+@@ -89,6 +89,9 @@ class COMPONENT_EXPORT(UI_BASE_X) XCursorLoader {
+   base::WeakPtrFactory<XCursorLoader> weak_factory_{this};
+ };
+ 
++COMPONENT_EXPORT(UI_BASE_X)
++bool IsValidCursorThemeNameForTesting(const std::string& theme);
++
+ COMPONENT_EXPORT(UI_BASE_X)
+ std::vector<XCursorLoader::Image> ParseCursorFile(
+     scoped_refptr<base::RefCountedMemory> file,
+diff --git a/ui/base/x/x11_cursor_loader_unittest.cc b/ui/base/x/x11_cursor_loader_unittest.cc
+index d72f51d933da6dc160c53d63ae266d69cfef97f6..3cdf6dbd25514b1221ac5948e0d5a2dc33ce359c 100644
+--- a/ui/base/x/x11_cursor_loader_unittest.cc
++++ b/ui/base/x/x11_cursor_loader_unittest.cc
+@@ -262,4 +262,31 @@ TEST(XCursorLoaderTest, Animated) {
+   EXPECT_EQ(images[1].frame_delay.InMilliseconds(), 500);
+ }
+ 
++TEST(XCursorLoaderTest, ThemeNameValidation) {
++  const char* const kInvalidThemes[] = {
++      "",
++      ".",
++      "..",
++      "/foo",
++      "/tmp/evil",
++      "../foo",
++      "foo/..",
++      "../../../../tmp/poc-cursor-evil",
++      "foo/bar",
++  };
++  for (const char* theme : kInvalidThemes) {
++    EXPECT_FALSE(IsValidCursorThemeNameForTesting(theme));
++  }
++
++  const char* const kValidThemes[] = {
++      "default",
++      "Adwaita",
++      "DMZ-White",
++      "my_theme-123",
++  };
++  for (const char* theme : kValidThemes) {
++    EXPECT_TRUE(IsValidCursorThemeNameForTesting(theme));
++  }
++}
++
+ }  // namespace ui

--- a/patches/chromium/cherry-pick-3f57fbc717d7.patch
+++ b/patches/chromium/cherry-pick-3f57fbc717d7.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Wed, 3 Jun 2026 14:26:59 -0700
+Subject: [M148] Fix UAF in BluetoothDeviceInquiryDelegate on macOS
+
+Original change's description:
+> Fix UAF in BluetoothDeviceInquiryDelegate on macOS
+>
+> On destruction, BluetoothDiscoveryManagerMacClassic releases its strong
+> reference to BluetoothDeviceInquiryDelegate while an asynchronous
+> callback may be enqueued on the main run loop. The subsequent callback
+> execution on a deallocated receiver could lead to memory corruption.
+>
+> This CL fixes the issue by:
+> 1. Adding a `resetOwner` method to `BluetoothDeviceInquiryDelegate` to
+>    clear its weak pointer to the manager.
+> 2. Checking if the manager is still valid in the delegate callbacks.
+> 3. In `~BluetoothDiscoveryManagerMacClassic`, stopping the inquiry,
+>    resetting the delegate's owner, and keeping the delegate alive for
+>    one turn of the main run loop using `dispatch_async`.
+>
+> Bug: 518237527
+> Change-Id: I34d77372651e1996fcf9e6b709eaad1cf44540e6
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7889579
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640412}
+
+(cherry picked from commit 673a5aee77ad12e118c8edac73359acdeb7f491c)
+
+Bug: 519444194,518237527
+Change-Id: I34d77372651e1996fcf9e6b709eaad1cf44540e6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7900417
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4227}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_discovery_manager_mac.mm b/device/bluetooth/bluetooth_discovery_manager_mac.mm
+index bccb75c98b137ef735bb0c3eed5ed71ba4a6e94f..42a26abcfe7924e3dc51550beeb66e6c1137fac1 100644
+--- a/device/bluetooth/bluetooth_discovery_manager_mac.mm
++++ b/device/bluetooth/bluetooth_discovery_manager_mac.mm
+@@ -26,6 +26,8 @@ @interface BluetoothDeviceInquiryDelegate
+ - (instancetype)initWithManager:
+     (device::BluetoothDiscoveryManagerMacClassic*)manager;
+ 
++- (void)resetOwner;
++
+ @end
+ 
+ namespace device {
+@@ -48,10 +50,21 @@ explicit BluetoothDiscoveryManagerMacClassic(Observer* observer)
+       const BluetoothDiscoveryManagerMacClassic&) = delete;
+ 
+   ~BluetoothDiscoveryManagerMacClassic() override {
++    [inquiry_ stop];
++    [inquiry_delegate_ resetOwner];
+     // IOBluetoothDeviceInquiry's delegate property is configured as "assign"
+     // rather than "weak". If it is not manually reset then our delegate could be
+     // accessed after we drop our strong reference and the object is freed.
+     inquiry_.delegate = nil;
++
++    // Keep the delegate alive for one more turn of the main run loop to allow
++    // any already-enqueued callbacks to fire safely (and become no-ops since
++    // the owner has been reset to nullptr) rather than hitting a deallocated
++    // object. See FB13705522.
++    BluetoothDeviceInquiryDelegate* __strong delegate = inquiry_delegate_;
++    dispatch_async(dispatch_get_main_queue(), ^{
++      (void)delegate;
++    });
+   }
+ 
+   // BluetoothDiscoveryManagerMac override.
+@@ -213,18 +226,31 @@ - (instancetype)initWithManager:
+   return self;
+ }
+ 
++- (void)resetOwner {
++  _manager = nullptr;
++}
++
+ - (void)deviceInquiryStarted:(IOBluetoothDeviceInquiry*)sender {
++  if (!_manager) {
++    return;
++  }
+   _manager->DeviceInquiryStarted(sender);
+ }
+ 
+ - (void)deviceInquiryDeviceFound:(IOBluetoothDeviceInquiry*)sender
+                           device:(IOBluetoothDevice*)device {
++  if (!_manager) {
++    return;
++  }
+   _manager->DeviceFound(sender, device);
+ }
+ 
+ - (void)deviceInquiryComplete:(IOBluetoothDeviceInquiry*)sender
+                         error:(IOReturn)error
+                       aborted:(BOOL)aborted {
++  if (!_manager) {
++    return;
++  }
+   _manager->DeviceInquiryComplete(sender, error, aborted);
+ }
+ 

--- a/patches/chromium/cherry-pick-44d6bf109100.patch
+++ b/patches/chromium/cherry-pick-44d6bf109100.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenichi Ishibashi <bashi@chromium.org>
+Date: Thu, 4 Jun 2026 05:39:03 -0700
+Subject: [M148] Restrict CreateNetLogExporter to browser process
+
+Original change's description:
+> Restrict CreateNetLogExporter to browser process
+>
+> The network::mojom::NetworkContext::CreateNetLogExporter Mojo interface
+> method previously lacked an AllowedContext restriction.
+>
+> This CL applies [AllowedContext=sandbox.mojom.Context.kBrowser] to
+> CreateNetLogExporter. This enforces at the Mojo binding layer that only the
+> highly privileged browser process can request a NetLogExporter.
+>
+> Bug: 517130229
+> Change-Id: Ibd6f167cfb21e97433683d5bf935a21982ab0da2
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7885519
+> Reviewed-by: Takashi Toyoshima <toyoshim@chromium.org>
+> Commit-Queue: Kenichi Ishibashi <bashi@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640662}
+
+(cherry picked from commit 87c69081905e215d4ddcfdbb23a21221906f2ba3)
+
+Bug: 519856903,517130229
+Change-Id: Ibd6f167cfb21e97433683d5bf935a21982ab0da2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7902731
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4237}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/services/network/public/mojom/network_context.mojom b/services/network/public/mojom/network_context.mojom
+index 7493bd8dd37b36a3e7a96b1373619fee0b6a9d8e..f3f98c86bb08b0fe229d5dd57b30a696d6ad5952 100644
+--- a/services/network/public/mojom/network_context.mojom
++++ b/services/network/public/mojom/network_context.mojom
+@@ -1513,6 +1513,7 @@ interface NetworkContext {
+   // managed by the same NetworkService. The particular NetworkContext this is
+   // called on will determine which NetworkContext gets its information and
+   // configuration summary written out at the end of the log.
++  [AllowedContext=sandbox.mojom.Context.kBrowser]
+   CreateNetLogExporter(pending_receiver<NetLogExporter> receiver);
+ 
+   // Tries to preconnect to `url`. `num_streams` may be used to request more

--- a/patches/chromium/cherry-pick-8db4874bd3ff.patch
+++ b/patches/chromium/cherry-pick-8db4874bd3ff.patch
@@ -1,0 +1,588 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dale Curtis <dalecurtis@chromium.org>
+Date: Mon, 8 Jun 2026 16:36:00 -0700
+Subject: [M148] Harden MojoAudioDecoderService and various implementations
+
+Original change's description:
+> Harden MojoAudioDecoderService and various implementations
+>
+> Specifically this change ensures proper sequencing of MojoAudioDecoder
+> calls via BadMessages. Underlying implementations have CHECK() added
+> where appropriate to further enforce this.
+>
+> R=tguilbert
+>
+> Fixed: 517533654
+> Change-Id: Id3ffc0b0541e4f152a4b4bcd5d8c676ad769839e
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7883468
+> Reviewed-by: Thomas Guilbert <tguilbert@chromium.org>
+> Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1640608}
+
+(cherry picked from commit dc9eaa50e8fcb4a2b5151243d55d8d2bd1245773)
+
+Bug: 519857435,517533654
+Change-Id: Id3ffc0b0541e4f152a4b4bcd5d8c676ad769839e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7901520
+Reviewed-by: Thomas Guilbert <tguilbert@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4281}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/media/filters/android/media_codec_audio_decoder.cc b/media/filters/android/media_codec_audio_decoder.cc
+index 2ee2b4905ffc3ece35264d3277be24f8d6e6bcc4..42de67d5448ee9eff25e81a6ef565e9a9ed6b135 100644
+--- a/media/filters/android/media_codec_audio_decoder.cc
++++ b/media/filters/android/media_codec_audio_decoder.cc
+@@ -71,6 +71,7 @@ void MediaCodecAudioDecoder::Initialize(const AudioDecoderConfig& config,
+   // decode.
+   DCHECK(input_queue_.empty());
+   ClearInputQueue(DecoderStatus::Codes::kAborted);
++  codec_loop_.reset();
+ 
+   if (state_ == STATE_ERROR) {
+     DVLOG(1) << "Decoder is in error state.";
+@@ -197,6 +198,8 @@ bool MediaCodecAudioDecoder::CreateMediaCodecLoop() {
+ 
+ void MediaCodecAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+                                     DecodeCB decode_cb) {
++  CHECK(codec_loop_);
++
+   DecodeCB bound_decode_cb =
+       base::BindPostTaskToCurrentDefault(std::move(decode_cb));
+ 
+@@ -222,8 +225,6 @@ void MediaCodecAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+     return;
+   }
+ 
+-  DCHECK(codec_loop_);
+-
+   DVLOG(3) << __func__ << " " << buffer->AsHumanReadableString();
+ 
+   DCHECK_EQ(state_, STATE_READY) << " unexpected state " << AsString(state_);
+@@ -240,6 +241,7 @@ void MediaCodecAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+ 
+ void MediaCodecAudioDecoder::Reset(base::OnceClosure closure) {
+   DVLOG(2) << __func__;
++  CHECK(codec_loop_);
+ 
+   ClearInputQueue(DecoderStatus::Codes::kAborted);
+ 
+diff --git a/media/filters/mac/audio_toolbox_audio_decoder.cc b/media/filters/mac/audio_toolbox_audio_decoder.cc
+index 07673488250088cfbf941362b4585e9287a977aa..19a06a9fd25bce369347eb610be6e7c0191b9501 100644
+--- a/media/filters/mac/audio_toolbox_audio_decoder.cc
++++ b/media/filters/mac/audio_toolbox_audio_decoder.cc
+@@ -131,14 +131,18 @@ void AudioToolboxAudioDecoder::Initialize(const AudioDecoderConfig& config,
+   decoder_.reset();
+ 
+   output_cb_ = output_cb;
++  const bool success = CreateDecoder(config);
++  if (!success) {
++    decoder_.reset();
++  }
+   base::BindPostTaskToCurrentDefault(std::move(init_cb))
+-      .Run(CreateDecoder(config)
+-               ? DecoderStatus::Codes::kOk
+-               : DecoderStatus::Codes::kFailedToCreateDecoder);
++      .Run(success ? DecoderStatus::Codes::kOk
++                   : DecoderStatus::Codes::kFailedToCreateDecoder);
+ }
+ 
+ void AudioToolboxAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+                                       DecodeCB decode_cb) {
++  CHECK(decoder_);
+   DecodeCB decode_cb_bound =
+       base::BindPostTaskToCurrentDefault(std::move(decode_cb));
+ 
+@@ -226,6 +230,7 @@ void AudioToolboxAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+ }
+ 
+ void AudioToolboxAudioDecoder::Reset(base::OnceClosure reset_cb) {
++  CHECK(decoder_);
+   // This could fail, but ResetCB has no error reporting mechanism, so just let
+   // a subsequent decode call fail.
+   const auto result = AudioConverterReset(decoder_.get());
+diff --git a/media/filters/win/media_foundation_audio_decoder.cc b/media/filters/win/media_foundation_audio_decoder.cc
+index 5b0c6f1f8035b14ec5ade059c6535e8fa743b428..00fcea389c3161e36e8e9cdc1dad22aa87f50dc0 100644
+--- a/media/filters/win/media_foundation_audio_decoder.cc
++++ b/media/filters/win/media_foundation_audio_decoder.cc
+@@ -198,8 +198,10 @@ void MediaFoundationAudioDecoder::Initialize(const AudioDecoderConfig& config,
+   config_ = config;
+   output_cb_ = output_cb;
+ 
++  decoder_.Reset();
+   HRESULT hr = CreateDecoder();
+   if (FAILED(hr)) {
++    decoder_.Reset();
+     base::BindPostTaskToCurrentDefault(std::move(init_cb))
+         .Run(DecoderStatus(DecoderStatus::Codes::kUnsupportedCodec));
+     return;
+@@ -210,6 +212,7 @@ void MediaFoundationAudioDecoder::Initialize(const AudioDecoderConfig& config,
+ 
+ void MediaFoundationAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+                                          DecodeCB decode_cb) {
++  CHECK(decoder_);
+   DecodeCB decode_cb_bound =
+       base::BindPostTaskToCurrentDefault(std::move(decode_cb));
+ 
+@@ -314,6 +317,7 @@ void MediaFoundationAudioDecoder::Decode(scoped_refptr<DecoderBuffer> buffer,
+ }
+ 
+ void MediaFoundationAudioDecoder::Reset(base::OnceClosure reset_cb) {
++  CHECK(decoder_);
+   has_reset_ = true;
+   auto hr = decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0);
+   if (hr != S_OK) {
+diff --git a/media/mojo/services/BUILD.gn b/media/mojo/services/BUILD.gn
+index b1e661fc46fdaa59ffdea6c1d5dd233829d8adaa..28d464cfcb9825ac287daf1b79d3d794116641cf 100644
+--- a/media/mojo/services/BUILD.gn
++++ b/media/mojo/services/BUILD.gn
+@@ -262,6 +262,7 @@ source_set("unit_tests") {
+     "media_metrics_provider_unittest.cc",
+     "media_service_unittest.cc",
+     "mojo_audio_input_stream_unittest.cc",
++    "mojo_audio_decoder_service_unittest.cc",
+     "mojo_demuxer_stream_adapter_unittest.cc",
+     "mojo_video_encode_accelerator_service_unittest.cc",
+     "mojo_video_encoder_metrics_provider_service_unittest.cc",
+diff --git a/media/mojo/services/mojo_audio_decoder_service.cc b/media/mojo/services/mojo_audio_decoder_service.cc
+index b76c5eab09257042d41ab4b6fbec21309524fdb8..42ea52d820b99e3fbdbe0f1aac0ec8105f3c0515 100644
+--- a/media/mojo/services/mojo_audio_decoder_service.cc
++++ b/media/mojo/services/mojo_audio_decoder_service.cc
+@@ -24,6 +24,11 @@
+ 
+ namespace media {
+ 
++static constexpr std::string_view kNotInitializedMessage =
++    "Decoder can't be used after Initialize() fails.";
++static constexpr std::string_view kDataSourceNotSetMessage =
++    "SetDataSource() must be called before Decode() or Reset().";
++
+ MojoAudioDecoderService::MojoAudioDecoderService(
+     MojoMediaClient* mojo_media_client,
+     MojoCdmServiceContext* mojo_cdm_service_context,
+@@ -54,6 +59,11 @@ void MojoAudioDecoderService::Construct(
+     mojo::PendingAssociatedRemote<mojom::AudioDecoderClient> client,
+     mojo::PendingRemote<mojom::MediaLog> media_log) {
+   DVLOG(1) << __func__;
++  if (client_) {
++    mojo::ReportBadMessage("Construct() may only be called once.");
++    return;
++  }
++
+   client_.Bind(std::move(client));
+ 
+   auto mojo_media_log =
+@@ -69,8 +79,9 @@ void MojoAudioDecoderService::Initialize(
+   DVLOG(1) << __func__ << " " << config.AsHumanReadableString();
+ 
+   if (!decoder_) {
+-    OnInitialized(std::move(callback),
+-                  DecoderStatus::Codes::kFailedToCreateDecoder);
++    std::move(callback).Run(DecoderStatus::Codes::kFailed, false,
++                            AudioDecoderType::kUnknown);
++    mojo::ReportBadMessage(kNotInitializedMessage);
+     return;
+   }
+ 
+@@ -114,6 +125,10 @@ void MojoAudioDecoderService::Initialize(
+ void MojoAudioDecoderService::SetDataSource(
+     mojo::ScopedDataPipeConsumerHandle receive_pipe) {
+   DVLOG(1) << __func__;
++  if (mojo_decoder_buffer_reader_) {
++    mojo::ReportBadMessage("SetDataSource() may only be called once.");
++    return;
++  }
+ 
+   mojo_decoder_buffer_reader_ =
+       std::make_unique<MojoDecoderBufferReader>(std::move(receive_pipe));
+@@ -122,6 +137,18 @@ void MojoAudioDecoderService::SetDataSource(
+ void MojoAudioDecoderService::Decode(mojom::DecoderBufferPtr buffer,
+                                      DecodeCallback callback) {
+   DVLOG(3) << __func__;
++  if (!decoder_) {
++    std::move(callback).Run(DecoderStatus::Codes::kFailed);
++    mojo::ReportBadMessage(kNotInitializedMessage);
++    return;
++  }
++
++  if (!mojo_decoder_buffer_reader_) {
++    std::move(callback).Run(DecoderStatus::Codes::kFailed);
++    mojo::ReportBadMessage(kDataSourceNotSetMessage);
++    return;
++  }
++
+   mojo_decoder_buffer_reader_->ReadDecoderBuffer(
+       std::move(buffer),
+       base::BindOnce(&MojoAudioDecoderService::OnReadDone, weak_this_,
+@@ -130,6 +157,17 @@ void MojoAudioDecoderService::Decode(mojom::DecoderBufferPtr buffer,
+ 
+ void MojoAudioDecoderService::Reset(ResetCallback callback) {
+   DVLOG(1) << __func__;
++  if (!decoder_) {
++    std::move(callback).Run();
++    mojo::ReportBadMessage(kNotInitializedMessage);
++    return;
++  }
++
++  if (!mojo_decoder_buffer_reader_) {
++    std::move(callback).Run();
++    mojo::ReportBadMessage(kDataSourceNotSetMessage);
++    return;
++  }
+ 
+   // Reset the reader so that pending decodes will be dispatches first.
+   mojo_decoder_buffer_reader_->Flush(
+@@ -144,9 +182,9 @@ void MojoAudioDecoderService::OnInitialized(InitializeCallback callback,
+                                 status.code());
+   if (!status.is_ok()) {
+     // Do not call decoder_->NeedsBitstreamConversion() if init failed.
+-    std::move(callback).Run(
+-        std::move(status), false,
+-        decoder_ ? decoder_->GetDecoderType() : AudioDecoderType::kUnknown);
++    std::move(callback).Run(std::move(status), false,
++                            decoder_->GetDecoderType());
++    decoder_.reset();
+     return;
+   }
+ 
+@@ -202,8 +240,6 @@ void MojoAudioDecoderService::OnResetDone(ResetCallback callback) {
+ void MojoAudioDecoderService::OnAudioBufferReady(
+     scoped_refptr<AudioBuffer> audio_buffer) {
+   DVLOG(1) << __func__;
+-
+-  // TODO(timav): Use DataPipe.
+   client_->OnBufferDecoded(mojom::AudioBuffer::From(*audio_buffer));
+ }
+ 
+diff --git a/media/mojo/services/mojo_audio_decoder_service_unittest.cc b/media/mojo/services/mojo_audio_decoder_service_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..16ed8c720c2cfb373b7ed85d7aa52d329a8737c2
+--- /dev/null
++++ b/media/mojo/services/mojo_audio_decoder_service_unittest.cc
+@@ -0,0 +1,327 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "media/mojo/services/mojo_audio_decoder_service.h"
++
++#include <memory>
++#include <utility>
++#include <vector>
++
++#include "base/functional/bind.h"
++#include "base/functional/callback_helpers.h"
++#include "base/memory/raw_ptr.h"
++#include "base/run_loop.h"
++#include "base/test/gmock_callback_support.h"
++#include "base/test/task_environment.h"
++#include "media/base/audio_decoder_config.h"
++#include "media/base/channel_layout.h"
++#include "media/base/media_log.h"
++#include "media/base/media_util.h"
++#include "media/base/mock_filters.h"
++#include "media/mojo/mojom/audio_decoder.mojom.h"
++#include "media/mojo/services/mojo_cdm_service_context.h"
++#include "media/mojo/services/mojo_media_client.h"
++#include "mojo/public/cpp/bindings/associated_receiver.h"
++#include "mojo/public/cpp/bindings/associated_remote.h"
++#include "mojo/public/cpp/bindings/pending_associated_remote.h"
++#include "mojo/public/cpp/bindings/receiver.h"
++#include "mojo/public/cpp/bindings/remote.h"
++#include "mojo/public/cpp/bindings/self_owned_associated_receiver.h"
++#include "mojo/public/cpp/system/data_pipe.h"
++#include "mojo/public/cpp/system/functions.h"
++#include "testing/gmock/include/gmock/gmock.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++using base::test::RunOnceCallback;
++using testing::_;
++using testing::StrictMock;
++
++namespace media {
++
++namespace {
++
++class MockAudioDecoderClient : public mojom::AudioDecoderClient {
++ public:
++  MockAudioDecoderClient() = default;
++  ~MockAudioDecoderClient() override = default;
++
++  MOCK_METHOD(void, OnBufferDecoded, (mojom::AudioBufferPtr), (override));
++  MOCK_METHOD(void, OnWaiting, (WaitingReason), (override));
++};
++
++class TestMockAudioDecoder : public MockAudioDecoder {
++ public:
++  TestMockAudioDecoder() = default;
++  ~TestMockAudioDecoder() override = default;
++
++  base::WeakPtr<TestMockAudioDecoder> GetWeakPtr() {
++    return weak_factory_.GetWeakPtr();
++  }
++
++ private:
++  base::WeakPtrFactory<TestMockAudioDecoder> weak_factory_{this};
++};
++
++using CreateAudioDecoderCB =
++    base::RepeatingCallback<std::unique_ptr<AudioDecoder>()>;
++
++class TestMojoMediaClient : public MojoMediaClient {
++ public:
++  explicit TestMojoMediaClient(CreateAudioDecoderCB create_audio_decoder_cb)
++      : create_audio_decoder_cb_(std::move(create_audio_decoder_cb)) {}
++
++  std::unique_ptr<AudioDecoder> CreateAudioDecoder(
++      scoped_refptr<base::SequencedTaskRunner> task_runner,
++      std::unique_ptr<MediaLog> media_log) override {
++    return create_audio_decoder_cb_.Run();
++  }
++
++ private:
++  CreateAudioDecoderCB create_audio_decoder_cb_;
++};
++
++}  // namespace
++
++class MojoAudioDecoderServiceTest : public testing::Test {
++ public:
++  MojoAudioDecoderServiceTest()
++      : mojo_media_client_(base::BindRepeating(
++            &MojoAudioDecoderServiceTest::CreateAudioDecoder,
++            base::Unretained(this))) {
++    mojo::SetDefaultProcessErrorHandler(base::BindRepeating(
++        &MojoAudioDecoderServiceTest::OnProcessError, base::Unretained(this)));
++
++    service_ = std::make_unique<MojoAudioDecoderService>(
++        &mojo_media_client_, &mojo_cdm_service_context_,
++        task_environment_.GetMainThreadTaskRunner());
++
++    receiver_ = std::make_unique<mojo::Receiver<mojom::AudioDecoder>>(
++        service_.get(), remote_service_.BindNewPipeAndPassReceiver());
++  }
++
++  ~MojoAudioDecoderServiceTest() override {
++    mojo::SetDefaultProcessErrorHandler(base::NullCallback());
++    if (client_receiver_) {
++      client_receiver_->Close();
++    }
++  }
++
++  std::unique_ptr<AudioDecoder> CreateAudioDecoder() {
++    if (should_create_decoder_fail_) {
++      return nullptr;
++    }
++    auto decoder = std::make_unique<StrictMock<TestMockAudioDecoder>>();
++    mock_audio_decoder_ = decoder->GetWeakPtr();
++    return decoder;
++  }
++
++  void OnProcessError(const std::string& error) {
++    bad_message_called_ = true;
++    if (bad_message_quit_closure_) {
++      std::move(bad_message_quit_closure_).Run();
++    }
++  }
++
++  void ConstructService() {
++    mojo::PendingAssociatedRemote<mojom::AudioDecoderClient> client_remote;
++    client_receiver_ = mojo::MakeSelfOwnedAssociatedReceiver(
++        std::make_unique<MockAudioDecoderClient>(),
++        client_remote.InitWithNewEndpointAndPassReceiver());
++
++    mojo::PendingRemote<mojom::MediaLog> media_log_remote;
++    std::ignore = media_log_remote.InitWithNewPipeAndPassReceiver();
++
++    remote_service_->Construct(std::move(client_remote),
++                               std::move(media_log_remote));
++    remote_service_.FlushForTesting();
++  }
++
++  bool WaitForBadMessage() {
++    if (bad_message_called_) {
++      return true;
++    }
++    base::RunLoop run_loop;
++    bad_message_quit_closure_ = run_loop.QuitClosure();
++    run_loop.Run();
++    return bad_message_called_;
++  }
++
++  void InitializeService(const AudioDecoderConfig& config,
++                         bool expected_success = true) {
++    base::RunLoop run_loop;
++    remote_service_->Initialize(
++        config, std::nullopt,
++        base::BindOnce(
++            [](base::OnceClosure quit_closure, bool expected_success,
++               const DecoderStatus& status, bool needs_bitstream_conversion,
++               AudioDecoderType decoder_type) {
++              EXPECT_EQ(status.is_ok(), expected_success);
++              std::move(quit_closure).Run();
++            },
++            run_loop.QuitClosure(), expected_success));
++    run_loop.Run();
++  }
++
++  void SetDataSource() {
++    mojo::ScopedDataPipeProducerHandle producer;
++    mojo::ScopedDataPipeConsumerHandle consumer;
++    ASSERT_EQ(mojo::CreateDataPipe(nullptr, producer, consumer),
++              MOJO_RESULT_OK);
++    remote_service_->SetDataSource(std::move(consumer));
++    remote_service_.FlushForTesting();
++  }
++
++  AudioDecoderConfig GetTestConfig() {
++    return AudioDecoderConfig(AudioCodec::kVorbis, kSampleFormatPlanarF32,
++                              ChannelLayoutConfig::Stereo(), 44100,
++                              std::vector<uint8_t>(),
++                              EncryptionScheme::kUnencrypted);
++  }
++
++ protected:
++  base::test::TaskEnvironment task_environment_;
++  MojoCdmServiceContext mojo_cdm_service_context_;
++  TestMojoMediaClient mojo_media_client_;
++  std::unique_ptr<MojoAudioDecoderService> service_;
++  std::unique_ptr<mojo::Receiver<mojom::AudioDecoder>> receiver_;
++  mojo::Remote<mojom::AudioDecoder> remote_service_;
++
++  base::WeakPtr<TestMockAudioDecoder> mock_audio_decoder_;
++  bool should_create_decoder_fail_ = false;
++
++  mojo::SelfOwnedAssociatedReceiverRef<mojom::AudioDecoderClient>
++      client_receiver_;
++
++  bool bad_message_called_ = false;
++  base::OnceClosure bad_message_quit_closure_;
++};
++
++TEST_F(MojoAudioDecoderServiceTest, Construct_Success) {
++  ConstructService();
++  EXPECT_FALSE(bad_message_called_);
++  EXPECT_NE(mock_audio_decoder_, nullptr);
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Construct_Duplicate) {
++  ConstructService();
++  EXPECT_FALSE(bad_message_called_);
++
++  // Call Construct again manually to avoid overwriting client_receiver_
++  // and causing a leak.
++  mojo::PendingAssociatedRemote<mojom::AudioDecoderClient> client_remote2;
++  auto client_receiver2 = mojo::MakeSelfOwnedAssociatedReceiver(
++      std::make_unique<MockAudioDecoderClient>(),
++      client_remote2.InitWithNewEndpointAndPassReceiver());
++
++  mojo::PendingRemote<mojom::MediaLog> media_log_remote2;
++  std::ignore = media_log_remote2.InitWithNewPipeAndPassReceiver();
++
++  remote_service_->Construct(std::move(client_remote2),
++                             std::move(media_log_remote2));
++  remote_service_.FlushForTesting();
++
++  ASSERT_TRUE(WaitForBadMessage());
++
++  if (client_receiver2) {
++    client_receiver2->Close();
++  }
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Initialize_BeforeConstruct) {
++  // Call Initialize before Construct.
++  InitializeService(GetTestConfig(), /*expected_success=*/false);
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, SetDataSource_Duplicate) {
++  ConstructService();
++  SetDataSource();
++  EXPECT_FALSE(bad_message_called_);
++
++  // Call SetDataSource again.
++  SetDataSource();
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Initialize_Success) {
++  ConstructService();
++  EXPECT_CALL(*mock_audio_decoder_, Initialize_(_, _, _, _, _))
++      .WillOnce(RunOnceCallback<2>(DecoderStatus::Codes::kOk));
++  InitializeService(GetTestConfig(), /*expected_success=*/true);
++  EXPECT_FALSE(bad_message_called_);
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Initialize_Failure_ResetsDecoder) {
++  ConstructService();
++  EXPECT_CALL(*mock_audio_decoder_, Initialize_(_, _, _, _, _))
++      .WillOnce(
++          RunOnceCallback<2>(DecoderStatus::Codes::kFailedToCreateDecoder));
++  InitializeService(GetTestConfig(), /*expected_success=*/false);
++  EXPECT_FALSE(bad_message_called_);
++
++  // Subsequent Initialize should fail with bad message because decoder_ was
++  // reset.
++  InitializeService(GetTestConfig(), /*expected_success=*/false);
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Decode_BeforeConstruct) {
++  base::RunLoop run_loop;
++  remote_service_->Decode(
++      mojom::DecoderBuffer::NewEos(mojom::EosDecoderBuffer::New()),
++      base::BindOnce(
++          [](base::OnceClosure quit_closure, const DecoderStatus& status) {
++            EXPECT_FALSE(status.is_ok());
++            std::move(quit_closure).Run();
++          },
++          run_loop.QuitClosure()));
++  run_loop.Run();
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Reset_BeforeConstruct) {
++  base::RunLoop run_loop;
++  remote_service_->Reset(base::BindOnce(
++      [](base::OnceClosure quit_closure) { std::move(quit_closure).Run(); },
++      run_loop.QuitClosure()));
++  run_loop.Run();
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Decode_BeforeSetDataSource) {
++  ConstructService();
++  EXPECT_CALL(*mock_audio_decoder_, Initialize_(_, _, _, _, _))
++      .WillOnce(RunOnceCallback<2>(DecoderStatus::Codes::kOk));
++  InitializeService(GetTestConfig(), /*expected_success=*/true);
++  EXPECT_FALSE(bad_message_called_);
++
++  base::RunLoop run_loop;
++  remote_service_->Decode(
++      mojom::DecoderBuffer::NewEos(mojom::EosDecoderBuffer::New()),
++      base::BindOnce(
++          [](base::OnceClosure quit_closure, const DecoderStatus& status) {
++            EXPECT_FALSE(status.is_ok());
++            std::move(quit_closure).Run();
++          },
++          run_loop.QuitClosure()));
++  run_loop.Run();
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++TEST_F(MojoAudioDecoderServiceTest, Reset_BeforeSetDataSource) {
++  ConstructService();
++  EXPECT_CALL(*mock_audio_decoder_, Initialize_(_, _, _, _, _))
++      .WillOnce(RunOnceCallback<2>(DecoderStatus::Codes::kOk));
++  InitializeService(GetTestConfig(), /*expected_success=*/true);
++  EXPECT_FALSE(bad_message_called_);
++
++  base::RunLoop run_loop;
++  remote_service_->Reset(base::BindOnce(
++      [](base::OnceClosure quit_closure) { std::move(quit_closure).Run(); },
++      run_loop.QuitClosure()));
++  run_loop.Run();
++  ASSERT_TRUE(WaitForBadMessage());
++}
++
++}  // namespace media

--- a/patches/chromium/cherry-pick-8ed77b6a0d7a.patch
+++ b/patches/chromium/cherry-pick-8ed77b6a0d7a.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charlie Reis <creis@chromium.org>
+Date: Tue, 2 Jun 2026 12:36:08 -0700
+Subject: [M148] Early return if a nested message loop deletes the RFH.
+
+Original change's description:
+> Early return if a nested message loop deletes the RFH.
+>
+> Bug: 516608438
+> Change-Id: Id8dca00538f844f024d31c3f362363582d2dd1f6
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7879617
+> Reviewed-by: Arthur Sonzogni <arthursonzogni@chromium.org>
+> Commit-Queue: Charlie Reis <creis@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1637734}
+
+(cherry picked from commit f4e79665719591b82490c347611095cb4f6098b8)
+
+Bug: 517793443,516608438
+Change-Id: Id8dca00538f844f024d31c3f362363582d2dd1f6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7886194
+Commit-Queue: Charlie Reis <creis@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4212}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 4b9a7cbedd85bb7325fe83be7e0dc6ea207643a2..99004db96460d97596efadd1fb054facddff6c46 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -6453,10 +6453,16 @@ void RenderFrameHostImpl::DidCommitPageActivation(
+   });
+ #endif
+ 
++  base::WeakPtr<RenderFrameHostImpl> weak_ptr = GetWeakPtr();
+   DidCommitNavigationInternal(
+       std::move(owned_request), std::move(params),
+       /*same_document_params=*/nullptr,
+       /*did_commit_ipc_received_time=*/base::TimeTicks());
++  if (!weak_ptr) {
++    // This RFH may be deleted after DidCommitNavigationInternal due to a nested
++    // message loop. All callers should handle this.
++    return;
++  }
+ 
+   // NOTE: Navigation metrics assume that not much work is done between
+   // DidCommitNavigationInternal() and the end of this function. Avoid adding
+@@ -16502,10 +16508,17 @@ bool RenderFrameHostImpl::DidCommitNavigationInternal(
+                                            : navigation_request->StartedByAd();
+ 
+   // TODO(crbug.com/40150370): Do not pass |params| to DidNavigate().
+-  NavigationRequest* raw_navigation_request = navigation_request.get();
+-  raw_navigation_request->frame_tree_node()->navigator().DidNavigate(
++  FrameTreeNode* frame_tree_node = navigation_request->frame_tree_node();
++  base::WeakPtr<RenderFrameHostImpl> weak_ptr = GetWeakPtr();
++  frame_tree_node->navigator().DidNavigate(
+       this, *params, std::move(navigation_request), is_same_document_navigation,
+       caused_by_ad);
++  if (!weak_ptr) {
++    // This RFH may be deleted after DidNavigate due to a nested message loop.
++    // That occurs before the navigation has actually committed, so return false
++    // to indicate that the commit did not succeed.
++    return false;
++  }
+ 
+   // Run any deferred shared storage operations from response headers now that
+   // commit has occurred.

--- a/patches/chromium/cherry-pick-b46a51655dd6.patch
+++ b/patches/chromium/cherry-pick-b46a51655dd6.patch
@@ -1,0 +1,313 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fredrik=20S=C3=B6derquist?= <fs@opera.com>
+Date: Wed, 3 Jun 2026 08:17:21 -0700
+Subject: [M148] Ensure the lifecycle is updated for external SVG resources
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Original change's description:
+> Ensure the lifecycle is updated for external SVG resources
+>
+> In some cases, the external SVG resource document can be invalidated,
+> and the elements referring would end up using potentially dirty layout
+> state.
+>
+> Add a UpdateContentLifecycleForUse() hook to SVGResource and call that
+> before each access to the target element. Implement
+> UpdateContentLifecycleForUse() for the different types of resources
+> (local, svg resource document content and image content).
+>
+> Fixed: 517309206
+> Change-Id: I341249b259de3d10d363039dc901054d10b07786
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7880227
+> Reviewed-by: Philip Rogers <pdr@chromium.org>
+> Commit-Queue: Fredrik Söderquist <fs@opera.com>
+> Cr-Commit-Position: refs/heads/main@{#1640064}
+
+(cherry picked from commit 7a5040845ca31241a97e5aff86df1000ac1c6c67)
+
+Bug: 519444575,517309206
+Change-Id: I341249b259de3d10d363039dc901054d10b07786
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7895707
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Fredrik Söderquist <fs@opera.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4223}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/core/svg/graphics/svg_image.cc b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+index 8fc784bbabe87d265379fdf443c987613c2f946b..81fa1fe0602130e10992bc94ce123f189a393570 100644
+--- a/third_party/blink/renderer/core/svg/graphics/svg_image.cc
++++ b/third_party/blink/renderer/core/svg/graphics/svg_image.cc
+@@ -674,13 +674,27 @@ void SVGImage::MaybeRecordSvgImageProcessingTime(const Document& document) {
+   }
+ }
+ 
+-Element* SVGImage::GetResourceElement(const AtomicString& id) const {
++Element* SVGImage::GetResourceElement(
++    base::PassKey<ExternalSVGResourceImageContent>,
++    const AtomicString& id) const {
+   if (!document_host_) {
+     return nullptr;
+   }
+   return GetFrame()->GetDocument()->getElementById(id);
+ }
+ 
++void SVGImage::UpdateLifecycleForUse(
++    base::PassKey<ExternalSVGResourceImageContent>) {
++  if (!document_host_) {
++    return;
++  }
++  // Temporarily disable change notifications triggered by the lifecycle
++  // update.
++  ImageObserverDisabler disable_image_observer(this);
++  GetFrame()->View()->UpdateAllLifecyclePhasesExceptPaint(
++      DocumentUpdateReason::kSVGImage);
++}
++
+ void SVGImage::NotifyAsyncLoadCompleted() {
+   if (GetImageObserver())
+     GetImageObserver()->AsyncLoadCompleted(this);
+diff --git a/third_party/blink/renderer/core/svg/graphics/svg_image.h b/third_party/blink/renderer/core/svg/graphics/svg_image.h
+index 660c73cab311614d2ed28698a83e82b4decf468e..ad54ab6e44b25641df86308bcbb22f35051068d0 100644
+--- a/third_party/blink/renderer/core/svg/graphics/svg_image.h
++++ b/third_party/blink/renderer/core/svg/graphics/svg_image.h
+@@ -31,6 +31,7 @@
+ 
+ #include "base/gtest_prod_util.h"
+ #include "base/memory/weak_ptr.h"
++#include "base/types/pass_key.h"
+ #include "third_party/blink/public/mojom/css/preferred_color_scheme.mojom-blink-forward.h"
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/platform/geometry/physical_size.h"
+@@ -48,6 +49,7 @@ namespace blink {
+ 
+ class Document;
+ class Element;
++class ExternalSVGResourceImageContent;
+ class IsolatedSVGDocumentHost;
+ class LayoutSVGRoot;
+ class LocalFrame;
+@@ -135,8 +137,10 @@ class CORE_EXPORT SVGImage final : public Image {
+   void SetPreferredColorScheme(
+       mojom::blink::PreferredColorScheme preferred_color_scheme);
+ 
+-  // Introspective service hatch for mask-image. Don't abuse for anything else.
+-  Element* GetResourceElement(const AtomicString& id) const;
++  // Specialized interface for mask-image (via ExternalSVGResourceImageContent).
++  Element* GetResourceElement(base::PassKey<ExternalSVGResourceImageContent>,
++                              const AtomicString& id) const;
++  void UpdateLifecycleForUse(base::PassKey<ExternalSVGResourceImageContent>);
+ 
+  protected:
+   // Whether or not size is available yet.
+diff --git a/third_party/blink/renderer/core/svg/svg_resource.cc b/third_party/blink/renderer/core/svg/svg_resource.cc
+index 4a48bbc88781114c4d268a2f1be6c0168b4bac1d..f91eebaf19cf64921c1bcf74b2990f8e8ebd3def 100644
+--- a/third_party/blink/renderer/core/svg/svg_resource.cc
++++ b/third_party/blink/renderer/core/svg/svg_resource.cc
+@@ -120,10 +120,17 @@ void SVGResource::NotifyContentChanged() {
+     client->ResourceContentChanged(this);
+ }
+ 
++Element* SVGResource::Target() const {
++  UpdateContentLifecycleForUse();
++  return target_.Get();
++}
++
+ LayoutSVGResourceContainer* SVGResource::ResourceContainerNoCycleCheck() const {
+-  if (!target_)
++  Element* target = Target();
++  if (!target) {
+     return nullptr;
+-  return DynamicTo<LayoutSVGResourceContainer>(target_->GetLayoutObject());
++  }
++  return DynamicTo<LayoutSVGResourceContainer>(target->GetLayoutObject());
+ }
+ 
+ LayoutSVGResourceContainer* SVGResource::ResourceContainer(
+@@ -319,6 +326,13 @@ Element* ExternalSVGResourceDocumentContent::ResolveTarget() {
+   return external_document->getElementById(decoded_fragment);
+ }
+ 
++void ExternalSVGResourceDocumentContent::UpdateContentLifecycleForUse() const {
++  if (!document_content_) {
++    return;
++  }
++  document_content_->UpdateLifecycleForUse();
++}
++
+ void ExternalSVGResourceDocumentContent::Trace(Visitor* visitor) const {
+   visitor->Trace(document_content_);
+   SVGResource::Trace(visitor);
+@@ -353,7 +367,17 @@ Element* ExternalSVGResourceImageContent::ResolveTarget() {
+   }
+   AtomicString decoded_fragment(
+       DecodeUrlEscapeSequences(fragment_, DecodeUrlMode::kUtf8OrIsomorphic));
+-  return svg_image->GetResourceElement(decoded_fragment);
++  return svg_image->GetResourceElement(
++      base::PassKey<ExternalSVGResourceImageContent>(), decoded_fragment);
++}
++
++void ExternalSVGResourceImageContent::UpdateContentLifecycleForUse() const {
++  auto* svg_image = DynamicTo<SVGImage>(image_content_->GetImage());
++  if (!svg_image) {
++    return;
++  }
++  svg_image->UpdateLifecycleForUse(
++      base::PassKey<ExternalSVGResourceImageContent>());
+ }
+ 
+ void ExternalSVGResourceImageContent::ImageNotifyFinished(
+diff --git a/third_party/blink/renderer/core/svg/svg_resource.h b/third_party/blink/renderer/core/svg/svg_resource.h
+index 83944ac51b2d8454adea6e0c8ea8c9d40790c310..dfb322b1bf78305b9296d52491f3a21d1a16764f 100644
+--- a/third_party/blink/renderer/core/svg/svg_resource.h
++++ b/third_party/blink/renderer/core/svg/svg_resource.h
+@@ -77,7 +77,7 @@ class SVGResource : public GarbageCollected<SVGResource> {
+ 
+   virtual bool IsLoading() const { return false; }
+ 
+-  Element* Target() const { return target_.Get(); }
++  Element* Target() const;
+   // Returns the target's LayoutObject (if target exists and is attached to the
+   // layout tree). Also perform cycle-checking, and may thus return nullptr if
+   // this SVGResourceClient -> SVGResource reference would start a cycle.
+@@ -103,6 +103,7 @@ class SVGResource : public GarbageCollected<SVGResource> {
+   SVGResource();
+ 
+   void InvalidateCycleCache();
++  virtual void UpdateContentLifecycleForUse() const = 0;
+   void NotifyContentChanged();
+ 
+   Member<Element> target_;
+@@ -141,6 +142,7 @@ class LocalSVGResource final : public SVGResource {
+   void Trace(Visitor*) const override;
+ 
+  private:
++  void UpdateContentLifecycleForUse() const override {}
+   void TargetChanged(const AtomicString& id);
+ 
+   Member<TreeScope> tree_scope_;
+@@ -163,6 +165,7 @@ class ExternalSVGResourceDocumentContent final
+  private:
+   bool IsLoading() const override;
+   Element* ResolveTarget();
++  void UpdateContentLifecycleForUse() const override;
+ 
+   // SVGResourceDocumentObserver:
+   void ResourceNotifyFinished(SVGResourceDocumentContent*) override;
+@@ -189,6 +192,7 @@ class ExternalSVGResourceImageContent final : public SVGResource,
+ 
+   bool IsLoading() const override;
+   Element* ResolveTarget();
++  void UpdateContentLifecycleForUse() const override;
+ 
+   // ImageResourceObserver overrides
+   void ImageNotifyFinished(ImageResourceContent*) override;
+diff --git a/third_party/blink/renderer/core/svg/svg_resource_document_content.cc b/third_party/blink/renderer/core/svg/svg_resource_document_content.cc
+index 7620e5609ca60acf35d3063da57adcac6e597199..66cbff8b5e4fbc3462afc1113cde9443ff292134 100644
+--- a/third_party/blink/renderer/core/svg/svg_resource_document_content.cc
++++ b/third_party/blink/renderer/core/svg/svg_resource_document_content.cc
+@@ -22,6 +22,7 @@
+ 
+ #include "third_party/blink/renderer/core/svg/svg_resource_document_content.h"
+ 
++#include "base/auto_reset.h"
+ #include "base/notreached.h"
+ #include "base/task/single_thread_task_runner.h"
+ #include "third_party/blink/renderer/core/frame/local_frame.h"
+@@ -157,9 +158,7 @@ SVGResourceDocumentContent::UpdateDocument(scoped_refptr<SharedBuffer> data,
+ }
+ 
+ void SVGResourceDocumentContent::LoadingFinished() {
+-  LocalFrame* frame = document_host_->GetFrame();
+-  frame->View()->UpdateAllLifecyclePhasesExceptPaint(
+-      DocumentUpdateReason::kSVGImage);
++  UpdateLifecycleForUse();
+   UpdateStatus(ResourceStatus::kCached);
+ }
+ 
+@@ -244,7 +243,22 @@ SVGResourceTarget* SVGResourceDocumentContent::GetResourceTarget(
+   return &svg_target->EnsureResourceTarget();
+ }
+ 
++void SVGResourceDocumentContent::UpdateLifecycleForUse() {
++  if (!document_host_) {
++    return;
++  }
++  // Temporarily disable content-changed notifications triggered by the
++  // lifecycle update.
++  base::AutoReset validate_scope(&inhibit_content_change_, true);
++  LocalFrame* frame = document_host_->GetFrame();
++  frame->View()->UpdateAllLifecyclePhasesExceptPaint(
++      DocumentUpdateReason::kSVGImage);
++}
++
+ void SVGResourceDocumentContent::ContentChanged() {
++  if (inhibit_content_change_) {
++    return;
++  }
+   for (auto& observer : observers_) {
+     observer->ResourceContentChanged(this);
+   }
+diff --git a/third_party/blink/renderer/core/svg/svg_resource_document_content.h b/third_party/blink/renderer/core/svg/svg_resource_document_content.h
+index 924b406d95d77c68ac4fa3b1b7a2f03f8ecb7977..7e86cb6655088eee7b9cd333df048641f21acc0c 100644
+--- a/third_party/blink/renderer/core/svg/svg_resource_document_content.h
++++ b/third_party/blink/renderer/core/svg/svg_resource_document_content.h
+@@ -100,6 +100,8 @@ class CORE_EXPORT SVGResourceDocumentContent final
+   void NotifyObservers();
+ 
+   SVGResourceTarget* GetResourceTarget(const AtomicString& element_id);
++  void UpdateLifecycleForUse();
++
+   void Trace(Visitor*) const;
+ 
+  private:
+@@ -116,6 +118,7 @@ class CORE_EXPORT SVGResourceDocumentContent final
+   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
+   KURL url_;
+   ResourceStatus status_ = ResourceStatus::kNotStarted;
++  bool inhibit_content_change_ = false;
+   bool was_disposed_ = false;
+ };
+ 
+diff --git a/third_party/blink/web_tests/external/wpt/svg/crashtests/chrome-bug-517309206.html b/third_party/blink/web_tests/external/wpt/svg/crashtests/chrome-bug-517309206.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..cd303e13557e018345c6d208f2a6e9c3e3c26b92
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/svg/crashtests/chrome-bug-517309206.html
+@@ -0,0 +1,19 @@
++<!DOCTYPE html>
++<html class="test-wait">
++<link rel="help" href="https://crbug.com/517309206">
++<p>This test should not crash.</p>
++<svg>
++  <rect width="100" height="100" fill="url(support/ext.svg#p)"/>
++</svg>
++<script>
++  let n = 0;
++  function bump() {
++    document.body.style.opacity = 1 - (n % 2) * 0.001;
++    if (++n < 60) {
++      requestAnimationFrame(bump);
++    } else {
++      document.documentElement.className = '';
++    }
++  }
++  requestAnimationFrame(bump);
++</script>
+diff --git a/third_party/blink/web_tests/external/wpt/svg/crashtests/support/ext.svg b/third_party/blink/web_tests/external/wpt/svg/crashtests/support/ext.svg
+new file mode 100644
+index 0000000000000000000000000000000000000000..8950531d832a77207c2b1f1bb34437ae862b6d90
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/svg/crashtests/support/ext.svg
+@@ -0,0 +1,9 @@
++<svg xmlns="http://www.w3.org/2000/svg">
++  <pattern id="p" patternUnits="userSpaceOnUse" width="100" height="100">
++    <filter id="fp">
++      <!-- An SVG with a nested (raster) image load. -->
++      <feImage href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MiIgaGVpZ2h0PSI1MiI+PGltYWdlIHg9IjAiIHk9IjAiIGhyZWY9ImRhdGE6aW1hZ2UvcG5nO2Jhc2U2NCxpVkJPUncwS0dnb0FBQUFOU1VoRVVnQUFBQUVBQUFBQkNBUUFBQUMxSEF3Q0FBQUFDMGxFUVZSNDJtUDgveDhBQXVzQjlRRHE2UUFBQUFCSlJVNUVya0pnZ2c9PSIvPjwvc3ZnPg=="/>
++    </filter>
++    <rect x="0" y="0" width="100" height="100" fill="orange" filter="url(#fp)"/>
++  </pattern>
++</svg>

--- a/patches/chromium/cherry-pick-c6c60af71b11.patch
+++ b/patches/chromium/cherry-pick-c6c60af71b11.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shunya Shishido <sisidovski@chromium.org>
+Date: Wed, 3 Jun 2026 03:10:50 -0700
+Subject: [M148] Prevent UAF on duplicate RaceNetworkRequest tokens
+
+Original change's description:
+> Prevent UAF on duplicate RaceNetworkRequest tokens
+>
+> Reorder map insertions in
+> ServiceWorkerGlobalScope::InsertNewItemToRaceNetworkRequests
+> to only publish the raw pointer into the secondary lookup index
+> (race_network_request_fetch_event_ids_)
+> AFTER the owning std::unique_ptr has been successfully inserted into the
+> primary map (race_network_requests_).
+>
+> Previously, the raw pointer was published before the owning insert was
+> attempted. Since WTF::HashMap::insert does not consume the unique_ptr on
+> a key collision, the newly allocated RaceNetworkRequestInfo object was
+> deleted at function scope exit, leaving a dangling pointer in the
+> secondary index. Subsequent event resolution or abortion triggered a UaF
+> during lookup in RemoveItemFromRaceNetworkRequests.
+>
+> Bug: 517705966
+> Change-Id: I9563109b4f2603f5bf5893a6351300d38a91e7f7
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7889215
+> Reviewed-by: Takashi Nakayama <tnak@chromium.org>
+> Commit-Queue: Shunya Shishido <sisidovski@chromium.org>
+> Reviewed-by: Minoru Chikamune <chikamune@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639189}
+
+(cherry picked from commit 22e05cd18d2bac48027a218d142a074061177f4b)
+
+Bug: 519444118,517705966
+Change-Id: I9563109b4f2603f5bf5893a6351300d38a91e7f7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7898679
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4220}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
+index e717c66501152e668ea4fa4374532015bc24b71b..c98f4aee812b862bf4dfbe688a383eed45aa2ec3 100644
+--- a/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
++++ b/third_party/blink/renderer/modules/service_worker/service_worker_global_scope.cc
+@@ -2799,9 +2799,15 @@ void ServiceWorkerGlobalScope::InsertNewItemToRaceNetworkRequests(
+   auto info = std::make_unique<RaceNetworkRequestInfo>(
+       fetch_event_id, race_network_request_token,
+       std::move(url_loader_factory));
+-  race_network_request_fetch_event_ids_.insert(fetch_event_id, info.get());
++  RaceNetworkRequestInfo* info_raw = info.get();
+   auto insert_result = race_network_requests_.insert(race_network_request_token,
+                                                      std::move(info));
++  // WTF::HashMap::insert does not consume |info| on a duplicate key; in that
++  // case |info| (and |info_raw|) is freed at scope exit. Only publish the raw
++  // pointer into the secondary index after the owning insert succeeds.
++  if (insert_result.is_new_entry) {
++    race_network_request_fetch_event_ids_.insert(fetch_event_id, info_raw);
++  }
+ 
+   // DumpWithoutCrashing if the token is empty, or not inserted as a new entry
+   // to |race_network_request_loader_factories_|.

--- a/patches/chromium/cherry-pick-df3780d115a3.patch
+++ b/patches/chromium/cherry-pick-df3780d115a3.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas Guilbert <tguilbert@chromium.org>
+Date: Tue, 2 Jun 2026 15:56:20 -0700
+Subject: [M148] Use checked math before allocating ScopedAudioChannelLayout
+
+Original change's description:
+> Use checked math before allocating ScopedAudioChannelLayout
+>
+> This CL fixes a potential issue when trying to allocate a
+> `ScopedAudioChannelLayout` with a huge number of channels.
+>
+> The CL fixes the issue by using checked math, and preventing integer
+> truncation when converting from `size_t` to `int`.
+>
+> We prefer this approach over adding CHECKs to guard against a channel
+> count higher than `media::limits::kMaxChannels`, since `kMaxChannels`
+> (32 channels as of this commit) is lower than some high-end audio
+> interfaces (e.g. 40 channels), and this could introduce crashes in
+> otherwise valid scenarios.
+>
+> Fixed: 513396305
+> Change-Id: I65f3f41bcffef5ce193f623eeac5d5178cdf6502
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7876673
+> Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+> Auto-Submit: Thomas Guilbert <tguilbert@chromium.org>
+> Commit-Queue: Thomas Guilbert <tguilbert@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1638201}
+
+(cherry picked from commit 136bb7f450dae7225bb90c721f1616d4e57d1e78)
+
+Bug: 518123496,513396305
+Change-Id: I65f3f41bcffef5ce193f623eeac5d5178cdf6502
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7895384
+Commit-Queue: Thomas Guilbert <tguilbert@chromium.org>
+Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4215}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/media/audio/apple/audio_auhal.cc b/media/audio/apple/audio_auhal.cc
+index fb15417b895e93a0dbd95b12f5faeed3ef383ebb..d3dc8e8fe23f886cdd5bbc92912c648d01bc174b 100644
+--- a/media/audio/apple/audio_auhal.cc
++++ b/media/audio/apple/audio_auhal.cc
+@@ -173,6 +173,10 @@ void SetAudioChannelLayout(int channels,
+ 
+   auto coreaudio_layout =
+       ChannelLayoutToAudioChannelLayout(channel_layout, channels);
++  if (!coreaudio_layout) {
++    DLOG(ERROR) << "Failed to create audio channel layout.";
++    return;
++  }
+ 
+   MaybeMapRearSurroundChannelToSurroundChannel(audio_unit,
+                                                coreaudio_layout->layout());
+diff --git a/media/audio/mac/avfoundation_output_stream.mm b/media/audio/mac/avfoundation_output_stream.mm
+index 11d60e7005cc47f23bd54d430767d9913d65a602..39da2556c3f558813fca5136532c4a88987c5bb6 100644
+--- a/media/audio/mac/avfoundation_output_stream.mm
++++ b/media/audio/mac/avfoundation_output_stream.mm
+@@ -92,6 +92,7 @@
+       callback_(nullptr),
+       objc_storage_(std::make_unique<ObjCStorage>()),
+       audio_bus_(AudioBus::Create(params)) {
++  CHECK(params_.IsValid());
+   DVLOG(1)
+       << __func__
+       << ": Initializing AVFoundationOutputStream with these AudioParameters:: "
+@@ -144,6 +145,10 @@
+ 
+   auto scoped_layout = ChannelLayoutToAudioChannelLayout(
+       params_.channel_layout(), params_.channels());
++  if (!scoped_layout) {
++    LOG(ERROR) << "Failed to create audio channel layout.";
++    return false;
++  }
+ 
+   OSStatus status = CMAudioFormatDescriptionCreate(
+       /*allocator=*/kCFAllocatorDefault,
+diff --git a/media/base/mac/channel_layout_util_mac.cc b/media/base/mac/channel_layout_util_mac.cc
+index 82424dba68b652dc765c67bdb9b500170910da70..dc06d0696dd3a6b43812f4c43377b5f79421331b 100644
+--- a/media/base/mac/channel_layout_util_mac.cc
++++ b/media/base/mac/channel_layout_util_mac.cc
+@@ -9,6 +9,9 @@
+ 
+ #include "base/check_op.h"
+ #include "base/compiler_specific.h"
++#include "base/containers/span.h"
++#include "base/logging.h"
++#include "base/numerics/safe_math.h"
+ #include "media/base/channel_layout.h"
+ 
+ namespace media {
+@@ -119,8 +122,21 @@ std::unique_ptr<ScopedAudioChannelLayout> ChannelLayoutToAudioChannelLayout(
+   //
+   // Code modeled after example from Apple documentation here:
+   // https://developer.apple.com/library/content/qa/qa1627/_index.html
+-  int output_layout_size =
+-      offsetof(AudioChannelLayout, mChannelDescriptions[input_channels]);
++  // Modified to use `size_t` and `base::CheckedNumeric` to prevent integer
++  // truncation and overflow.
++  // `AudioChannelLayout` already includes one `AudioChannelDescription` in its
++  // definition, so we allocate space for `input_channels - 1` additional
++  // descriptions.
++  base::CheckedNumeric<size_t> checked_layout_size =
++      sizeof(AudioChannelLayout) +
++      base::CheckedNumeric<size_t>(input_channels - 1) *
++          sizeof(AudioChannelDescription);
++  size_t output_layout_size = 0;
++  if (!checked_layout_size.AssignIfValid(&output_layout_size)) {
++    DLOG(ERROR) << "Invalid AudioChannelLayout size.";
++    return nullptr;
++  }
++
+   auto new_layout =
+       std::make_unique<ScopedAudioChannelLayout>(output_layout_size);
+ 
+diff --git a/media/filters/mac/audio_toolbox_audio_decoder.cc b/media/filters/mac/audio_toolbox_audio_decoder.cc
+index b3697c7db6239d8b4d915f73aa8e6299875a5269..07673488250088cfbf941362b4585e9287a977aa 100644
+--- a/media/filters/mac/audio_toolbox_audio_decoder.cc
++++ b/media/filters/mac/audio_toolbox_audio_decoder.cc
+@@ -362,6 +362,11 @@ bool AudioToolboxAudioDecoder::CreateDecoder(const AudioDecoderConfig& config) {
+   // channel order description. This let decoder output correct orders.
+   auto ordered_layout =
+       ChannelLayoutToAudioChannelLayout(channel_layout_, channel_count_);
++  if (!ordered_layout) {
++    MEDIA_LOG(ERROR, media_log_) << "Failed to create audio channel layout.";
++    return false;
++  }
++
+   result = AudioConverterSetProperty(
+       decoder_.get(), kAudioConverterOutputChannelLayout,
+       ordered_layout->layout_size(), ordered_layout->layout());

--- a/patches/chromium/cherry-pick-e819a80f8ff8.patch
+++ b/patches/chromium/cherry-pick-e819a80f8ff8.patch
@@ -1,0 +1,205 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sangbaek Park <sangbaekpark@google.com>
+Date: Wed, 3 Jun 2026 15:59:42 -0700
+Subject: [M148] media: Fix uninitialized GPU VRAM leak in MFVEA NV12 copy
+ paths
+
+Original change's description:
+> media: Fix uninitialized GPU VRAM leak in MFVEA NV12 copy paths
+>
+> When the Windows Media Foundation Video Encode Accelerator (MFVEA)
+> performs a zero-copy GPU encode, it may allocate intermediate D3D11
+> textures to copy NV12 video frames. Previously, these textures were
+> allocated using the `coded_size` of the video frame, but only the
+> `visible_rect` portion was copied over via `CopySubresourceRegion`.
+> This left the padding region between the visible rect and the coded
+> size uninitialized, potentially leaking stale GPU memory to the
+> compressed video stream.
+>
+> This CL updates the D3D11 texture allocation logic in the copy paths
+> (`CreateSampleFromTexture`, `GenerateResourceOnSyncTokenReleased`,
+> and `PerformD3DCopy`) to allocate the intermediate textures using the
+> exact dimensions of the `visible_rect`. This ensures that the texture
+> is completely filled by `CopySubresourceRegion`, eliminating any
+> uninitialized padding and preventing cross-origin information
+> disclosure.
+>
+> The newly added unit test (repro case) fails without this fix.
+>
+> Tests added: {
+> MFHelpersTest.CreateSampleFromTextureDoesNotLeakUninitializedMemory }
+>
+> Bug: 517993381
+> Change-Id: Ifffcc8df7fb735ebd96c030fa46f75831298c12b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7886163
+> Reviewed-by: Dale Curtis <dalecurtis@chromium.org>
+> Commit-Queue: Sangbaek Park <sangbaekpark@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1639808}
+
+(cherry picked from commit ebecb74997d7acdeeb3a808e8abc8ec37ced5444)
+
+Bug: 519444902,517993381
+Change-Id: Ifffcc8df7fb735ebd96c030fa46f75831298c12b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7898833
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4231}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/media/base/BUILD.gn b/media/base/BUILD.gn
+index 2c821705cf510e407ea3c63826a1d7fccb3ace90..8244e4c7f8d3d7929c85ab2f9f4ae294402b2e50 100644
+--- a/media/base/BUILD.gn
++++ b/media/base/BUILD.gn
+@@ -713,6 +713,7 @@ source_set("unit_tests") {
+     sources += [
+       "win/dxgi_device_scope_handle_unittest.cc",
+       "win/media_foundation_package_locator_unittest.cc",
++      "win/mf_helpers_unittest.cc",
+     ]
+     deps += [
+       "//media",
+diff --git a/media/base/win/mf_helpers.cc b/media/base/win/mf_helpers.cc
+index f3e00c4e6b93f0a6dcefe4f1174703a4f5a3d417..ea6395b9d07920b30c4412aa0171c5baee18585e 100644
+--- a/media/base/win/mf_helpers.cc
++++ b/media/base/win/mf_helpers.cc
+@@ -875,6 +875,8 @@ Microsoft::WRL::ComPtr<IMFSample> CreateSampleFromTexture(
+   if (need_perform_copy) {
+     D3D11_TEXTURE2D_DESC desc;
+     input_texture->GetDesc(&desc);
++    desc.Width = static_cast<UINT>(frame->visible_rect().width());
++    desc.Height = static_cast<UINT>(frame->visible_rect().height());
+     desc.Usage = D3D11_USAGE_DEFAULT;
+     desc.BindFlags = D3D11_BIND_VIDEO_ENCODER;
+     desc.ArraySize = 1;
+@@ -1131,6 +1133,8 @@ void GenerateResourceOnSyncTokenReleased(
+     texture_desc.CPUAccessFlags = 0;
+     texture_desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+                              D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
++    texture_desc.Width = static_cast<UINT>(frame->visible_rect().width());
++    texture_desc.Height = static_cast<UINT>(frame->visible_rect().height());
+     Microsoft::WRL::ComPtr<ID3D11Texture2D> shared_texture;
+     hr = shared_d3d11_device->CreateTexture2D(&texture_desc, nullptr,
+                                               &shared_texture);
+diff --git a/media/base/win/mf_helpers_unittest.cc b/media/base/win/mf_helpers_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..d39e2bc5359d316723c50909cc80ed2679f0727e
+--- /dev/null
++++ b/media/base/win/mf_helpers_unittest.cc
+@@ -0,0 +1,84 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "media/base/win/mf_helpers.h"
++
++#include <d3d11.h>
++#include <mfapi.h>
++#include <wrl/client.h>
++
++#include "base/memory/scoped_refptr.h"
++#include "media/base/video_frame.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace media {
++namespace {
++
++TEST(MFHelpersTest, CreateSampleFromTextureDoesNotLeakUninitializedMemory) {
++  Microsoft::WRL::ComPtr<ID3D11Device> device;
++  Microsoft::WRL::ComPtr<ID3D11DeviceContext> context;
++  HRESULT hr =
++      D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, nullptr,
++                        0, D3D11_SDK_VERSION, &device, nullptr, &context);
++  if (FAILED(hr)) {
++    // Fallback to WARP if hardware is not available.
++    hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr, 0, nullptr,
++                           0, D3D11_SDK_VERSION, &device, nullptr, &context);
++    if (FAILED(hr)) {
++      GTEST_SKIP() << "D3D11 device creation failed";
++    }
++  }
++
++  // Create a texture with a larger coded size than the visible size.
++  D3D11_TEXTURE2D_DESC desc = {};
++  desc.Width = 1920;
++  desc.Height = 1088;
++  desc.MipLevels = 1;
++  desc.ArraySize = 1;
++  desc.Format = DXGI_FORMAT_NV12;
++  desc.SampleDesc.Count = 1;
++  desc.Usage = D3D11_USAGE_DEFAULT;
++  desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
++
++  Microsoft::WRL::ComPtr<ID3D11Texture2D> input_texture;
++  hr = device->CreateTexture2D(&desc, nullptr, &input_texture);
++  ASSERT_TRUE(SUCCEEDED(hr));
++
++  // Create a video frame with a smaller visible rect.
++  gfx::Size coded_size(1920, 1088);
++  gfx::Rect visible_rect(0, 0, 1920, 1080);
++  gfx::Size natural_size(1920, 1080);
++  scoped_refptr<VideoFrame> frame =
++      VideoFrame::CreateFrame(PIXEL_FORMAT_NV12, coded_size, visible_rect,
++                              natural_size, base::TimeDelta());
++
++  // Create the sample and perform the copy.
++  Microsoft::WRL::ComPtr<IMFSample> sample = CreateSampleFromTexture(
++      device, frame, input_texture, /*need_perform_copy=*/true);
++  ASSERT_TRUE(sample);
++
++  // Get the texture from the sample.
++  Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer;
++  hr = sample->GetBufferByIndex(0, &buffer);
++  ASSERT_TRUE(SUCCEEDED(hr));
++
++  Microsoft::WRL::ComPtr<IMFDXGIBuffer> dxgi_buffer;
++  hr = buffer.As(&dxgi_buffer);
++  ASSERT_TRUE(SUCCEEDED(hr));
++
++  Microsoft::WRL::ComPtr<ID3D11Texture2D> output_texture;
++  hr = dxgi_buffer->GetResource(IID_PPV_ARGS(&output_texture));
++  ASSERT_TRUE(SUCCEEDED(hr));
++
++  D3D11_TEXTURE2D_DESC output_desc;
++  output_texture->GetDesc(&output_desc);
++
++  // The copied texture should exactly match the visible rect, not the coded
++  // size. This ensures no uninitialized padding is left.
++  EXPECT_EQ(output_desc.Width, static_cast<UINT>(visible_rect.width()));
++  EXPECT_EQ(output_desc.Height, static_cast<UINT>(visible_rect.height()));
++}
++
++}  // namespace
++}  // namespace media
+diff --git a/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc b/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+index 55d8c7e582e829e084e71029460cabeb464c3d28..693bbf4bc8311caf9600fffef71e021f690f2d32 100644
+--- a/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
++++ b/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+@@ -2883,23 +2883,21 @@ HRESULT MediaFoundationVideoEncodeAccelerator::PerformD3DScaling(
+ HRESULT MediaFoundationVideoEncodeAccelerator::InitializeD3DCopying(
+     ID3D11Texture2D* input_texture) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  D3D11_TEXTURE2D_DESC input_desc = {};
+-  input_texture->GetDesc(&input_desc);
+   // Return early if `copied_d3d11_texture_` is already the correct size,
+   // avoiding the overhead of creating a new destination texture.
+   if (copied_d3d11_texture_) {
+     D3D11_TEXTURE2D_DESC copy_desc = {};
+     copied_d3d11_texture_->GetDesc(&copy_desc);
+-    if (input_desc.Width == copy_desc.Width &&
+-        input_desc.Height == copy_desc.Height) {
++    if (static_cast<UINT>(input_visible_size_.width()) == copy_desc.Width &&
++        static_cast<UINT>(input_visible_size_.height()) == copy_desc.Height) {
+       return S_OK;
+     }
+   }
+   ComD3D11Device texture_device;
+   input_texture->GetDevice(&texture_device);
+   D3D11_TEXTURE2D_DESC copy_desc = {
+-      .Width = input_desc.Width,
+-      .Height = input_desc.Height,
++      .Width = static_cast<UINT>(input_visible_size_.width()),
++      .Height = static_cast<UINT>(input_visible_size_.height()),
+       .MipLevels = 1,
+       .ArraySize = 1,
+       .Format = DXGI_FORMAT_NV12,

--- a/patches/config.json
+++ b/patches/config.json
@@ -11,5 +11,7 @@
   { "patch_dir": "src/electron/patches/ReactiveObjC", "repo": "src/third_party/squirrel.mac/vendor/ReactiveObjC" },
   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" },
-  { "patch_dir": "src/electron/patches/sqlite", "repo": "src/third_party/sqlite/src" }
+  { "patch_dir": "src/electron/patches/sqlite", "repo": "src/third_party/sqlite/src" },
+  { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia" },
+  { "patch_dir": "src/electron/patches/dawn", "repo": "src/third_party/dawn" }
 ]

--- a/patches/dawn/.patches
+++ b/patches/dawn/.patches
@@ -1,0 +1,2 @@
+cherry-pick-ba03542094db.patch
+cherry-pick-74f80741f8bc.patch

--- a/patches/dawn/cherry-pick-74f80741f8bc.patch
+++ b/patches/dawn/cherry-pick-74f80741f8bc.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Corentin Wallez <cwallez@chromium.org>
+Date: Mon, 8 Jun 2026 04:56:47 -0700
+Subject: [M148] [dawn][native] Disallow TransientAttachment for internal
+ usages.
+
+Original change's description:
+> [dawn][native] Disallow TransientAttachment for internal usages.
+>
+> Contrary to additional usages that are strict additions,
+> TransientAttachment is an opt-in to additional constraints, so it would
+> have user-visible effects (plus validation for external usages would need
+> to take into account the potential internal TransientAttachment).
+>
+> Fixed: 517247333
+> Change-Id: Ib197ad592433a2c6ee1b2de2e50e734995f3a111
+> Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/311915
+> Commit-Queue: Corentin Wallez <cwallez@chromium.org>
+> Reviewed-by: Kai Ninomiya <kainino@chromium.org>
+> Commit-Queue: David Neto <dneto@google.com>
+> Auto-Submit: Corentin Wallez <cwallez@chromium.org>
+
+(cherry picked from commit 836ae06d5a9063469d793f6f176e4f69f992df24)
+
+Bug: 519444790,517247333
+Change-Id: Ib197ad592433a2c6ee1b2de2e50e734995f3a111
+Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/314775
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Chrome Cherry Picker <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+
+diff --git a/src/dawn/native/Texture.cpp b/src/dawn/native/Texture.cpp
+index 019644e357b4d2773b6b382144f3b1781daf074b..aaf4cbf4891f3d05d69720a60712f25c3f1aa5f7 100644
+--- a/src/dawn/native/Texture.cpp
++++ b/src/dawn/native/Texture.cpp
+@@ -737,6 +737,19 @@ MaybeError ValidateTextureDescriptor(
+             !device->HasFeature(Feature::DawnInternalUsages),
+             "The internalUsageDesc is not empty while the dawn-internal-usages feature is not "
+             "enabled");
++
++        // Disallow TransientAttachment because it is not an expansion of usages but instead an
++        // additional constraint and would need to have visible effects (for users of the API that
++        // don't have access to the internal usages). Use an allow-list to explicitly opt-in usages
++        // to be allowed as internal usages in the future.
++        constexpr wgpu::TextureUsage kAllowedInternalUsages =
++            wgpu::TextureUsage::CopySrc | wgpu::TextureUsage::CopyDst |
++            wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::StorageBinding |
++            wgpu::TextureUsage::RenderAttachment;
++        DAWN_INVALID_IF(!IsSubset(internalUsageDesc->internalUsage, kAllowedInternalUsages),
++                        "internalUsage contains %s which are not allowed as internal usages.",
++                        internalUsageDesc->internalUsage & ~kAllowedInternalUsages);
++
+         usage |= internalUsageDesc->internalUsage;
+     }
+ 
+diff --git a/src/dawn/tests/unittests/validation/InternalUsageValidationTests.cpp b/src/dawn/tests/unittests/validation/InternalUsageValidationTests.cpp
+index e1a6e4a1b00db746ed8b8f32bc6d6f356d8e8f6f..8977ddf7b7ad9efa959b5164bd48ac41577d5471 100644
+--- a/src/dawn/tests/unittests/validation/InternalUsageValidationTests.cpp
++++ b/src/dawn/tests/unittests/validation/InternalUsageValidationTests.cpp
+@@ -108,6 +108,29 @@ TEST_F(TextureInternalUsageValidationTest, Basic) {
+     device.CreateTexture(&textureDesc);
+ }
+ 
++// Test that TransientAttachment cannot be passed as internal usage.
++TEST_F(TextureInternalUsageValidationTest, TransientAttachment) {
++    wgpu::TextureDescriptor textureDesc = {};
++    textureDesc.size = {1, 1};
++    textureDesc.format = wgpu::TextureFormat::RGBA8Unorm;
++
++    wgpu::DawnTextureInternalUsageDescriptor internalDesc = {};
++    textureDesc.nextInChain = &internalDesc;
++
++    // Success case: Texture is Render+Transient and Render as internal usage.
++    textureDesc.usage =
++        wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TransientAttachment;
++    internalDesc.internalUsage = wgpu::TextureUsage::RenderAttachment;
++    device.CreateTexture(&textureDesc);
++
++    // Failure case: Texture is Render+Transient for both normal and internal usages.
++    textureDesc.usage =
++        wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TransientAttachment;
++    internalDesc.internalUsage =
++        wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TransientAttachment;
++    ASSERT_DEVICE_ERROR(device.CreateTexture(&textureDesc));
++}
++
+ // Test that internal usages takes part in other validation that
+ // depends on the usage.
+ TEST_F(TextureInternalUsageValidationTest, UsageValidation) {

--- a/patches/dawn/cherry-pick-ba03542094db.patch
+++ b/patches/dawn/cherry-pick-ba03542094db.patch
@@ -1,0 +1,219 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Antonio Maiorano <amaiorano@google.com>
+Date: Wed, 3 Jun 2026 09:33:32 -0700
+Subject: [M148] [native] Fix IndirectDrawValidationEncoder merging
+ non-matching passes
+
+Cherry pick of b648c9039c49cf9664fe2f9a00e770090173b575
+
+Original change:
+
+> If two passes had different kDuplicateBaseVertexInstance values, the
+> encoder would erroneously merge them.
+>
+> Fixed by making sure to take this flag into account. To help avoid this
+> happening in the future should we add or modify more fields to the
+> config, I added a constructor to force all fields to be passed in. The
+> comparison code now inline constructs the config object and compares it
+> use the equality operator.
+>
+> Fixes: 513948465
+> Change-Id: I9e22feb9d6f407126c604a872ddd5c45aab4ef04
+> Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/311995
+> Reviewed-by: Brandon Jones <bajones@chromium.org>
+> Commit-Queue: Antonio Maiorano <amaiorano@google.com>
+
+Bug: 513948465
+Fixed: 518646700
+Change-Id: I514b1f12960ad3c29a5795088ab09ebf6206c63d
+Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/313516
+Commit-Queue: Antonio Maiorano <amaiorano@google.com>
+Reviewed-by: Corentin Wallez <cwallez@chromium.org>
+
+diff --git a/src/dawn/native/IndirectDrawMetadata.cpp b/src/dawn/native/IndirectDrawMetadata.cpp
+index 72fa797e9fedfbf3bffc204388c73a7943906031..701390dab722f3639e9851512eae97cb66bad928 100644
+--- a/src/dawn/native/IndirectDrawMetadata.cpp
++++ b/src/dawn/native/IndirectDrawMetadata.cpp
+@@ -201,8 +201,8 @@ void IndirectDrawMetadata::AddIndexedIndirectDraw(wgpu::IndexFormat indexFormat,
+             DAWN_UNREACHABLE();
+     }
+ 
+-    const IndexedIndirectConfig config = {reinterpret_cast<uintptr_t>(indirectBuffer),
+-                                          duplicateBaseVertexInstance, DrawType::Indexed};
++    const IndexedIndirectConfig config{reinterpret_cast<uintptr_t>(indirectBuffer),
++                                       duplicateBaseVertexInstance, DrawType::Indexed};
+     auto it = mIndexedIndirectBufferValidationInfo.find(config);
+     if (it == mIndexedIndirectBufferValidationInfo.end()) {
+         auto result = mIndexedIndirectBufferValidationInfo.emplace(
+@@ -222,8 +222,8 @@ void IndirectDrawMetadata::AddIndirectDraw(BufferBase* indirectBuffer,
+                                            uint64_t indirectOffset,
+                                            bool duplicateBaseVertexInstance,
+                                            DrawIndirectCmd* cmd) {
+-    const IndexedIndirectConfig config = {reinterpret_cast<uintptr_t>(indirectBuffer),
+-                                          duplicateBaseVertexInstance, DrawType::NonIndexed};
++    const IndexedIndirectConfig config{reinterpret_cast<uintptr_t>(indirectBuffer),
++                                       duplicateBaseVertexInstance, DrawType::NonIndexed};
+     auto it = mIndexedIndirectBufferValidationInfo.find(config);
+     if (it == mIndexedIndirectBufferValidationInfo.end()) {
+         auto result = mIndexedIndirectBufferValidationInfo.emplace(
+diff --git a/src/dawn/native/IndirectDrawMetadata.h b/src/dawn/native/IndirectDrawMetadata.h
+index e58813b36729003dbb2708b2c71c5bf23dc0b010..3a143a0b026c53455fdb75266cd135586c9d44c8 100644
+--- a/src/dawn/native/IndirectDrawMetadata.h
++++ b/src/dawn/native/IndirectDrawMetadata.h
+@@ -137,9 +137,16 @@ class IndirectDrawMetadata : public NonCopyable {
+     };
+ 
+     struct IndexedIndirectConfig {
+-        uintptr_t inputIndirectBufferPtr;
+-        bool duplicateBaseVertexInstance;
+-        DrawType drawType;
++        const uintptr_t inputIndirectBufferPtr;
++        const bool duplicateBaseVertexInstance;
++        const DrawType drawType;
++
++        IndexedIndirectConfig(uintptr_t inputIndirectBufferPtr,
++                              bool duplicateBaseVertexInstance,
++                              DrawType drawType)
++            : inputIndirectBufferPtr(inputIndirectBufferPtr),
++              duplicateBaseVertexInstance(duplicateBaseVertexInstance),
++              drawType(drawType) {}
+ 
+         bool operator<(const IndexedIndirectConfig& other) const;
+         bool operator==(const IndexedIndirectConfig& other) const = default;
+diff --git a/src/dawn/native/IndirectDrawValidationEncoder.cpp b/src/dawn/native/IndirectDrawValidationEncoder.cpp
+index fd2576b80d563a63f07b242fa0f8912a9c93808a..55839e4cbe96b5642ec85963a7d129dc1be8ce78 100644
+--- a/src/dawn/native/IndirectDrawValidationEncoder.cpp
++++ b/src/dawn/native/IndirectDrawValidationEncoder.cpp
+@@ -527,9 +527,10 @@ MaybeError EncodeIndirectDrawValidationCommands(DeviceBase* device,
+ 
+             Pass* currentPass = passes.empty() ? nullptr : &passes.back();
+             if (currentPass &&
+-                reinterpret_cast<uintptr_t>(currentPass->inputIndirectBuffer.get()) ==
+-                    config.inputIndirectBufferPtr &&
+-                currentPass->drawType == config.drawType) {
++                IndirectDrawMetadata::IndexedIndirectConfig{
++                    reinterpret_cast<uintptr_t>(currentPass->inputIndirectBuffer.get()),
++                    bool(currentPass->flags & kDuplicateBaseVertexInstance),
++                    currentPass->drawType} == config) {
+                 uint64_t nextBatchDataOffset =
+                     Align(currentPass->batchDataSize, minStorageBufferOffsetAlignment);
+                 uint64_t newPassBatchDataSize = nextBatchDataOffset + newBatch.dataSize;
+diff --git a/src/dawn/tests/end2end/DrawIndexedIndirectTests.cpp b/src/dawn/tests/end2end/DrawIndexedIndirectTests.cpp
+index 2d1d24a82214e2fc9bd0c49ba9f5595de932e08d..8512321354af7e68074869c21c6468053e3ce374 100644
+--- a/src/dawn/tests/end2end/DrawIndexedIndirectTests.cpp
++++ b/src/dawn/tests/end2end/DrawIndexedIndirectTests.cpp
+@@ -721,5 +721,114 @@ DAWN_INSTANTIATE_TEST(DrawIndexedIndirectTest,
+                       VulkanBackend(),
+                       WebGPUBackend());
+ 
++class DrawIndexedIndirectTest_IndirectFirstInstance : public DawnTest {
++    std::vector<wgpu::FeatureName> GetRequiredFeatures() override {
++        return {wgpu::FeatureName::IndirectFirstInstance};
++    }
++};
++
++// Test that makes sure indirect-draw validation merges passes correctly.
++// A bug was found in D3D12 where it would merge passes despite kDuplicateBaseVertexInstance being
++// different between the passes. Note that the test did not reproduce a failure, which is likely due
++// to GPU driver robustness; however, the logic was indeed incorrect. Presumably on GPUs that do not
++// implement such robustness, an OOB read would be possible.
++TEST_P(DrawIndexedIndirectTest_IndirectFirstInstance, IndirectDrawValidationMergesMatchingPasses) {
++    DAWN_ASSERT(device.HasFeature(wgpu::FeatureName::IndirectFirstInstance));
++
++    // Test expects validation to be enabled
++    DAWN_TEST_UNSUPPORTED_IF(HasToggleEnabled("skip_validation"));
++
++    // Create pNo pipeline (no vertex_index)
++    wgpu::ShaderModule modNo = utils::CreateShaderModule(device, R"(
++        @vertex fn vs() -> @builtin(position) vec4f {
++            // No vertex_index / instance_index builtin -> dup=false on D3D12.
++            return vec4f(0.0, 0.0, 0.0, 1.0);
++        }
++        @fragment fn fs() -> @location(0) vec4f {
++            return vec4f(0.0, 0.0, 0.0, 1.0);
++        }
++    )");
++
++    // Create pDup pipeline (uses vertex_index)
++    wgpu::ShaderModule modDup = utils::CreateShaderModule(device, R"(
++        struct VOut {
++            @builtin(position) pos : vec4f,
++            @location(0) @interpolate(flat) vidx : u32,
++        };
++        @vertex fn vs(@builtin(vertex_index) vi : u32) -> VOut {
++            // Reading @builtin(vertex_index) sets usesVertexIndex=true in the
++            // compiled D3D12 shader, so this pipeline gets the 7-u32
++            // ExecuteIndirect signature. After the OOB index fetch, vi carries the
++            // OOB-read index value (SV_VertexID) -- exfiltratable here.
++            var o : VOut;
++            o.pos = vec4f(0.0, 0.0, 0.0, 1.0);
++            o.vidx = vi;
++            return o;
++        }
++        @fragment fn fs(in : VOut) -> @location(0) vec4f {
++            return vec4f(f32(in.vidx & 255u) / 255.0, 0.0, 0.0, 1.0);
++        }
++    )");
++
++    utils::BasicRenderPass renderPass = utils::CreateBasicRenderPass(device, kRTSize, kRTSize);
++
++    utils::ComboRenderPipelineDescriptor descNo;
++    descNo.vertex.module = modNo;
++    descNo.cFragment.module = modNo;
++    descNo.primitive.topology = wgpu::PrimitiveTopology::PointList;
++    descNo.cTargets[0].format = renderPass.colorFormat;
++    wgpu::RenderPipeline pNo = device.CreateRenderPipeline(&descNo);
++
++    utils::ComboRenderPipelineDescriptor descDup;
++    descDup.vertex.module = modDup;
++    descDup.cFragment.module = modDup;
++    descDup.primitive.topology = wgpu::PrimitiveTopology::PointList;
++    descDup.cTargets[0].format = renderPass.colorFormat;
++    wgpu::RenderPipeline pDup = device.CreateRenderPipeline(&descDup);
++
++    // Index buffer: 1 MiB uint16 -> numIndexBufferElements = 524288.
++    const uint32_t NUM_IDX = 524288;
++    std::vector<uint16_t> idxData(NUM_IDX);
++    for (size_t i = 0; i < NUM_IDX; ++i) {
++        idxData[i] = static_cast<uint16_t>(i);
++    }
++    wgpu::Buffer idxBuf = utils::CreateBufferFromData(
++        device, idxData.data(), idxData.size() * sizeof(uint16_t), wgpu::BufferUsage::Index);
++
++    // Indirect buffer with three 5-u32 DrawIndexedIndirect records.
++    wgpu::Buffer indBuf = utils::CreateBufferFromData<uint32_t>(
++        device, wgpu::BufferUsage::Indirect | wgpu::BufferUsage::CopyDst,
++        {0, 0, 0, 0, 0,                 // record 0: harmless no-op for pNo
++         0, 1, NUM_IDX, 1, 0xFFFFFFFF,  // record 1: dup=true config (merged)
++         0, 0, 0, 0, 0});               // record 2: zeros
++
++    wgpu::CommandEncoder enc = device.CreateCommandEncoder();
++    wgpu::RenderPassEncoder pass = enc.BeginRenderPass(&renderPass.renderPassInfo);
++    pass.SetIndexBuffer(idxBuf, wgpu::IndexFormat::Uint16);
++
++    pass.SetPipeline(pNo);
++    pass.DrawIndexedIndirect(indBuf, 0);
++
++    pass.SetPipeline(pDup);
++    pass.DrawIndexedIndirect(indBuf, 20);
++    pass.DrawIndexedIndirect(indBuf, 40);
++
++    pass.End();
++    wgpu::CommandBuffer commands = enc.Finish();
++    queue.Submit(1, &commands);
++
++    // If the bug triggers, the driver will read 7-u32 records and execute a draw with a large
++    // number of vertices, overdrawing at the center of the viewport. Since we expect no pixels to
++    // be drawn (indexCount = 0 in record 1), the center pixel should remain clear.
++    EXPECT_PIXEL_RGBA8_EQ(utils::RGBA8(0, 0, 0, 0), renderPass.color, 2, 2);
++}
++
++DAWN_INSTANTIATE_TEST(DrawIndexedIndirectTest_IndirectFirstInstance,
++                      D3D12Backend(),
++                      MetalBackend(),
++                      OpenGLBackend(),
++                      VulkanBackend(),
++                      WebGPUBackend());
++
+ }  // anonymous namespace
+ }  // namespace dawn

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,0 +1,1 @@
+cherry-pick-3646e4efab31.patch

--- a/patches/skia/cherry-pick-3646e4efab31.patch
+++ b/patches/skia/cherry-pick-3646e4efab31.patch
@@ -1,0 +1,164 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Ludwig <michaelludwig@google.com>
+Date: Mon, 1 Jun 2026 10:49:39 -0400
+Subject: Turn off LCD in SDF slugs when downscaling too far
+
+LCD text samples the glyph at 1/3 offsets derived from screen-space
+derivatives of its local coords. Each SDF atlas only has 2px of
+transparent padding that these offsets can read into.
+
+If an LCD slug was downscaled after creating its masks by a scale
+of ~0.2, its R and B samples could extend into adjacent glyphs.
+At such a downscaling, the SDF is already fairly low quality because
+it's not sampled by mipmaps. IMO switching to grayscale SDF looked
+better because it approached smooth gray vs. randomized colors.
+
+This applies to both Ganesh and Graphite, although Graphite is able to
+continue to use LCD with SDFs when there's perspective. Since Ganesh
+only uses SkMatrix and not Transform, there's no easy way to estimate
+the perspective scale factors applied over the slug's bounding box.
+
+I tested by modifying GM_slug to use LCD and SDF fonts and interacted
+with viewer's dynamic transforms to trigger the switch between modes.
+
+Bug: 516915337
+Change-Id: Idfa838cfe4ff9443bf2c15078ff52d34a5a5c8f3
+Fixed: 519445030
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1251156
+Reviewed-by: Thomas Smith <thomsmit@google.com>
+Commit-Queue: Michael Ludwig <michaelludwig@google.com>
+(cherry picked from commit 95dbfa24e0b470253c9c8c35e07635a0e90e433b)
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1256456
+Commit-Queue: Thomas Smith <thomsmit@google.com>
+Auto-Submit: Michael Ludwig <michaelludwig@google.com>
+
+diff --git a/src/gpu/ganesh/ops/AtlasTextOp.cpp b/src/gpu/ganesh/ops/AtlasTextOp.cpp
+index 1ec75d6bda1da3a539a3bf4346b076514525b9da..9bcca1219565eebcdc8cc135f6e9896dba58731c 100644
+--- a/src/gpu/ganesh/ops/AtlasTextOp.cpp
++++ b/src/gpu/ganesh/ops/AtlasTextOp.cpp
+@@ -14,6 +14,7 @@
+ #include "include/private/base/SkDebug.h"
+ #include "include/private/base/SkTArray.h"
+ #include "src/base/SkArenaAlloc.h"
++#include "src/core/SkDistanceFieldGen.h"
+ #include "src/core/SkMatrixPriv.h"
+ #include "src/core/SkPaintPriv.h"
+ #include "src/core/SkTraceEvent.h"
+@@ -160,23 +161,37 @@ calculate_clip(const GrClip* clip, SkRect deviceBounds, SkRect glyphBounds) {
+ #if !defined(SK_DISABLE_SDF_TEXT)
+ static std::tuple<AtlasTextOp::MaskType, uint32_t, bool> calculate_sdf_parameters(
+         const skgpu::ganesh::SurfaceDrawContext& sdc,
+-        const SkMatrix& drawMatrix,
++        const SkMatrix& viewDiffMatrix,
+         bool useLCDText,
+         bool isAntiAliased) {
+     const GrColorInfo& colorInfo = sdc.colorInfo();
+     const SkSurfaceProps& props = sdc.surfaceProps();
+     using MT = AtlasTextOp::MaskType;
+     bool isLCD = useLCDText && props.pixelGeometry() != kUnknown_SkPixelGeometry;
++    if (isLCD) {
++        // Must check the scaling ratio of the mask texels vs. screen space since the offset for
++        // R and B samples is based on the derivative. If it gets too big, it would sample outside
++        // the 2px padding of each glyph (SK_DistanceFieldInset). We can't allow offsetting to
++        // go outside of our padding (e.g. 2*SK_DistanceFieldInset if two SDF glyphs were next to
++        // each other is theoretically ok). This is because SDF and regular A8 masks are shared in
++        // the same atlas, so an adjacent glyph may not actually have its own padding.
++        //
++        // Multiply by 3 because the derivative offset is multiplied by 1/3 for R and B offsets.
++        static constexpr float kLCDOffsetLimit = 3.f * (SK_DistanceFieldInset - 0.5f);
++        const float maxLCDOffset = viewDiffMatrix.getMaxScale();
++        isLCD &= (maxLCDOffset > 0.f && maxLCDOffset < kLCDOffsetLimit);
++    }
++
+     MT maskType = !isAntiAliased ? MT::kAliasedDistanceField
+                                  : isLCD ? MT::kLCDDistanceField
+                                          : MT::kGrayscaleDistanceField;
+ 
+     bool useGammaCorrectDistanceTable = colorInfo.isLinearlyBlended();
+-    uint32_t DFGPFlags = drawMatrix.isSimilarity() ? kSimilarity_DistanceFieldEffectFlag : 0;
+-    DFGPFlags |= drawMatrix.isScaleTranslate() ? kScaleOnly_DistanceFieldEffectFlag : 0;
++    uint32_t DFGPFlags = viewDiffMatrix.isSimilarity() ? kSimilarity_DistanceFieldEffectFlag : 0;
++    DFGPFlags |= viewDiffMatrix.isScaleTranslate() ? kScaleOnly_DistanceFieldEffectFlag : 0;
+     DFGPFlags |= useGammaCorrectDistanceTable ? kGammaCorrect_DistanceFieldEffectFlag : 0;
+     DFGPFlags |= MT::kAliasedDistanceField == maskType ? kAliased_DistanceFieldEffectFlag : 0;
+-    DFGPFlags |= drawMatrix.hasPerspective() ? kPerspective_DistanceFieldEffectFlag : 0;
++    DFGPFlags |= viewDiffMatrix.hasPerspective() ? kPerspective_DistanceFieldEffectFlag : 0;
+ 
+     if (isLCD) {
+         bool isBGR = SkPixelGeometryIsBGR(props.pixelGeometry());
+@@ -253,18 +268,19 @@ std::tuple<const GrClip*, GrOp::Owner> AtlasTextOp::Make(SurfaceDrawContext* sdc
+ #if !defined(SK_DISABLE_SDF_TEXT)
+     auto glyphParams = subrun->glyphParams();
+     if (glyphParams.isSDF) {
+-         auto [maskType, DFGPFlags, useGammaCorrectDistanceTable] =
+-                 calculate_sdf_parameters(*sdc, viewMatrix, glyphParams.isLCD, glyphParams.isAA);
+-         op = GrOp::Make<AtlasTextOp>(rContext,
+-                                      maskType,
+-                                      true,
+-                                      subrun->glyphCount(),
+-                                      subRunDeviceBounds,
+-                                      SkPaintPriv::ComputeLuminanceColor(paint),
+-                                      useGammaCorrectDistanceTable,
+-                                      DFGPFlags,
+-                                      geometry,
+-                                      std::move(grPaint));
++        SkMatrix viewDiff = subrun->vertexFiller().viewDifference(positionMatrix);
++        auto [maskType, DFGPFlags, useGammaCorrectDistanceTable] =
++                 calculate_sdf_parameters(*sdc, viewDiff, glyphParams.isLCD, glyphParams.isAA);
++        op = GrOp::Make<AtlasTextOp>(rContext,
++                                     maskType,
++                                     true,
++                                     subrun->glyphCount(),
++                                     subRunDeviceBounds,
++                                     SkPaintPriv::ComputeLuminanceColor(paint),
++                                     useGammaCorrectDistanceTable,
++                                     DFGPFlags,
++                                     geometry,
++                                     std::move(grPaint));
+      } else
+ #endif
+      {
+diff --git a/src/gpu/graphite/render/SDFTextLCDRenderStep.cpp b/src/gpu/graphite/render/SDFTextLCDRenderStep.cpp
+index 9190fb350ae0b4c01e1aca85be6428ee9574fd46..188c4849c433a980914b7a5acced2de125ea6638 100644
+--- a/src/gpu/graphite/render/SDFTextLCDRenderStep.cpp
++++ b/src/gpu/graphite/render/SDFTextLCDRenderStep.cpp
+@@ -18,6 +18,7 @@
+ #include "include/private/base/SkAssert.h"
+ #include "include/private/base/SkDebug.h"
+ #include "src/base/SkEnumBitMask.h"
++#include "src/core/SkDistanceFieldGen.h"
+ #include "src/core/SkSLTypeShared.h"
+ #include "src/gpu/graphite/AtlasProvider.h"
+ #include "src/gpu/graphite/Attribute.h"
+@@ -164,13 +165,24 @@ void SDFTextLCDRenderStep::writeUniformsAndTextures(const DrawParams& params,
+ 
+     // compute and write pixelGeometry vector
+     SkV2 pixelGeometryDelta = {0, 0};
+-    if (SkPixelGeometryIsH(subRunData.pixelGeometry())) {
+-        pixelGeometryDelta = {1.f/(3*proxies[0]->dimensions().width()), 0};
+-    } else if (SkPixelGeometryIsV(subRunData.pixelGeometry())) {
+-        pixelGeometryDelta = {0, 1.f/(3*proxies[0]->dimensions().height())};
+-    }
+-    if (SkPixelGeometryIsBGR(subRunData.pixelGeometry())) {
+-        pixelGeometryDelta = -pixelGeometryDelta;
++
++    // There is 2px padding of each glyph (SK_DistanceFieldInset). We can't allow offsetting to go
++    // outside of our padding (e.g. 2*SK_DistanceFieldInset if two SDF glyphs were next to each
++    // other is theoretically ok). This is because SDF and regular A8 masks are shared in the same
++    // atlas, so an adjacent glyph may not actually have its own padding.
++    //
++    // NOTE: kLCDOffsetLimit is multiplied by 3 to account for the scale added to pixelGeometryDelta
++    static constexpr float kLCDOffsetLimit = 3.f * (SK_DistanceFieldInset - 0.5f);
++    float maxLCDOffset = params.transform().localAARadius(subRunData.bounds());
++    if (maxLCDOffset < kLCDOffsetLimit) {
++        if (SkPixelGeometryIsH(subRunData.pixelGeometry())) {
++            pixelGeometryDelta = {1.f/(3*proxies[0]->dimensions().width()), 0};
++        } else if (SkPixelGeometryIsV(subRunData.pixelGeometry())) {
++            pixelGeometryDelta = {0, 1.f/(3*proxies[0]->dimensions().height())};
++        }
++        if (SkPixelGeometryIsBGR(subRunData.pixelGeometry())) {
++            pixelGeometryDelta = -pixelGeometryDelta;
++        }
+     }
+     gatherer->writeHalf(pixelGeometryDelta);
+ 


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`12de7ea26453`](https://chromium-review.googlesource.com/c/chromium/src/+/7886775) from chromium — [Extensions] Fix Site Isolation bypass in WebRequest API via EventRouter
* [`df3780d115a3`](https://chromium-review.googlesource.com/c/chromium/src/+/7895384) from chromium — Use checked math before allocating ScopedAudioChannelLayout
* [`8ed77b6a0d7a`](https://chromium-review.googlesource.com/c/chromium/src/+/7886194) from chromium — Early return if a nested message loop deletes the RFH.
* [`18ce72db3063`](https://chromium-review.googlesource.com/c/chromium/src/+/7902751) from chromium — Improve temporary file creation and error handling in SimpleURLLoader
* [`44d6bf109100`](https://chromium-review.googlesource.com/c/chromium/src/+/7902731) from chromium — Restrict CreateNetLogExporter to browser process
* [`b46a51655dd6`](https://chromium-review.googlesource.com/c/chromium/src/+/7895707) from chromium — Ensure the lifecycle is updated for external SVG resources
* [`8db4874bd3ff`](https://chromium-review.googlesource.com/c/chromium/src/+/7901520) from chromium — Harden MojoAudioDecoderService and various implementations
* [`c6c60af71b11`](https://chromium-review.googlesource.com/c/chromium/src/+/7898679) from chromium — Prevent UAF on duplicate RaceNetworkRequest tokens
* [`e819a80f8ff8`](https://chromium-review.googlesource.com/c/chromium/src/+/7898833) from chromium — media: Fix uninitialized GPU VRAM leak in MFVEA NV12 copy paths
* [`22e4bb302a14`](https://chromium-review.googlesource.com/c/chromium/src/+/7895318) from chromium — Add validation to cursor theme name to prevent path traversal.
* [`17f11eae14fd`](https://chromium-review.googlesource.com/c/chromium/src/+/7899243) from chromium — Fix UAF in BluetoothRfcommChannelMac and BluetoothL2capChannelMac delegates on macOS
* [`3f57fbc717d7`](https://chromium-review.googlesource.com/c/chromium/src/+/7900417) from chromium — Fix UAF in BluetoothDeviceInquiryDelegate on macOS
* [`3646e4efab31`](https://skia-review.googlesource.com/c/skia/+/1256456) from skia — Turn off LCD in SDF slugs when downscaling too far
* [`ba03542094db`](https://dawn-review.googlesource.com/c/dawn/+/313516) from dawn — [native] Fix IndirectDrawValidationEncoder merging non-matching passes
* [`74f80741f8bc`](https://dawn-review.googlesource.com/c/dawn/+/314775) from dawn — [dawn][native] Disallow TransientAttachment for internal usages.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium, Skia and Dawn.
