### PR TITLE
fix: fix `additionalData` parsing when serialized form has null byte followed by whitespace

### DIFF
--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -65,7 +65,7 @@ index 7da4c199de1d2721a2e6ba9cb10ba0bc146917b7..b100f5feb95aabf63558aebc4d0054c9
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 55f935f38bf05586650e7a83a689347bb41a45a4..3dc3e4836238c92b4a192a410f3b7c643a39611e 100644
+index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0df993b22 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -621,6 +621,7 @@ class ProcessSingleton::LinuxWatcher
@@ -106,6 +106,15 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..3dc3e4836238c92b4a192a410f3b7c64
    const size_t kMinMessageLength = kStartToken.length() + 4;
    if (bytes_read_ < kMinMessageLength) {
      buf_[bytes_read_] = 0;
+@@ -729,7 +735,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+       base::as_string_view(base::span(buf_).first(bytes_read_));
+   std::vector<std::string> tokens =
+       base::SplitString(str, std::string(1, kTokenDelimiter),
+-                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
++                        base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
+ 
+   if (tokens.size() < 3 || tokens[0] != kStartToken) {
+     LOG(ERROR) << "Wrong message format: " << str;
 @@ -747,10 +753,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -359,6 +359,19 @@ describe('app module', () => {
       });
     });
 
+    it('preserves NUL followed by whitespace in additional data', async () => {
+      // The real invariant here is the V8-serialized format of the data. Using
+      // a string here is just a convenient way to test the invariant.
+      const expectedAdditionalData = {
+        value: 'foo\0\tbar'
+      };
+
+      await testArgumentPassing({
+        args: ['--send-data', `--data-content=${JSON.stringify(expectedAdditionalData)}`],
+        expectedAdditionalData
+      });
+    });
+
     it('sends and receives boolean data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=false'],


### PR DESCRIPTION
#### Description of Change

Resolves #52020. `additionalData` is serialized and then put into a string that is split on `\0`. We put the pieces back together, but the split operation also trims whitespace, which can corrupt the serialized value if there is a `\0` byte with a whitespace byte immediately following. This is a minimum fix that disables the whitespace trimming. More complex approaches may be more preferable.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some values passed into `requestSingleInstanceLock` could result in a crash.