### PR TITLE
fix: edge resizing of frameless windows on Linux/Wayland

### DIFF
--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -218,6 +218,15 @@ void ElectronDesktopWindowTreeHostLinux::UpdateFrameHints() {
     if (!layout)
       return;
 
+    // The layout caches CheckClientFrameShadowSupport() in its constructor,
+    // which runs during widget init before the platform window can answer —
+    // a stale `false` permanently zeroes the CSD resize band and the
+    // decoration insets reported via CalculateInsetsInDIP(), leaving
+    // frameless windows impossible to resize by their edges on Wayland.
+    // Refresh it from the live capability whenever the frame hints update.
+    layout->set_host_supports_client_frame_shadow(
+        SupportsClientFrameShadow() && !native_window_view_->IsTranslucent());
+
     ui::PlatformWindow* window = platform_window();
     auto window_state = window->GetPlatformWindowState();
     float scale = device_scale_factor();

--- a/shell/browser/ui/views/linux_frame_layout.h
+++ b/shell/browser/ui/views/linux_frame_layout.h
@@ -55,6 +55,9 @@ class LinuxFrameLayout {
 
   bool IsShowingShadow() const;
   bool SupportsClientFrameShadow() const;
+  void set_host_supports_client_frame_shadow(bool supports) {
+    host_supports_client_frame_shadow_ = supports;
+  }
 
   bool tiled() const;
   void set_tiled(bool tiled);

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -168,7 +168,23 @@ void OpaqueFrameView::ResetWindowControls() {
 
 views::View* OpaqueFrameView::TargetForRect(views::View* root,
                                             const gfx::Rect& rect) {
-  return views::FrameView::TargetForRect(root, rect);
+  // Presses that hit-test to a resize border must be targeted at the frame
+  // view itself: for frameless windows the client (web contents) view covers
+  // the same pixels, and if it becomes the event target the interactive
+  // resize never starts. Everything else keeps the existing routing.
+  switch (NonClientHitTest(rect.origin())) {
+    case HTLEFT:
+    case HTRIGHT:
+    case HTTOP:
+    case HTBOTTOM:
+    case HTTOPLEFT:
+    case HTTOPRIGHT:
+    case HTBOTTOMLEFT:
+    case HTBOTTOMRIGHT:
+      return this;
+    default:
+      return views::FrameView::TargetForRect(root, rect);
+  }
 }
 
 void OpaqueFrameView::Layout(PassKey) {


### PR DESCRIPTION
Manual backport of https://github.com/electron/electron/pull/51992.

See that PR for details.

Notes: Fixed an issue where resizing didn't work on Wayland in some circumstances.