### PR TITLE
docs: fix Electron Fiddle documentation

### DIFF
--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -27,10 +27,9 @@ Electron's maintainers. We highly recommend installing it as a learning tool to
 experiment with Electron's APIs or to prototype features during development.
 
 Fiddle also integrates nicely with our documentation. When browsing through examples
-in our tutorials, you'll frequently see an "Open in Electron Fiddle" button next to
-a code block. If you have Fiddle installed, this button will open a
-`fiddle.electronjs.org` link that will automatically load the example into Fiddle,
-no copy-pasting required.
+in our tutorials, you'll frequently see an "Open in Fiddle" button next to a code
+block. If you have Fiddle installed, this button will open a `fiddle.electronjs.org`
+link that will automatically load the example into Fiddle, no copy-pasting required.
 
 ```fiddle docs/fiddles/quick-start
 ```

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -27,7 +27,7 @@ Electron's maintainers. We highly recommend installing it as a learning tool to
 experiment with Electron's APIs or to prototype features during development.
 
 Fiddle also integrates nicely with our documentation. When browsing through examples
-in our tutorials, you'll frequently see an "Open in Electron Fiddle" button underneath
+in our tutorials, you'll frequently see an "Open in Electron Fiddle" button next to
 a code block. If you have Fiddle installed, this button will open a
 `fiddle.electronjs.org` link that will automatically load the example into Fiddle,
 no copy-pasting required.

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -27,7 +27,7 @@ Electron's maintainers. We highly recommend installing it as a learning tool to
 experiment with Electron's APIs or to prototype features during development.
 
 Fiddle also integrates nicely with our documentation. When browsing through examples
-in our tutorials, you'll frequently see an "Open in Fiddle" button next to a code
+in our tutorials, you'll frequently see an "Open in Fiddle" button above a code
 block. If you have Fiddle installed, this button will open a `fiddle.electronjs.org`
 link that will automatically load the example into Fiddle, no copy-pasting required.
 


### PR DESCRIPTION
#### Description of Change

The documentation page that mentions Electron Fiddle says there's an "Open in Electron Fiddle" button underneath the code blocks. However this appears to have changed and is now above/next to them (also the button name is slightly different):

<img width="844" height="389" alt="image" src="https://github.com/user-attachments/assets/27ea83ae-94c6-4d2c-ad91-0f2af7e31cfe" />

So updated the documentation to fix this.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
