### PR TITLE
build: allow context line changes in Chromium roll patch updates

### DIFF
--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -314,7 +314,11 @@ async function main() {
 
         const changedLines = fileDiff.matchAll(/^[-+].*$/gm);
         for (const line of changedLines) {
-          if (!line[0].match(/^[-+](--|\+\+|index|@@) /)) {
+          // Allowed non-content changes: diff metadata (`--- `/`+++ ` file
+          // headers, `index `, `@@ ` hunk headers) and context line changes
+          // (`^[-+] `), which only reflect upstream drift around the patched
+          // region, not changes to what the patch itself adds or removes.
+          if (!line[0].match(/^[-+]( |(--|\+\+|index|@@) )/)) {
             console.error(`  ❌ "${PATCHES_UPDATE_MSG}" commit contains content changes in ${filename}`);
             hasErrors = true;
             commitValid = false;


### PR DESCRIPTION
#### Description of Change

The Chromium roll lint (`script/lint-roller-chromium-changes.mjs`) requires `chore: update patches` commits to contain only non-content changes under `patches/`, previously permitting just diff metadata (`--- `/`+++ ` headers, `index ` hashes, `@@ ` hunk headers).

But re-exporting patches after a Chromium bump can also shift the **context lines** within a hunk — as upstream code around the patched region changes, or when resolving upstream merge conflicts. These show up as `^[-+] ` (a diff marker followed by a space) and reflect upstream drift, not changes to what the patch adds or removes.

This allows `^[-+] ` as a non-content change. Genuine edits to a patch's own hunk body still appear as `^[-+][-+]` and remain flagged.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
