### PR TITLE
ci: fix generating ffmpeg

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -257,20 +257,9 @@ runs:
       shell: bash
       if: ${{ inputs.is-release == 'true' }}
       run: |
-        cd src
-        # Reuse the hermetic mac_sdk_path that `e build` wrote for out/Default so
-        # out/ffmpeg builds against the same SDK instead of the runner's system Xcode.
-        # The path has to live under root_build_dir, so copy the symlink tree and
-        # rewrite Default -> ffmpeg.
-        MAC_SDK_ARG=""
-        if [ "$(uname)" = "Darwin" ]; then
-          mkdir -p out/ffmpeg
-          cp -a out/Default/xcode_links out/ffmpeg/
-          MAC_SDK_ARG=$(sed -n 's|^\(mac_sdk_path = "//out/\)Default/|\1ffmpeg/|p' out/Default/args.gn)
-        fi
-        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") use_remoteexec=true use_siso=true $MAC_SDK_ARG $GN_EXTRA_ARGS"
+        e init -f --root=$(pwd) --out=ffmpeg fmmpeg --import ffmpeg --target-cpu ${{ inputs.target-arch }} --remote-build siso
         QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.is-release }}" = "true" ] || echo -quiet)
-        e build --target electron:electron_ffmpeg_zip -C ../../out/ffmpeg $QUIET_FLAG
+        e build --target electron:electron_ffmpeg_zip $QUIET_FLAG
     - name: Remove Clang problem matcher
       shell: bash
       run: echo "::remove-matcher owner=clang::"


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Landing #52059 exposed that we're generating `ffmpeg.zip` in a clunky way (mixing `gn gen` and `e build`) when we should just be using `build-tools` properly and use `e init` to set things up how we want them instead of manually poking at stuff.

Validated with a release build: https://github.com/electron/electron/actions/runs/28114374016/job/83267451637?pr=52108

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
