### PR TITLE
ci: improve lint job code reuse

### DIFF
--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -36,12 +36,6 @@ jobs:
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
-    - name: Setup third_party Depot Tools
-      shell: bash
-      run: |
-        # "depot_tools" has to be checkout into "//third_party/depot_tools" so pylint.py can a "pylintrc" file.
-        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git src/third_party/depot_tools
-        echo "$(pwd)/src/third_party/depot_tools" >> $GITHUB_PATH
     - name: Download GN Binary
       shell: bash
       run: |

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -38,14 +38,21 @@ jobs:
       uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
-    - name: Download GN Binary
+    - name: Get Chromium revision
+      id: get-chromium-revision
       shell: bash
       run: |
-        chromium_revision="$(grep -A1 chromium_version src/electron/DEPS | tr -d '\n' | cut -d\' -f4)"
+        chromium_revision=$(e depot-tools gclient getdep --deps-file=src/electron/DEPS --revision=src | tail -1)
         if [[ ! "$chromium_revision" =~ ^[a-zA-Z0-9._-]+$ ]]; then
           echo "::error::Invalid chromium_revision: $chromium_revision"
           exit 1
         fi
+        echo "revision=$chromium_revision" >> "$GITHUB_OUTPUT"
+    - name: Download GN Binary
+      shell: bash
+      env:
+        chromium_revision: ${{ steps.get-chromium-revision.outputs.revision }}
+      run: |
         gn_version="$(curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/DEPS" | grep gn_version | head -n1 | cut -d\' -f4)"
 
         e d cipd ensure -ensure-file - -root . <<-CIPD
@@ -55,13 +62,9 @@ jobs:
         CIPD
     - name: Download clang-format Binary
       shell: bash
+      env:
+        chromium_revision: ${{ steps.get-chromium-revision.outputs.revision }}
       run: |
-        chromium_revision="$(grep -A1 chromium_version src/electron/DEPS | tr -d '\n' | cut -d\' -f4)"
-        if [[ ! "$chromium_revision" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-          echo "::error::Invalid chromium_revision: $chromium_revision"
-          exit 1
-        fi
-
         mkdir -p src/buildtools
         curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/buildtools/DEPS" > src/buildtools/DEPS
 

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -46,7 +46,7 @@ jobs:
         fi
         gn_version="$(curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/DEPS" | grep gn_version | head -n1 | cut -d\' -f4)"
 
-        cipd ensure -ensure-file - -root . <<-CIPD
+        e d cipd ensure -ensure-file - -root . <<-CIPD
         \$ServiceURL https://chrome-infra-packages.appspot.com/
         @Subdir src/buildtools/linux64
         gn/gn/linux-amd64 $gn_version
@@ -63,7 +63,7 @@ jobs:
         mkdir -p src/buildtools
         curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/buildtools/DEPS" > src/buildtools/DEPS
 
-        gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
+        e d gclient sync --spec="solutions=[{'name':'src/buildtools','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':True},'managed':False}]"
     - name: Add problem matchers
       shell: bash
       run: |

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -53,7 +53,8 @@ jobs:
       env:
         chromium_revision: ${{ steps.get-chromium-revision.outputs.revision }}
       run: |
-        gn_version="$(curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/DEPS" | grep gn_version | head -n1 | cut -d\' -f4)"
+        curl -sL "https://raw.githubusercontent.com/chromium/chromium/refs/tags/${chromium_revision}/DEPS" > src/DEPS
+        gn_version=$(e depot-tools gclient getdep --deps-file=src/DEPS --var=gn_version | tail -1)
 
         e d cipd ensure -ensure-file - -root . <<-CIPD
         \$ServiceURL https://chrome-infra-packages.appspot.com/

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -36,6 +36,8 @@ jobs:
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
+    - name: Install Build Tools
+      uses: ./src/electron/.github/actions/install-build-tools
     - name: Download GN Binary
       shell: bash
       run: |


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Handful of improvements to make this less repetitive and more maintainable:
* Use `install-build-tools` instead of doing a bespoke checkout of `depot_tools`
* Use `gclient getdep` to get values out of DEPS files instead of bespoke grepping
* Push the `chromium_revision` extraction into a single step instead of doing it twice

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
