### PR TITLE
feat: rounded corners for frameless windows on Linux

### DIFF
--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -101,10 +101,11 @@
 * `accentColor` boolean | string (optional) _Windows_ - The accent color for the window. By default, follows user preference in System Settings. Set to `false` to explicitly disable, or set the color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. Alpha values will be ignored.
 * `trafficLightPosition` [Point](point.md) (optional) _macOS_ -
   Set a custom position for the traffic light buttons in frameless windows.
-* `roundedCorners` boolean (optional) _macOS_ _Windows_ - Whether frameless window
+* `roundedCorners` boolean (optional) - Whether a frameless window
   should have rounded corners. Default is `true`. On Windows versions older than
   Windows 11 Build 22000 this property has no effect, and frameless windows will
-  not have rounded corners.
+  not have rounded corners. On Linux, rounded corners are only drawn when the
+  desktop environment supports client-side decorations.
 * `thickFrame` boolean (optional) _Windows_ - Use `WS_THICKFRAME` style for
   frameless windows on Windows, which adds the standard window frame. Setting it
   to `false` will remove window shadow and window animations, and disable window

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -41,6 +41,11 @@ When using `contextBridge` care must be taken to ensure that the [`clipboard API
 
 ## Planned Breaking API Changes (43.0)
 
+### Behavior Changed: Rounded corners on Linux
+
+Frameless windows default to rounded corners on Linux if the desktop environment supports client-side decorations. This can be configured using the existing `roundedCorners` option on `BrowserWindow`,
+which is now supported on Linux and defaults to `true` on all platforms.
+
 ### Behavior Changed: WCO respects the native title bar layout on Linux
 
 Frameless windows with Window Controls Overlay (WCO) now adopt the native title bar layout and user settings on Linux. For example, controls will appear on the left side of the frame on RTL systems, and only the close button will be visible by default on GNOME. Depending on the user's desktop environment and configuration, buttons can appear on the left or right side of the frame (or both). To account for all possibilities, use the CSS variables `env(titlebar-area-x, 0px)` and `env(titlebar-area-width, 100%)` to constrain your app's title bar content to a safe area.

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -12,6 +12,7 @@
 #include "shell/browser/api/electron_api_web_contents_view.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window.h"
+#include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/web_contents_preferences.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/color_util.h"
@@ -69,6 +70,8 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
       WebContentsView::Create(isolate, web_preferences);
   DCHECK(web_contents_view.get());
   window()->AddDraggableRegionProvider(web_contents_view.get());
+  window()->set_primary_web_contents_view(
+      static_cast<InspectableWebContentsView*>(web_contents_view->view()));
   web_contents_view_.Reset(isolate, web_contents_view.ToV8());
 
   // Save a reference of the WebContents.
@@ -99,6 +102,8 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 }
 
 BrowserWindow::~BrowserWindow() {
+  window()->set_primary_web_contents_view(nullptr);
+
   if (api_web_contents_) {
     // Cleanup the observers if user destroyed this instance directly instead of
     // gracefully closing content::WebContents.
@@ -112,6 +117,7 @@ void BrowserWindow::BeforeUnloadDialogCancelled() {
 }
 
 void BrowserWindow::WebContentsDestroyed() {
+  window()->set_primary_web_contents_view(nullptr);
   api_web_contents_ = nullptr;
   CloseImmediately();
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -48,6 +48,7 @@ namespace electron {
 
 class ElectronMenuModel;
 class BackgroundThrottlingSource;
+class InspectableWebContentsView;
 
 #if BUILDFLAG(IS_MAC)
 using NativeWindowHandle = gfx::NativeView;
@@ -407,6 +408,13 @@ class NativeWindow : public views::WidgetDelegate {
 
   [[nodiscard]] constexpr int32_t window_id() const { return window_id_; }
 
+  InspectableWebContentsView* primary_web_contents_view() const {
+    return primary_web_contents_view_;
+  }
+  void set_primary_web_contents_view(InspectableWebContentsView* view) {
+    primary_web_contents_view_ = view;
+  }
+
   void add_child_window(NativeWindow* child) {
     child_windows_.push_back(child);
   }
@@ -555,6 +563,8 @@ class NativeWindow : public views::WidgetDelegate {
   std::string background_material_;
 
   gfx::Rect overlay_rect_;
+
+  raw_ptr<InspectableWebContentsView> primary_web_contents_view_ = nullptr;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
 };

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -409,6 +409,10 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+  options.Get(options::kRoundedCorners, &rounded_corner_);
+#endif
+
   if (has_frame() && !has_client_frame()) {
     // TODO(zcbenz): This was used to force using native frame on Windows 2003,
     // we should check whether setting it in InitParams can work.

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -213,6 +213,8 @@ class NativeWindowViews : public NativeWindow,
   views::FrameViewLinux* GetFrameViewLinux() const;
 #endif
 
+  [[nodiscard]] bool has_rounded_corners() const { return rounded_corner_; }
+
  private:
   void set_overlay_button_color(std::optional<SkColor> color) {
     overlay_button_color_ = color;
@@ -242,6 +244,7 @@ class NativeWindowViews : public NativeWindow,
   std::unique_ptr<views::FrameView> CreateFrameView(
       views::Widget* widget) override;
   void OnWidgetMove() override;
+
 #if BUILDFLAG(IS_WIN)
   bool ExecuteWindowsCommand(int command_id) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
@@ -305,6 +308,9 @@ class NativeWindowViews : public NativeWindow,
   // windows on Linux).
   SkColor background_color_ = SK_ColorTRANSPARENT;
 
+  // This value is determined when the window is created.
+  bool rounded_corner_ = true;
+
 #if BUILDFLAG(IS_WIN)
 
   ui::mojom::WindowShowState last_window_state_;
@@ -336,9 +342,6 @@ class NativeWindowViews : public NativeWindow,
   bool forwarding_mouse_messages_ = false;
   HWND legacy_window_ = nullptr;
   bool layered_ = false;
-
-  // This value is determined when the window is created.
-  bool rounded_corner_ = true;
 
   // Set to true if the window is always on top and behind the task bar.
   bool behind_task_bar_ = false;

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -17,11 +17,16 @@
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
 #include "ui/base/models/image_model.h"
+#include "ui/compositor/layer.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/views/window/client_view.h"
+
+#if defined(USE_AURA)
+#include "ui/aura/window.h"
+#endif
 
 namespace electron {
 namespace {
@@ -120,6 +125,17 @@ void InspectableWebContentsView::SetCornerRadii(
   // WebView won't exist for offscreen rendering.
   if (contents_web_view_) {
     contents_web_view_->holder()->SetCornerRadii(corner_radii);
+
+#if defined(USE_AURA)
+    // Aura calls SetIsFastRoundedCorner(true) which clips each tile separately.
+    // This creates a jagged edge at fractional DPI if the view is taller than
+    // one tile, so we use the slow method for a smooth edge at the cost
+    // of an extra render surface.
+    if (auto* native_view = contents_web_view_->holder()->native_view()) {
+      if (auto* layer = native_view->layer())
+        layer->SetIsFastRoundedCorner(false);
+    }
+#endif
   }
 }
 

--- a/shell/browser/ui/views/electron_frame_view_layout_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_layout_linux.cc
@@ -75,8 +75,14 @@ gfx::ShadowValues ElectronFrameViewLayoutLinux::GetShadowValues(
 }
 
 gfx::RoundedCornersF ElectronFrameViewLayoutLinux::GetCornerRadii() const {
-  // TODO: implement client-area clipping for rounded corners.
-  return gfx::RoundedCornersF();
+  if (!window_->has_rounded_corners())
+    return gfx::RoundedCornersF();
+  if (window_->IsMaximized() || window_->IsFullscreen())
+    return gfx::RoundedCornersF();
+
+  // Chrome rounds only the top corners, so mirror its default value to all 4.
+  return gfx::RoundedCornersF(
+      FrameViewLayoutLinux::GetCornerRadii().upper_left());
 }
 
 bool ElectronFrameViewLayoutLinux::ShouldShowTitlebarAndBorder() const {

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -5,7 +5,9 @@
 
 #include "shell/browser/ui/views/electron_frame_view_linux.h"
 
+#include "base/i18n/rtl.h"
 #include "shell/browser/native_window_views.h"
+#include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/ui/views/caption_button_placeholder_container.h"
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
 #include "ui/base/hit_test.h"
@@ -48,6 +50,13 @@ void ElectronFrameViewLinux::CreateCaptionButtons() {
       AddChildView(std::make_unique<CaptionButtonPlaceholderContainer>());
   trailing_button_container_ =
       AddChildView(std::make_unique<CaptionButtonPlaceholderContainer>());
+
+  // Allow containers to be clipped for rounded corners.
+  for (auto* container :
+       {leading_button_container_.get(), trailing_button_container_.get()}) {
+    container->layer()->SetFillsBoundsOpaquely(false);
+    container->layer()->SetIsFastRoundedCorner(true);
+  }
 
   FrameViewLinux::CreateCaptionButtons();
 
@@ -114,6 +123,9 @@ int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
 void ElectronFrameViewLinux::Layout(PassKey) {
   LayoutSuperclass<FrameViewLinux>(this);
 
+  if (auto* iwcv = window_->primary_web_contents_view())
+    iwcv->SetCornerRadii(GetCornerRadii());
+
   if (!window_->IsWindowControlsOverlayEnabled())
     return;
 
@@ -130,6 +142,16 @@ void ElectronFrameViewLinux::Layout(PassKey) {
       efv_layout()->GetLeadingButtonRect());
   trailing_button_container_->SetBoundsRect(
       efv_layout()->GetTrailingButtonRect());
+
+  // Apply the frame's corner radius to the button containers.
+  const float radius = GetCornerRadii().upper_left();
+  const bool rtl = base::i18n::IsRTL();
+  leading_button_container_->layer()->SetRoundedCornerRadius(
+      rtl ? gfx::RoundedCornersF(0, radius, 0, 0)
+          : gfx::RoundedCornersF(radius, 0, 0, 0));
+  trailing_button_container_->layer()->SetRoundedCornerRadius(
+      rtl ? gfx::RoundedCornersF(radius, 0, 0, 0)
+          : gfx::RoundedCornersF(0, radius, 0, 0));
 
   UpdateCaptionButtonPlaceholderContainerBackground();
   LayoutWindowControlsOverlay();


### PR DESCRIPTION
Backport of #51459.

See that PR for details.

Notes: On Linux, frameless windows now have rounded corners by default, just like on macOS and Windows. Rounded corners can be disabled on all platforms by setting `roundedCorners: false` on the window