### PR TITLE
fix: preserve explicit zoom overrides across navigation

### DIFF
--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -6,6 +6,8 @@
 
 #include <string>
 
+#include "base/functional/bind.h"
+#include "base/auto_reset.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
@@ -70,6 +72,17 @@ void WebContentsZoomController::SetEmbedderZoomController(
 
 bool WebContentsZoomController::SetZoomLevel(double level) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  has_explicit_zoom_level_ = true;
+  explicit_zoom_level_ = level;
+  return ApplyZoomLevel(level, false);
+}
+
+bool WebContentsZoomController::ApplyZoomLevel(double level,
+                                             bool refresh_renderer) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  if (zoom_mode_ != ZOOM_MODE_MANUAL)
+    zoom_level_ = level;
+
   // Cannot zoom in disabled mode. Also, don't allow changing zoom level on
   // a crashed tab, an error page or an interstitial page.
   if (zoom_mode_ == ZOOM_MODE_DISABLED ||
@@ -93,6 +106,9 @@ bool WebContentsZoomController::SetZoomLevel(double level) {
 
     return true;
   }
+
+  if (!refresh_renderer && blink::ZoomValuesEqual(level, GetZoomLevel()))
+    return true;
 
   content::HostZoomMap* zoom_map =
       content::HostZoomMap::GetForWebContents(web_contents());
@@ -122,6 +138,9 @@ bool WebContentsZoomController::SetZoomLevel(double level) {
     std::string host = net::GetHostOrSpecFromURL(url);
     zoom_map->SetZoomLevelForHost(host, level);
   }
+
+  if (refresh_renderer)
+    content::HostZoomMap::SendErrorPageZoomLevelRefresh(web_contents());
 
   DCHECK(!event_data_);
   return true;
@@ -294,6 +313,9 @@ void WebContentsZoomController::ProcessNavigationZoom(
     return;
   last_processed_navigation_id_ = navigation_handle->GetNavigationId();
 
+  base::AutoReset<bool> processing_navigation_zoom(&processing_navigation_zoom_,
+                                                   true);
+
   if (!navigation_handle->IsInPrimaryMainFrame() ||
       !navigation_handle->HasCommitted()) {
     return;
@@ -305,10 +327,13 @@ void WebContentsZoomController::ProcessNavigationZoom(
   if (!navigation_handle->IsSameDocument()) {
     ResetZoomModeOnNavigationIfNeeded(navigation_handle->GetURL());
     SetZoomFactorOnNavigationIfNeeded(navigation_handle->GetURL());
+    ApplyExplicitZoomIfNeeded();
 
     // If the main frame's content has changed, the new page may have a
     // different zoom level from the old one.
     UpdateState(std::string());
+
+    ScheduleExplicitZoomReapply();
   }
 
   DCHECK(!event_data_);
@@ -342,6 +367,8 @@ void WebContentsZoomController::RenderFrameHostChanged(
   zoom_subscription_ = host_zoom_map_->AddZoomLevelChangedCallback(
       base::BindRepeating(&WebContentsZoomController::OnZoomLevelChanged,
                           base::Unretained(this)));
+  ApplyExplicitZoomIfNeeded();
+  ScheduleExplicitZoomReapply();
 }
 
 void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
@@ -370,21 +397,30 @@ void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
     return;
   }
 
-  // When kZoomFactor is available, it takes precedence over
-  // pref store values but if the host has zoom factor set explicitly
-  // then it takes precedence.
+  // When kZoomFactor is available, it takes precedence over pref store values.
   // pref store < kZoomFactor < setZoomLevel
-  std::string host = net::GetHostOrSpecFromURL(url);
-  std::string scheme = url.GetScheme();
-  double zoom_factor = default_zoom_factor();
-  double zoom_level = blink::ZoomFactorToZoomLevel(zoom_factor);
-  if (host_zoom_map_->HasZoomLevel(scheme, host)) {
-    zoom_level = host_zoom_map_->GetZoomLevelForHostAndScheme(scheme, host);
-  }
-  if (blink::ZoomValuesEqual(zoom_level, GetZoomLevel()))
+  double zoom_level =
+      blink::ZoomFactorToZoomLevel(default_zoom_factor());
+  ApplyZoomLevel(zoom_level, false);
+}
+
+void WebContentsZoomController::ApplyExplicitZoomIfNeeded() {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  if (!has_explicit_zoom_level_ || !explicit_zoom_level_.has_value())
     return;
 
-  SetZoomLevel(zoom_level);
+  ApplyZoomLevel(explicit_zoom_level_.value(), true);
+}
+
+void WebContentsZoomController::ScheduleExplicitZoomReapply() {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  if (!has_explicit_zoom_level_)
+    return;
+
+  content::GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(&WebContentsZoomController::ApplyExplicitZoomIfNeeded,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void WebContentsZoomController::OnZoomLevelChanged(
@@ -416,6 +452,15 @@ void WebContentsZoomController::UpdateState(const std::string& host) {
     observers_.Notify(&WebContentsZoomObserver::OnZoomChanged,
                       zoom_change_data);
   } else {
+    // Zoom changed externally (e.g. user Ctrl+scroll). Clear any pending
+    // explicit override so later navigations don't revert the user's choice.
+    if (!processing_navigation_zoom_) {
+      has_explicit_zoom_level_ = false;
+      explicit_zoom_level_ = std::nullopt;
+    }
+    if (zoom_mode_ != ZOOM_MODE_MANUAL)
+      zoom_level_ = GetZoomLevel();
+
     double zoom_level = GetZoomLevel();
     ZoomChangedEventData zoom_change_data(web_contents(), zoom_level,
                                           zoom_level, false, zoom_mode_);

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -9,6 +9,7 @@
 
 #include "base/callback_list.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -134,6 +135,9 @@ class WebContentsZoomController
 
   void ResetZoomModeOnNavigationIfNeeded(const GURL& url);
   void SetZoomFactorOnNavigationIfNeeded(const GURL& url);
+  bool ApplyZoomLevel(double level, bool refresh_renderer);
+  void ApplyExplicitZoomIfNeeded();
+  void ScheduleExplicitZoomReapply();
   void OnZoomLevelChanged(const content::HostZoomMap::ZoomLevelChange& change);
 
   // Updates the zoom icon and zoom percentage based on current values and
@@ -159,6 +163,15 @@ class WebContentsZoomController
   // The current default zoom factor.
   double default_zoom_factor_;
 
+  // Zoom level explicitly requested via setZoomLevel/setZoomFactor. Takes
+  // precedence over persisted per-host zoom levels restored from preferences.
+  bool has_explicit_zoom_level_ = false;
+  std::optional<double> explicit_zoom_level_;
+
+  // True while ProcessNavigationZoom is running. Prevents persisted zoom
+  // restoration from clearing an explicit zoom override mid-navigation.
+  bool processing_navigation_zoom_ = false;
+
   int old_process_id_ = -1;
   int old_view_id_ = -1;
 
@@ -173,6 +186,8 @@ class WebContentsZoomController
   raw_ptr<content::HostZoomMap> host_zoom_map_;
 
   base::CallbackListSubscription zoom_subscription_;
+
+  base::WeakPtrFactory<WebContentsZoomController> weak_ptr_factory_{this};
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2423,6 +2423,50 @@ describe('webContents module', () => {
         expect(zoomLevel).to.equal(0);
       });
     });
+
+    it('programmatic zoom reset overrides persisted per-host zoom', async () => {
+      const partition = 'persist:zoom-reset-test';
+      const server = http.createServer((req, res) => {
+        res.end('<html><body>zoom test</body></html>');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w1 = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          partition,
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+      await w1.loadURL(serverUrl);
+      w1.webContents.setZoomFactor(0.25);
+      w1.close();
+
+      const w2 = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          partition,
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+
+      w2.webContents.setZoomLevel(0);
+      w2.webContents.setZoomFactor(1.0);
+      await w2.loadURL(serverUrl);
+      w2.webContents.setZoomFactor(1.0);
+      w2.webContents.setZoomLevel(0);
+
+      expect(w2.webContents.getZoomFactor()).to.be.closeTo(1.0, 0.05);
+
+      const rendererZoomFactor = await w2.webContents.executeJavaScript(
+        'require("electron").webFrame.getZoomFactor()');
+      expect(rendererZoomFactor).to.be.closeTo(1.0, 0.05);
+
+      w2.webContents.setZoomLevel(0);
+    });
   });
 
   describe('zoom mode', () => {
@@ -2802,6 +2846,35 @@ describe('webContents module', () => {
 
       expect(w.webContents.getZoomMode()).to.equal('isolated');
       expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('webPreferences zoomFactor overrides persisted per-host zoom', async () => {
+      const partition = 'persist:zoom-factor-pref-test';
+      const server = http.createServer((req, res) => {
+        res.end('<html><body>zoom test</body></html>');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w1 = new BrowserWindow({
+        show: false,
+        webPreferences: { partition }
+      });
+      await w1.loadURL(serverUrl);
+      w1.webContents.setZoomFactor(0.25);
+      w1.close();
+
+      const w2 = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          partition,
+          zoomFactor: 1.5
+        }
+      });
+      await w2.loadURL(serverUrl);
+
+      expect(w2.webContents.getZoomFactor()).to.be.closeTo(1.5, 0.05);
+      w2.webContents.setZoomLevel(0);
     });
 
     it('webPreferences zoomFactor is applied as initial zoom in isolated mode', async () => {


### PR DESCRIPTION
#### Description of Change

Fixes #52086

This change preserves explicit zoom values set through `webContents.setZoomLevel()` and `webContents.setZoomFactor()` when Chromium restores persisted per-host zoom settings.

#### Checklist

* [ ] I have built and tested this change
* [x] I have filled out the PR description
* [x] I have reviewed and verified the changes
* [ ] npm test passes
* [x] tests are changed or added
* [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
* [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Fixed persisted per-host zoom settings overriding explicit zoom values set through webContents APIs.
