### PR TITLE
fix: use the registering session for ProtocolResponse.url requests

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1531,6 +1531,7 @@ void ElectronBrowserClient::WillCreateURLLoaderFactory(
   new ProxyingURLLoaderFactory{
       web_request,
       protocol_registry->intercept_handlers(),
+      static_cast<ElectronBrowserContext*>(browser_context)->GetWeakPtr(),
       render_process_id,
       frame_host ? frame_host->GetRoutingID() : IPC::mojom::kRoutingIdNone,
       &next_id_,

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -361,7 +361,7 @@ ElectronBrowserContext::ElectronBrowserContext(
     base::DictValue options)
     : in_memory_pref_store_(new ValueMapPrefStore),
       storage_policy_(base::MakeRefCounted<SpecialStoragePolicy>()),
-      protocol_registry_(base::WrapUnique(new ProtocolRegistry)),
+      protocol_registry_(base::WrapUnique(new ProtocolRegistry(this))),
       in_memory_(in_memory),
       ssl_config_(network::mojom::SSLConfig::New()) {
   // Read options.

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -98,6 +98,10 @@ class ElectronBrowserContext : public content::BrowserContext {
   scoped_refptr<network::SharedURLLoaderFactory> InterceptURLLoaderFactory(
       scoped_refptr<network::SharedURLLoaderFactory> factory);
 
+  base::WeakPtr<ElectronBrowserContext> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
   std::pair<network::URLLoaderFactoryBuilder,
             mojo::PendingRemote<network::mojom::TrustedURLLoaderHeaderClient>>
   CreateURLLoaderFactoryBuilder();

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -396,13 +396,15 @@ void ElectronURLLoaderFactory::RedirectedRequest::DeleteThis() {
 
 // static
 mojo::PendingRemote<network::mojom::URLLoaderFactory>
-ElectronURLLoaderFactory::Create(ProtocolType type,
-                                 const ProtocolHandler& handler) {
+ElectronURLLoaderFactory::Create(
+    ProtocolType type,
+    const ProtocolHandler& handler,
+    base::WeakPtr<ElectronBrowserContext> browser_context) {
   mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote;
 
   // The ElectronURLLoaderFactory will delete itself when there are no more
   // receivers - see the SelfDeletingURLLoaderFactory::OnDisconnect method.
-  new ElectronURLLoaderFactory(type, handler,
+  new ElectronURLLoaderFactory(type, handler, std::move(browser_context),
                                pending_remote.InitWithNewPipeAndPassReceiver());
 
   return pending_remote;
@@ -411,10 +413,12 @@ ElectronURLLoaderFactory::Create(ProtocolType type,
 ElectronURLLoaderFactory::ElectronURLLoaderFactory(
     ProtocolType type,
     const ProtocolHandler& handler,
+    base::WeakPtr<ElectronBrowserContext> browser_context,
     mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver)
     : network::SelfDeletingURLLoaderFactory(std::move(factory_receiver)),
       type_(type),
-      handler_(handler) {}
+      handler_(handler),
+      browser_context_(std::move(browser_context)) {}
 
 ElectronURLLoaderFactory::~ElectronURLLoaderFactory() = default;
 
@@ -457,7 +461,8 @@ void ElectronURLLoaderFactory::CreateLoaderAndStart(
       request,
       base::BindOnce(&ElectronURLLoaderFactory::StartLoading, std::move(loader),
                      request_id, options, request, std::move(client),
-                     traffic_annotation, std::move(target_factory), type_));
+                     traffic_annotation, std::move(target_factory), type_,
+                     browser_context_));
 }
 
 // static
@@ -482,6 +487,7 @@ void ElectronURLLoaderFactory::StartLoading(
     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
     mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
     ProtocolType type,
+    base::WeakPtr<ElectronBrowserContext> browser_context,
     gin::Arguments* args) {
   // Send network error when there is no argument passed.
   //
@@ -608,7 +614,7 @@ void ElectronURLLoaderFactory::StartLoading(
     case ProtocolType::kHttp:
       if (GURL url; !dict.IsEmpty() && dict.Get("url", &url) && url.is_valid())
         StartLoadingHttp(std::move(client), std::move(loader), request,
-                         traffic_annotation, dict);
+                         traffic_annotation, std::move(browser_context), dict);
       else
         OnComplete(std::move(client), request_id,
                    network::URLLoaderCompletionStatus(net::ERR_FAILED));
@@ -641,7 +647,8 @@ void ElectronURLLoaderFactory::StartLoading(
         // |response.path|.
         if (GURL url; dict.Get("url", &url))
           StartLoadingHttp(std::move(client), std::move(loader), request,
-                           traffic_annotation, dict);
+                           traffic_annotation, std::move(browser_context),
+                           dict);
         else if (base::FilePath path; dict.Get("path", &path))
           StartLoadingFile(std::move(client), std::move(loader),
                            std::move(head), request, path, dict);
@@ -695,6 +702,7 @@ void ElectronURLLoaderFactory::StartLoadingHttp(
     mojo::PendingReceiver<network::mojom::URLLoader> loader,
     const network::ResourceRequest& original_request,
     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+    base::WeakPtr<ElectronBrowserContext> serving_browser_context,
     const gin_helper::Dictionary& dict) {
   auto request = std::make_unique<network::ResourceRequest>();
   request->headers = original_request.headers;
@@ -710,11 +718,19 @@ void ElectronURLLoaderFactory::StartLoadingHttp(
       request->method != net::HttpRequestHeaders::kHeadMethod)
     dict.Get("uploadData", &upload_data);
 
+  // Default to the session this protocol handler was registered on when one
+  // isn't specified in the response.
   api::Session* session = nullptr;
-  auto* browser_context =
-      dict.Get("session", &session) && session
-          ? session->browser_context()
-          : ElectronBrowserContext::GetDefaultBrowserContext();
+  ElectronBrowserContext* browser_context =
+      dict.Get("session", &session) && session ? session->browser_context()
+                                               : serving_browser_context.get();
+  if (!browser_context) {
+    mojo::Remote<network::mojom::URLLoaderClient> client_remote(
+        std::move(client));
+    client_remote->OnComplete(
+        network::URLLoaderCompletionStatus(net::ERR_FAILED));
+    return;
+  }
 
   new URLPipeLoader(
       browser_context->GetURLLoaderFactory(), std::move(request),

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -36,6 +37,8 @@ class PendingReceiver;
 }  // namespace mojo
 
 namespace electron {
+
+class ElectronBrowserContext;
 
 // Old Protocol API can only serve one type of response for one scheme.
 enum class ProtocolType {
@@ -105,7 +108,8 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
 
   static mojo::PendingRemote<network::mojom::URLLoaderFactory> Create(
       ProtocolType type,
-      const ProtocolHandler& handler);
+      const ProtocolHandler& handler,
+      base::WeakPtr<ElectronBrowserContext> browser_context);
 
   // network::mojom::URLLoaderFactory:
   void CreateLoaderAndStart(
@@ -126,6 +130,7 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
       mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
       ProtocolType type,
+      base::WeakPtr<ElectronBrowserContext> browser_context,
       gin::Arguments* args);
 
   // disable copy
@@ -136,6 +141,7 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
   ElectronURLLoaderFactory(
       ProtocolType type,
       const ProtocolHandler& handler,
+      base::WeakPtr<ElectronBrowserContext> browser_context,
       mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver);
   ~ElectronURLLoaderFactory() override;
 
@@ -160,6 +166,7 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       mojo::PendingReceiver<network::mojom::URLLoader> loader,
       const network::ResourceRequest& original_request,
       const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+      base::WeakPtr<ElectronBrowserContext> browser_context,
       const gin_helper::Dictionary& dict);
   static void StartLoadingStream(
       mojo::PendingRemote<network::mojom::URLLoaderClient> client,
@@ -175,6 +182,7 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
 
   ProtocolType type_;
   ProtocolHandler handler_;
+  base::WeakPtr<ElectronBrowserContext> browser_context_;
 };
 
 }  // namespace electron

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -780,6 +780,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
 ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
     api::WebRequest* web_request,
     const HandlersMap& intercepted_handlers,
+    base::WeakPtr<ElectronBrowserContext> browser_context,
     int render_process_id,
     int frame_routing_id,
     uint64_t* request_id_generator,
@@ -792,6 +793,7 @@ ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
     content::ContentBrowserClient::URLLoaderFactoryType loader_factory_type)
     : web_request_{web_request},
       intercepted_handlers_(intercepted_handlers),
+      browser_context_(std::move(browser_context)),
       render_process_id_(render_process_id),
       frame_routing_id_(frame_routing_id),
       request_id_generator_(request_id_generator),
@@ -848,7 +850,7 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
     auto it = intercepted_handlers_->find(request.url.scheme());
     if (it != intercepted_handlers_->end()) {
       override_target_factory.Bind(ElectronURLLoaderFactory::Create(
-          it->second.first, it->second.second));
+          it->second.first, it->second.second, browser_context_));
     }
   }
 

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -205,6 +205,7 @@ class ProxyingURLLoaderFactory
   ProxyingURLLoaderFactory(
       api::WebRequest* web_request,
       const HandlersMap& intercepted_handlers,
+      base::WeakPtr<ElectronBrowserContext> browser_context,
       int render_process_id,
       int frame_routing_id,
       uint64_t* request_id_generator,
@@ -265,6 +266,8 @@ class ProxyingURLLoaderFactory
   //
   // In this way we can avoid using code from api namespace in this file.
   const raw_ref<const HandlersMap> intercepted_handlers_;
+
+  const base::WeakPtr<ElectronBrowserContext> browser_context_;
 
   const int render_process_id_;
   const int frame_routing_id_;

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -16,7 +16,8 @@ ProtocolRegistry* ProtocolRegistry::FromBrowserContext(
   return static_cast<ElectronBrowserContext*>(context)->protocol_registry();
 }
 
-ProtocolRegistry::ProtocolRegistry() = default;
+ProtocolRegistry::ProtocolRegistry(ElectronBrowserContext* browser_context)
+    : browser_context_(browser_context) {}
 
 ProtocolRegistry::~ProtocolRegistry() = default;
 
@@ -42,7 +43,8 @@ void ProtocolRegistry::RegisterURLLoaderFactories(
 
   for (const auto& it : handlers_) {
     factories->emplace(it.first, ElectronURLLoaderFactory::Create(
-                                     it.second.first, it.second.second));
+                                     it.second.first, it.second.second,
+                                     browser_context_->GetWeakPtr()));
   }
 }
 
@@ -57,7 +59,8 @@ ProtocolRegistry::CreateNonNetworkNavigationURLLoaderFactory(
     auto handler = handlers_.find(scheme);
     if (handler != handlers_.end()) {
       return ElectronURLLoaderFactory::Create(handler->second.first,
-                                              handler->second.second);
+                                              handler->second.second,
+                                              browser_context_->GetWeakPtr());
     }
   }
   return {};

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 
+#include "base/memory/raw_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "shell/browser/net/electron_url_loader_factory.h"
 
@@ -16,6 +17,8 @@ class BrowserContext;
 }
 
 namespace electron {
+
+class ElectronBrowserContext;
 
 class ProtocolRegistry {
  public:
@@ -54,7 +57,9 @@ class ProtocolRegistry {
  private:
   friend class ElectronBrowserContext;
 
-  ProtocolRegistry();
+  explicit ProtocolRegistry(ElectronBrowserContext* browser_context);
+
+  const raw_ptr<ElectronBrowserContext> browser_context_;
 
   HandlersMap handlers_;
   HandlersMap intercept_handlers_;

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -49,6 +49,7 @@
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "shell/browser/electron_browser_context.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/net/asar/asar_url_loader_factory.h"
 #include "shell/browser/protocol_registry.h"
@@ -735,10 +736,13 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
             std::move(pending_remote)));
   } else if (const auto* const protocol_handler =
                  protocol_registry->FindRegistered(gurl.scheme())) {
+    auto* browser_context = static_cast<ElectronBrowserContext*>(
+        GetDevToolsWebContents()->GetBrowserContext());
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             ElectronURLLoaderFactory::Create(protocol_handler->first,
-                                             protocol_handler->second)));
+                                             protocol_handler->second,
+                                             browser_context->GetWeakPtr())));
   } else {
     auto* partition = GetDevToolsWebContents()
                           ->GetBrowserContext()

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -528,8 +528,9 @@ SimpleURLLoaderWrapper::GetURLLoaderFactoryForURL(const GURL& url) {
       return browser_context_->InterceptURLLoaderFactory(
           network::SharedURLLoaderFactory::Create(
               std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
-                  ElectronURLLoaderFactory::Create(protocol_handler->first,
-                                                   protocol_handler->second))));
+                  ElectronURLLoaderFactory::Create(
+                      protocol_handler->first, protocol_handler->second,
+                      browser_context_->GetWeakPtr()))));
     }
   }
 

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -380,6 +380,45 @@ describe('protocol module', () => {
     });
   }
 
+  describe('ProtocolResponse.url', () => {
+    it('uses the handling session for the upstream request when session is not specified', async () => {
+      const server = http.createServer((req, res) => {
+        res.setHeader('content-type', 'text/html');
+        res.end(text);
+      });
+      defer(() => server.close());
+      const { url } = await listen(server);
+
+      const ses = session.fromPartition(`protocol-response-url-session-${v4()}`);
+      let upstreamSeenByHandlingSession = false;
+      let upstreamSeenByDefaultSession = false;
+      ses.webRequest.onBeforeRequest((details, callback) => {
+        if (details.url.startsWith(url)) upstreamSeenByHandlingSession = true;
+        callback({});
+      });
+      session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
+        if (details.url.startsWith(url)) upstreamSeenByDefaultSession = true;
+        callback({});
+      });
+      defer(() => {
+        ses.webRequest.onBeforeRequest(null);
+        session.defaultSession.webRequest.onBeforeRequest(null);
+      });
+
+      ses.protocol.registerHttpProtocol(protocolName, (request, callback) => callback({ url }));
+      defer(() => ses.protocol.unregisterProtocol(protocolName));
+
+      const w = new BrowserWindow({ show: false, webPreferences: { session: ses, sandbox: true } });
+      defer(() => w.destroy());
+      await w.webContents.loadFile(path.join(__dirname, 'fixtures', 'pages', 'fetch.html'));
+      const r = await w.webContents.executeJavaScript(`ajax("${protocolName}://fake-host", {})`);
+      expect(r.data).to.equal(text);
+
+      expect(upstreamSeenByHandlingSession).to.be.true('upstream request did not go through the handling session');
+      expect(upstreamSeenByDefaultSession).to.be.false('upstream request went through the default session');
+    });
+  });
+
   for (const [registerStreamProtocol, name] of [
     [protocol.registerStreamProtocol, 'protocol.registerStreamProtocol'] as const,
     [(protocol as any).registerProtocol as typeof protocol.registerStreamProtocol, 'protocol.registerProtocol'] as const


### PR DESCRIPTION
#### Description of Change

`ProtocolResponse.session` is documented as:

> By default the HTTP request will reuse the current session.

In practice, when `session` was omitted the upstream request was always
made through `session.defaultSession`, regardless of which session the
protocol handler was registered on. Thread the registering browser
context through `ElectronURLLoaderFactory` so the upstream request
defaults to the handler's own session, as documented.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Fixed `ProtocolResponse.url` requests being made through the default session instead of the session the protocol handler was registered on when `ProtocolResponse.session` was not set.
