### PR TITLE
chore: cherry-pick 4 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -161,3 +161,7 @@ cherry-pick-5f731169915a.patch
 cherry-pick-bdb3d3b0479a.patch
 cherry-pick-7d1c92a1029e.patch
 cherry-pick-396621520f68.patch
+cherry-pick-57f1f723d5d5.patch
+cherry-pick-f583b94a1374.patch
+cherry-pick-04f66fb96767.patch
+cherry-pick-449a1ea22a42.patch

--- a/patches/chromium/cherry-pick-04f66fb96767.patch
+++ b/patches/chromium/cherry-pick-04f66fb96767.patch
@@ -1,0 +1,248 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Russell <kbr@chromium.org>
+Date: Mon, 22 Jun 2026 20:35:29 -0700
+Subject: [M149] Rebind original FBO earlier in ClearLevelUsingGL.
+
+Original change's description:
+> Rebind original FBO earlier in ClearLevelUsingGL.
+>
+> Avoid triggering problems on some drivers when deleting an in-use FBO.
+>
+> Co-authored with jetski-cli.
+>
+> Fixed: 523591974
+> Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7953879
+> Reviewed-by: Brandon Jones <bajones@chromium.org>
+> Commit-Queue: Kenneth Russell <kbr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648728}
+
+(cherry picked from commit feb103bc1c01d1a1e62383f906346d23bb725fb1)
+
+Bug: 525661769,523591974
+Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7975811
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3693}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index d39a1632e3c23fa1367d22ecb3932e160f06fe8d..a2f75be5ef8abfac071289bcf59d7337486e8d3c 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -12269,11 +12269,16 @@ bool GLES2DecoderImpl::ClearLevelUsingGL(Texture* texture,
+     result = true;
+   }
+   RestoreClearState();
+-  api()->glDeleteFramebuffersEXTFn(1, &fb);
++  // Restore the previous framebuffer binding *before* deleting the temporary
++  // FBO. Some Imagination/PowerVR drivers retain an internal reference to the
++  // previously-bound FBO across bind transitions; deleting it while bound and
++  // then rebinding can dereference freed driver state. See the
++  // ensure_previous_framebuffer_not_deleted workaround.
+   Framebuffer* framebuffer = GetFramebufferInfoForTarget(fb_target);
+   GLuint fb_service_id =
+       framebuffer ? framebuffer->service_id() : GetBackbufferServiceId();
+   BindFramebuffer(fb_target, fb_service_id);
++  api()->glDeleteFramebuffersEXTFn(1, &fb);
+   return result;
+ }
+ 
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+index 874098118b2ddf4e02218818ce28e4b71b030484..9e4d6e3bf3c6788ad3984dd46bcdb1d2b7ec3866 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+@@ -543,6 +543,7 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+   }
+ 
+  protected:
++  virtual void SetupMockGLBehaviors();
+   static const int kBackBufferWidth = 128;
+   static const int kBackBufferHeight = 64;
+ 
+@@ -787,7 +788,6 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+     GLuint bound_vertex_array_object_;
+   };  // class MockGLStates
+ 
+-  void SetupMockGLBehaviors();
+ 
+   GpuPreferences gpu_preferences_;
+   ShaderTranslatorCache shader_translator_cache_;
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+index def979a3dfc8142fc63ae3aaf250b363a1669af2..8221dd0b24400df0e6650ce87974ec2f4cae5462 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+@@ -3195,6 +3195,171 @@ TEST_P(GLES2DecoderManualInitTest, GenerateMipmapDepthTexture) {
+   EXPECT_EQ(GL_INVALID_OPERATION, GetGLError());
+ }
+ 
++class GLES2DecoderEnsurePrevFboWorkaroundTest
++    : public GLES2DecoderManualInitTest {
++ public:
++  GLES2DecoderEnsurePrevFboWorkaroundTest() = default;
++
++  void SetupMockGLBehaviors() override {
++    GLES2DecoderManualInitTest::SetupMockGLBehaviors();
++    if (enable_workaround_expectations_) {
++      EXPECT_CALL(*gl_, GenTextures(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboTextureId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindTexture(GL_TEXTURE_2D, kCompleteFboTextureId))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA,
++                                   GL_UNSIGNED_BYTE, nullptr))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++          .Times(3)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, FramebufferTexture2DEXT(
++                            GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                            kCompleteFboTextureId, 0))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++          .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, DeleteTextures(1, Pointee(kCompleteFboTextureId)))
++          .Times(1)
++          .RetiresOnSaturation();
++    }
++  }
++
++ protected:
++  bool enable_workaround_expectations_ = false;
++  static constexpr GLuint kCompleteFboTextureId = 999;
++  static constexpr GLuint kCompleteFboId = 998;
++};
++
++// The test uses a depth texture to force GLES2DecoderImpl::ClearLevel to use
++// the ClearLevelUsingGL path, which is required to trigger the FBO restoration
++// workaround logic. For color textures, ClearLevel may fallback to the
++// TexSubImage2D clear path which does not use a temporary FBO.
++TEST_P(GLES2DecoderEnsurePrevFboWorkaroundTest, ClearLevelUsingGLOrder) {
++  enable_workaround_expectations_ = true;
++  gpu::GpuDriverBugWorkarounds workarounds;
++  workarounds.ensure_previous_framebuffer_not_deleted = true;
++  InitState init;
++  init.extensions = "GL_ANGLE_depth_texture";
++  init.gl_version = "OpenGL ES 2.0";
++  init.has_depth = true;
++  init.request_depth = true;
++  InitDecoderWithWorkarounds(init, workarounds);
++
++  // Set up texture
++  DoBindTexture(GL_TEXTURE_2D, client_texture_id_, kServiceTextureId);
++  DoTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, 1, 1, 0,
++               GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0);
++
++  TextureRef* texture_ref =
++      group().texture_manager()->GetTexture(client_texture_id_);
++  ASSERT_TRUE(texture_ref != nullptr);
++  Texture* texture = texture_ref->texture();
++
++  // Expectations for ClearLevel
++  const GLuint kTempFboId = 777;
++  InSequence seq;
++
++  // 1. Gen temp FBO
++  EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++      .WillOnce(SetArgPointee<1>(kTempFboId))
++      .RetiresOnSaturation();
++
++  // 2. Bind temp FBO (wrapper triggers complete_fbo bind first)
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kTempFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 3. Attach texture
++  EXPECT_CALL(*gl_,
++              FramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
++                                      GL_TEXTURE_2D, kServiceTextureId, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 4. Check status
++  EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++      .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++      .RetiresOnSaturation();
++
++  // 5. Clear calls
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, ColorMask(true, true, true, true))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_BACK, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, DepthMask(true)).Times(1).RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, Enable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Scissor(0, 0, 1, 1)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Clear(GL_DEPTH_BUFFER_BIT)).Times(1).RetiresOnSaturation();
++
++  // 6. Restore state
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Disable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_,
++              Scissor(0, 0, 128, 64))  // 128x64 is the default backbuffer size
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 7. Restore FBO binding (CRITICAL: Must happen BEFORE delete)
++  // Wrapper triggers complete_fbo bind first
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 8. Delete temp FBO
++  EXPECT_CALL(*gl_, DeleteFramebuffersEXT(1, Pointee(kTempFboId)))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // Call ClearLevel
++  EXPECT_TRUE(decoder_->ClearLevel(texture, GL_TEXTURE_2D, 0,
++                                   GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0, 1,
++                                   1));
++
++  DoDeleteTexture(client_texture_id_, kServiceTextureId);
++}
++
++// The boolean parameter controls whether ignore_cached_state_for_test is
++// enabled in the base fixture GLES2DecoderTestBase. This forces GL state
++// restoration and helps test state-dirtying paths.
++INSTANTIATE_TEST_SUITE_P(Service,
++                         GLES2DecoderEnsurePrevFboWorkaroundTest,
++                         ::testing::Bool());
++
+ TEST_P(GLES2DecoderManualInitTest, DrawWithGLImageExternal) {
+   InitState init;
+   init.extensions = "GL_OES_EGL_image_external";

--- a/patches/chromium/cherry-pick-449a1ea22a42.patch
+++ b/patches/chromium/cherry-pick-449a1ea22a42.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brandon Jones <bajones@chromium.org>
+Date: Tue, 16 Jun 2026 14:30:01 -0700
+Subject: [M149] Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
+
+Original change's description:
+> Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
+>
+> One Android path in CopyTextureCHROMIUM uses a glReadPixels call
+> to a client buffer, but doesn't clear the PIXEL_PACK_BUFFER
+> before doing the read. If the page sets the PIXEL_PACK_BUFFER
+> in a WebGL 2 context prior to this method being called it could
+> interfere with the data being read, leading the client buffer to
+> potentially contain uninitialized memory.
+>
+> This change ensures the PIXEL_PACK_BUFFER is always set to 0
+> before performing the client read.
+>
+> Fixed: 522840723
+> Change-Id: I95c3ad176a2759b490b0b36555c186489fe9153d
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7927868
+> Commit-Queue: Brandon Jones <bajones@chromium.org>
+> Reviewed-by: Kenneth Russell <kbr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1646051}
+
+(cherry picked from commit 92b7a3ad4869e940d79019996d0751f739e1a842)
+
+Bug: 523531700,522840723
+Change-Id: I95c3ad176a2759b490b0b36555c186489fe9153d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7944906
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Brandon Jones <bajones@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3297}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc b/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
+index f06fba6aaa6098167b3e40a2469c3d981932090b..ab61c962d41fa3dfabac47997ace699e58e5e23c 100644
+--- a/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
++++ b/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
+@@ -715,6 +715,7 @@ bool PrepareUnpackBuffer(base::span<const GLuint> buffer,
+     // GLCopyTextureCHROMIUMES3Test.FormatCombinations in gl_tests. This is seen
+     // on Nexus 5 but not Nexus 4. Read pixels to client memory, then upload to
+     // pixel unpack buffer with glBufferData.
++    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+     auto pixels = base::HeapArray<uint8_t>::Uninit(pixel_num * 4);
+     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+     auto data = base::HeapArray<float>::Uninit(pixel_num * 3);

--- a/patches/chromium/cherry-pick-57f1f723d5d5.patch
+++ b/patches/chromium/cherry-pick-57f1f723d5d5.patch
@@ -1,0 +1,376 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fergal Daly <fergal@chromium.org>
+Date: Tue, 23 Jun 2026 02:47:50 -0700
+Subject: [M148] Fix data race on SandboxFileSystemBackendDelegate observers
+
+Original change's description:
+> Fix data race on SandboxFileSystemBackendDelegate observers
+>
+> FileSystemAccessBucketPathWatcher::Initialize was registering observers
+> on the UI thread, while concurrent file operations on the IO thread were
+> reading them, causing a data race.
+>
+> The `io_thread_checker_` was actually bound to the UI thread (by all 3
+> Add* methods) and none of the reader methods were ever checking the
+> thread. `AddFileChangeObserver` was the only writer that is called
+> post-open.
+>
+> All calls to `Initialize` originate in `DoFileOperation` and the chain
+> of calls are all tail-calls so it's safe to change `Initialize` to call
+> `on_source_initialized` asynchronously.
+>
+> This CL fixes the issue by:
+> 1. Posting the observer registration to the IO thread in
+> FileSystemAccessBucketPathWatcher::Initialize.
+> 2. Using PostTaskAndReply to ensure the on_source_initialized callback
+> runs on the UI thread after registration is complete.
+> 3. Adding thread checks (DCHECKs) to the reader methods in
+> SandboxFileSystemBackendDelegate.
+>
+> Adding the new DCHECKs caused existing tests to uncovere a threading
+> issue in `FileSystemAccessFileModificationHostImpl::OnContentsModified`
+> which has a similar fix.
+>
+> A flaky test also uncovered that `ApplyPendingUsageUpdate` needed to
+> look at `is_disabled_` before proceeding.
+>
+> This adds a new unittest. If the fix is reverted, this tests triggers
+> the newly added DCHECKs in the readers.
+>
+> TAG=agy
+> CONV=c63ee629-91da-4fcb-a6cb-d27497e0fcb7
+>
+> Fixed: 520543781
+> Change-Id: I6c185b37f1c8a7c1e83f163af177fb8f4086d3c1
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7901886
+> Reviewed-by: Ming-Ying Chung <mych@chromium.org>
+> Commit-Queue: Fergal Daly <fergal@chromium.org>
+> Auto-Submit: Fergal Daly <fergal@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648080}
+
+(cherry picked from commit 9e5f886aa8383d6db96bceee30ebda5641ae0bfe)
+
+Bug: 525281018,520543781
+Change-Id: I6c185b37f1c8a7c1e83f163af177fb8f4086d3c1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7977798
+Commit-Queue: Fergal Daly <fergal@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4411}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc b/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
+index b5a837f7be066058a145175cbd3dcd06e6a4df1e..33b31268e9d6248362f755bfedbaa944da12a773 100644
+--- a/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
++++ b/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
+@@ -13,6 +13,7 @@
+ #include "base/threading/sequence_bound.h"
+ #include "content/browser/file_system_access/file_system_access_error.h"
+ #include "content/browser/file_system_access/file_system_access_watcher_manager.h"
++#include "content/public/browser/browser_thread.h"
+ #include "storage/browser/file_system/file_observers.h"
+ #include "storage/browser/file_system/file_system_url.h"
+ #include "storage/browser/file_system/sandbox_file_system_backend_delegate.h"
+@@ -65,11 +66,20 @@ void FileSystemAccessBucketPathWatcher::Initialize(
+     return;
+   }
+ 
+-  sandbox_delegate->AddFileChangeObserver(
+-      storage::FileSystemType::kFileSystemTypeTemporary, this,
+-      base::SequencedTaskRunner::GetCurrentDefault().get());
+-
+-  std::move(on_source_initialized).Run(file_system_access_error::Ok());
++  // Observer registration must happen on the IO thread to avoid a data race
++  // with concurrent file operations reading the observer list.
++  // The callback `on_source_initialized` is run as a reply on the UI thread
++  // once registration is complete.
++  content::GetIOThreadTaskRunner({})->PostTaskAndReply(
++      FROM_HERE,
++      base::BindOnce(
++          &storage::SandboxFileSystemBackendDelegate::AddFileChangeObserver,
++          base::Unretained(sandbox_delegate),
++          storage::FileSystemType::kFileSystemTypeTemporary,
++          base::WrapRefCounted(this),
++          base::RetainedRef(base::SequencedTaskRunner::GetCurrentDefault())),
++      base::BindOnce(std::move(on_source_initialized),
++                     file_system_access_error::Ok()));
+ }
+ 
+ void FileSystemAccessBucketPathWatcher::OnCreateFile(
+diff --git a/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc b/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
+index 007d0927b9d1dc82262f25cd0aaee11db4fbc5fa..aca794c49a35f33cb0d32e1c89227fcde09ff244 100644
+--- a/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
++++ b/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
+@@ -8,6 +8,8 @@
+ #include "base/task/sequenced_task_runner.h"
+ #include "base/time/time.h"
+ #include "base/types/pass_key.h"
++#include "content/public/browser/browser_task_traits.h"
++#include "content/public/browser/browser_thread.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+ #include "storage/browser/file_system/file_observers.h"
+ #include "storage/browser/file_system/task_runner_bound_observer_list.h"
+@@ -123,10 +125,19 @@ void FileSystemAccessFileModificationHostImpl::DidGetUsageAndQuota(
+ void FileSystemAccessFileModificationHostImpl::OnContentsModified() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
+-  if (const storage::ChangeObserverList* change_observers =
+-          manager_->context()->GetChangeObservers(url_.type())) {
+-    change_observers->Notify(&storage::FileChangeObserver::OnModifyFile, url_);
+-  }
++  scoped_refptr<storage::FileSystemContext> context =
++      base::WrapRefCounted(manager_->context());
++  GetIOThreadTaskRunner({})->PostTask(
++      FROM_HERE, base::BindOnce(
++                     [](scoped_refptr<storage::FileSystemContext> context,
++                        storage::FileSystemURL url) {
++                       if (const storage::ChangeObserverList* change_observers =
++                               context->GetChangeObservers(url.type())) {
++                         change_observers->Notify(
++                             &storage::FileChangeObserver::OnModifyFile, url);
++                       }
++                     },
++                     std::move(context), url_));
+ }
+ 
+ }  // namespace content
+diff --git a/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc b/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
+index ca78c76d3838e32b4791e76733656763adaba3a4..498c8fe7dae97b86e0114d4e9f2ae3cde2c78e55 100644
+--- a/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
++++ b/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
+@@ -24,12 +24,14 @@
+ #include "content/browser/file_system_access/file_system_access_observation_group.h"
+ #include "content/browser/file_system_access/file_system_access_observer_quota_manager.h"
+ #include "content/browser/file_system_access/file_system_access_watch_scope.h"
++#include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "content/public/test/test_browser_context.h"
+ #include "content/public/test/test_web_contents_factory.h"
+ #include "content/test/test_web_contents.h"
+ #include "storage/browser/file_system/external_mount_points.h"
++#include "storage/browser/file_system/file_system_backend.h"
+ #include "storage/browser/file_system/file_system_context.h"
+ #include "storage/browser/file_system/file_system_url.h"
+ #include "storage/browser/quota/quota_manager_proxy.h"
+@@ -257,10 +259,12 @@ class FakeChangeSource : public FileSystemAccessChangeSource {
+ 
+ }  // namespace
+ 
+-class FileSystemAccessWatcherManagerTest : public testing::Test {
++class FileSystemAccessWatcherManagerTestBase : public testing::Test {
+  public:
+-  FileSystemAccessWatcherManagerTest()
+-      : task_environment_(base::test::TaskEnvironment::MainThreadType::IO) {}
++  template <typename... TaskEnvironmentTraits>
++  explicit FileSystemAccessWatcherManagerTestBase(
++      TaskEnvironmentTraits&&... traits)
++      : task_environment_(std::forward<TaskEnvironmentTraits>(traits)...) {}
+ 
+   void SetUp() override {
+ #if BUILDFLAG(IS_WIN)
+@@ -286,23 +290,32 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+     static_cast<TestWebContents*>(web_contents_)->NavigateAndCommit(kTestUrl);
+ 
+     quota_manager_ = base::MakeRefCounted<storage::MockQuotaManager>(
+-        /*is_incognito=*/false, dir_.GetPath(),
+-        base::SingleThreadTaskRunner::GetCurrentDefault(),
++        /*is_incognito=*/false, dir_.GetPath(), io_task_runner(),
+         special_storage_policy_);
+     quota_manager_proxy_ = base::MakeRefCounted<storage::MockQuotaManagerProxy>(
+-        quota_manager_.get(),
+-        base::SingleThreadTaskRunner::GetCurrentDefault().get());
++        quota_manager_.get(), io_task_runner());
+ 
+-    file_system_context_ = storage::CreateFileSystemContextForTesting(
+-        quota_manager_proxy_.get(), dir_.GetPath());
++    file_system_context_ =
++        storage::CreateFileSystemContextWithAdditionalProvidersForTesting(
++            io_task_runner(),
++            base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}),
++            quota_manager_proxy_.get(),
++            std::vector<std::unique_ptr<storage::FileSystemBackend>>(),
++            dir_.GetPath());
+ 
+     storage::ExternalMountPoints::GetSystemInstance()->RegisterFileSystem(
+         kTestMountPoint, storage::kFileSystemTypeLocal,
+         storage::FileSystemMountOption(), dir_.GetPath());
+ 
+     chrome_blob_context_ = base::MakeRefCounted<ChromeBlobStorageContext>();
+-    chrome_blob_context_->InitializeOnIOThread(base::FilePath(),
+-                                               base::FilePath(), nullptr);
++    base::RunLoop run_loop;
++    io_task_runner()->PostTaskAndReply(
++        FROM_HERE,
++        base::BindOnce(&ChromeBlobStorageContext::InitializeOnIOThread,
++                       chrome_blob_context_, base::FilePath(), base::FilePath(),
++                       nullptr),
++        run_loop.QuitClosure());
++    run_loop.Run();
+ 
+     manager_ = base::MakeRefCounted<FileSystemAccessManagerImpl>(
+         file_system_context_, chrome_blob_context_,
+@@ -324,7 +337,7 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+     manager_.reset();
+     file_system_context_.reset();
+     chrome_blob_context_.reset();
+-    task_environment_.RunUntilIdle();
++    RunUntilIdle();
+     // On Windows, a synchronous delete of the directory can fail.
+     GetDeleteFileCallback(dir_.GetPath()).Run();
+   }
+@@ -465,8 +478,10 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+   FileSystemAccessManagerImpl::BindingContext binding_context_ = {
+       kTestStorageKey, kTestUrl, GlobalRenderFrameHostId()};
+ 
+-  BrowserTaskEnvironment task_environment_;
++  virtual scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() = 0;
++  virtual void RunUntilIdle() = 0;
+ 
++  BrowserTaskEnvironment task_environment_;
+   base::ScopedTempDir dir_;
+ 
+   TestBrowserContext browser_context_;
+@@ -484,6 +499,37 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+   raw_ptr<WebContents> web_contents_ = nullptr;
+ };
+ 
++class FileSystemAccessWatcherManagerTest
++    : public FileSystemAccessWatcherManagerTestBase {
++ public:
++  FileSystemAccessWatcherManagerTest()
++      : FileSystemAccessWatcherManagerTestBase(
++            base::test::TaskEnvironment::MainThreadType::IO) {}
++
++ protected:
++  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() override {
++    return base::SingleThreadTaskRunner::GetCurrentDefault();
++  }
++  void RunUntilIdle() override { task_environment_.RunUntilIdle(); }
++};
++
++class FileSystemAccessWatcherManagerRealIOTest
++    : public FileSystemAccessWatcherManagerTestBase {
++ public:
++  FileSystemAccessWatcherManagerRealIOTest()
++      : FileSystemAccessWatcherManagerTestBase(
++            BrowserTaskEnvironment::REAL_IO_THREAD) {}
++
++ protected:
++  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() override {
++    return GetIOThreadTaskRunner({});
++  }
++  void RunUntilIdle() override {
++    task_environment_.RunUntilIdle();
++    task_environment_.RunIOThreadUntilIdle();
++  }
++};
++
+ // Watching the local file system is not supported on Android or Fuchsia.
+ #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA) && !BUILDFLAG(IS_IOS)
+ TEST_F(FileSystemAccessWatcherManagerTest, BasicRegistration) {
+@@ -718,6 +764,42 @@ TEST_F(FileSystemAccessWatcherManagerTest, ObserveBucketFS) {
+   }));
+ }
+ 
++// See https://crbug.com/520543781. Ensure that we are correctly respecting
++// threading for file change observers.
++TEST_F(FileSystemAccessWatcherManagerRealIOTest, ObserveBucketFS) {
++  ASSERT_OK_AND_ASSIGN(auto default_bucket,
++                       CreateSandboxFileSystemAndGetDefaultBucket());
++  auto test_file_url = file_system_context_->CreateCrackedFileSystemURL(
++      kTestStorageKey, storage::kFileSystemTypeTemporary,
++      base::FilePath::FromUTF8Unsafe("test/foo/bar"));
++  test_file_url.SetBucket(default_bucket);
++
++#if BUILDFLAG(IS_MAC)
++  // Flush setup events before observation begins.
++  SpinEventLoopForABit();
++#endif
++
++  // Attempting to observe the given file will succeed.
++  ChangeAccumulator accumulator(ObserveFile(test_file_url));
++
++  base::test::TestFuture<base::File::Error> create_file_future;
++  manager_->DoFileSystemOperation(
++      FROM_HERE, &storage::FileSystemOperationRunner::CreateDirectory,
++      create_file_future.GetCallback(), test_file_url,
++      /*exclusive=*/false, /*recursive=*/true);
++  ASSERT_EQ(create_file_future.Get(), base::File::Error::FILE_OK);
++
++  // TODO(crbug.com/40283118): Expect changes for recursively-created
++  // intermediate directories.
++  ChangeInfo change_info(FilePathType::kDirectory, ChangeType::kCreated,
++                         test_file_url.path());
++  Change expected_change{test_file_url, change_info};
++  EXPECT_TRUE(base::test::RunUntil([&]() {
++    return testing::Matches(testing::Contains(expected_change))(
++        accumulator.changes());
++  }));
++}
++
+ TEST_F(FileSystemAccessWatcherManagerTest, UnsupportedScope) {
+   // TODO(crbug.com/321980129): External backends are not yet supported.
+   base::FilePath test_external_path =
+diff --git a/storage/browser/file_system/sandbox_file_system_backend_delegate.cc b/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
+index 77d28908d96d0a9411289ec1d98204ea0c08b189..6a641f68b370065bff653c34d7480731e4008cd6 100644
+--- a/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
++++ b/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
+@@ -458,6 +458,9 @@ void SandboxFileSystemBackendDelegate::AddFileAccessObserver(
+ 
+ const UpdateObserverList* SandboxFileSystemBackendDelegate::GetUpdateObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = update_observers_.find(type);
+   if (iter == update_observers_.end())
+     return nullptr;
+@@ -466,6 +469,9 @@ const UpdateObserverList* SandboxFileSystemBackendDelegate::GetUpdateObservers(
+ 
+ const ChangeObserverList* SandboxFileSystemBackendDelegate::GetChangeObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = change_observers_.find(type);
+   if (iter == change_observers_.end())
+     return nullptr;
+@@ -474,6 +480,9 @@ const ChangeObserverList* SandboxFileSystemBackendDelegate::GetChangeObservers(
+ 
+ const AccessObserverList* SandboxFileSystemBackendDelegate::GetAccessObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = access_observers_.find(type);
+   if (iter == access_observers_.end())
+     return nullptr;
+diff --git a/storage/browser/file_system/sandbox_quota_observer.cc b/storage/browser/file_system/sandbox_quota_observer.cc
+index c1d98a978c6239962a7a38f95e771ec2345e428e..a9df2d1db71678ca2df9c76455ca5022e6130263 100644
+--- a/storage/browser/file_system/sandbox_quota_observer.cc
++++ b/storage/browser/file_system/sandbox_quota_observer.cc
+@@ -148,6 +148,10 @@ base::FileErrorOr<base::FilePath> SandboxQuotaObserver::GetUsageCachePath(
+ }
+ 
+ void SandboxQuotaObserver::ApplyPendingUsageUpdate() {
++  base::AutoLock lock(is_disabled_lock_);
++  if (is_disabled_) {
++    return;
++  }
+   delayed_cache_update_helper_.Stop();
+   for (const auto& path_delta_pair : pending_update_notification_)
+     UpdateUsageCacheFile(path_delta_pair.first, path_delta_pair.second);
+diff --git a/storage/browser/file_system/sandbox_quota_observer.h b/storage/browser/file_system/sandbox_quota_observer.h
+index 07af63f39ea4689f5cac209879356fd1b88640ec..ec9cdffb9e3760d41c104e15178bf05902b141ce 100644
+--- a/storage/browser/file_system/sandbox_quota_observer.h
++++ b/storage/browser/file_system/sandbox_quota_observer.h
+@@ -79,7 +79,7 @@ class SandboxQuotaObserver
+   bool is_disabled_ GUARDED_BY(is_disabled_lock_) = false;
+   ~SandboxQuotaObserver() override;
+ 
+-  void ApplyPendingUsageUpdate() EXCLUSIVE_LOCKS_REQUIRED(is_disabled_lock_);
++  void ApplyPendingUsageUpdate();
+   void UpdateUsageCacheFile(const base::FilePath& usage_file_path,
+                             int64_t delta)
+       EXCLUSIVE_LOCKS_REQUIRED(is_disabled_lock_);

--- a/patches/chromium/cherry-pick-f583b94a1374.patch
+++ b/patches/chromium/cherry-pick-f583b94a1374.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sunny Sachanandani <sunnyps@chromium.org>
+Date: Thu, 18 Jun 2026 13:41:43 -0700
+Subject: [M149] [gpu] Check GL error before marking GLTexture/EGLImage cleared
+
+Original change's description:
+> [gpu] Check GL error before marking GLTexture/EGLImage cleared
+>
+> GLTextureImageBacking and EGLImageBacking currently mark the backing as
+> cleared unconditionally when initial pixel data is provided, even if the
+> subsequent upload via glTexSubImage2D fails (e.g. under resource
+> pressure / GL_OUT_OF_MEMORY). This bypasses the IsCleared() check,
+> potentially exposing uninitialized VRAM allocator residue during
+> readback.
+>
+> This CL checks for GL errors before calling SetCleared(). If a GL error
+> is detected, the backing remains uncleared so subsequent read access is
+> refused.
+>
+> Landing a shared image unittest for this wasn't feasible since it needs
+> patching GL function pointers which won't work well in any parallel test
+> setup. However, I was able to verify the fix locally with a unit test.
+>
+> Fixed: 517080836
+> Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7909296
+> Commit-Queue: Sunny Sachanandani <sunnyps@chromium.org>
+> Auto-Submit: Sunny Sachanandani <sunnyps@chromium.org>
+> Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1647933}
+
+(cherry picked from commit 7f4181fabb329920be950c95b76e69d1ad296cda)
+
+Bug: 525281583,517080836
+Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7962562
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3415}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/shared_image/egl_image_backing.cc b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+index 3d144b39647347c648720115604e3626d48516a0..426bf4fbdb7e142ee204a7c6032ff72338ae63b3 100644
+--- a/gpu/command_buffer/service/shared_image/egl_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+@@ -456,6 +456,17 @@ gl::ScopedEGLImage EGLImageBacking::GenEGLImageSibling(
+                         format_info.adjusted_format, format_info.gl_type, data);
+   }
+ 
++  // The storage allocation of the sibling texture allocates undefined-content
++  // storage on a context without robust-resource-init. If the following upload
++  // upload failed (e.g. GL_OUT_OF_MEMORY) the storage is still uninitialized.
++  // Return an invalid image so that we don't call SetCleared() on the backing.
++  const GLenum error = api->glGetErrorFn();
++  if (error != GL_NO_ERROR) {
++    LOG(ERROR) << "EGLImageBacking: initial pixel upload failed (GL error 0x"
++               << std::hex << error << ")";
++    return gl::ScopedEGLImage();
++  }
++
+   // Use service id of the texture as a source to create the EGLImage.
+   const EGLint egl_attrib_list[] = {
+       EGL_GL_TEXTURE_LEVEL_KHR, 0, EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
+@@ -482,6 +493,12 @@ EGLImageBacking::GenEGLImageSiblings(base::span<const uint8_t> pixel_data) {
+     AutoLock auto_lock(this);
+     create_egl_images = egl_images_.empty();
+     if (create_egl_images) {
++      // Drain any pre-existing GL errors so the post-allocation check below in
++      // GenEGLImageSibling is attributable to the storage call. Silently
++      // squelching these errors is unfortunate, but is done in order to mirror
++      // other allocation checks done in the command decoder.
++      while (api->glGetErrorFn() != GL_NO_ERROR) {
++      }
+       for (int plane = 0; plane < num_planes; plane++) {
+         gl::ScopedEGLImage egl_image =
+             GenEGLImageSibling(pixel_data, service_ids, plane);
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+index 05d020ec55dc43ddfdc4146b6bf874e9d0e35542..0ca351e125917dcf36839c246fe8e4cdadef298e 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+@@ -222,10 +222,12 @@ void GLTextureHolder::Initialize(
+       // that it can be used in other ES2 contexts, and so we have to pass
+       // gl_format as the internal format in the LevelInfo.
+       // https://crbug.com/628064
+-      texture_->SetLevelInfo(format_desc_.target, 0, format_desc_.data_format,
+-                             size_.width(), size_.height(), /*depth=*/1, 0,
+-                             format_desc_.data_format, format_desc_.data_type,
+-                             /*cleared_rect=*/gfx::Rect());
++      const gfx::Rect cleared_rect =
++          !pixel_data.empty() ? gfx::Rect(size_) : gfx::Rect();
++      texture_->SetLevelInfo(
++          format_desc_.target, /*level=*/0, format_desc_.data_format,
++          size_.width(), size_.height(), /*depth=*/1, /*border=*/0,
++          format_desc_.data_format, format_desc_.data_type, cleared_rect);
+       texture_->SetImmutable(true, format_info.supports_storage);
+     } else {
+       LOG(ERROR) << "GLTextureHolder: native storage allocation failed";
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+index 9d025ee656e3eeaade4ae60b9070c9fa7a8b22ba..dee67a02ac2b59b37a4f0b1570dc04b6f2b3b1cf 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+@@ -509,6 +509,14 @@ void GLTextureImageBacking::InitializeGLTexture(
+     base::span<const uint8_t> pixel_data,
+     gl::ProgressReporter* progress_reporter,
+     bool framebuffer_attachment_angle) {
++  // Drain any pre-existing GL errors so the post-allocation check below is
++  // attributable to the storage call. Silently squelching these errors is
++  // unfortunate, but is done in order to mirror other allocation checks done in
++  // the command decoder.
++  gl::GLApi* const api = gl::g_current_gl_context;
++  while (api->glGetErrorFn() != GL_NO_ERROR) {
++  }
++
+   const std::string debug_label =
+       "GLSharedImage_" + SharedImageBacking::debug_label();
+   int num_planes = format().NumberOfPlanes();
+@@ -522,8 +530,23 @@ void GLTextureImageBacking::InitializeGLTexture(
+                                 debug_label);
+   }
+ 
+-  if (!pixel_data.empty()) {
+-    SetCleared();
++  // Update the cleared state for passthrough textures if the pixel data upload
++  // was successful. We don't need to update the cleared state for validating
++  // decoder textures because we track the cleared state in the decoder texture
++  // objects whose cleared state is set in TextureHolder::Initialize above.
++  if (is_passthrough_ && !pixel_data.empty()) {
++    // The storage allocation allocates undefined-content storage on a context
++    // without robust-resource-init. If the subsequent upload failed (e.g.
++    // GL_OUT_OF_MEMORY) the storage is still uninitialised; only mark the
++    // backing cleared if no GL error was raised.
++    GLenum error = api->glGetErrorFn();
++    if (error == GL_NO_ERROR) {
++      SetCleared();
++    } else {
++      LOG(ERROR)
++          << "GLTextureImageBacking: initial pixel upload failed (GL error 0x"
++          << std::hex << error << ")";
++    }
+   }
+ }
+ 


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`f583b94a1374`](https://chromium-review.googlesource.com/c/chromium/src/+/7962562) from chromium — [M149] [gpu] Check GL error before marking GLTexture/EGLImage cleared
* [`449a1ea22a42`](https://chromium-review.googlesource.com/c/chromium/src/+/7944906) from chromium — [M149] Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
* [`04f66fb96767`](https://chromium-review.googlesource.com/c/chromium/src/+/7975811) from chromium — [M149] Rebind original FBO earlier in ClearLevelUsingGL.
* [`57f1f723d5d5`](https://chromium-review.googlesource.com/c/chromium/src/+/7977798) from chromium — [M148] Fix data race on SandboxFileSystemBackendDelegate observers

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium.
