### PR TITLE
build: remove unneeded stripping

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1817,8 +1817,6 @@ dist_zip("electron_dist_zip") {
         ":strip_chrome_crashpad_handler",
         ":strip_chrome_sandbox",
         ":strip_electron_binary",
-        ":strip_libEGL_shlib",
-        ":strip_libGLESv2_shlib",
         ":strip_libffmpeg_shlib",
         ":strip_libvk_swiftshader_shlib",
       ]
@@ -1877,8 +1875,6 @@ dist_zip("electron_mksnapshot_zip") {
   data_deps = mksnapshot_deps
   if (is_linux && is_official_build) {
     data_deps += [
-      ":strip_libEGL_shlib",
-      ":strip_libGLESv2_shlib",
       ":strip_libffmpeg_shlib",
       ":strip_libvk_swiftshader_shlib",
       ":strip_mksnapshot_binary",
@@ -2055,20 +2051,6 @@ if (is_linux && is_official_build) {
     symbol_output = "$root_out_dir/debug/chrome-sandbox.debug"
     compress_debug_sections = true
     deps = [ "//sandbox/linux:chrome_sandbox" ]
-  }
-
-  strip_binary("strip_libEGL_shlib") {
-    binary_input = "$root_out_dir/libEGL.so"
-    symbol_output = "$root_out_dir/debug/libEGL.so.debug"
-    compress_debug_sections = true
-    deps = [ "//third_party/angle:libEGL" ]
-  }
-
-  strip_binary("strip_libGLESv2_shlib") {
-    binary_input = "$root_out_dir/libGLESv2.so"
-    symbol_output = "$root_out_dir/debug/libGLESv2.so.debug"
-    compress_debug_sections = true
-    deps = [ "//third_party/angle:libGLESv2" ]
   }
 
   strip_binary("strip_libffmpeg_shlib") {


### PR DESCRIPTION
- #51967 included https://chromium-review.googlesource.com/c/chromium/src/+/7932888 which broke our Linux release builds with the following error:
```
ERROR at //electron/build/linux/strip_binary.gni:27:3: Duplicate output file.
  action("${target_name}") {
  ^-------------------------
Two or more targets generate the same output:
  libEGL.so.stripped

This is can often be fixed by changing one of the target names, or by 
setting an output_name on one of them.

Collisions:
  //electron:strip_libEGL_shlib(//build/toolchain/linux:clang_x64)
  //ui/gl:generate_angle_stubs_action(//build/toolchain/linux:clang_x64)

See //ui/gl/BUILD.gn:81:5: Collision.
    action("generate_angle_stubs_action") {
    ^--------------------------------------
```
- This PR fixes that build error, but it does look like the offending CL is reverted upstream, so we may need to back this change out once that revert lands in #52044
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
