### PR TITLE
test: use node16 moduleResolution in tsconfig and clean up imports

### DIFF
--- a/spec/api-autoupdater-darwin-spec.ts
+++ b/spec/api-autoupdater-darwin-spec.ts
@@ -1,8 +1,8 @@
 import { autoUpdater, systemPreferences } from 'electron';
 
 import { expect } from 'chai';
-import * as express from 'express';
-import * as psList from 'ps-list';
+import express from 'express';
+import psList from 'ps-list';
 import * as uuid from 'uuid';
 
 import * as cp from 'node:child_process';

--- a/spec/api-autoupdater-msix-spec.ts
+++ b/spec/api-autoupdater-msix-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as express from 'express';
+import express from 'express';
 
 import * as http from 'node:http';
 import { AddressInfo } from 'node:net';

--- a/spec/api-crash-reporter-spec.ts
+++ b/spec/api-crash-reporter-spec.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron/main';
 
-import * as Busboy from 'busboy';
+import Busboy from 'busboy';
 import { expect } from 'chai';
 import * as uuid from 'uuid';
 

--- a/spec/api-safe-storage-spec.ts
+++ b/spec/api-safe-storage-spec.ts
@@ -2,7 +2,7 @@ import { safeStorage } from 'electron/main';
 
 import * as chai from 'chai';
 import { expect } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised from 'chai-as-promised';
 
 import * as cp from 'node:child_process';
 import { once } from 'node:events';

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -1,8 +1,8 @@
 import { app, session, BrowserWindow, net, ipcMain, Session, webFrameMain, WebFrameMain } from 'electron/main';
 
-import * as auth from 'basic-auth';
+import auth from 'basic-auth';
 import { expect } from 'chai';
-import * as send from 'send';
+import send from 'send';
 
 import * as ChildProcess from 'node:child_process';
 import { once } from 'node:events';

--- a/spec/modules-spec.ts
+++ b/spec/modules-spec.ts
@@ -319,7 +319,7 @@ describe('modules support', () => {
     it('the built-in "electron" module loaded via ESM import has the same exports as the CJS module', async () => {
       const esmElectron = await import('electron');
       const cjsElectron = require('electron');
-      expect(Object.keys(esmElectron)).to.deep.equal(Object.keys(cjsElectron));
+      expect(Object.keys(esmElectron)).to.include.members(Object.keys(cjsElectron));
     });
   });
 });

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
 
-import * as auth from 'basic-auth';
+import auth from 'basic-auth';
 import { expect } from 'chai';
 
 import { once } from 'node:events';

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "module": "nodenext",
+    "moduleResolution": "node16",
+    "noEmit": true
+  },
   "include": [
     "spec",
     "typings"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Moves our `tsconfig.spec.json` file to using `node16` for `moduleResolution` and `nodenext` for `module` settings. This aligns us with [the defaults from `@tsconfig/node22`](https://github.com/tsconfig/bases/blob/12474cd696ec17c6ac4ccc19261860bf3c7fdc56/bases/node22.json#L6-L15), and should let us start consuming newer versions of our ecosystem packages like `@electron/fuses` and `@electron/packager` in our tests.

This also throws in `skipLibCheck` too so that `yarn tsc -p tsconfig.spec.json` runs clean.

Small change needed in `spec/modules-spec.ts` as after this change the ESM exports in the test include `default` and `module.exports` (which aligns better with what you get in Fiddle if you dynamic import `electron`), so check that the CJS exports are all included in the ESM exports but not strictly equal.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
