### PR TITLE
build: don't extract symbols from ANGLE libraries on Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1724,24 +1724,29 @@ if (is_mac) {
       deps = [ ":electron_app" ]
     }
 
-    extract_symbols("egl_symbols") {
-      binary = "$root_out_dir/libEGL$_target_shared_library_suffix"
-      symbol_dir = "$root_out_dir/breakpad_symbols"
-      deps = [ "//third_party/angle:libEGL" ]
-    }
+    if (!is_linux) {
+      extract_symbols("egl_symbols") {
+        binary = "$root_out_dir/libEGL$_target_shared_library_suffix"
+        symbol_dir = "$root_out_dir/breakpad_symbols"
+        deps = [ "//third_party/angle:libEGL" ]
+      }
 
-    extract_symbols("gles_symbols") {
-      binary = "$root_out_dir/libGLESv2$_target_shared_library_suffix"
-      symbol_dir = "$root_out_dir/breakpad_symbols"
-      deps = [ "//third_party/angle:libGLESv2" ]
+      extract_symbols("gles_symbols") {
+        binary = "$root_out_dir/libGLESv2$_target_shared_library_suffix"
+        symbol_dir = "$root_out_dir/breakpad_symbols"
+        deps = [ "//third_party/angle:libGLESv2" ]
+      }
     }
 
     group("electron_symbols") {
-      deps = [
-        ":egl_symbols",
-        ":electron_app_symbols",
-        ":gles_symbols",
-      ]
+      deps = [ ":electron_app_symbols" ]
+
+      if (!is_linux) {
+        deps += [
+          ":egl_symbols",
+          ":gles_symbols",
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Follow-up to #52071, we also need to skip extracting symbols from the non-existent libraries.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
