### PR TITLE
fix: update BrowserWindow title on same-document history back/forward navigation (#51948)

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2387,6 +2387,14 @@ void WebContents::DidFinishNavigation(
     if (is_same_document) {
       Emit("did-navigate-in-page", url, is_main_frame, frame_process_id,
            frame_routing_id);
+      if (is_main_frame) {
+        content::NavigationEntry* entry =
+            navigation_handle->GetNavigationEntry();
+        if (entry &&
+            (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK)) {
+          WebContents::TitleWasSet(entry);
+        }
+      }
     } else {
       const net::HttpResponseHeaders* http_response =
           navigation_handle->GetResponseHeaders();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4585,6 +4585,25 @@ describe('BrowserWindow module', () => {
           waitUntil(() => w.title === newTitle);
         });
 
+        it('updates title on same-document history navigation', async () => {
+          const newTitle = 'Second Title';
+          const pageTitleUpdated = once(w, 'page-title-updated');
+          await w.loadURL('data:text/html,<html><head><title>First Title</title></head><body></body></html>');
+          expect(w.title).to.equal('First Title');
+
+          await w.webContents.executeJavaScript(`
+            history.pushState({}, '', '/second');
+            document.title = '${newTitle}';
+          `);
+          await pageTitleUpdated;
+          await waitUntil(() => w.title === newTitle);
+
+          const backTitleUpdated = once(w, 'page-title-updated');
+          w.webContents.goBack();
+          await backTitleUpdated;
+          await waitUntil(() => w.title === 'First Title');
+        });
+
         it('works for stop events', async () => {
           const done = Promise.all(
             ['did-navigate', 'did-fail-load', 'did-stop-loading'].map((name) => once(w.webContents, name))


### PR DESCRIPTION
## Summary

Fixes #51948

BrowserWindow title was not updating when an SPA navigated via
`history.back()` / `history.forward()` / `webContents.goBack()` /
`webContents.goForward()`.

## Problem

In `WebContents::DidFinishNavigation`, same-document navigations are
handled in a separate branch that only emits `did-navigate-in-page`.
Unlike cross-document history transitions, this branch never called
`TitleWasSet()`, so the window title silently stayed out of sync with
the destination entry's cached title. The `page-title-updated` event
was never fired.

## Root Cause

The C++ workaround for Chromium issue (checking
`PAGE_TRANSITION_FORWARD_BACK` and calling `TitleWasSet(entry)`) was
only applied to **cross-document** navigations. Same-document
navigations in the `is_same_document` branch had no equivalent logic.

## Fix

In `WebContents::DidFinishNavigation`, after emitting
`did-navigate-in-page` for a same-document navigation on the **main
frame**, retrieve the committed `NavigationEntry` and check if its
transition type contains `ui::PAGE_TRANSITION_FORWARD_BACK`. If it
does, call `TitleWasSet(entry)` — identical to the existing
cross-document workaround — to correctly emit `page-title-updated` and
update the window title.

```cpp
if (is_main_frame) {
  content::NavigationEntry* entry =
      navigation_handle->GetNavigationEntry();
  if (entry &&
      (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK)) {
    WebContents::TitleWasSet(entry);
  }
}
