### PR TITLE
fix: running under `NODE_OPTIONS='--import=tsx'`

### DIFF
--- a/patches/node/fix_expose_the_built-in_electron_module_via_the_esm_loader.patch
+++ b/patches/node/fix_expose_the_built-in_electron_module_via_the_esm_loader.patch
@@ -5,6 +5,18 @@ Subject: fix: expose the built-in electron module via the ESM loader
 
 This allows usage of `import { app } from 'electron'` and `import('electron')` natively in the browser + non-sandboxed renderer
 
+diff --git a/lib/internal/modules/customization_hooks.js b/lib/internal/modules/customization_hooks.js
+index c2579269ec6396097aee1acd45d2830500a6a57a..70cb459d10d60caac56f9c980fbba242d5e7881c 100644
+--- a/lib/internal/modules/customization_hooks.js
++++ b/lib/internal/modules/customization_hooks.js
+@@ -286,6 +286,7 @@ function validateSourceStrict(url, context, result) {
+   // the builtins even though the default load step only provides null as source,
+   // and any source content for builtins provided by the user hooks are ignored.
+   if (!StringPrototypeStartsWith(url, 'node:') &&
++    !StringPrototypeStartsWith(url, 'electron:') &&
+     typeof result.source !== 'string' &&
+       !isAnyArrayBuffer(source) &&
+       !isArrayBufferView(source) &&
 diff --git a/lib/internal/modules/esm/get_format.js b/lib/internal/modules/esm/get_format.js
 index 4f334c7d88c3369578880d5d343b756c3dda0a5a..c26059eb083ae721eddeeb85a3a0a1cb84217fe2 100644
 --- a/lib/internal/modules/esm/get_format.js

--- a/spec/fixtures/bar.txt
+++ b/spec/fixtures/bar.txt
@@ -1,0 +1,1 @@
+Lorem Ipsum

--- a/spec/fixtures/baz.txt
+++ b/spec/fixtures/baz.txt
@@ -1,0 +1,1 @@
+Lorem Ipsum

--- a/spec/fixtures/foo.txt
+++ b/spec/fixtures/foo.txt
@@ -1,0 +1,1 @@
+Lorem Ipsum

--- a/spec/fixtures/module/hook.mjs
+++ b/spec/fixtures/module/hook.mjs
@@ -1,0 +1,7 @@
+import { registerHooks } from 'node:module';
+
+registerHooks({
+  load(url, context, nextLoad) {
+    return nextLoad(url, context);
+  }
+});

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -7,6 +7,7 @@ import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { EventEmitter } from 'node:stream';
+import { pathToFileURL } from 'node:url';
 import * as util from 'node:util';
 
 import {
@@ -818,6 +819,21 @@ describe('node feature', () => {
         ...process.env,
         ELECTRON_FORCE_IS_PACKAGED: 'true',
         NODE_OPTIONS: `--require=${path.join(fixtures, 'module', 'fail.js')}`
+      };
+      // App should exit with code 0.
+      const child = childProcess.spawn(process.execPath, [appPath], { env });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+    });
+
+    it('does not throw --import hook in non-packaged apps', async () => {
+      const appPath = path.join(fixtures, 'module', 'noop.js');
+      // Since this is the import path - we should always use backward slashes
+      // regardless of the `path.sep` value.
+      const hookUrl = pathToFileURL(path.join(fixtures, 'module', 'hook.mjs'));
+      const env = {
+        ...process.env,
+        NODE_OPTIONS: `--import=${hookUrl}`
       };
       // App should exit with code 0.
       const child = childProcess.spawn(process.execPath, [appPath], { env });


### PR DESCRIPTION
#### Description of Change

Backport of #51947

Newer versions of `tsx` use Node.js customization hooks for transpiling .ts files on the fly. Here we add `electron:` scheme to the validation list so that it doesn't throw an error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fix running under tsx import transpilation