### PR TITLE
ci: calculate rerun apply patches date from first run attempt

### DIFF
--- a/.github/workflows/rerun-apply-patches.yml
+++ b/.github/workflows/rerun-apply-patches.yml
@@ -60,7 +60,9 @@ jobs:
             fi
 
             # Skip runs older than 25 days (GitHub does not allow rerunning after ~1 month)
-            RUN_CREATED=$(gh run view "$RUN_ID" --json createdAt --jq '.createdAt')
+            # Use the first attempt's creation date: createdAt reflects the most recent
+            # rerun, so it would reset the age on every rerun and never trip this check
+            RUN_CREATED=$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/attempts/1" --jq '.created_at')
             RUN_AGE_DAYS=$(( ($(date +%s) - $(date -d "$RUN_CREATED" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$RUN_CREATED" +%s)) / 86400 ))
 
             if [ "$RUN_AGE_DAYS" -gt 25 ]; then


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Follow-up to #51524, which didn't fully fix the issue as it was pulling the age of the most recent run, while GitHub uses the age of the first run.

It looks like there was also a Trop hiccup on #51524 and it didn't get backported to all of the target branches, so when I backport this PR I'll roll those changes into the branches that didn't get that PR originally.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
