### PR TITLE
docs: fix heap dump screenshot in contentTracing

### DIFF
--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -183,6 +183,6 @@ To view the recorded heap dumps:
 5. Click on one of the `M` symbols
 6. Click on a `☰` triple bar icon (e.g., in the `malloc` column)
 
-<img src="../images/viewing-heap-dumps.png" alt="Screenshot showing how to view a heapdump in Chromium's tracing view" />
+![Screenshot showing how to view a heapdump in Chromium's tracing view](../images/viewing-heap-dumps.png)
 
 [trace viewer]: https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Converted raw HTML `<img>` to Markdown image syntax `![](...)`

Fix <https://github.com/electron/electron/issues/51984>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none