### PR TITLE
fix: edge resizing of frameless windows on Linux/Wayland

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -222,6 +222,19 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
                              native_window_view_->GetOpacity() < 1.0;
 
   auto* fvl = native_window_view_->GetFrameViewLinux();
+  if (fvl) {
+    // Re-evaluate shadow support on every hints update instead of relying
+    // solely on the one-shot call in OnWidgetInitDone(): the platform
+    // window's capabilities are only meaningful once it exists, and a stale
+    // `false` permanently zeroes the CSD resize band and the decoration
+    // insets reported through CalculateInsetsInDIP(), leaving frameless
+    // windows impossible to resize by their edges on Wayland.
+    // BrowserDesktopWindowTreeHostLinux checks SupportsClientFrameShadow()
+    // live on every update for the same reason.
+    fvl->SetSupportsClientFrameShadow(SupportsClientFrameShadow() &&
+                                      !native_window_view_->IsTranslucent());
+  }
+
   if (!fvl || !fvl->ShouldDrawRestoredFrameShadow()) {
     platform_window()->SetInputRegion(std::nullopt);
     if (ui::OzonePlatform::GetInstance()->IsWindowCompositingSupported()) {

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -5,14 +5,17 @@
 
 #include "shell/browser/ui/views/electron_frame_view_linux.h"
 
+#include "base/check_op.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/caption_button_placeholder_container.h"
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
+#include "shell/browser/ui/views/frameless_view.h"
 #include "ui/base/hit_test.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_delegate.h"
 #include "ui/views/window/frame_caption_button.h"
 
 namespace electron {
@@ -66,10 +69,53 @@ bool ElectronFrameViewLinux::HasWindowTitle() const {
   return false;
 }
 
+views::View* ElectronFrameViewLinux::TargetForRect(views::View* root,
+                                                   const gfx::Rect& rect) {
+  CHECK_EQ(root, this);
+
+  // Events that hit-test to a resize border must be targeted at the frame
+  // view: for frameless windows the client (web contents) view covers the
+  // same pixels, and if it becomes the event target the interactive resize
+  // never starts. FramelessView and WinFrameView do the equivalent; this
+  // view lost that behaviour when it moved onto views::FrameViewLinux.
+  switch (NonClientHitTest(rect.origin())) {
+    case HTLEFT:
+    case HTRIGHT:
+    case HTTOP:
+    case HTBOTTOM:
+    case HTTOPLEFT:
+    case HTTOPRIGHT:
+    case HTBOTTOMLEFT:
+    case HTBOTTOMRIGHT:
+      return this;
+    default:
+      return FrameViewLinux::TargetForRect(root, rect);
+  }
+}
+
 int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
   int result = FrameViewLinux::NonClientHitTest(point);
   if (result != HTCLIENT)
     return result;
+
+  // FrameViewLinux's resize hit-test only sees GetFrameBorderInsets(), i.e.
+  // the (shadow-only on Wayland) outer border, and the client_view() check
+  // returns HTCLIENT before it even runs for inside-edge points. Re-test
+  // here with an additive inside-edge band so frameless/WCO windows have a
+  // draggable resize handle inside the visible window edge — the same band
+  // FramelessView uses, which NativeWindow::NonClientHitTest can't reach
+  // because this view is not a FramelessView.
+  if (GetWidget()->widget_delegate()->CanResize()) {
+    constexpr int kResizeAreaCornerSize = 16;  // matches FrameViewLinux
+    const gfx::Insets resize_border =
+        GetFrameBorderInsets() +
+        gfx::Insets(FramelessView::kResizeInsideBoundsSize);
+    int component =
+        GetHTComponentForFrame(point, resize_border, kResizeAreaCornerSize,
+                               kResizeAreaCornerSize, /*can_resize=*/true);
+    if (component != HTNOWHERE)
+      return component;
+  }
 
   // The base class returns HTCLIENT for the WCO titlebar area because the
   // client view overlaps it. Check buttons and the draggable overlay region.

--- a/shell/browser/ui/views/electron_frame_view_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_linux.h
@@ -31,6 +31,7 @@ class ElectronFrameViewLinux : public views::FrameViewLinux {
 
   // views::FrameViewLinux:
   bool HasWindowTitle() const override;
+  views::View* TargetForRect(views::View* root, const gfx::Rect& rect) override;
   int NonClientHitTest(const gfx::Point& point) override;
   void Layout(PassKey) override;
   gfx::Size GetMinimumSize() const override;


### PR DESCRIPTION
#### Description of Change

ElectronFrameViewLinux sits on views::FrameViewLinux, not FramelessView,
so it lost two things FramelessView provides: a TargetForRect that keeps
resize-border events on the frame view, and the kResizeInsideBoundsSize
inside-edge hit band (NativeWindow::NonClientHitTest only re-adds that
when the frame view is a FramelessView). FrameViewLinux's own resize
hit-test only covers GetFrameBorderInsets(), which on Wayland is the
shadow-only outer margin — and that band is zero anyway when
supports_client_frame_shadow_ stays cached at the value read before the
platform window existed.

* electron_desktop_window_tree_host_linux: refresh
  SetSupportsClientFrameShadow() in UpdateFrameHints(), same as
  BrowserDesktopWindowTreeHostLinux, so the layout doesn't keep a stale
  false from widget-init time.
* ElectronFrameViewLinux::NonClientHitTest: when the base class says
  HTCLIENT, re-test with GetFrameBorderInsets() + kResizeInsideBoundsSize
  so there's a 5px resize band just inside the visible edge.
* ElectronFrameViewLinux::TargetForRect: return `this` for the eight
  resize HT components so the overlapping client view doesn't swallow the
  press; scoped to resize codes only so WCO caption-button clicks still
  reach the buttons.

cc @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where resizing didn't work on Wayland in some circumstances.