### PR TITLE
docs: clarify the way electron is downloaded in faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,11 +20,12 @@ the [Advanced Installation](./tutorial/installation.md) documentation for more d
 
 ## How are Electron binaries downloaded?
 
-When you run `npm install electron`, the Electron binary for the corresponding version is downloaded
-into your project's `node_modules` folder via npm's `postinstall` lifecycle script.
+When you run `npm install electron`, the main `bin` script is downloaded.
+Once this is run (for example, via `npx electron`), the Electron binary for the corresponding version is downloaded into your project's node_modules folder dynamically via the `install-electron` script.
 
-This logic is handled by the [`@electron/get`](https://github.com/electron/get) utility package
-under the hood.
+The download logic is handled by the [`@electron/get`](https://github.com/electron/get) utility package under the hood.
+
+You can also call the `install-electron` script manually.
 
 ## When will Electron upgrade to latest Chromium?
 


### PR DESCRIPTION
#### Description of Change
ever since the `postinstall` script was deprecated the FAQ still mentioned that the `postinstall` script was used for binary downloads, so cleared that up and mentioned the new dynamic download approach instead :D
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
