### PR TITLE
fix: only set Node's WASM streaming callback when fetch is enabled

### DIFF
--- a/patches/node/api_delete_deprecated_fields_on_v8_isolate.patch
+++ b/patches/node/api_delete_deprecated_fields_on_v8_isolate.patch
@@ -6,7 +6,7 @@ Subject: Delete deprecated fields on v8::Isolate
 https://chromium-review.googlesource.com/c/v8/v8/+/7081397
 
 diff --git a/src/api/environment.cc b/src/api/environment.cc
-index dd0100693afdabaf8d7bae25dccee237b3c0a5c2..31199141b71ebe05c1171476fdef50cb0cad110e 100644
+index 6873a9f203ccace7d5c501b62bed56732332d060..7ba7943c666d9cf3de47bf9a18b8e6e0e1196886 100644
 --- a/src/api/environment.cc
 +++ b/src/api/environment.cc
 @@ -218,8 +218,6 @@ void SetIsolateCreateParamsForNode(Isolate::CreateParams* params) {

--- a/patches/node/fix_allow_disabling_fetch_in_renderer_and_worker_processes.patch
+++ b/patches/node/fix_allow_disabling_fetch_in_renderer_and_worker_processes.patch
@@ -78,6 +78,26 @@ index 4a42dd66f451eece98fded909a72dd5ffcfd9708..a693e35135fc8f7e918e1410a104d460
  // https://websockets.spec.whatwg.org/
  function setupWebsocket() {
    if (getOptionValue('--no-experimental-websocket')) {
+diff --git a/src/api/environment.cc b/src/api/environment.cc
+index dd0100693afdabaf8d7bae25dccee237b3c0a5c2..6873a9f203ccace7d5c501b62bed56732332d060 100644
+--- a/src/api/environment.cc
++++ b/src/api/environment.cc
+@@ -269,9 +269,13 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
+   isolate->SetModifyCodeGenerationFromStringsCallback(
+       modify_code_generation_from_strings_callback);
+ 
+-  isolate->SetWasmStreamingCallback(wasm_web_api::StartStreamingCompilation);
+-
+   Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
++  if (per_process::cli_options->get_per_isolate_options()
++          ->get_per_env_options()
++          ->experimental_fetch) {
++    isolate->SetWasmStreamingCallback(wasm_web_api::StartStreamingCompilation);
++  }
++
+   if (per_process::cli_options->get_per_isolate_options()
+           ->experimental_shadow_realm) {
+     isolate->SetHostCreateShadowRealmContextCallback(
 diff --git a/src/node_options.cc b/src/node_options.cc
 index b7062241d590e36f797babffb5945060ef759322..ae895839723609dcdec2c037facb17208c757d58 100644
 --- a/src/node_options.cc

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -452,6 +452,29 @@ describe('web security', () => {
     });
   });
 
+  describe('WebAssembly streaming compilation', () => {
+    it('works in a renderer with nodeIntegration', async () => {
+      const server = http.createServer((req, res) => {
+        res.setHeader('Content-Type', 'application/wasm');
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        // Minimal valid WebAssembly module (magic number + version).
+        res.end(Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true, contextIsolation: false }
+      });
+      await w.loadURL('about:blank');
+      const result = await w.webContents.executeJavaScript(
+        `WebAssembly.instantiateStreaming(fetch('${serverUrl}')).then(() => 'loaded')`
+      );
+      expect(result).to.equal('loaded');
+    });
+  });
+
   describe('csp', () => {
     for (const sandbox of [true, false]) {
       describe(`when sandbox: ${sandbox}`, () => {


### PR DESCRIPTION
Fixes #51950

#### Description of Change

Node.js v24.16.0 removed the `experimental_fetch` gate around `isolate->SetWasmStreamingCallback()` (nodejs/node#62759). When `fix_allow_disabling_fetch_in_renderer_and_worker_processes.patch` was rebased for the Node bump, the flag was restored but that gate was not.

As a result, Node.js unconditionally overrode Blink's WebAssembly streaming callback in renderer and worker processes — where we pass `--no-experimental-fetch` and never register Node's JS-side streaming implementation. Any `WebAssembly.compileStreaming()` / `instantiateStreaming()` call in a renderer with `nodeIntegration: true` then failed the `CHECK(!impl.IsEmpty())` assertion in `node_wasm_web_api.cc` and crashed the renderer.

This restores the gate (matching the v24.15.0 behavior) so Blink's streaming callback stays installed in processes where Node's fetch is disabled, and adds a regression test. Browser, utility, and `ELECTRON_RUN_AS_NODE` processes are unaffected — fetch is enabled there, so Node's streaming implementation is still installed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added/changed

#### Release Notes

Notes: Fixed a renderer crash when calling `WebAssembly.compileStreaming()` or `WebAssembly.instantiateStreaming()` with `nodeIntegration` enabled.