### PR TITLE
build: add release build workflow separate from publishing

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -37,9 +37,20 @@ inputs:
     description: 'Generate artifacts only consumed by test jobs (src artifacts, cross-arch snapshots, mksnapshot fixup). Only disable when no test job consumes this build.'
     required: false
     default: 'true'
+  publish:
+    description: 'Whether to publish a release'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ "${{ inputs.publish }}" = "true" ] && [ "${{ inputs.is-release }}" != "true" ]; then
+          echo "Can only publish release builds"
+          exit 1
+        fi
     - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
       shell: bash
       if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
@@ -90,10 +101,10 @@ runs:
 
         export NINJA_SUMMARIZE_BUILD=1
         export NO_COLOR=1
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
 
         if [ "${{ inputs.is-release }}" = "true" ]; then
-          e build --target electron:release_build
+          e build --target electron:release_build $QUIET_FLAG
         else
           e build --target electron:testing_build $QUIET_FLAG
         fi
@@ -215,7 +226,7 @@ runs:
       if: ${{ inputs.generate-chromedriver == 'true' }}
       run: |
         cd src
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
         e build --target electron:electron_chromedriver_zip $QUIET_FLAG
         if [ "${{ inputs.is-asan }}" != "true" ]; then
           target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
@@ -258,7 +269,7 @@ runs:
       if: ${{ inputs.is-release == 'true' }}
       run: |
         e init -f --root=$(pwd) --out=ffmpeg fmmpeg --import ffmpeg --target-cpu ${{ inputs.target-arch }} --remote-build siso
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
         e build --target electron:electron_ffmpeg_zip $QUIET_FLAG
     - name: Remove Clang problem matcher
       shell: bash
@@ -303,7 +314,7 @@ runs:
 
         echo "Disk space metrics logged to Datadog"
     - name: Publish Electron Dist ${{ inputs.step-suffix }}
-      if: ${{ inputs.is-release == 'true' }}
+      if: ${{ inputs.publish == 'true' }}
       shell: bash
       id: github-upload
       run: |
@@ -317,7 +328,7 @@ runs:
           script/release/uploaders/upload.py --verbose
         fi
     - name: Generate artifact attestation
-      if: ${{ inputs.is-release == 'true' }}
+      if: ${{ inputs.publish == 'true' }}
       uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
       with:
         subject-path: ${{ steps.github-upload.outputs.UPLOADED_PATHS }}

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -74,6 +74,7 @@ jobs:
       target-platform: linux
       target-arch: x64
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -94,6 +95,7 @@ jobs:
       target-platform: linux
       target-arch: arm
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -114,6 +116,7 @@ jobs:
       target-platform: linux
       target-arch: arm64
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -77,6 +77,7 @@ jobs:
       target-arch: x64
       target-variant: darwin
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -97,6 +98,7 @@ jobs:
       target-arch: x64
       target-variant: mas
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -117,6 +119,7 @@ jobs:
       target-arch: arm64
       target-variant: darwin
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -137,6 +140,7 @@ jobs:
       target-arch: arm64
       target-variant: mas
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -68,6 +68,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish:
+        description: 'Whether to publish a release'
+        required: false
+        type: boolean
+        default: false
       enable-ssh:
         description: 'Enable SSH debugging'
         required: false
@@ -77,7 +82,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.target-variant }}-${{ inputs.is-asan }}-${{ github.ref_protected == true && github.run_id || github.ref }}
+  group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.target-variant }}-${{ inputs.is-asan }}-${{ inputs.is-release }}-${{ github.ref_protected == true && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref_protected != true }}
 
 env:
@@ -244,6 +249,7 @@ jobs:
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         is-asan: '${{ inputs.is-asan }}'
         upload-out-gen-artifacts: '${{ inputs.upload-out-gen-artifacts }}'
+        publish: '${{ inputs.publish }}'
     - name: Set GN_EXTRA_ARGS for MAS Build
       if: ${{ inputs.target-platform == 'macos' && (inputs.target-variant == 'all' || inputs.target-variant == 'mas') }}
       run: |
@@ -263,3 +269,4 @@ jobs:
         generate-test-artifacts: '${{ inputs.generate-test-artifacts }}'
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         step-suffix: '(mas)'
+        publish: '${{ inputs.publish }}'

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -71,6 +71,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish:
+        description: Whether to publish a release
+        required: false
+        type: boolean
+        default: false
       enable-ssh:
         description: Enable SSH debugging
         required: false
@@ -79,8 +84,8 @@ on:
 permissions: {}
 concurrency:
   group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch
-    }}-${{ inputs.target-variant }}-${{ inputs.is-asan }}-${{
-    github.ref_protected == true && github.run_id || github.ref }}
+    }}-${{ inputs.target-variant }}-${{ inputs.is-asan }}-${{ inputs.is-release
+    }}-${{ github.ref_protected == true && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref_protected != true }}
 env:
   CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
@@ -255,6 +260,7 @@ jobs:
           upload-to-storage: ${{ inputs.upload-to-storage }}
           is-asan: ${{ inputs.is-asan }}
           upload-out-gen-artifacts: ${{ inputs.upload-out-gen-artifacts }}
+          publish: ${{ inputs.publish }}
       - name: Set GN_EXTRA_ARGS for MAS Build
         if: ${{ inputs.target-platform == 'macos' && (inputs.target-variant == 'all' ||
           inputs.target-variant == 'mas') }}
@@ -276,3 +282,4 @@ jobs:
           generate-test-artifacts: ${{ inputs.generate-test-artifacts }}
           upload-to-storage: ${{ inputs.upload-to-storage }}
           step-suffix: (mas)
+          publish: ${{ inputs.publish }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,208 @@
+name: Release Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-image-sha:
+        type: string
+        description: 'SHA for electron/build image'
+        default: ''
+        required: false
+      skip-macos:
+        type: boolean
+        description: 'Skip macOS release builds'
+        default: false
+        required: false
+      skip-linux:
+        type: boolean
+        description: 'Skip Linux release builds'
+        default: false
+        required: false
+      skip-windows:
+        type: boolean
+        description: 'Skip Windows release builds'
+        default: false
+        required: false
+
+permissions: {}
+
+jobs:
+  setup:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+    - name: Set Build Image SHA
+      id: build-image-sha
+      uses: ./.github/actions/build-image-sha
+      with:
+        override: ${{ inputs.build-image-sha }}
+
+  # Checkout Jobs
+  checkout-macos:
+    needs: setup
+    if: ${{ !inputs.skip-macos }}
+    runs-on: electron-arc-centralus-linux-amd64-32core
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}
+      options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
+    env:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        path: src/electron
+        fetch-depth: 0
+    - name: Checkout & Sync & Save
+      uses: ./src/electron/.github/actions/checkout
+      with:
+        generate-sas-token: 'true'
+        target-platform: macos
+
+  checkout-linux:
+    needs: setup
+    if: ${{ !inputs.skip-linux }}
+    runs-on: electron-arc-centralus-linux-amd64-32core
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}
+      options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
+    env:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        path: src/electron
+        fetch-depth: 0
+    - name: Checkout & Sync & Save
+      uses: ./src/electron/.github/actions/checkout
+
+  checkout-windows:
+    needs: setup
+    if: ${{ !inputs.skip-windows }}
+    runs-on: electron-arc-centralus-linux-amd64-32core
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}
+      options: --user root --device /dev/fuse --cap-add SYS_ADMIN
+      volumes:
+        - /mnt/win-cache:/mnt/win-cache
+        - /var/run/sas:/var/run/sas
+    env:
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_win=True'
+      TARGET_OS: 'win'
+      ELECTRON_DEPOT_TOOLS_WIN_TOOLCHAIN: '1'
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        path: src/electron
+        fetch-depth: 0
+    - name: Checkout & Sync & Save
+      uses: ./src/electron/.github/actions/checkout
+      with:
+        generate-sas-token: 'true'
+        target-platform: win
+
+  # Build a patched siso binary for Windows in parallel with checkout-windows;
+  # the windows build jobs consume it via SISO_PATH.
+  build-siso-windows:
+    needs: setup
+    if: ${{ !inputs.skip-windows }}
+    uses: ./.github/workflows/pipeline-segment-build-siso-windows.yml
+    permissions:
+      contents: read
+
+  macos:
+    name: macos-${{ matrix.target-arch }}-${{ matrix.target-variant }}
+    needs: checkout-macos
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target-arch: x64
+            target-variant: darwin
+          - target-arch: x64
+            target-variant: mas
+          - target-arch: arm64
+            target-variant: darwin
+          - target-arch: arm64
+            target-variant: mas
+    uses: ./.github/workflows/pipeline-segment-electron-build.yml
+    with:
+      build-runs-on: macos-15-xlarge
+      target-platform: macos
+      target-arch: ${{ matrix.target-arch }}
+      target-variant: ${{ matrix.target-variant }}
+      is-release: true
+      gn-build-type: release
+      generate-symbols: true
+      upload-to-storage: '0'
+    secrets: inherit
+
+  linux:
+    name: linux-${{ matrix.target-arch }}
+    needs: [setup, checkout-linux]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target-arch: x64
+          - target-arch: arm
+          - target-arch: arm64
+    uses: ./.github/workflows/pipeline-segment-electron-build.yml
+    with:
+      build-runs-on: electron-arc-centralus-linux-amd64-32core
+      build-container: '{"image":"ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
+      target-platform: linux
+      target-arch: ${{ matrix.target-arch }}
+      is-release: true
+      gn-build-type: release
+      generate-symbols: true
+      upload-to-storage: '0'
+    secrets: inherit
+
+  windows:
+    name: windows-${{ matrix.target-arch }}
+    needs: [checkout-windows, build-siso-windows]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target-arch: x64
+          - target-arch: arm64
+          - target-arch: x86
+    uses: ./.github/workflows/pipeline-segment-electron-build.yml
+    with:
+      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      target-platform: win
+      target-arch: ${{ matrix.target-arch }}
+      is-release: true
+      gn-build-type: release
+      generate-symbols: true
+      upload-to-storage: '0'
+    secrets: inherit

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -86,6 +86,7 @@ jobs:
       target-platform: win
       target-arch: x64
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -105,6 +106,7 @@ jobs:
       target-platform: win
       target-arch: arm64
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -124,6 +126,7 @@ jobs:
       target-platform: win
       target-arch: x86
       is-release: true
+      publish: true
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We're getting bit by nightlies failing due to some GN changes not being tested until the nightly job kicks off. Lets start with a manually runnable release build job for validating fixes, and in the future we could look at it being required for specific situations like Chromium rolls or changes to GN files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
