### PR TITLE
docs: added documentation and a Fiddle for WCO breaking changes on Linux in Electron 43.x

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,10 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (43.0)
 
+### Behavior Changed: WCO respects user settings for the title bar layout on Linux
+
+Frameless windows with Window Controls Overlay (WCO) now take into account user settings from the desktop environment on Linux. For example, on GNOME, there may be only a Close button by default. Controls may appear on the left or right side of the frame (or both). To account for all possibilities, use CSS variables to constrain your title bar content to the safe area. See the updated [custom title bar](./tutorial/custom-title-bar.md) guide for an example.
+
 ### Removed: Unity desktop environment support on Linux
 
 Unity has not been the default desktop environment in Ubuntu LTS since version 16.04, which is not supported by current versions of Electron. The deprecation does not

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,9 +14,9 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (43.0)
 
-### Behavior Changed: WCO respects user settings for the title bar layout on Linux
+### Behavior Changed: WCO respects the native title bar layout on Linux
 
-Frameless windows with Window Controls Overlay (WCO) now take into account user settings from the desktop environment on Linux. For example, on GNOME, there may be only a Close button by default. Controls may appear on the left or right side of the frame (or both). To account for all possibilities, use CSS variables to constrain your title bar content to the safe area. See the updated [custom title bar](./tutorial/custom-title-bar.md) guide for an example.
+Frameless windows with Window Controls Overlay (WCO) now adopt the native title bar layout and user settings on Linux. For example, controls will appear on the left side of the frame on RTL systems, and only the close button will be visible by default on GNOME. Depending on the user's desktop environment and configuration, buttons can appear on the left or right side of the frame (or both). To account for all possibilities, use the CSS variables `env(titlebar-area-x, 0px)` and `env(titlebar-area-width, 100%)` to constrain your app's title bar content to a safe area.
 
 ### Removed: Unity desktop environment support on Linux
 

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/index.html
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <link href="./styles.css" rel="stylesheet">
+    <title>Custom Titlebar App</title>
+  </head>
+  <body>
+	  <!-- mount your title bar at the top of you application's body tag -->
+    <div class="titlebar">Cool titlebar</div>
+  </body>
+</html>

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/main.js
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/main.js
@@ -1,0 +1,16 @@
+const { app, BrowserWindow } = require('electron')
+
+function createWindow () {
+  const win = new BrowserWindow({
+    // remove the default titlebar
+    titleBarStyle: 'hidden',
+    // expose window controls in Windows/Linux
+    ...(process.platform !== 'darwin' ? { titleBarOverlay: true } : {})
+  })
+
+  win.loadFile('index.html')
+}
+
+app.whenReady().then(() => {
+  createWindow()
+})

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/styles.css
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/styles.css
@@ -1,0 +1,17 @@
+body {
+  margin: 0;
+}
+.titlebar {
+  background: blue;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  app-region: drag;
+  
+  margin-left: env(titlebar-area-x, 0);
+  width:       env(titlebar-area-width, 100%);
+  height:      env(titlebar-area-height, 30px);
+  box-sizing: border-box;
+  border: 1px dashed red;
+}

--- a/docs/tutorial/custom-title-bar.md
+++ b/docs/tutorial/custom-title-bar.md
@@ -62,9 +62,10 @@ bar to reposition our app window!
 For more information around how to manage drag regions defined by your electron application,
 see the [Custom draggable regions][] section below.
 
-One more step: depending on the platform and user settings, the window may show a different
-number of controls, and they may be on the left or right side of the frame (or both). We can
-create a safe area so our own content and controls won't overlap.
+One more step: we should make sure our title bar content doesn't overlap with the native
+window controls. Buttons can appear on the right or left side of the frame (or both) depending
+on RTL and the user's settings. We can create a safe area using the CSS variables
+`env(titlebar-area-x, 0px)` and `env(titlebar-area-width, 100%)`.
 
 ```fiddle docs/fiddles/features/window-customization/custom-title-bar/safe-area
 

--- a/docs/tutorial/custom-title-bar.md
+++ b/docs/tutorial/custom-title-bar.md
@@ -62,6 +62,14 @@ bar to reposition our app window!
 For more information around how to manage drag regions defined by your electron application,
 see the [Custom draggable regions][] section below.
 
+One more step: depending on the platform and user settings, the window may show a different
+number of controls, and they may be on the left or right side of the frame (or both). We can
+create a safe area so our own content and controls won't overlap.
+
+```fiddle docs/fiddles/features/window-customization/custom-title-bar/safe-area
+
+```
+
 Congratulations, you've just implemented a basic custom title bar!
 
 ## Advanced window customization


### PR DESCRIPTION
#### Description of Change

Electron 43 introduces ElectronFrameViewLinux, which respects platform/user settings for button layout and visibility for WCO. This can impact apps which use WCO, so I called out the breaking change and provided an example Fiddle in the custom title bar tutorial. 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> none
