### PR TITLE
fix: devTools network events dropped on RenderFrameHost swap

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -89,11 +89,25 @@ void Debugger::RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
   // so if the new_rfh is not the primary main frame, we don't want to
   // reconnect otherwise we'll end up trying to reconnect to a RenderFrameHost
   // that already has a DevToolsAgentHost associated with it.
-  if (agent_host_ && new_rfh->IsInPrimaryMainFrame()) {
-    agent_host_->DisconnectWebContents();
-    auto* web_contents = content::WebContents::FromRenderFrameHost(new_rfh);
-    agent_host_->ConnectWebContents(web_contents);
-  }
+  if (!agent_host_ || !new_rfh->IsInPrimaryMainFrame())
+    return;
+
+  auto* web_contents = content::WebContents::FromRenderFrameHost(new_rfh);
+
+  // The DevToolsAgentHost already follows primary main-frame RenderFrameHost
+  // changes within the same WebContents on its own. Disconnecting and
+  // reconnecting here is therefore redundant for such navigations, and is
+  // actively harmful: it tears down and rebinds the DevTools session mojo
+  // pipe, discarding any protocol notifications that the renderer has already
+  // emitted onto the pipe. With RenderDocument enabled the main-frame RFH
+  // changes on every navigation, so this dropped requests for every page load
+  // whenever a debugger was attached. Only reconnect when the WebContents
+  // actually changed, which the agent host does not track on its own.
+  if (agent_host_->GetWebContents() == web_contents)
+    return;
+
+  agent_host_->DisconnectWebContents();
+  agent_host_->ConnectWebContents(web_contents);
 }
 
 void Debugger::Attach(gin::Arguments* args) {

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -230,6 +230,64 @@ describe('debugger module', () => {
       }
     });
 
+    it('reports network requests for a new document after a main-frame navigation', async () => {
+      server = http.createServer((req, res) => {
+        if (req.url === '/page') {
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(
+            '<!DOCTYPE html><html><head>' +
+              '<link rel="stylesheet" href="/style.css">' +
+              '<script src="/script.js"></script>' +
+              '</head><body>page</body></html>'
+          );
+        } else if (req.url === '/style.css') {
+          res.setHeader('Content-Type', 'text/css; charset=utf-8');
+          res.end('body { color: red; }');
+        } else if (req.url === '/script.js') {
+          res.setHeader('Content-Type', 'text/javascript; charset=utf-8');
+          res.end('void 0;');
+        } else {
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end('<!DOCTYPE html><html><body>start</body></html>');
+        }
+      });
+
+      const { url } = await listen(server);
+      await w.loadURL(`${url}/start`);
+      w.webContents.debugger.attach();
+      try {
+        await w.webContents.debugger.sendCommand('Network.enable');
+        await w.webContents.debugger.sendCommand('Target.setAutoAttach', {
+          autoAttach: true,
+          flatten: true,
+          waitForDebuggerOnStart: false
+        });
+
+        const pending = new Set([`${url}/style.css`, `${url}/script.js`]);
+        const sawSubresources = new Promise<void>((resolve) => {
+          w.webContents.debugger.on('message', (_event, method, params) => {
+            if (method === 'Network.requestWillBeSent' && pending.has(params.request.url)) {
+              pending.delete(params.request.url);
+              if (pending.size === 0) {
+                resolve();
+              }
+            }
+          });
+        });
+
+        // This navigation swaps the main-frame RenderFrameHost under
+        // RenderDocument. Before the fix, the debugger tore down and rebound its
+        // session here, dropping these subresource requests.
+        await w.loadURL(`${url}/page`);
+
+        await sawSubresources;
+      } finally {
+        if (w.webContents.debugger.isAttached()) {
+          w.webContents.debugger.detach();
+        }
+      }
+    });
+
     it('can get and set cookies using the Storage API', async () => {
       await w.webContents.loadURL('about:blank');
       w.webContents.debugger.attach('1.1');

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -257,20 +257,20 @@ describe('debugger module', () => {
       w.webContents.debugger.attach();
       try {
         await w.webContents.debugger.sendCommand('Network.enable');
+        await w.webContents.debugger.sendCommand('Page.enable');
         await w.webContents.debugger.sendCommand('Target.setAutoAttach', {
           autoAttach: true,
           flatten: true,
           waitForDebuggerOnStart: false
         });
 
-        const pending = new Set([`${url}/style.css`, `${url}/script.js`]);
-        const sawSubresources = new Promise<void>((resolve) => {
+        const requestedUrls = new Set<string>();
+        const loadEvent = new Promise<void>((resolve) => {
           w.webContents.debugger.on('message', (_event, method, params) => {
-            if (method === 'Network.requestWillBeSent' && pending.has(params.request.url)) {
-              pending.delete(params.request.url);
-              if (pending.size === 0) {
-                resolve();
-              }
+            if (method === 'Network.requestWillBeSent') {
+              requestedUrls.add(params.request.url);
+            } else if (method === 'Page.loadEventFired') {
+              resolve();
             }
           });
         });
@@ -280,7 +280,9 @@ describe('debugger module', () => {
         // session here, dropping these subresource requests.
         await w.loadURL(`${url}/page`);
 
-        await sawSubresources;
+        await loadEvent;
+        expect(requestedUrls).to.include(`${url}/style.css`);
+        expect(requestedUrls).to.include(`${url}/script.js`);
       } finally {
         if (w.webContents.debugger.isAttached()) {
           w.webContents.debugger.detach();


### PR DESCRIPTION
#### Description of Change

When a debugger is attached to a WebContents (e.g. via `webContents.debugger`), `Debugger::RenderFrameHostChanged` unconditionally called `DisconnectWebContents` followed by `ConnectWebContents` on every primary main-frame RenderFrameHost change.

That disconnect/reconnect round-trip resets the DevTools session's mojo receiver `DevToolsSession::AttachToAgent`, discarding any protocol notifications already queued on the pipe.

Since Chromium 148 enabled RenderDocument with the `all-frames` level by default on desktop https://chromium-review.googlesource.com/c/chromium/src/+/7534620, the main-frame RenderFrameHost now changes on every navigation, so this dropped the bulk of a page's network requests from the DevTools Network panel on each load whenever a debugger was attached.

`RenderFrameDevToolsAgentHost` already follows primary main-frame RenderFrameHost changes within the same WebContents on its own, so the manual reconnect is redundant. Only disconnect/reconnect when the WebContents actually changed, which the agent host does not track.

Refs https://github.com/microsoft/vscode/issues/320157

#### Release Notes

Notes: Fixed DevTools Network panel missing most requests after navigating when webContents.debugger is attached.