### PR TITLE
docs: clarify that only executables should be signed with entitlements

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -130,7 +130,7 @@ the app bundle's entitlements have at least following keys:
 The `TEAM_ID` should be replaced with your Apple Developer account's Team ID,
 and the `your.bundle.id` should be replaced with the App ID of the app.
 
-And the following entitlements must be added to the binaries and helpers in
+And the following entitlements must be added to the executables in
 the app's bundle:
 
 ```xml


### PR DESCRIPTION
#### Description of Change

This is a clarification meant to help in cases where users do not use `@electron/osx-sign`. Recently, we received a report that App Store Connect responded to an app submission wherein non-executables were signed with entitlements. The `codesign` CLI on macOS already silently drops entitlements when asked to sign libraries on macOS 15.0+ (see the manpage for `codesign`). However, users using custom code-signing setups must understand this to avoid issues. This just changes our wording on what files need to be signed with entitlements to make this more clear. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none