### PR TITLE
fix: make reload menu items work with `BaseWindow`

### DIFF
--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -1,12 +1,4 @@
-import {
-  app,
-  BaseWindow,
-  BrowserWindow,
-  session,
-  webContents,
-  WebContents,
-  MenuItemConstructorOptions
-} from 'electron/main';
+import { app, BaseWindow, session, webContents, WebContents, MenuItemConstructorOptions } from 'electron/main';
 
 const isMac = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
@@ -67,6 +59,12 @@ interface Role {
   submenu?: MenuItemConstructorOptions[];
 }
 
+/**
+ * Returns the parent webContents if wc is a DevTools webContents. Returns undefined otherwise.
+ */
+const getDevToolsParentWebContents = (wc: WebContents): WebContents | undefined =>
+  webContents.getAllWebContents().find(({ devToolsWebContents }) => devToolsWebContents === wc);
+
 export const roleList: Record<RoleId, Role> = {
   about: {
     get label() {
@@ -99,10 +97,8 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Force Reload',
     accelerator: 'Shift+CmdOrCtrl+R',
     nonNativeMacOSRole: true,
-    windowMethod: (window: BaseWindow) => {
-      if (window instanceof BrowserWindow) {
-        window.webContents.reloadIgnoringCache();
-      }
+    webContentsMethod: (wc: WebContents) => {
+      (getDevToolsParentWebContents(wc) || wc).reloadIgnoringCache();
     }
   },
   front: {
@@ -163,10 +159,8 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Reload',
     accelerator: 'CmdOrCtrl+R',
     nonNativeMacOSRole: true,
-    windowMethod: (w: BaseWindow) => {
-      if (w instanceof BrowserWindow) {
-        w.reload();
-      }
+    webContentsMethod: (wc: WebContents) => {
+      (getDevToolsParentWebContents(wc) || wc).reload();
     }
   },
   resetzoom: {
@@ -214,10 +208,7 @@ export const roleList: Record<RoleId, Role> = {
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
     webContentsMethod: (wc) => {
-      const parentForDevToolsWebContents = webContents
-        .getAllWebContents()
-        .find(({ devToolsWebContents }) => devToolsWebContents === wc);
-      (parentForDevToolsWebContents || wc).toggleDevTools();
+      (getDevToolsParentWebContents(wc) || wc).toggleDevTools();
     }
   },
   togglefullscreen: {

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -574,6 +574,78 @@ describe('MenuItems', () => {
     });
   });
 
+  describe('MenuItem reload roles', () => {
+    afterEach(closeAllWindows);
+    afterEach(cleanupWebContents);
+
+    const title = 'TEST';
+    const htmlUrl = `data:text/html,<html><head><title>${title}</title></head><body></body></html>`;
+
+    const changeTitle = async (wcv: WebContentsView) => {
+      const changedTitle = 'CHANGED';
+      await wcv.webContents.executeJavaScript(`document.title = '${changedTitle}'`);
+      expect(wcv.webContents.getTitle()).to.equal(changedTitle);
+    };
+
+    const testReloadRole = async (role: 'reload' | 'forceReload') => {
+      const w = new BaseWindow({ show: false });
+      const wcv = new WebContentsView();
+      w.contentView.addChildView(wcv);
+
+      await wcv.webContents.loadURL(htmlUrl);
+      await changeTitle(wcv);
+
+      const didStartLoading = once(wcv.webContents, 'did-start-loading');
+      expect(executeByRole(role, w, wcv.webContents)).to.be.true();
+      await didStartLoading;
+      await once(wcv.webContents, 'did-finish-load');
+
+      // If the page was reloaded, the title should have been reset.
+      expect(wcv.webContents.getTitle()).to.equal(title);
+    };
+
+    const testReloadRoleOnDevToolsWebContents = async (role: 'reload' | 'forceReload') => {
+      const w = new BaseWindow({ show: false });
+      const wcv = new WebContentsView();
+      w.contentView.addChildView(wcv);
+
+      await wcv.webContents.loadURL(htmlUrl);
+      await changeTitle(wcv);
+
+      const opened = once(wcv.webContents, 'devtools-opened');
+      wcv.webContents.openDevTools();
+      await opened;
+
+      const didStartLoading = once(wcv.webContents, 'did-start-loading');
+      expect(executeByRole(role, w, wcv.webContents.devToolsWebContents!)).to.be.true();
+      await didStartLoading;
+      await once(wcv.webContents, 'did-finish-load');
+
+      // If the page was reloaded, the title should have been reset.
+      expect(wcv.webContents.getTitle()).to.equal(title);
+    };
+
+    describe('reload role', () => {
+      it('reloads the focused webContents', async () => {
+        await testReloadRole('reload');
+      });
+
+      it('reloads the parent webContents when called on DevTools webContents', async () => {
+        await testReloadRoleOnDevToolsWebContents('reload');
+      });
+    });
+
+    describe('forceReload role', () => {
+      it('reloads the focused webContents', async () => {
+        await testReloadRole('forceReload');
+      });
+
+      it('reloads the parent webContents when called on DevTools webContents', async () => {
+        await testReloadRoleOnDevToolsWebContents('forceReload');
+      });
+    });
+  });
+
   describe('MenuItem windowMenu', () => {
     it('includes a default submenu layout when submenu is empty', () => {
       const item = new MenuItem({ role: 'windowMenu' });


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This PR makes the `Ctrl+R` and `Ctrl+Shift+R` shortcuts work in `WebContentsView`s that are added to `BaseWindow`s.

Can be tested with this gist: https://gist.github.com/nikwen/d20a57fc1b0f0494ba32b80cffd4285f

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Made "reload" menu items work with `BaseWindow`.
