### PR TITLE
fix: remove 1px frame background color from the top of frameless windows on Linux

### DIFF
--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -13,6 +13,7 @@
 #include "ui/compositor/layer.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
+#include "ui/views/window/frame_background.h"
 #include "ui/views/window/frame_caption_button.h"
 
 namespace electron {
@@ -138,6 +139,11 @@ void ElectronFrameViewLinux::Layout(PassKey) {
 void ElectronFrameViewLinux::PaintRestoredFrameBorder(gfx::Canvas* canvas) {
   if (!WantsFrame())
     return;
+
+  // Prevent the default system titlebar background from being drawn at the top
+  // of frameless windows. Does not affect WCO which draws its own top area.
+  frame_background()->set_top_area_height(0);
+
   FrameViewLinux::PaintRestoredFrameBorder(canvas);
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/51457.

Frameless windows on Linux were still drawing the system titlebar background, which could sometimes leak through at the top edge of the frame. This was especially obvious at fractional scales when the system theme contrasted with the window's background colour.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed an issue on Linux where the system theme color appeared at the top edge of frameless windows.