### PR TITLE
docs: remove unnecessary heading

### DIFF
--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -167,8 +167,6 @@ async function recordTrace () {
 }
 ```
 
-## Viewing recorded heap dumps
-
 To view the recorded heap dumps:
 
 1. Download the breakpad symbols for your Electron version from the Electron GitHub


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This heading sneaked in via https://github.com/electron/electron/pull/51987.

1. This is documentation for the function. It's not a separate section. It should show up in the JSDoc of the function.
2. It should thus not be a separate heading (and especially not one that's further up in the hierarchy than the function itself).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none