### PR TITLE
fix: frameless window shrinks on `maximize()` when compositor declines

### DIFF
--- a/shell/browser/ui/views/electron_frame_view_layout_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_layout_linux.cc
@@ -56,7 +56,21 @@ gfx::ShadowValues ElectronFrameViewLayoutLinux::GetShadowValues(
     bool active) const {
   if (!window_->HasShadow())
     return gfx::ShadowValues();
-  return FrameViewLayoutLinux::GetShadowValues(active);
+  // FrameViewLayoutLinux::GetShadowValues() returns {} when
+  // widget->IsMaximized()/IsFullscreen(), which makes
+  // GetRestoredFrameBorderInsets() — and so CalculateInsetsInDIP() — depend
+  // on the optimistic applied_state set by TriggerStateChanges.
+  // On compositors that decline set_maximized (e.g.
+  // sway floating) the two CalculateInsetsInDIP calls per configure then
+  // disagree and the window shrinks by ~30x41px per maximize().
+  if (tiled())
+    return gfx::ShadowValues();
+  auto* provider = views::LayoutProvider::Get();
+  if (!provider)
+    return gfx::ShadowValues();
+  return gfx::ShadowValue::MakeMdShadowValues(
+      provider->GetShadowElevationMetric(active ? views::Emphasis::kMaximum
+                                                : views::Emphasis::kMedium));
 }
 
 gfx::RoundedCornersF ElectronFrameViewLayoutLinux::GetCornerRadii() const {

--- a/shell/browser/ui/views/electron_frame_view_layout_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_layout_linux.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
 
 #include "shell/browser/native_window_views.h"
+#include "ui/views/layout/layout_provider.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/caption_button_layout_constants.h"
 #include "ui/views/window/frame_view_linux.h"


### PR DESCRIPTION
#### Description of Change

On Wayland, `BrowserWindow.maximize()` on a frameless / titleBarStyle:hidden / WCO window shrinks the window by ~30x41px each call when the compositor ignores `xdg_toplevel.set_maximized` (sway floating windows, any tiling WM).

Ozone calls `PlatformWindowDelegate::CalculateInsetsInDIP(window_state)` twice per configure — once in `HandleToplevelConfigureWithOrigin` to outset the compositor geometry to widget bounds, and again in `SetWindowGeometry` to inset back — and assumes both calls return the same value for the same `window_state`. Our override returns `GetRestoredFrameBorderInsets()` for `kNormal`, which reaches `FrameViewLayoutLinux::GetShadowValues()` and reads `widget->IsMaximized()`. `TriggerStateChanges()`' optimistic `ForceApplyWindowStateDoNotUse(kMaximized)` is live for the first call and reverted by the second, so the insets are ~2x1 then ~32x42 and the geometry round-trip loses 30x41px.

Stop delegating to the base `GetShadowValues()` and compute the restored shadow values directly, so "restored" insets describe the restored state regardless of current widget state. Painting is unaffected: the maximized and fullscreen paint paths don't consult `GetShadowValues()`, and `GetFrameBorderInsets()` has its own `IsMaximized()` guard.

Also quiets the` xdg_toplevel.set_min_size` (2,1)<->(1,1) flutter on every `maximize()` which had the same cause.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixes an issue where clicking the maximize button could progressively shrink the window in some Wayland environments.