### PR TITLE
chore: cherry-pick 9 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -157,3 +157,12 @@ feat_carry_embedder_startup_data_in_createnewwindowreply.patch
 feat_deliver_service_worker_preload_data_via_embeddedworkerstartparams.patch
 build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch
 build_disable_llvm_unroll-add-parallel-reductions_on_apple_targets.patch
+cherry-pick-c3f3e076d61a.patch
+cherry-pick-045d3557e2ad.patch
+cherry-pick-dc52460d5bf2.patch
+cherry-pick-851acf8f74cf.patch
+cherry-pick-05b31a349539.patch
+cherry-pick-7decfe7398f7.patch
+cherry-pick-83a9ebad816e.patch
+cherry-pick-5822dea3c6e8.patch
+cherry-pick-3e497ff45cf2.patch

--- a/patches/chromium/cherry-pick-045d3557e2ad.patch
+++ b/patches/chromium/cherry-pick-045d3557e2ad.patch
@@ -1,0 +1,248 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Russell <kbr@chromium.org>
+Date: Mon, 22 Jun 2026 20:43:50 -0700
+Subject: [M150] Rebind original FBO earlier in ClearLevelUsingGL.
+
+Original change's description:
+> Rebind original FBO earlier in ClearLevelUsingGL.
+>
+> Avoid triggering problems on some drivers when deleting an in-use FBO.
+>
+> Co-authored with jetski-cli.
+>
+> Fixed: 523591974
+> Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7953879
+> Reviewed-by: Brandon Jones <bajones@chromium.org>
+> Commit-Queue: Kenneth Russell <kbr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648728}
+
+(cherry picked from commit feb103bc1c01d1a1e62383f906346d23bb725fb1)
+
+Bug: 525661861,523591974
+Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7982244
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1960}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index 7c26b89c67f7f97d19425725a90d4c81bbe03b1b..3ba1ade7c812450d66e419a7366ade310953df84 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -12272,11 +12272,16 @@ bool GLES2DecoderImpl::ClearLevelUsingGL(Texture* texture,
+     result = true;
+   }
+   RestoreClearState();
+-  api()->glDeleteFramebuffersEXTFn(1, &fb);
++  // Restore the previous framebuffer binding *before* deleting the temporary
++  // FBO. Some Imagination/PowerVR drivers retain an internal reference to the
++  // previously-bound FBO across bind transitions; deleting it while bound and
++  // then rebinding can dereference freed driver state. See the
++  // ensure_previous_framebuffer_not_deleted workaround.
+   Framebuffer* framebuffer = GetFramebufferInfoForTarget(fb_target);
+   GLuint fb_service_id =
+       framebuffer ? framebuffer->service_id() : GetBackbufferServiceId();
+   BindFramebuffer(fb_target, fb_service_id);
++  api()->glDeleteFramebuffersEXTFn(1, &fb);
+   return result;
+ }
+ 
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+index 874098118b2ddf4e02218818ce28e4b71b030484..9e4d6e3bf3c6788ad3984dd46bcdb1d2b7ec3866 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+@@ -543,6 +543,7 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+   }
+ 
+  protected:
++  virtual void SetupMockGLBehaviors();
+   static const int kBackBufferWidth = 128;
+   static const int kBackBufferHeight = 64;
+ 
+@@ -787,7 +788,6 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+     GLuint bound_vertex_array_object_;
+   };  // class MockGLStates
+ 
+-  void SetupMockGLBehaviors();
+ 
+   GpuPreferences gpu_preferences_;
+   ShaderTranslatorCache shader_translator_cache_;
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+index 826c27a8ae46c2e6e6fb55af6993f20147555a9f..407f6b9ff5c92bedb3666216e9089c47bafc1bcb 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+@@ -3211,6 +3211,171 @@ TEST_P(GLES2DecoderManualInitTest, GenerateMipmapDepthTexture) {
+   EXPECT_EQ(GL_INVALID_OPERATION, GetGLError());
+ }
+ 
++class GLES2DecoderEnsurePrevFboWorkaroundTest
++    : public GLES2DecoderManualInitTest {
++ public:
++  GLES2DecoderEnsurePrevFboWorkaroundTest() = default;
++
++  void SetupMockGLBehaviors() override {
++    GLES2DecoderManualInitTest::SetupMockGLBehaviors();
++    if (enable_workaround_expectations_) {
++      EXPECT_CALL(*gl_, GenTextures(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboTextureId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindTexture(GL_TEXTURE_2D, kCompleteFboTextureId))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA,
++                                   GL_UNSIGNED_BYTE, nullptr))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++          .Times(3)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, FramebufferTexture2DEXT(
++                            GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                            kCompleteFboTextureId, 0))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++          .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, DeleteTextures(1, Pointee(kCompleteFboTextureId)))
++          .Times(1)
++          .RetiresOnSaturation();
++    }
++  }
++
++ protected:
++  bool enable_workaround_expectations_ = false;
++  static constexpr GLuint kCompleteFboTextureId = 999;
++  static constexpr GLuint kCompleteFboId = 998;
++};
++
++// The test uses a depth texture to force GLES2DecoderImpl::ClearLevel to use
++// the ClearLevelUsingGL path, which is required to trigger the FBO restoration
++// workaround logic. For color textures, ClearLevel may fallback to the
++// TexSubImage2D clear path which does not use a temporary FBO.
++TEST_P(GLES2DecoderEnsurePrevFboWorkaroundTest, ClearLevelUsingGLOrder) {
++  enable_workaround_expectations_ = true;
++  gpu::GpuDriverBugWorkarounds workarounds;
++  workarounds.ensure_previous_framebuffer_not_deleted = true;
++  InitState init;
++  init.extensions = "GL_ANGLE_depth_texture";
++  init.gl_version = "OpenGL ES 2.0";
++  init.has_depth = true;
++  init.request_depth = true;
++  InitDecoderWithWorkarounds(init, workarounds);
++
++  // Set up texture
++  DoBindTexture(GL_TEXTURE_2D, client_texture_id_, kServiceTextureId);
++  DoTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, 1, 1, 0,
++               GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0);
++
++  TextureRef* texture_ref =
++      group().texture_manager()->GetTexture(client_texture_id_);
++  ASSERT_TRUE(texture_ref != nullptr);
++  Texture* texture = texture_ref->texture();
++
++  // Expectations for ClearLevel
++  const GLuint kTempFboId = 777;
++  InSequence seq;
++
++  // 1. Gen temp FBO
++  EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++      .WillOnce(SetArgPointee<1>(kTempFboId))
++      .RetiresOnSaturation();
++
++  // 2. Bind temp FBO (wrapper triggers complete_fbo bind first)
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kTempFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 3. Attach texture
++  EXPECT_CALL(*gl_,
++              FramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
++                                      GL_TEXTURE_2D, kServiceTextureId, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 4. Check status
++  EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++      .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++      .RetiresOnSaturation();
++
++  // 5. Clear calls
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, ColorMask(true, true, true, true))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_BACK, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, DepthMask(true)).Times(1).RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, Enable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Scissor(0, 0, 1, 1)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Clear(GL_DEPTH_BUFFER_BIT)).Times(1).RetiresOnSaturation();
++
++  // 6. Restore state
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Disable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_,
++              Scissor(0, 0, 128, 64))  // 128x64 is the default backbuffer size
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 7. Restore FBO binding (CRITICAL: Must happen BEFORE delete)
++  // Wrapper triggers complete_fbo bind first
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 8. Delete temp FBO
++  EXPECT_CALL(*gl_, DeleteFramebuffersEXT(1, Pointee(kTempFboId)))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // Call ClearLevel
++  EXPECT_TRUE(decoder_->ClearLevel(texture, GL_TEXTURE_2D, 0,
++                                   GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0, 1,
++                                   1));
++
++  DoDeleteTexture(client_texture_id_, kServiceTextureId);
++}
++
++// The boolean parameter controls whether ignore_cached_state_for_test is
++// enabled in the base fixture GLES2DecoderTestBase. This forces GL state
++// restoration and helps test state-dirtying paths.
++INSTANTIATE_TEST_SUITE_P(Service,
++                         GLES2DecoderEnsurePrevFboWorkaroundTest,
++                         ::testing::Bool());
++
+ TEST_P(GLES2DecoderManualInitTest, DrawWithGLImageExternal) {
+   InitState init;
+   init.extensions = "GL_OES_EGL_image_external";

--- a/patches/chromium/cherry-pick-05b31a349539.patch
+++ b/patches/chromium/cherry-pick-05b31a349539.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Kosyakov <caseq@chromium.org>
+Date: Wed, 17 Jun 2026 12:04:07 -0700
+Subject: [M150] Copy devtools messages from renderer when backed by shmem
+
+Original change's description:
+> Copy devtools messages from renderer when backed by shmem
+>
+> Fixed: 518043569
+> Change-Id: I9910fd3801de94f6e142d85d9e2c59ca098ddb49
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7935128
+> Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
+> Reviewed-by: Peter Kvitek <kvitekp@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1646948}
+
+(cherry picked from commit 59621765eb49f2895805f256243ddb1f30297e55)
+
+Bug: 524508475,518043569
+Change-Id: I9910fd3801de94f6e142d85d9e2c59ca098ddb49
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7957921
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1472}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/content/browser/devtools/devtools_session.cc b/content/browser/devtools/devtools_session.cc
+index e8cb680f169ff23327fa280e56d6923a7dae8609..221784dfd178d86fc6670aa005240311e78871f6 100644
+--- a/content/browser/devtools/devtools_session.cc
++++ b/content/browser/devtools/devtools_session.cc
+@@ -572,8 +572,26 @@ void DevToolsSession::DispatchProtocolResponseOrNotification(
+     blink::mojom::DevToolsMessagePtr message,
+     const std::string& session_id,
+     const bool& is_notification) {
+-  base::span<const uint8_t> message_span = message->data;
+-  if (!ValidateMessage(session_id, /*expected_has_id=*/!is_notification,
++  // If BigBuffer is backed by shared memory, make a copy so that a compromised
++  // renderer wouldn't be able to mess with the message as we validate it.
++  std::vector<uint8_t> message_bytes;
++  base::span<const uint8_t> message_span;
++  switch (message->data.storage_type()) {
++    case mojo_base::BigBuffer::StorageType::kBytes:
++      message_span = message->data.byte_span();
++      break;
++    case mojo_base::BigBuffer::StorageType::kSharedMemory:
++      message_bytes.assign(message->data.begin(), message->data.end());
++      message_span = message_bytes;
++      break;
++    default:
++      // just keep span empty, this will cause renderer killed for invalid
++      // message below.
++      break;
++  }
++
++  if (message_span.empty() ||
++      !ValidateMessage(session_id, /*expected_has_id=*/!is_notification,
+                        message_span)) {
+     if (RenderProcessHost* process_host = agent_host->GetProcessHost()) {
+       bad_message::ReceivedBadMessage(

--- a/patches/chromium/cherry-pick-3e497ff45cf2.patch
+++ b/patches/chromium/cherry-pick-3e497ff45cf2.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Fri, 19 Jun 2026 10:35:12 -0700
+Subject: [M150] Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel
+
+Original change's description:
+> Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel
+>
+> Prevent synchronous destruction of BluetoothSocketMac when releasing the
+> channel by moving connect and receive callbacks to local variables. This
+> ensures the socket remains alive until ReleaseChannel finishes
+> execution, avoiding use-after-free when accessing other member
+> variables.
+>
+> Change-Id: I872d682b6a4d0887b8f93e118db54e51f57321f5
+> Bug: 523704570
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7948137
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648713}
+
+(cherry picked from commit 30838188f5ff65357672bcd00dfaff982ca7ca25)
+
+Bug: 525661474,523704570
+Change-Id: I872d682b6a4d0887b8f93e118db54e51f57321f5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7961535
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1703}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/device/bluetooth/bluetooth_socket_mac.mm b/device/bluetooth/bluetooth_socket_mac.mm
+index 315f1ddfe4d200f0697938b9087628262ab54282..abdc9a18ce27f24929f914f6a85182a90fad716e 100644
+--- a/device/bluetooth/bluetooth_socket_mac.mm
++++ b/device/bluetooth/bluetooth_socket_mac.mm
+@@ -1038,9 +1038,12 @@ bool VerifyL2capService(const std::optional<int>& requested_psm,
+   DCHECK(thread_checker_.CalledOnValidThread());
+   channel_.reset();
+ 
+-  // Closing the channel above prevents the callback delegate from being called
+-  // so it is now safe to release all callback state.
+-  connect_callbacks_.reset();
++  // Move connect_callbacks_ to a local variable to prevent synchronous
++  // destruction of 'this' if it holds the last reference to the socket.
++  // This keeps 'this' alive until the end of this method.
++  std::unique_ptr<ConnectCallbacks> temp_connect =
++      std::move(connect_callbacks_);
++
+   receive_callbacks_.reset();
+   empty_queue(receive_queue_);
+   empty_queue(send_queue_);

--- a/patches/chromium/cherry-pick-5822dea3c6e8.patch
+++ b/patches/chromium/cherry-pick-5822dea3c6e8.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anna Tsvirchkova <atsvirchkova@google.com>
+Date: Mon, 22 Jun 2026 06:40:43 -0700
+Subject: [M150] Fix leak of grouped credentials to renderer
+
+Original change's description:
+> Fix leak of grouped credentials to renderer
+>
+> If there are multiple matches e. g. the preferred match is an exact
+> match and the additional one is a grouped match (or PSL), there is a
+> possibility that the additional one will be leaked to the renderer
+> process though the filling on page load flow. On the rederer side, all
+> matches with non-empty realm are not used for filling anyway
+> (https://source.chromium.org/chromium/chromium/src/+/main:components/autofill/content/renderer/password_autofill_agent.cc;l=229;bpv=0;bpt=1),
+> so this fix clears the passwords for non-empty realm credentials to
+> avoid the leak.
+>
+> Bug: 523699355
+> Change-Id: I341cbb03752537c1ebc67b005d29de065eeca53c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7941892
+> Commit-Queue: Anna Tsvirchkova <atsvirchkova@google.com>
+> Reviewed-by: Maria Kazinova <kazinova@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1648968}
+
+(cherry picked from commit 0be87b4e25bf905accc522efa61a431de40a2ae9)
+
+Bug: 525662024,523699355
+Change-Id: I341cbb03752537c1ebc67b005d29de065eeca53c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7978757
+Commit-Queue: Anna Tsvirchkova <atsvirchkova@google.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1870}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/components/autofill/core/common/password_form_fill_data.cc b/components/autofill/core/common/password_form_fill_data.cc
+index 2fcba043f9fe6a379a839c01fb166c479117350e..b9e948889910ddca45faa5a07efbf2bad28ce2db 100644
+--- a/components/autofill/core/common/password_form_fill_data.cc
++++ b/components/autofill/core/common/password_form_fill_data.cc
+@@ -95,14 +95,19 @@ PasswordFormFillData MaybeClearPasswordValues(
+   // field), credentials from |additional_logins| could be used for filling
+   // on load. So in case of filling on load nor |password_field| nor
+   // |additional_logins| can't be cleared
+-  bool is_fallback = data.password_element_renderer_id.is_null();
+-  if (!data.wait_for_username && !is_fallback) {
+-    return data;
+-  }
++  bool no_fill_on_page_load =
++      data.wait_for_username || data.password_element_renderer_id.is_null();
+   PasswordFormFillData result(data);
+-  result.preferred_login.password_value.clear();
++  if (no_fill_on_page_load) {
++    result.preferred_login.password_value.clear();
++  }
+   for (auto& credentials : result.additional_logins) {
+-    credentials.password_value.clear();
++    // Realm is only set for credentials initially associated with a different
++    // domain. For security reasons, such credentials are never filled on page
++    // load and should not be passed to the renderer.
++    if (!credentials.realm.empty() || no_fill_on_page_load) {
++      credentials.password_value.clear();
++    }
+   }
+   return result;
+ }
+diff --git a/components/password_manager/core/browser/password_form_filling_unittest.cc b/components/password_manager/core/browser/password_form_filling_unittest.cc
+index 5a21847151422d01a552860227eb6e3e8c223969..949d150e919bcc69548da486f52130f2af30d1b0 100644
+--- a/components/password_manager/core/browser/password_form_filling_unittest.cc
++++ b/components/password_manager/core/browser/password_form_filling_unittest.cc
+@@ -999,4 +999,51 @@ TEST(PasswordFormFillDataTest, TestGroupedAffiliation) {
+   EXPECT_TRUE(result.preferred_login.is_grouped_affiliation);
+ }
+ 
++// Tests that `MaybeClearPasswordValues` clears the passwords of non-exact
++// matches (such as grouped credentials) when page-load filling is allowed, and
++// clears all passwords when `wait_for_username` is true.
++TEST(PasswordFormFillDataTest, MaybeClearPasswordValues) {
++  using autofill::PasswordAndMetadata;
++
++  // Create a PasswordFormFillData simulating:
++  // - preferred_login: exact match (has password)
++  // - additional_logins:
++  //   - exact match (realm is empty, has password)
++  //   - grouped match (realm is non-empty, has password)
++  PasswordFormFillData data;
++  data.preferred_login.password_value = u"preferred_password";
++  data.password_element_renderer_id =
++      FieldRendererId(123);  // Non-fallback form
++
++  PasswordAndMetadata exact_additional;
++  exact_additional.realm = "";
++  exact_additional.password_value = u"exact_password";
++  data.additional_logins.push_back(exact_additional);
++
++  PasswordAndMetadata grouped_additional;
++  grouped_additional.realm = "https://grouped.com";
++  grouped_additional.password_value = u"grouped_password";
++  data.additional_logins.push_back(grouped_additional);
++
++  // Scenario 1: wait_for_username = false (allow auto-fill on page load)
++  {
++    data.wait_for_username = false;
++    PasswordFormFillData result = autofill::MaybeClearPasswordValues(data);
++
++    EXPECT_EQ(u"preferred_password", result.preferred_login.password_value);
++    EXPECT_EQ(result.additional_logins[0].password_value, u"exact_password");
++    EXPECT_TRUE(result.additional_logins[1].password_value.empty());
++  }
++
++  // Scenario 2: wait_for_username = true (wait for user interaction)
++  {
++    data.wait_for_username = true;
++    PasswordFormFillData result = autofill::MaybeClearPasswordValues(data);
++
++    EXPECT_TRUE(result.preferred_login.password_value.empty());
++    EXPECT_TRUE(result.additional_logins[0].password_value.empty());
++    EXPECT_TRUE(result.additional_logins[1].password_value.empty());
++  }
++}
++
+ }  // namespace password_manager

--- a/patches/chromium/cherry-pick-7decfe7398f7.patch
+++ b/patches/chromium/cherry-pick-7decfe7398f7.patch
@@ -1,0 +1,376 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fergal Daly <fergal@chromium.org>
+Date: Mon, 22 Jun 2026 02:24:38 -0700
+Subject: [M150] Fix data race on SandboxFileSystemBackendDelegate observers
+
+Original change's description:
+> Fix data race on SandboxFileSystemBackendDelegate observers
+>
+> FileSystemAccessBucketPathWatcher::Initialize was registering observers
+> on the UI thread, while concurrent file operations on the IO thread were
+> reading them, causing a data race.
+>
+> The `io_thread_checker_` was actually bound to the UI thread (by all 3
+> Add* methods) and none of the reader methods were ever checking the
+> thread. `AddFileChangeObserver` was the only writer that is called
+> post-open.
+>
+> All calls to `Initialize` originate in `DoFileOperation` and the chain
+> of calls are all tail-calls so it's safe to change `Initialize` to call
+> `on_source_initialized` asynchronously.
+>
+> This CL fixes the issue by:
+> 1. Posting the observer registration to the IO thread in
+> FileSystemAccessBucketPathWatcher::Initialize.
+> 2. Using PostTaskAndReply to ensure the on_source_initialized callback
+> runs on the UI thread after registration is complete.
+> 3. Adding thread checks (DCHECKs) to the reader methods in
+> SandboxFileSystemBackendDelegate.
+>
+> Adding the new DCHECKs caused existing tests to uncovere a threading
+> issue in `FileSystemAccessFileModificationHostImpl::OnContentsModified`
+> which has a similar fix.
+>
+> A flaky test also uncovered that `ApplyPendingUsageUpdate` needed to
+> look at `is_disabled_` before proceeding.
+>
+> This adds a new unittest. If the fix is reverted, this tests triggers
+> the newly added DCHECKs in the readers.
+>
+> TAG=agy
+> CONV=c63ee629-91da-4fcb-a6cb-d27497e0fcb7
+>
+> Fixed: 520543781
+> Change-Id: I6c185b37f1c8a7c1e83f163af177fb8f4086d3c1
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7901886
+> Reviewed-by: Ming-Ying Chung <mych@chromium.org>
+> Commit-Queue: Fergal Daly <fergal@chromium.org>
+> Auto-Submit: Fergal Daly <fergal@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648080}
+
+(cherry picked from commit 9e5f886aa8383d6db96bceee30ebda5641ae0bfe)
+
+Bug: 525281153,520543781
+Change-Id: I6c185b37f1c8a7c1e83f163af177fb8f4086d3c1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7977078
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1856}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc b/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
+index b5a837f7be066058a145175cbd3dcd06e6a4df1e..33b31268e9d6248362f755bfedbaa944da12a773 100644
+--- a/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
++++ b/content/browser/file_system_access/file_system_access_bucket_path_watcher.cc
+@@ -13,6 +13,7 @@
+ #include "base/threading/sequence_bound.h"
+ #include "content/browser/file_system_access/file_system_access_error.h"
+ #include "content/browser/file_system_access/file_system_access_watcher_manager.h"
++#include "content/public/browser/browser_thread.h"
+ #include "storage/browser/file_system/file_observers.h"
+ #include "storage/browser/file_system/file_system_url.h"
+ #include "storage/browser/file_system/sandbox_file_system_backend_delegate.h"
+@@ -65,11 +66,20 @@ void FileSystemAccessBucketPathWatcher::Initialize(
+     return;
+   }
+ 
+-  sandbox_delegate->AddFileChangeObserver(
+-      storage::FileSystemType::kFileSystemTypeTemporary, this,
+-      base::SequencedTaskRunner::GetCurrentDefault().get());
+-
+-  std::move(on_source_initialized).Run(file_system_access_error::Ok());
++  // Observer registration must happen on the IO thread to avoid a data race
++  // with concurrent file operations reading the observer list.
++  // The callback `on_source_initialized` is run as a reply on the UI thread
++  // once registration is complete.
++  content::GetIOThreadTaskRunner({})->PostTaskAndReply(
++      FROM_HERE,
++      base::BindOnce(
++          &storage::SandboxFileSystemBackendDelegate::AddFileChangeObserver,
++          base::Unretained(sandbox_delegate),
++          storage::FileSystemType::kFileSystemTypeTemporary,
++          base::WrapRefCounted(this),
++          base::RetainedRef(base::SequencedTaskRunner::GetCurrentDefault())),
++      base::BindOnce(std::move(on_source_initialized),
++                     file_system_access_error::Ok()));
+ }
+ 
+ void FileSystemAccessBucketPathWatcher::OnCreateFile(
+diff --git a/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc b/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
+index 007d0927b9d1dc82262f25cd0aaee11db4fbc5fa..aca794c49a35f33cb0d32e1c89227fcde09ff244 100644
+--- a/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
++++ b/content/browser/file_system_access/file_system_access_file_modification_host_impl.cc
+@@ -8,6 +8,8 @@
+ #include "base/task/sequenced_task_runner.h"
+ #include "base/time/time.h"
+ #include "base/types/pass_key.h"
++#include "content/public/browser/browser_task_traits.h"
++#include "content/public/browser/browser_thread.h"
+ #include "mojo/public/cpp/bindings/pending_receiver.h"
+ #include "storage/browser/file_system/file_observers.h"
+ #include "storage/browser/file_system/task_runner_bound_observer_list.h"
+@@ -123,10 +125,19 @@ void FileSystemAccessFileModificationHostImpl::DidGetUsageAndQuota(
+ void FileSystemAccessFileModificationHostImpl::OnContentsModified() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
+-  if (const storage::ChangeObserverList* change_observers =
+-          manager_->context()->GetChangeObservers(url_.type())) {
+-    change_observers->Notify(&storage::FileChangeObserver::OnModifyFile, url_);
+-  }
++  scoped_refptr<storage::FileSystemContext> context =
++      base::WrapRefCounted(manager_->context());
++  GetIOThreadTaskRunner({})->PostTask(
++      FROM_HERE, base::BindOnce(
++                     [](scoped_refptr<storage::FileSystemContext> context,
++                        storage::FileSystemURL url) {
++                       if (const storage::ChangeObserverList* change_observers =
++                               context->GetChangeObservers(url.type())) {
++                         change_observers->Notify(
++                             &storage::FileChangeObserver::OnModifyFile, url);
++                       }
++                     },
++                     std::move(context), url_));
+ }
+ 
+ }  // namespace content
+diff --git a/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc b/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
+index f3fcbea84cfd299b91543a404d22fb06d5a43c65..dbf7eb9a388a6b7a253070e1f6efff66394d3788 100644
+--- a/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
++++ b/content/browser/file_system_access/file_system_access_watcher_manager_unittest.cc
+@@ -25,12 +25,14 @@
+ #include "content/browser/file_system_access/file_system_access_observation_group.h"
+ #include "content/browser/file_system_access/file_system_access_observer_quota_manager.h"
+ #include "content/browser/file_system_access/file_system_access_watch_scope.h"
++#include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "content/public/test/test_browser_context.h"
+ #include "content/public/test/test_web_contents_factory.h"
+ #include "content/test/test_web_contents.h"
+ #include "storage/browser/file_system/external_mount_points.h"
++#include "storage/browser/file_system/file_system_backend.h"
+ #include "storage/browser/file_system/file_system_context.h"
+ #include "storage/browser/file_system/file_system_url.h"
+ #include "storage/browser/quota/quota_manager_proxy.h"
+@@ -258,10 +260,12 @@ class FakeChangeSource : public FileSystemAccessChangeSource {
+ 
+ }  // namespace
+ 
+-class FileSystemAccessWatcherManagerTest : public testing::Test {
++class FileSystemAccessWatcherManagerTestBase : public testing::Test {
+  public:
+-  FileSystemAccessWatcherManagerTest()
+-      : task_environment_(base::test::TaskEnvironment::MainThreadType::IO) {}
++  template <typename... TaskEnvironmentTraits>
++  explicit FileSystemAccessWatcherManagerTestBase(
++      TaskEnvironmentTraits&&... traits)
++      : task_environment_(std::forward<TaskEnvironmentTraits>(traits)...) {}
+ 
+   void SetUp() override {
+ #if BUILDFLAG(IS_WIN)
+@@ -287,23 +291,32 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+     static_cast<TestWebContents*>(web_contents_)->NavigateAndCommit(kTestUrl);
+ 
+     quota_manager_ = base::MakeRefCounted<storage::MockQuotaManager>(
+-        /*is_incognito=*/false, dir_.GetPath(),
+-        base::SingleThreadTaskRunner::GetCurrentDefault(),
++        /*is_incognito=*/false, dir_.GetPath(), io_task_runner(),
+         special_storage_policy_);
+     quota_manager_proxy_ = base::MakeRefCounted<storage::MockQuotaManagerProxy>(
+-        quota_manager_.get(),
+-        base::SingleThreadTaskRunner::GetCurrentDefault().get());
++        quota_manager_.get(), io_task_runner());
+ 
+-    file_system_context_ = storage::CreateFileSystemContextForTesting(
+-        quota_manager_proxy_.get(), dir_.GetPath());
++    file_system_context_ =
++        storage::CreateFileSystemContextWithAdditionalProvidersForTesting(
++            io_task_runner(),
++            base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}),
++            quota_manager_proxy_.get(),
++            std::vector<std::unique_ptr<storage::FileSystemBackend>>(),
++            dir_.GetPath());
+ 
+     storage::ExternalMountPoints::GetSystemInstance()->RegisterFileSystem(
+         kTestMountPoint, storage::kFileSystemTypeLocal,
+         storage::FileSystemMountOption(), dir_.GetPath());
+ 
+     chrome_blob_context_ = base::MakeRefCounted<ChromeBlobStorageContext>();
+-    chrome_blob_context_->InitializeOnIOThread(base::FilePath(),
+-                                               base::FilePath(), nullptr);
++    base::RunLoop run_loop;
++    io_task_runner()->PostTaskAndReply(
++        FROM_HERE,
++        base::BindOnce(&ChromeBlobStorageContext::InitializeOnIOThread,
++                       chrome_blob_context_, base::FilePath(), base::FilePath(),
++                       nullptr),
++        run_loop.QuitClosure());
++    run_loop.Run();
+ 
+     manager_ = base::MakeRefCounted<FileSystemAccessManagerImpl>(
+         file_system_context_, chrome_blob_context_,
+@@ -325,7 +338,7 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+     manager_.reset();
+     file_system_context_.reset();
+     chrome_blob_context_.reset();
+-    task_environment_.RunUntilIdle();
++    RunUntilIdle();
+     // On Windows, a synchronous delete of the directory can fail.
+     GetDeleteFileCallback(dir_.GetPath()).Run();
+   }
+@@ -466,8 +479,10 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+   FileSystemAccessManagerImpl::BindingContext binding_context_ = {
+       kTestStorageKey, kTestUrl, GlobalRenderFrameHostId()};
+ 
+-  BrowserTaskEnvironment task_environment_;
++  virtual scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() = 0;
++  virtual void RunUntilIdle() = 0;
+ 
++  BrowserTaskEnvironment task_environment_;
+   base::ScopedTempDir dir_;
+ 
+   TestBrowserContext browser_context_;
+@@ -485,6 +500,37 @@ class FileSystemAccessWatcherManagerTest : public testing::Test {
+   raw_ptr<WebContents> web_contents_ = nullptr;
+ };
+ 
++class FileSystemAccessWatcherManagerTest
++    : public FileSystemAccessWatcherManagerTestBase {
++ public:
++  FileSystemAccessWatcherManagerTest()
++      : FileSystemAccessWatcherManagerTestBase(
++            base::test::TaskEnvironment::MainThreadType::IO) {}
++
++ protected:
++  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() override {
++    return base::SingleThreadTaskRunner::GetCurrentDefault();
++  }
++  void RunUntilIdle() override { task_environment_.RunUntilIdle(); }
++};
++
++class FileSystemAccessWatcherManagerRealIOTest
++    : public FileSystemAccessWatcherManagerTestBase {
++ public:
++  FileSystemAccessWatcherManagerRealIOTest()
++      : FileSystemAccessWatcherManagerTestBase(
++            BrowserTaskEnvironment::REAL_IO_THREAD) {}
++
++ protected:
++  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner() override {
++    return GetIOThreadTaskRunner({});
++  }
++  void RunUntilIdle() override {
++    task_environment_.RunUntilIdle();
++    task_environment_.RunIOThreadUntilIdle();
++  }
++};
++
+ // Watching the local file system is not supported on Android or Fuchsia.
+ #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_FUCHSIA) && !BUILDFLAG(IS_IOS)
+ TEST_F(FileSystemAccessWatcherManagerTest, BasicRegistration) {
+@@ -719,6 +765,42 @@ TEST_F(FileSystemAccessWatcherManagerTest, ObserveBucketFS) {
+   }));
+ }
+ 
++// See https://crbug.com/520543781. Ensure that we are correctly respecting
++// threading for file change observers.
++TEST_F(FileSystemAccessWatcherManagerRealIOTest, ObserveBucketFS) {
++  ASSERT_OK_AND_ASSIGN(auto default_bucket,
++                       CreateSandboxFileSystemAndGetDefaultBucket());
++  auto test_file_url = file_system_context_->CreateCrackedFileSystemURL(
++      kTestStorageKey, storage::kFileSystemTypeTemporary,
++      base::FilePath::FromUTF8Unsafe("test/foo/bar"));
++  test_file_url.SetBucket(default_bucket);
++
++#if BUILDFLAG(IS_MAC)
++  // Flush setup events before observation begins.
++  SpinEventLoopForABit();
++#endif
++
++  // Attempting to observe the given file will succeed.
++  ChangeAccumulator accumulator(ObserveFile(test_file_url));
++
++  base::test::TestFuture<base::File::Error> create_file_future;
++  manager_->DoFileSystemOperation(
++      FROM_HERE, &storage::FileSystemOperationRunner::CreateDirectory,
++      create_file_future.GetCallback(), test_file_url,
++      /*exclusive=*/false, /*recursive=*/true);
++  ASSERT_EQ(create_file_future.Get(), base::File::Error::FILE_OK);
++
++  // TODO(crbug.com/40283118): Expect changes for recursively-created
++  // intermediate directories.
++  ChangeInfo change_info(FilePathType::kDirectory, ChangeType::kCreated,
++                         test_file_url.path());
++  Change expected_change{test_file_url, change_info};
++  EXPECT_TRUE(base::test::RunUntil([&]() {
++    return testing::Matches(testing::Contains(expected_change))(
++        accumulator.changes());
++  }));
++}
++
+ TEST_F(FileSystemAccessWatcherManagerTest, UnsupportedScope) {
+   // TODO(crbug.com/321980129): External backends are not yet supported.
+   base::FilePath test_external_path =
+diff --git a/storage/browser/file_system/sandbox_file_system_backend_delegate.cc b/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
+index 77d28908d96d0a9411289ec1d98204ea0c08b189..6a641f68b370065bff653c34d7480731e4008cd6 100644
+--- a/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
++++ b/storage/browser/file_system/sandbox_file_system_backend_delegate.cc
+@@ -458,6 +458,9 @@ void SandboxFileSystemBackendDelegate::AddFileAccessObserver(
+ 
+ const UpdateObserverList* SandboxFileSystemBackendDelegate::GetUpdateObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = update_observers_.find(type);
+   if (iter == update_observers_.end())
+     return nullptr;
+@@ -466,6 +469,9 @@ const UpdateObserverList* SandboxFileSystemBackendDelegate::GetUpdateObservers(
+ 
+ const ChangeObserverList* SandboxFileSystemBackendDelegate::GetChangeObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = change_observers_.find(type);
+   if (iter == change_observers_.end())
+     return nullptr;
+@@ -474,6 +480,9 @@ const ChangeObserverList* SandboxFileSystemBackendDelegate::GetChangeObservers(
+ 
+ const AccessObserverList* SandboxFileSystemBackendDelegate::GetAccessObservers(
+     FileSystemType type) const {
++#if DCHECK_IS_ON()
++  DCHECK(!is_filesystem_opened_ || io_thread_checker_.CalledOnValidThread());
++#endif
+   auto iter = access_observers_.find(type);
+   if (iter == access_observers_.end())
+     return nullptr;
+diff --git a/storage/browser/file_system/sandbox_quota_observer.cc b/storage/browser/file_system/sandbox_quota_observer.cc
+index c1d98a978c6239962a7a38f95e771ec2345e428e..a9df2d1db71678ca2df9c76455ca5022e6130263 100644
+--- a/storage/browser/file_system/sandbox_quota_observer.cc
++++ b/storage/browser/file_system/sandbox_quota_observer.cc
+@@ -148,6 +148,10 @@ base::FileErrorOr<base::FilePath> SandboxQuotaObserver::GetUsageCachePath(
+ }
+ 
+ void SandboxQuotaObserver::ApplyPendingUsageUpdate() {
++  base::AutoLock lock(is_disabled_lock_);
++  if (is_disabled_) {
++    return;
++  }
+   delayed_cache_update_helper_.Stop();
+   for (const auto& path_delta_pair : pending_update_notification_)
+     UpdateUsageCacheFile(path_delta_pair.first, path_delta_pair.second);
+diff --git a/storage/browser/file_system/sandbox_quota_observer.h b/storage/browser/file_system/sandbox_quota_observer.h
+index 07af63f39ea4689f5cac209879356fd1b88640ec..ec9cdffb9e3760d41c104e15178bf05902b141ce 100644
+--- a/storage/browser/file_system/sandbox_quota_observer.h
++++ b/storage/browser/file_system/sandbox_quota_observer.h
+@@ -79,7 +79,7 @@ class SandboxQuotaObserver
+   bool is_disabled_ GUARDED_BY(is_disabled_lock_) = false;
+   ~SandboxQuotaObserver() override;
+ 
+-  void ApplyPendingUsageUpdate() EXCLUSIVE_LOCKS_REQUIRED(is_disabled_lock_);
++  void ApplyPendingUsageUpdate();
+   void UpdateUsageCacheFile(const base::FilePath& usage_file_path,
+                             int64_t delta)
+       EXCLUSIVE_LOCKS_REQUIRED(is_disabled_lock_);

--- a/patches/chromium/cherry-pick-83a9ebad816e.patch
+++ b/patches/chromium/cherry-pick-83a9ebad816e.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dave Tapuska <dtapuska@chromium.org>
+Date: Wed, 17 Jun 2026 09:11:37 -0700
+Subject: [M150] Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
+
+Original change's description:
+> Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
+>
+> Add a weak pointer check after calling client_->OrientationChanged() because this call can cause the WidgetBase object to be destroyed.
+>
+> Bug: 523308824, 523711130
+> Change-Id: If70c28a4a616b4909dade238d8c39b001956fd05
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7930273
+> Reviewed-by: Vladimir Levin <vmpstr@chromium.org>
+> Commit-Queue: Vladimir Levin <vmpstr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1646821}
+
+(cherry picked from commit 6b6931e5c44fc5fe912a04d4c67503a770b07e3d)
+
+Bug: 524508630,523308824,523711130
+Change-Id: If70c28a4a616b4909dade238d8c39b001956fd05
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7957957
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: Dave Tapuska <dtapuska@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1461}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/third_party/blink/renderer/platform/widget/widget_base.cc b/third_party/blink/renderer/platform/widget/widget_base.cc
+index 00e308a0113a909f3ddb598c8fa12c4afbffa79f..66b33ab159f42ade4b63802ccfea06f4f774f83e 100644
+--- a/third_party/blink/renderer/platform/widget/widget_base.cc
++++ b/third_party/blink/renderer/platform/widget/widget_base.cc
+@@ -1087,7 +1087,11 @@ void WidgetBase::UpdateVisualState() {
+       ShouldRecordBeginMainFrameMetrics()
+           ? DocumentUpdateReason::kBeginMainFrame
+           : DocumentUpdateReason::kTest;
++  auto weak_this = weak_ptr_factory_.GetWeakPtr();
+   client_->UpdateLifecycle(WebLifecycleUpdate::kAll, lifecycle_reason);
++  if (!weak_this) {
++    return;
++  }
+   client_->SetSuppressFrameRequestsWorkaroundFor704763Only(false);
+ }
+ 
+@@ -1790,8 +1794,13 @@ void WidgetBase::UpdateSurfaceAndScreenInfo(
+         screen_infos_.current().display_color_spaces);
+   }
+ 
+-  if (orientation_changed)
++  if (orientation_changed) {
++    auto weak_this = weak_ptr_factory_.GetWeakPtr();
+     client_->OrientationChanged();
++    if (!weak_this) {
++      return;
++    }
++  }
+ 
+   client_->DidUpdateSurfaceAndScreen(previous_original_screen_infos);
+ }

--- a/patches/chromium/cherry-pick-851acf8f74cf.patch
+++ b/patches/chromium/cherry-pick-851acf8f74cf.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sunny Sachanandani <sunnyps@chromium.org>
+Date: Thu, 18 Jun 2026 13:41:32 -0700
+Subject: [M150] [gpu] Check GL error before marking GLTexture/EGLImage cleared
+
+Original change's description:
+> [gpu] Check GL error before marking GLTexture/EGLImage cleared
+>
+> GLTextureImageBacking and EGLImageBacking currently mark the backing as
+> cleared unconditionally when initial pixel data is provided, even if the
+> subsequent upload via glTexSubImage2D fails (e.g. under resource
+> pressure / GL_OUT_OF_MEMORY). This bypasses the IsCleared() check,
+> potentially exposing uninitialized VRAM allocator residue during
+> readback.
+>
+> This CL checks for GL errors before calling SetCleared(). If a GL error
+> is detected, the backing remains uncleared so subsequent read access is
+> refused.
+>
+> Landing a shared image unittest for this wasn't feasible since it needs
+> patching GL function pointers which won't work well in any parallel test
+> setup. However, I was able to verify the fix locally with a unit test.
+>
+> Fixed: 517080836
+> Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7909296
+> Commit-Queue: Sunny Sachanandani <sunnyps@chromium.org>
+> Auto-Submit: Sunny Sachanandani <sunnyps@chromium.org>
+> Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1647933}
+
+(cherry picked from commit 7f4181fabb329920be950c95b76e69d1ad296cda)
+
+Bug: 525280834,517080836
+Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7962925
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Sunny Sachanandani <sunnyps@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#1616}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/gpu/command_buffer/service/shared_image/egl_image_backing.cc b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+index d04887c446b6e5d64d2fc7b067b1aee005677922..583148a2c1382651610c10a303d3e3def13b7f24 100644
+--- a/gpu/command_buffer/service/shared_image/egl_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+@@ -445,6 +445,17 @@ gl::ScopedEGLImage EGLImageBacking::GenEGLImageSibling(
+                         format_info.adjusted_format, format_info.gl_type, data);
+   }
+ 
++  // The storage allocation of the sibling texture allocates undefined-content
++  // storage on a context without robust-resource-init. If the following upload
++  // upload failed (e.g. GL_OUT_OF_MEMORY) the storage is still uninitialized.
++  // Return an invalid image so that we don't call SetCleared() on the backing.
++  const GLenum error = api->glGetErrorFn();
++  if (error != GL_NO_ERROR) {
++    LOG(ERROR) << "EGLImageBacking: initial pixel upload failed (GL error 0x"
++               << std::hex << error << ")";
++    return gl::ScopedEGLImage();
++  }
++
+   // Use service id of the texture as a source to create the EGLImage.
+   const EGLint egl_attrib_list[] = {
+       EGL_GL_TEXTURE_LEVEL_KHR, 0, EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
+@@ -471,6 +482,12 @@ EGLImageBacking::GenEGLImageSiblings(base::span<const uint8_t> pixel_data) {
+     AutoLock auto_lock(this);
+     create_egl_images = egl_images_.empty();
+     if (create_egl_images) {
++      // Drain any pre-existing GL errors so the post-allocation check below in
++      // GenEGLImageSibling is attributable to the storage call. Silently
++      // squelching these errors is unfortunate, but is done in order to mirror
++      // other allocation checks done in the command decoder.
++      while (api->glGetErrorFn() != GL_NO_ERROR) {
++      }
+       for (int plane = 0; plane < num_planes; plane++) {
+         gl::ScopedEGLImage egl_image =
+             GenEGLImageSibling(pixel_data, service_ids, plane);
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+index a601dc164235283d0684a6456833279a895a1e42..8c35e9e706544a2ed78dc925105b5ed097c54da6 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+@@ -232,10 +232,12 @@ void GLTextureHolder::Initialize(
+       // that it can be used in other ES2 contexts, and so we have to pass
+       // gl_format as the internal format in the LevelInfo.
+       // https://crbug.com/628064
+-      texture_->SetLevelInfo(format_desc_.target, 0, format_desc_.data_format,
+-                             size_.width(), size_.height(), /*depth=*/1, 0,
+-                             format_desc_.data_format, format_desc_.data_type,
+-                             /*cleared_rect=*/gfx::Rect());
++      const gfx::Rect cleared_rect =
++          !pixel_data.empty() ? gfx::Rect(size_) : gfx::Rect();
++      texture_->SetLevelInfo(
++          format_desc_.target, /*level=*/0, format_desc_.data_format,
++          size_.width(), size_.height(), /*depth=*/1, /*border=*/0,
++          format_desc_.data_format, format_desc_.data_type, cleared_rect);
+       texture_->SetImmutable(true, format_info.supports_storage);
+     } else {
+       LOG(ERROR) << "GLTextureHolder: native storage allocation failed";
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+index c3f178bc8a45435473bbaaafbe3ae2f4261e1ac8..6b2e4df65e23eefe76a2b995c221e7b17b911cf8 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+@@ -497,6 +497,14 @@ void GLTextureImageBacking::InitializeGLTexture(
+     base::span<const uint8_t> pixel_data,
+     gl::ProgressReporter* progress_reporter,
+     bool framebuffer_attachment_angle) {
++  // Drain any pre-existing GL errors so the post-allocation check below is
++  // attributable to the storage call. Silently squelching these errors is
++  // unfortunate, but is done in order to mirror other allocation checks done in
++  // the command decoder.
++  gl::GLApi* const api = gl::g_current_gl_context;
++  while (api->glGetErrorFn() != GL_NO_ERROR) {
++  }
++
+   const std::string debug_label =
+       "GLSharedImage_" + SharedImageBacking::debug_label();
+   int num_planes = format().NumberOfPlanes();
+@@ -510,8 +518,23 @@ void GLTextureImageBacking::InitializeGLTexture(
+                                 debug_label);
+   }
+ 
+-  if (!pixel_data.empty()) {
+-    SetCleared();
++  // Update the cleared state for passthrough textures if the pixel data upload
++  // was successful. We don't need to update the cleared state for validating
++  // decoder textures because we track the cleared state in the decoder texture
++  // objects whose cleared state is set in TextureHolder::Initialize above.
++  if (is_passthrough_ && !pixel_data.empty()) {
++    // The storage allocation allocates undefined-content storage on a context
++    // without robust-resource-init. If the subsequent upload failed (e.g.
++    // GL_OUT_OF_MEMORY) the storage is still uninitialised; only mark the
++    // backing cleared if no GL error was raised.
++    GLenum error = api->glGetErrorFn();
++    if (error == GL_NO_ERROR) {
++      SetCleared();
++    } else {
++      LOG(ERROR)
++          << "GLTextureImageBacking: initial pixel upload failed (GL error 0x"
++          << std::hex << error << ")";
++    }
+   }
+ }
+ 

--- a/patches/chromium/cherry-pick-c3f3e076d61a.patch
+++ b/patches/chromium/cherry-pick-c3f3e076d61a.patch
@@ -1,0 +1,653 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Russell <kbr@chromium.org>
+Date: Wed, 17 Jun 2026 16:47:09 -0700
+Subject: [M150] Add workaround reattaching depth/stencil attachments.
+
+When a depth/stencil attachment to an FBO (bound or unbound) is
+redefined, this workaround first unbinds it from all FBOs and then
+reattaches it afterward. Apply this to certain vendors' GPUs.
+
+Disable the previous recreate_fbo_upon_flush workaround, as it has
+been demonstrated to be ineffective. Do not remove the code yet as the
+new approach must be tested first.
+
+Added tests ensuring the workaround has no unexpected side-effects.
+
+Co-authored with jetski-cli.
+
+(cherry picked from commit 092d0d9b5333e7d68a01f7e0dc44fd3c4f8a5b32)
+
+Bug: 520656244
+Fixed: 524509021
+Change-Id: Ib52d677881a391c98412182f284255fc250ac174
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7956727
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#1506}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/gpu/command_buffer/service/framebuffer_manager.cc b/gpu/command_buffer/service/framebuffer_manager.cc
+index 430d8a2d66ca3dff39b94896d0ef313a656ce67c..2dce59442cf9df2088f44d2c7a80c243bd0c9c87 100644
+--- a/gpu/command_buffer/service/framebuffer_manager.cc
++++ b/gpu/command_buffer/service/framebuffer_manager.cc
+@@ -138,6 +138,10 @@ class RenderbufferAttachment
+   scoped_refptr<Renderbuffer> renderbuffer_;
+ };
+ 
++GLint Framebuffer::Attachment::layer() const {
++  return 0;
++}
++
+ class TextureAttachment
+     : public Framebuffer::Attachment {
+  public:
+@@ -188,7 +192,7 @@ class TextureAttachment
+ 
+   GLsizei samples() const override { return samples_; }
+ 
+-  GLint layer() const { return layer_; }
++  GLint layer() const override { return layer_; }
+ 
+   GLenum target() const override { return target_; }
+ 
+@@ -1237,5 +1241,46 @@ bool FramebufferManager::IsComplete(const Framebuffer* framebuffer) {
+       framebuffer_state_change_count_;
+ }
+ 
++std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++FramebufferManager::GetBindingFramebuffersForTexture(TextureRef* texture_ref) {
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> result;
++  if (!texture_ref) {
++    return result;
++  }
++  for (const auto& pair : framebuffers_) {
++    Framebuffer* framebuffer = pair.second.get();
++    for (GLenum attachment_point :
++         {GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}) {
++      const Framebuffer::Attachment* attachment =
++          framebuffer->GetAttachment(attachment_point);
++      if (attachment && attachment->IsTexture(texture_ref)) {
++        result.push_back({pair.second, attachment_point});
++      }
++    }
++  }
++  return result;
++}
++
++std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++FramebufferManager::GetBindingFramebuffersForRenderbuffer(
++    Renderbuffer* renderbuffer) {
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> result;
++  if (!renderbuffer) {
++    return result;
++  }
++  for (const auto& pair : framebuffers_) {
++    Framebuffer* framebuffer = pair.second.get();
++    for (GLenum attachment_point :
++         {GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}) {
++      const Framebuffer::Attachment* attachment =
++          framebuffer->GetAttachment(attachment_point);
++      if (attachment && attachment->IsRenderbuffer(renderbuffer)) {
++        result.push_back({pair.second, attachment_point});
++      }
++    }
++  }
++  return result;
++}
++
+ }  // namespace gles2
+ }  // namespace gpu
+diff --git a/gpu/command_buffer/service/framebuffer_manager.h b/gpu/command_buffer/service/framebuffer_manager.h
+index c77b6bf2d167ae6922afbf79da10967b7fee1edd..376149bae58c40048869e05423b5c116ef2e74cd 100644
+--- a/gpu/command_buffer/service/framebuffer_manager.h
++++ b/gpu/command_buffer/service/framebuffer_manager.h
+@@ -58,6 +58,7 @@ class GPU_GLES2_EXPORT Framebuffer : public base::RefCounted<Framebuffer> {
+     virtual bool IsRenderbuffer(Renderbuffer* renderbuffer) const = 0;
+     virtual bool IsSameAttachment(const Attachment* attachment) const = 0;
+     virtual bool Is3D() const = 0;
++    virtual GLint layer() const;
+ 
+     // If it's a 3D texture attachment, return true if
+     // FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER is smaller than the number of
+@@ -383,6 +384,12 @@ class GPU_GLES2_EXPORT FramebufferManager {
+ 
+   bool IsComplete(const Framebuffer* framebuffer);
+ 
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++  GetBindingFramebuffersForTexture(TextureRef* texture_ref);
++
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++  GetBindingFramebuffersForRenderbuffer(Renderbuffer* renderbuffer);
++
+   void IncFramebufferStateChangeCount() {
+     // make sure this is never 0.
+     framebuffer_state_change_count_ =
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index e4fa0c8fa35cee141ade56add9c89ec86176a094..7c26b89c67f7f97d19425725a90d4c81bbe03b1b 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -726,6 +726,7 @@ class GLES2DecoderImpl : public GLES2Decoder,
+   friend class ScopedFramebufferCopyBinder;
+   friend class BackFramebuffer;
+   friend class BackTexture;
++  friend class ScopedDepthStencilReattacher;
+ 
+   enum FramebufferOperation {
+     kFramebufferDiscard,
+@@ -2550,6 +2551,157 @@ ScopedGLErrorSuppressor::~ScopedGLErrorSuppressor() {
+   ERRORSTATE_CLEAR_REAL_GL_ERRORS(error_state_, function_name_);
+ }
+ 
++class ScopedDepthStencilReattacher {
++ public:
++  ScopedDepthStencilReattacher(GLES2DecoderImpl* decoder,
++                               TextureRef* texture_ref);
++  ScopedDepthStencilReattacher(GLES2DecoderImpl* decoder,
++                               Renderbuffer* renderbuffer);
++  ~ScopedDepthStencilReattacher();
++
++ private:
++  struct SavedAttachmentInfo {
++    scoped_refptr<Framebuffer> framebuffer;
++    GLenum attachment_point;
++    GLenum texture_target = 0;
++    GLint texture_level = 0;
++    GLsizei texture_samples = 0;
++    GLint texture_layer = 0;
++    bool is_texture = false;
++    bool is_renderbuffer = false;
++  };
++
++  void Initialize();
++
++  raw_ptr<GLES2DecoderImpl> decoder_;
++  raw_ptr<TextureRef> texture_ref_ = nullptr;
++  raw_ptr<Renderbuffer> renderbuffer_ = nullptr;
++  std::vector<SavedAttachmentInfo> saved_attachments_;
++  scoped_refptr<Framebuffer> old_read_fbo_;
++  scoped_refptr<Framebuffer> old_draw_fbo_;
++};
++
++ScopedDepthStencilReattacher::ScopedDepthStencilReattacher(
++    GLES2DecoderImpl* decoder,
++    TextureRef* texture_ref)
++    : decoder_(decoder), texture_ref_(texture_ref) {
++  Initialize();
++}
++
++ScopedDepthStencilReattacher::ScopedDepthStencilReattacher(
++    GLES2DecoderImpl* decoder,
++    Renderbuffer* renderbuffer)
++    : decoder_(decoder), renderbuffer_(renderbuffer) {
++  Initialize();
++}
++
++void ScopedDepthStencilReattacher::Initialize() {
++  if (!decoder_->workarounds().reattach_fbo_depth_stencil_on_reallocation) {
++    return;
++  }
++
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> detached_fbos;
++  if (texture_ref_) {
++    detached_fbos =
++        decoder_->framebuffer_manager()->GetBindingFramebuffersForTexture(
++            texture_ref_);
++  } else if (renderbuffer_) {
++    detached_fbos =
++        decoder_->framebuffer_manager()->GetBindingFramebuffersForRenderbuffer(
++            renderbuffer_);
++  }
++
++  if (detached_fbos.empty()) {
++    return;
++  }
++
++  // Save old bindings to restore them later.
++  old_read_fbo_ = decoder_->framebuffer_state_.bound_read_framebuffer;
++  old_draw_fbo_ = decoder_->framebuffer_state_.bound_draw_framebuffer;
++
++  // Save attachment details and detach.
++  for (const auto& pair : detached_fbos) {
++    Framebuffer* fbo = pair.first.get();
++    GLenum attachment_point = pair.second;
++    const Framebuffer::Attachment* attachment =
++        fbo->GetAttachment(attachment_point);
++    if (!attachment) {
++      continue;
++    }
++
++    SavedAttachmentInfo info;
++    info.framebuffer = pair.first;
++    info.attachment_point = attachment_point;
++
++    if (attachment->IsTextureAttachment()) {
++      info.is_texture = true;
++      info.texture_target = attachment->target();
++      info.texture_level = attachment->level();
++      info.texture_samples = attachment->samples();
++      info.texture_layer = attachment->layer();
++    } else if (attachment->IsRenderbufferAttachment()) {
++      info.is_renderbuffer = true;
++    }
++
++    saved_attachments_.push_back(info);
++
++    // Detach in driver.
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, fbo->service_id());
++    if (info.is_texture) {
++      decoder_->api()->glFramebufferTexture2DEXTFn(
++          GL_FRAMEBUFFER, attachment_point, info.texture_target, 0, 0);
++    } else if (info.is_renderbuffer) {
++      decoder_->api()->glFramebufferRenderbufferEXTFn(
++          GL_FRAMEBUFFER, attachment_point, GL_RENDERBUFFER, 0);
++    }
++  }
++}
++
++ScopedDepthStencilReattacher::~ScopedDepthStencilReattacher() {
++  if (saved_attachments_.empty()) {
++    return;
++  }
++
++  // Reattach.
++  for (const auto& info : saved_attachments_) {
++    Framebuffer* fbo = info.framebuffer.get();
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, fbo->service_id());
++    if (info.is_texture) {
++      if (info.texture_layer == 0) {
++        if (info.texture_samples == 0) {
++          decoder_->api()->glFramebufferTexture2DEXTFn(
++              GL_FRAMEBUFFER, info.attachment_point, info.texture_target,
++              texture_ref_->service_id(), info.texture_level);
++        } else {
++          decoder_->api()->glFramebufferTexture2DMultisampleEXTFn(
++              GL_FRAMEBUFFER, info.attachment_point, info.texture_target,
++              texture_ref_->service_id(), info.texture_level,
++              info.texture_samples);
++        }
++      } else {
++        decoder_->api()->glFramebufferTextureLayerFn(
++            GL_FRAMEBUFFER, info.attachment_point, texture_ref_->service_id(),
++            info.texture_level, info.texture_layer);
++      }
++    } else if (info.is_renderbuffer) {
++      decoder_->api()->glFramebufferRenderbufferEXTFn(
++          GL_FRAMEBUFFER, info.attachment_point, GL_RENDERBUFFER,
++          renderbuffer_->service_id());
++    }
++  }
++
++  // Restore bindings.
++  if (old_read_fbo_ == old_draw_fbo_) {
++    GLuint service_id = old_read_fbo_ ? old_read_fbo_->service_id() : 0;
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, service_id);
++  } else {
++    GLuint read_id = old_read_fbo_ ? old_read_fbo_->service_id() : 0;
++    GLuint draw_id = old_draw_fbo_ ? old_draw_fbo_->service_id() : 0;
++    decoder_->api()->glBindFramebufferEXTFn(GL_READ_FRAMEBUFFER, read_id);
++    decoder_->api()->glBindFramebufferEXTFn(GL_DRAW_FRAMEBUFFER, draw_id);
++  }
++}
++
+ static void RestoreCurrentTextureBindings(ContextState* state,
+                                           GLenum target,
+                                           GLuint texture_unit) {
+@@ -7964,6 +8116,8 @@ void GLES2DecoderImpl::RenderbufferStorageMultisampleWithWorkaround(
+     GLsizei width,
+     GLsizei height,
+     ForcedMultisampleMode mode) {
++  ScopedDepthStencilReattacher reattacher(this,
++                                          state_.bound_renderbuffer.get());
+   RegenerateRenderbufferIfNeeded(state_.bound_renderbuffer.get());
+   EnsureRenderbufferBound();
+   RenderbufferStorageMultisampleHelper(target, samples, internal_format, width,
+@@ -12915,6 +13069,9 @@ error::Error GLES2DecoderImpl::HandleTexImage2D(uint32_t immediate_data_size,
+   // Set as failed for now, but if it successed, this will be set to not failed.
+   texture_state_.tex_image_failed = true;
+   GLenum target = static_cast<GLenum>(c.target);
++  TextureRef* texture_ref =
++      texture_manager()->GetTextureInfoForTarget(&state_, target);
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   GLint level = static_cast<GLint>(c.level);
+   GLenum internal_format = static_cast<GLenum>(c.internalformat);
+   GLsizei width = static_cast<GLsizei>(c.width);
+@@ -13008,6 +13165,9 @@ error::Error GLES2DecoderImpl::HandleTexImage3D(uint32_t immediate_data_size,
+   // Set as failed for now, but if it successed, this will be set to not failed.
+   texture_state_.tex_image_failed = true;
+   GLenum target = static_cast<GLenum>(c.target);
++  TextureRef* texture_ref =
++      texture_manager()->GetTextureInfoForTarget(&state_, target);
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   GLint level = static_cast<GLint>(c.level);
+   GLenum internal_format = static_cast<GLenum>(c.internalformat);
+   GLsizei width = static_cast<GLsizei>(c.width);
+@@ -13321,6 +13481,7 @@ void GLES2DecoderImpl::DoCopyTexImage2D(
+         GL_INVALID_OPERATION, func_name, "unknown texture for target");
+     return;
+   }
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   Texture* texture = texture_ref->texture();
+   if (texture->IsImmutable()) {
+     LOCAL_SET_GL_ERROR(
+@@ -15915,6 +16076,7 @@ void GLES2DecoderImpl::TexStorageImpl(GLenum target,
+                        "unknown texture for target");
+     return;
+   }
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   Texture* texture = texture_ref->texture();
+   // The glTexStorage entry points require width, height, and depth to be
+   // at least 1, but the other texture entry points (those which use
+diff --git a/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc b/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
+index 123aa81ec8cd2e5863cec63a6c87bab6ce05af10..704c02a845dae505f3171563b612aaa70fa1361e 100644
+--- a/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
++++ b/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
+@@ -706,4 +706,254 @@ TEST_P(ES3ClearBufferTest, RasterizerDiscardIntegerClearBypass) {
+   glDeleteRenderbuffers(1, &rb);
+ }
+ 
++class GLReattachFboDepthStencilTest : public GLClearFramebufferTest {
++ protected:
++  void SetUp() override {
++    GpuDriverBugWorkarounds workarounds;
++    if (GetParam()) {
++      workarounds.reattach_fbo_depth_stencil_on_reallocation = true;
++    }
++    gl_.InitializeWithWorkarounds(GetGlManagerOptions(), workarounds);
++  }
++
++  void RunReattachFboDepthStencilTest(bool use_texture,
++                                      bool bind_fbo_during_reallocation);
++};
++
++INSTANTIATE_TEST_SUITE_P(GLReattachFboDepthStencilTestWithParam,
++                         GLReattachFboDepthStencilTest,
++                         ::testing::Bool());
++
++void GLReattachFboDepthStencilTest::RunReattachFboDepthStencilTest(
++    bool use_texture,
++    bool bind_fbo_during_reallocation) {
++  GLuint fbo = 0;
++  glGenFramebuffers(1, &fbo);
++  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++
++  GLuint color_tex = 0;
++  glGenTextures(1, &color_tex);
++  glBindTexture(GL_TEXTURE_2D, color_tex);
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++               nullptr);
++  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                         color_tex, 0);
++
++  GLuint depth_obj = 0;
++  if (use_texture) {
++    glGenTextures(1, &depth_obj);
++    glBindTexture(GL_TEXTURE_2D, depth_obj);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, 16, 16, 0,
++                 GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, nullptr);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
++                           depth_obj, 0);
++  } else {
++    glGenRenderbuffers(1, &depth_obj);
++    glBindRenderbuffer(GL_RENDERBUFFER, depth_obj);
++    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, 16, 16);
++    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
++                              GL_RENDERBUFFER, depth_obj);
++  }
++
++  EXPECT_EQ(static_cast<GLenum>(GL_FRAMEBUFFER_COMPLETE),
++            glCheckFramebufferStatus(GL_FRAMEBUFFER));
++
++  // Clear color to Green, depth to 1.0 (far).
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClearDepthf(1.0f);
++  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
++
++  const uint8_t kGreen[] = {0, 255, 0, 255};
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  // Enable depth test. Draw Red quad at depth 0.5. Should pass (0.5 < 1.0).
++  glEnable(GL_DEPTH_TEST);
++  glDepthFunc(GL_LESS);
++
++  InitDraw();
++  SetDrawDepth(0.5f);
++  SetDrawColor(1.0f, 0.0f, 0.0f, 1.0f);
++  DrawQuad();
++
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kRed, nullptr));
++
++  // Clear color to Green, depth to 0.0 (near).
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClearDepthf(0.0f);
++  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  // Draw Red quad at depth 0.5. Should fail (0.5 is not < 0.0).
++  DrawQuad();
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  if (!bind_fbo_during_reallocation) {
++    glBindFramebuffer(GL_FRAMEBUFFER, 0);
++  }
++
++  // Redefine depth attachment (reallocate to 16x16).
++  if (use_texture) {
++    glBindTexture(GL_TEXTURE_2D, depth_obj);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, 16, 16, 0,
++                 GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, nullptr);
++  } else {
++    glBindRenderbuffer(GL_RENDERBUFFER, depth_obj);
++    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, 16, 16);
++  }
++
++  if (!bind_fbo_during_reallocation) {
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++  }
++
++  // Clear depth to 1.0.
++  glClearDepthf(1.0f);
++  glClear(GL_DEPTH_BUFFER_BIT);
++
++  // Draw Red quad at depth 0.5. Should pass (0.5 < 1.0).
++  SetDrawDepth(0.5f);
++  SetDrawColor(1.0f, 0.0f, 0.0f, 1.0f);
++  DrawQuad();
++
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kRed, nullptr));
++
++  glDeleteFramebuffers(1, &fbo);
++  glDeleteTextures(1, &color_tex);
++  if (use_texture) {
++    glDeleteTextures(1, &depth_obj);
++  } else {
++    glDeleteRenderbuffers(1, &depth_obj);
++  }
++}
++
++TEST_P(GLReattachFboDepthStencilTest, TextureReallocationBound) {
++  RunReattachFboDepthStencilTest(true, true);
++}
++
++TEST_P(GLReattachFboDepthStencilTest, TextureReallocationUnbound) {
++  RunReattachFboDepthStencilTest(true, false);
++}
++
++TEST_P(GLReattachFboDepthStencilTest, RenderbufferReallocationBound) {
++  RunReattachFboDepthStencilTest(false, true);
++}
++
++TEST_P(GLReattachFboDepthStencilTest, RenderbufferReallocationUnbound) {
++  RunReattachFboDepthStencilTest(false, false);
++}
++
++class ES3ReattachFboDepthStencilTest : public GLReattachFboDepthStencilTest {
++ protected:
++  GLManager::Options GetGlManagerOptions() override {
++    GLManager::Options options;
++    options.context_type = CONTEXT_TYPE_OPENGLES3;
++    return options;
++  }
++
++  bool ShouldSkipTest() const {
++    return (!gl_.decoder() || !gl_.decoder()->GetContextGroup());
++  }
++
++  void RunTexImage2DToTexStorage2DTest(bool bind_fbo_during_reallocation);
++};
++
++INSTANTIATE_TEST_SUITE_P(ES3ReattachFboDepthStencilTestWithParam,
++                         ES3ReattachFboDepthStencilTest,
++                         ::testing::Bool());
++
++void ES3ReattachFboDepthStencilTest::RunTexImage2DToTexStorage2DTest(
++    bool bind_fbo_during_reallocation) {
++  if (ShouldSkipTest()) {
++    return;
++  }
++
++  GLuint fbo = 0;
++  glGenFramebuffers(1, &fbo);
++  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++
++  GLuint color_tex = 0;
++  glGenTextures(1, &color_tex);
++  glBindTexture(GL_TEXTURE_2D, color_tex);
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++               nullptr);
++  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                         color_tex, 0);
++
++  GLuint depth_tex = 0;
++  glGenTextures(1, &depth_tex);
++  glBindTexture(GL_TEXTURE_2D, depth_tex);
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, 16, 16, 0,
++               GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, nullptr);
++  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
++                         depth_tex, 0);
++
++  EXPECT_EQ(static_cast<GLenum>(GL_FRAMEBUFFER_COMPLETE),
++            glCheckFramebufferStatus(GL_FRAMEBUFFER));
++
++  // Clear color to Green, depth to 1.0 (far).
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClearDepthf(1.0f);
++  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
++
++  const uint8_t kGreen[] = {0, 255, 0, 255};
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  // Enable depth test. Draw Red quad at depth 0.5. Should pass.
++  glEnable(GL_DEPTH_TEST);
++  glDepthFunc(GL_LESS);
++
++  InitDraw();
++  SetDrawDepth(0.5f);
++  SetDrawColor(1.0f, 0.0f, 0.0f, 1.0f);
++  DrawQuad();
++
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kRed, nullptr));
++
++  // Clear color to Green, depth to 0.0 (near).
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClearDepthf(0.0f);
++  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  // Draw Red quad at depth 0.5. Should fail.
++  DrawQuad();
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kGreen, nullptr));
++
++  if (!bind_fbo_during_reallocation) {
++    glBindFramebuffer(GL_FRAMEBUFFER, 0);
++  }
++
++  // Redefine depth attachment via glTexStorage2D.
++  glBindTexture(GL_TEXTURE_2D, depth_tex);
++  glTexStorage2DEXT(GL_TEXTURE_2D, 1, GL_DEPTH_COMPONENT16, 16, 16);
++
++  if (!bind_fbo_during_reallocation) {
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++  }
++
++  // Clear depth to 1.0.
++  glClearDepthf(1.0f);
++  glClear(GL_DEPTH_BUFFER_BIT);
++
++  // Draw Red quad at depth 0.5. Should pass.
++  SetDrawDepth(0.5f);
++  SetDrawColor(1.0f, 0.0f, 0.0f, 1.0f);
++  DrawQuad();
++
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0, kRed, nullptr));
++
++  glDeleteFramebuffers(1, &fbo);
++  glDeleteTextures(1, &color_tex);
++  glDeleteTextures(1, &depth_tex);
++}
++
++TEST_P(ES3ReattachFboDepthStencilTest, TexImage2DToTexStorage2DBound) {
++  RunTexImage2DToTexStorage2DTest(true);
++}
++
++TEST_P(ES3ReattachFboDepthStencilTest, TexImage2DToTexStorage2DUnbound) {
++  RunTexImage2DToTexStorage2DTest(false);
++}
++
+ }  // namespace gpu
+diff --git a/gpu/config/gpu_driver_bug_list.json b/gpu/config/gpu_driver_bug_list.json
+index 092b767473ac4cf640023fab0525c50b70b21350..670477338ffb7d6fac0fddb782f73337abb04c42 100644
+--- a/gpu/config/gpu_driver_bug_list.json
++++ b/gpu/config/gpu_driver_bug_list.json
+@@ -3755,18 +3755,6 @@
+         "dont_invalidate_incomplete_fbos"
+       ]
+     },
+-    {
+-      "id": 477,
+-      "description": "Recreate FBO upon flush/finish/fencesync under certain conditions on Qualcomm GPUs",
+-      "gl_vendor": "Qualcomm.*",
+-      "driver_version": {
+-        "op": "<",
+-        "value": "878"
+-      },
+-      "features": [
+-        "recreate_fbo_upon_flush"
+-      ]
+-    },
+     {
+       "id": 478,
+       "description": "Program binaries don't contain transform feedback varyings on Mali GPUs",
+@@ -3779,6 +3767,19 @@
+       "features": [
+         "disable_program_caching_for_transform_feedback"
+       ]
++    },
++    {
++      "id": 480,
++      "cr_bugs": [520656244],
++      "description": "Reattach FBO depth/stencil attachments when they are reallocated on Qualcomm GPUs",
++      "gl_vendor": "Qualcomm.*",
++      "driver_version": {
++        "op": "<",
++        "value": "878"
++      },
++      "features": [
++        "reattach_fbo_depth_stencil_on_reallocation"
++      ]
+     }
+   ]
+ }
+diff --git a/gpu/config/gpu_workaround_list.txt b/gpu/config/gpu_workaround_list.txt
+index 426a3016b03b753f76b26ea685b816238176c6a6..e62349b9cb23abfbf02dd0bffd13bfc0c5cbcd77 100644
+--- a/gpu/config/gpu_workaround_list.txt
++++ b/gpu/config/gpu_workaround_list.txt
+@@ -109,6 +109,7 @@ no_downscaled_overlay_promotion
+ pack_parameters_workaround_with_pack_buffer
+ prefer_draw_to_copy
+ r8_egl_images_broken
++reattach_fbo_depth_stencil_on_reallocation
+ recreate_fbo_upon_flush
+ rely_on_implicit_sync_for_swap_buffers
+ remove_dynamic_indexing_of_swizzled_vector

--- a/patches/chromium/cherry-pick-dc52460d5bf2.patch
+++ b/patches/chromium/cherry-pick-dc52460d5bf2.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Przemek Perkowski <perkowski@google.com>
+Date: Thu, 18 Jun 2026 03:46:59 -0700
+Subject: [M150] Fix the state desynchronization bug in autofill manager.
+
+Original change's description:
+> Fix the state desynchronization bug in autofill manager.
+>
+> As explained in the attached bug, the current implementation leads to
+> the popup not being hidden correctly.
+>
+> Bug: 516734537
+> Change-Id: If0370f3370240ef3904cbf7fbdc868766a6a6964
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7894738
+> Reviewed-by: Christoph Schwering <schwering@google.com>
+> Reviewed-by: Atalyk Akash <atalyk@google.com>
+> Commit-Queue: Przemek Perkowski <perkowski@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1640851}
+
+(cherry picked from commit 6e1a3c5dbaa5c8bc19a9d0ff07e7d416a70d7441)
+
+Bug: 524890166,516734537
+Change-Id: If0370f3370240ef3904cbf7fbdc868766a6a6964
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7958499
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Josef Raska <josefraska@google.com>
+Reviewed-by: Christoph Schwering <schwering@google.com>
+Commit-Queue: Josef Raska <josefraska@google.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#1572}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/components/autofill/core/browser/foundations/browser_autofill_manager.cc b/components/autofill/core/browser/foundations/browser_autofill_manager.cc
+index eb9bb298cce97a1583cd88dfe6cac1bac62aeb7d..24a899d266460c4b59570f374f3fc7c5e848d95c 100644
+--- a/components/autofill/core/browser/foundations/browser_autofill_manager.cc
++++ b/components/autofill/core/browser/foundations/browser_autofill_manager.cc
+@@ -1188,17 +1188,20 @@ void BrowserAutofillManager::OnAskForValuesToFillImpl(
+     return;
+   }
+ 
++  // TODO(crbug.com/519061643): Rely on central atMemory eligibility logic
++  // instead.
++  if (IsAtMemoryTriggerSource(trigger_source) &&
++      client().GetPersonalContextEnablementState() ==
++          personal_context::PersonalContextEnablementState::
++              kDisabledNotEligible) {
++    return;
++  }
++
+   const FormFieldData& field = CHECK_DEREF(form.FindFieldByGlobalId(field_id));
+   external_delegate_->OnQuery(form, field, caret_bounds, trigger_source,
+                               /*update_datalist=*/true);
+ 
+   if (IsAtMemoryTriggerSource(trigger_source)) {
+-    // Do not show the pop up at all for non eligible profiles.
+-    if (client().GetPersonalContextEnablementState() ==
+-        personal_context::PersonalContextEnablementState::
+-            kDisabledNotEligible) {
+-      return;
+-    }
+     std::vector<Suggestion> suggestions;
+     GetAtMemoryManager().MaybeAppendPersonalContextNotice(suggestions);
+ 


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`c3f3e076d61a`](https://chromium-review.googlesource.com/c/chromium/src/+/7956727) from chromium — [M150] Add workaround reattaching depth/stencil attachments.
* [`045d3557e2ad`](https://chromium-review.googlesource.com/c/chromium/src/+/7982244) from chromium — [M150] Rebind original FBO earlier in ClearLevelUsingGL.
* [`dc52460d5bf2`](https://chromium-review.googlesource.com/c/chromium/src/+/7958499) from chromium — [M150] Fix the state desynchronization bug in autofill manager.
* [`851acf8f74cf`](https://chromium-review.googlesource.com/c/chromium/src/+/7962925) from chromium — [M150] [gpu] Check GL error before marking GLTexture/EGLImage cleared
* [`05b31a349539`](https://chromium-review.googlesource.com/c/chromium/src/+/7957921) from chromium — [M150] Copy devtools messages from renderer when backed by shmem
* [`7decfe7398f7`](https://chromium-review.googlesource.com/c/chromium/src/+/7977078) from chromium — [M150] Fix data race on SandboxFileSystemBackendDelegate observers
* [`83a9ebad816e`](https://chromium-review.googlesource.com/c/chromium/src/+/7957957) from chromium — [M150] Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
* [`5822dea3c6e8`](https://chromium-review.googlesource.com/c/chromium/src/+/7978757) from chromium — [M150] Fix leak of grouped credentials to renderer
* [`3e497ff45cf2`](https://chromium-review.googlesource.com/c/chromium/src/+/7961535) from chromium — [M150] Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium.
