### PR TITLE
fix: non-resizable window not entering fullscreen

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -814,6 +814,19 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
     return;
 
   bool leaving_fullscreen = IsFullscreen() && !fullscreen;
+
+  // A non-resizable window pins min == max to its bounds (see SetBounds), which
+  // would also stop it filling the screen. Suspend the constraints while
+  // fullscreen and re-pin on leaving (below); a member is used because
+  // IsFullscreen() is unreliable mid-transition. Always assign it, so leaving
+  // fullscreen clears the flag even if the window became resizable in between.
+  const bool suspend_size_constraints = fullscreen && !CanResize();
+  fullscreen_size_constraints_suspended_ = suspend_size_constraints;
+  if (suspend_size_constraints) {
+    SetSizeConstraints({});
+    NotifySizeConstraintsChanged();
+  }
+
 #if BUILDFLAG(IS_WIN)
   // There is no native fullscreen state on Windows.
   if (fullscreen) {
@@ -861,6 +874,16 @@ void NativeWindowViews::SetFullScreen(bool fullscreen) {
     widget()->native_widget_private()->Show(
         ui::mojom::WindowShowState::kFullscreen, gfx::Rect());
 #endif
+
+  // The widget restores bounds without going through SetBounds(), so re-pin the
+  // suspended constraints here.
+  if (leaving_fullscreen && !CanResize()) {
+    const gfx::Size restored_size = GetSize();
+    SetSizeConstraints(
+        extensions::SizeConstraints(restored_size, restored_size));
+    NotifySizeConstraintsChanged();
+  }
+
   // Auto-hide menubar when in fullscreen.
   if (fullscreen) {
     menu_bar_visible_before_fullscreen_ = IsMenuBarVisible();
@@ -895,9 +918,10 @@ void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
 #endif
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
-  // On Linux and Windows the minimum and maximum size should be updated with
-  // window size when window is not resizable.
-  if (!CanResize()) {
+  // On Linux and Windows the minimum and maximum size should be set to
+  // window size when window is not resizable. Skip while fullscreen, where the
+  // constraints are suspended.
+  if (!CanResize() && !fullscreen_size_constraints_suspended_) {
     SetMaximumSize(bounds.size());
     SetMinimumSize(bounds.size());
   }
@@ -995,23 +1019,38 @@ void NativeWindowViews::SetResizable(bool resizable) {
       SetSizeConstraints(old_size_constraints_);
     } else {
       old_size_constraints_ = GetSizeConstraints();
-      gfx::Size window_size = GetSize();
-      SetSizeConstraints(extensions::SizeConstraints(window_size, window_size));
+      if (IsFullscreen()) {
+        // Pinning min == max to the current size would lock the window to the
+        // fullscreen size and stop it shrinking back on the way out. Suspend
+        // the constraints instead; SetFullScreen re-pins them to the restored
+        // size when the window leaves fullscreen.
+        fullscreen_size_constraints_suspended_ = true;
+        SetSizeConstraints({});
+      } else {
+        const gfx::Size window_size = GetSize();
+        SetSizeConstraints(
+            extensions::SizeConstraints(window_size, window_size));
+      }
     }
-    // Forcing OnSizeConstraintsChanged on Windows when !thick_frame_ would
-    // cause HWNDMessageHandler::SizeConstraintsChanged() to add WS_THICKFRAME
-    // based on CanResize(), which destroys transparency on layered windows.
-    // Min/max are still enforced through WM_GETMINMAXINFO directly from the
-    // widget delegate.
+    NotifySizeConstraintsChanged();
 #if BUILDFLAG(IS_WIN)
-    if (thick_frame_ && widget() && widget()->widget_delegate())
-      widget()->OnSizeConstraintsChanged();
     UpdateThickFrame();
-#else
-    if (widget() && widget()->widget_delegate())
-      widget()->OnSizeConstraintsChanged();
 #endif
   }
+}
+
+void NativeWindowViews::NotifySizeConstraintsChanged() {
+  // Forcing OnSizeConstraintsChanged on Windows when !thick_frame_ would cause
+  // HWNDMessageHandler::SizeConstraintsChanged() to add WS_THICKFRAME based on
+  // CanResize(), which destroys transparency on layered windows. Min/max are
+  // still enforced through WM_GETMINMAXINFO directly from the widget delegate.
+#if BUILDFLAG(IS_WIN)
+  if (thick_frame_ && widget() && widget()->widget_delegate())
+    widget()->OnSizeConstraintsChanged();
+#else
+  if (widget() && widget()->widget_delegate())
+    widget()->OnSizeConstraintsChanged();
+#endif
 }
 
 bool NativeWindowViews::MoveAbove(const std::string& sourceId) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -279,6 +279,11 @@ class NativeWindowViews : public NativeWindow,
   // Maintain window placement.
   void MoveBehindTaskBarIfNeeded();
 
+  // Notify the widget that the size constraints changed, guarding against the
+  // transparency loss this causes for frameless (!thick_frame_) windows on
+  // Windows. See SetResizable / SetFullScreen.
+  void NotifySizeConstraintsChanged();
+
   RootView root_view_{this};
 
   // The view should be focused by default.
@@ -289,6 +294,12 @@ class NativeWindowViews : public NativeWindow,
   // resizable again. This is also used on Windows, to keep taskbar resize
   // events from resizing the window.
   extensions::SizeConstraints old_size_constraints_;
+
+  // A non-resizable window pins its min and max size to its current bounds (see
+  // SetBounds). While fullscreen those constraints are suspended so the window
+  // can fill the screen; this tracks that suspended state so SetBounds does not
+  // re-pin the lock until the window leaves fullscreen. See SetFullScreen.
+  bool fullscreen_size_constraints_suspended_ = false;
 
 #if BUILDFLAG(IS_LINUX)
   std::unique_ptr<GlobalMenuBarX11> global_menu_bar_;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6130,6 +6130,123 @@ describe('BrowserWindow module', () => {
         w.setResizable(true);
         expectBoundsEqual(w.getBounds(), bounds);
       });
+
+      ifit(process.platform !== 'darwin')('opens fullscreen when resizable and frame are false', async () => {
+        const w = new BrowserWindow({
+          resizable: false,
+          frame: false,
+          fullscreen: true
+        });
+
+        if (!w.isFullScreen()) await once(w, 'enter-full-screen');
+        await setTimeout();
+
+        expect(w.isFullScreen()).to.be.true('isFullScreen');
+
+        const { bounds } = screen.getDisplayMatching(w.getBounds());
+        expectBoundsEqual(w.getSize(), [bounds.width, bounds.height]);
+
+        const leaveFullScreen = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+        await setTimeout();
+
+        expect(w.isFullScreen()).to.be.false('isFullScreen');
+        expect(w.isResizable()).to.be.false('isResizable');
+      });
+
+      ifit(process.platform !== 'darwin')('enters fullscreen via setFullScreen() when resizable and frame are false', async () => {
+        const w = new BrowserWindow({
+          width: 400,
+          height: 300,
+          resizable: false,
+          frame: false
+        });
+
+        const enterFullScreen = once(w, 'enter-full-screen');
+        w.show();
+        w.setFullScreen(true);
+        await enterFullScreen;
+        await setTimeout();
+
+        expect(w.isFullScreen()).to.be.true('isFullScreen');
+
+        const { bounds } = screen.getDisplayMatching(w.getBounds());
+        expectBoundsEqual(w.getSize(), [bounds.width, bounds.height]);
+
+        const leaveFullScreen = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+        await setTimeout();
+
+        expect(w.isFullScreen()).to.be.false('isFullScreen');
+        expect(w.isResizable()).to.be.false('isResizable');
+      });
+
+      ifit(process.platform !== 'darwin')('restores the size lock when resizable is toggled while fullscreen', async () => {
+        const w = new BrowserWindow({
+          width: 400,
+          height: 300,
+          resizable: false,
+          frame: false,
+          fullscreen: true
+        });
+
+        if (!w.isFullScreen()) await once(w, 'enter-full-screen');
+        await setTimeout();
+
+        // Becoming resizable while fullscreen must not leave the suspended
+        // size constraints stuck once fullscreen ends.
+        w.setResizable(true);
+
+        const leaveFullScreen = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+        await setTimeout();
+
+        w.setResizable(false);
+
+        // The size lock has to follow the new bounds; if it were still
+        // suspended it would stay pinned to the pre-resize size. Race the
+        // resize against a timeout: a suspended lock clamps the window to its
+        // current size, so no 'resize' arrives and the assertion below reports
+        // the stale size rather than hanging.
+        const resized = once(w, 'resize');
+        w.setSize(500, 400);
+        await Promise.race([resized, setTimeout(2000)]);
+
+        expectBoundsEqual(w.getSize(), [500, 400]);
+      });
+
+      ifit(process.platform !== 'darwin')('does not lock to the fullscreen size when made non-resizable while fullscreen', async () => {
+        const w = new BrowserWindow({
+          width: 400,
+          height: 300,
+          frame: false,
+          fullscreen: true
+        });
+
+        if (!w.isFullScreen()) await once(w, 'enter-full-screen');
+        await setTimeout();
+
+        // Pinning min == max to the current size here would lock the window to
+        // the fullscreen size, leaving it unable to shrink back on the way out.
+        w.setResizable(false);
+
+        const leaveFullScreen = once(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+        await setTimeout();
+
+        expect(w.isFullScreen()).to.be.false('isFullScreen');
+        expect(w.isResizable()).to.be.false('isResizable');
+
+        // The window has to have shrunk back, not stayed at fullscreen size.
+        const { bounds } = screen.getDisplayMatching(w.getBounds());
+        const [width, height] = w.getSize();
+        expect(width).to.be.below(bounds.width, 'width');
+        expect(height).to.be.below(bounds.height, 'height');
+      });
     });
 
     describe('loading main frame state', () => {


### PR DESCRIPTION
`NativeWindowViews::SetBounds()` pins a non-resizable window's minimum and maximum size to its current bounds so it cannot be resized. Those constraints also stopped the window from growing to fill the screen, so a window with `resizable: false` never actually entered fullscreen — whether created with `fullscreen: true` or sent there later via `setFullScreen(true)`. This affects Windows and Linux for the same reason.

This PR suspends the size constraints while the window is fullscreen and re-pins them to the restored size on leaving. The suspended state is tracked with a `fullscreen_size_constraints_suspended_` member managed in `SetFullScreen()`, so it works for runtime transitions as well as windows born fullscreen.

`SetResizable()` handles the mid-fullscreen cases too:

- Made non-resizable while fullscreen: the constraints are suspended instead of pinned to the fullscreen size, so the window can shrink back on the way out.
- Made resizable while fullscreen: leaving fullscreen always clears the suspended state, so the size lock keeps following the window's bounds afterwards.

Four specs cover these paths: born fullscreen, runtime `setFullScreen(true)`, and both orderings of toggling `resizable` while fullscreen.

Fixes #51957.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed non-resizable windows failing to enter fullscreen on Windows and Linux.
