### PR TITLE
fix: fix traffic light positioning when using `titleBarOverlay`

### DIFF
--- a/shell/browser/ui/cocoa/window_buttons_proxy.h
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.h
@@ -30,6 +30,8 @@
   gfx::Point margin_;
   // The default left-top margin.
   gfx::Point default_margin_;
+  // Whether the current margin was explicitly set by the embedder.
+  BOOL has_custom_margin_;
   // Current height of the title bar container.
   float height_;
 

--- a/shell/browser/ui/cocoa/window_buttons_proxy.mm
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.mm
@@ -124,8 +124,9 @@
 
   NSRect cbounds = titleBarContainer.frame;
   cbounds.size.height = button_height + 2 * margin_.y();
-  // Custom height must be larger than the button height to use
-  if ([self useCustomHeight]) {
+  // Custom height is used for default overlay layout. Explicit button
+  // positions should keep the same coordinate space as non-overlay windows.
+  if ([self useCustomHeight] && !has_custom_margin_) {
     cbounds.size.height = height_;
   }
   cbounds.origin.y = NSHeight(window_.frame) - NSHeight(cbounds);
@@ -207,13 +208,8 @@
   NSView* left = [self leftButton];
   NSView* right = [self rightButton];
 
-  if (height_ != 0) {
+  if (height_ != 0 && !has_custom_margin_) {
     result.set_y((height_ - NSHeight(left.frame)) / 2);
-
-    // Do not center buttons if height and button position specified
-    if (has_custom_margin_)
-      result.set_y(height_ - NSHeight(left.frame) - margin_.y());
-
   } else {
     result.set_y((NSHeight(titleBarContainer.frame) - NSHeight(left.frame)) /
                  2);

--- a/shell/browser/ui/cocoa/window_buttons_proxy.mm
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.mm
@@ -35,6 +35,7 @@
 
   // Remember the default margin.
   margin_ = default_margin_ = [self getCurrentMargin];
+  has_custom_margin_ = NO;
   // Custom height will be used if set larger than default
   height_ = 0;
 
@@ -79,6 +80,7 @@
 }
 
 - (void)setMargin:(const std::optional<gfx::Point>&)margin {
+  has_custom_margin_ = margin.has_value();
   if (margin)
     margin_ = *margin;
   else
@@ -209,7 +211,7 @@
     result.set_y((height_ - NSHeight(left.frame)) / 2);
 
     // Do not center buttons if height and button position specified
-    if (margin_.y() != default_margin_.y())
+    if (has_custom_margin_)
       result.set_y(height_ - NSHeight(left.frame) - margin_.y());
 
   } else {


### PR DESCRIPTION
#### Description of Change

Resolves #49183. This encodes a boolean for when custom margins are introduced and used this to help improve custom traffic light positioning.

Note: this PR was written largely with the help of GPT-5.5 in the Codex CLI.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed issue where using a `titleBarOverlay` would cause traffic lights with custom positioning to be misplaced on macOS.