### PR TITLE
fix: don't apply page csp to isolated preload codegen

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -364,6 +364,12 @@ void HostInitializeImportMetaObject(v8::Local<v8::Context> context,
                                                             meta);
 }
 
+bool IsElectronIsolatedWorld(v8::Local<v8::Context> context) {
+  blink::WebLocalFrame* frame = blink::WebLocalFrame::FrameForContext(context);
+  return frame && frame->GetScriptContextWorldId(context) ==
+                      electron::WorldIDs::ISOLATED_WORLD_ID;
+}
+
 v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(
     v8::Local<v8::Context> context,
     v8::Local<v8::Value> source,
@@ -386,6 +392,13 @@ v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(
   // If we're in the renderer with contextIsolation disabled, ask blink first
   // (for CSP), and iff that allows codegen, delegate to node.
   if (electron::IsRendererProcess()) {
+    // Electron preload scripts run in the isolated world when contextIsolation
+    // is enabled, so page CSP should not make their code generation change as
+    // the document parses.
+    if (IsElectronIsolatedWorld(context))
+      return node::ModifyCodeGenerationFromStrings(context, source,
+                                                   is_code_like);
+
     v8::ModifyCodeGenerationFromStringsResult result =
         blink::V8Initializer::CodeGenerationCheckCallbackInMainThread(
             context, source, is_code_like);

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -545,6 +545,54 @@ describe('web security', () => {
         }
       });
     }
+
+    it('does not apply page csp to isolated preload scripts', async () => {
+      const tmpDir = await fs.promises.mkdtemp(path.join(app.getPath('temp'), 'electron-preload-csp-'));
+      defer(() => fs.promises.rm(tmpDir, { recursive: true, force: true }));
+
+      const channel = `preload-csp-${path.basename(tmpDir)}`;
+      const preloadPath = path.join(tmpDir, 'preload.js');
+      await fs.promises.writeFile(
+        preloadPath,
+        `
+          const { ipcRenderer } = require('electron');
+          const results = [];
+          const checkCodeGeneration = (phase) => {
+            try {
+              new Function('return true')();
+              results.push([phase, 'allowed']);
+            } catch (error) {
+              results.push([phase, error.name]);
+            }
+          };
+          checkCodeGeneration('initial');
+          window.addEventListener('DOMContentLoaded', () => {
+            checkCodeGeneration('domcontentloaded');
+            ipcRenderer.send(${JSON.stringify(channel)}, results);
+          });
+        `
+      );
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          preload: preloadPath,
+          sandbox: false,
+          contextIsolation: true
+        }
+      });
+
+      const cspResults = once(ipcMain, channel);
+      await w.loadURL(`data:text/html,
+        <!DOCTYPE html>
+        <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+      `);
+      const [, results] = await cspResults;
+      expect(results).to.deep.equal([
+        ['initial', 'allowed'],
+        ['domcontentloaded', 'allowed']
+      ]);
+    });
   });
 
   it('does not crash when multiple WebContent are created with web security disabled', () => {


### PR DESCRIPTION
#### Description of Change

This fixes a regression where an unsandboxed, context-isolated preload script can run string code generation initially, but the same preload context becomes blocked by the embedding page's CSP once `DOMContentLoaded` fires.

- Keep page CSP enforcement for main-world renderer code generation.
- Exempt Electron's isolated preload world from the page CSP code-generation callback, so preload string code generation does not change after document parsing begins.
- Add a regression spec for an unsandboxed, context-isolated preload under a restrictive page CSP.

Fixes #48240.

#### Validation

- `python3 script/run-clang-format.py -c shell/common/node_bindings.cc`
- `python3 script/run-clang-format.py -r -c shell/common/node_bindings.cc`
- `yarn oxfmt --check spec/chromium-spec.ts`
- `node script/lint.js --js --only -- spec/chromium-spec.ts`
- `node script/lint.js --cc --only -- shell/common/node_bindings.cc`
- `git diff --check`
- `e build`
- `ELECTRON_OUT_DIR=Testing npm run test -- -g "does not apply page csp to isolated preload scripts"`
- `npm run lint`

I also attempted `ELECTRON_OUT_DIR=Testing npm test`; it progressed through 3,347 tests and then stalled locally in the fullscreen/UI portion of the Chromium feature tests. I stopped that local full-suite run after confirming the log was no longer advancing. The focused regression test above passed against the built Electron binary.

#### AI Assistance Disclosure

This contribution was prepared with AI assistance and reviewed before submission. The commit includes an `Assisted-By: OpenAI Codex` trailer.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed isolated preload scripts being blocked by page Content-Security-Policy after page parsing.

