### PR TITLE
fix: remove observer before GC in UtilityProcessWrapper

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -303,6 +303,9 @@ void UtilityProcessWrapper::HandleTermination(uint32_t exit_code) {
 #endif
   }
   EmitWithoutEvent("exit", exit_code);
+
+  // Stop observing before clearing the self-keep-alive
+  content::ServiceProcessHost::RemoveObserver(this);
   keep_alive_.Clear();
 }
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Fix for an [ASAN `use-after-poison` failure in CI](https://github.com/electron/electron/actions/runs/27787569267/job/82245196102?pr=52076). Removing the observer before clearing the self-keep-alive should ensure it can't receive any more events, which would be no-ops anyway since `HandleTerminated` has run.

With cppgc mark and sweep happen at different times, so there's a period of time when `UtilityProcessWrapper` is dead and shouldn't be interacted with. ASAN ensures this by poisoning when it's marked dead (via [`UnmarkedObjectsPoisoner`](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/heap/cppgc/object-poisoner.h;l=20;drc=db9c81d6880dfa94bafac91f798161f5251e9259)) and [unpoisoning before running the destructor](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/heap/cppgc/heap-object-header.cc;l=33;drc=4697757e4cac692b7257f31798a6c496ee1dbfa0). That's why the ASAN test job failed with `use-after-poison` - it was after marking but before sweeping.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: Fixed a potential crash with utility process under race conditions <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
