### PR TITLE
fix: edge resizing of frameless windows on Linux/Wayland

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -218,6 +218,15 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     if (!layout)
       return;
 
+    // The layout caches CheckClientFrameShadowSupport() in its constructor,
+    // which runs during widget init before the platform window can answer —
+    // a stale `false` permanently zeroes the CSD resize band and the
+    // decoration insets reported via CalculateInsetsInDIP(), leaving
+    // frameless windows impossible to resize by their edges on Wayland.
+    // Refresh it from the live capability whenever the frame hints update.
+    layout->set_host_supports_client_frame_shadow(
+        SupportsClientFrameShadow() && !native_window_view_->IsTranslucent());
+
     ui::PlatformWindow* window = platform_window();
     auto window_state = window->GetPlatformWindowState();
     float scale = device_scale_factor();

--- a/shell/browser/ui/views/linux_frame_layout.cc
+++ b/shell/browser/ui/views/linux_frame_layout.cc
@@ -53,8 +53,13 @@ std::unique_ptr<LinuxFrameLayout> LinuxFrameLayout::Create(
 }
 
 gfx::Insets LinuxFrameLayout::GetResizeBorderInsets() const {
-  gfx::Insets insets = RestoredFrameBorderInsets();
-  return insets.IsEmpty() ? GetInputInsets() : insets;
+  const gfx::Insets insets = RestoredFrameBorderInsets();
+  if (insets.IsEmpty())
+    return GetInputInsets();
+  // The frame border (shadow) band sits entirely outside the window geometry
+  // and Wayland compositors don't reliably deliver pointer events there, so
+  // also hit-test a band just inside the visible edge.
+  return insets + gfx::Insets(kResizeInsideBoundsSize);
 }
 
 SkRRect LinuxFrameLayout::GetRoundedWindowBounds() const {

--- a/shell/browser/ui/views/linux_frame_layout.h
+++ b/shell/browser/ui/views/linux_frame_layout.h
@@ -55,6 +55,9 @@ class LinuxFrameLayout {
 
   bool IsShowingShadow() const;
   bool SupportsClientFrameShadow() const;
+  void set_host_supports_client_frame_shadow(bool supports) {
+    host_supports_client_frame_shadow_ = supports;
+  }
 
   bool tiled() const;
   void set_tiled(bool tiled);

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -167,7 +167,25 @@ void OpaqueFrameView::ResetWindowControls() {
 
 views::View* OpaqueFrameView::TargetForRect(views::View* root,
                                             const gfx::Rect& rect) {
-  return views::FrameView::TargetForRect(root, rect);
+  // Events that hit-test to a resize border must be targeted at the frame
+  // view: the client (web contents) view covers the same pixels, and if it
+  // becomes the event target the interactive resize never starts.
+  // FramelessView::TargetForRect forwards every non-HTCLIENT component, which
+  // would also swallow WCO caption-button clicks, so forward only the resize
+  // components here.
+  switch (NonClientHitTest(rect.origin())) {
+    case HTLEFT:
+    case HTRIGHT:
+    case HTTOP:
+    case HTBOTTOM:
+    case HTTOPLEFT:
+    case HTTOPRIGHT:
+    case HTBOTTOMLEFT:
+    case HTBOTTOMRIGHT:
+      return this;
+    default:
+      return views::FrameView::TargetForRect(root, rect);
+  }
 }
 
 void OpaqueFrameView::Layout(PassKey) {


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/51992.

See that PR for details.

Notes: Fixed an issue where resizing didn't work on Wayland in some circumstances.