### PR TITLE
chore: cherry-pick 12 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -283,3 +283,15 @@ cherry-pick-e819a80f8ff8.patch
 cherry-pick-22e4bb302a14.patch
 cherry-pick-17f11eae14fd.patch
 cherry-pick-3f57fbc717d7.patch
+cherry-pick-067fd777c0d1.patch
+cherry-pick-04f66fb96767.patch
+cherry-pick-814cb4953ecb.patch
+cherry-pick-b9b2f0b7eca8.patch
+cherry-pick-f583b94a1374.patch
+cherry-pick-d7593e5c3f70.patch
+cherry-pick-1285ece45c13.patch
+cherry-pick-0babc641d95e.patch
+cherry-pick-449a1ea22a42.patch
+cherry-pick-806fda7e35f3.patch
+cherry-pick-4febc44304bf.patch
+cherry-pick-30a20a1cc67a.patch

--- a/patches/chromium/cherry-pick-04f66fb96767.patch
+++ b/patches/chromium/cherry-pick-04f66fb96767.patch
@@ -1,0 +1,248 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Russell <kbr@chromium.org>
+Date: Mon, 22 Jun 2026 20:35:29 -0700
+Subject: [M149] Rebind original FBO earlier in ClearLevelUsingGL.
+
+Original change's description:
+> Rebind original FBO earlier in ClearLevelUsingGL.
+>
+> Avoid triggering problems on some drivers when deleting an in-use FBO.
+>
+> Co-authored with jetski-cli.
+>
+> Fixed: 523591974
+> Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7953879
+> Reviewed-by: Brandon Jones <bajones@chromium.org>
+> Commit-Queue: Kenneth Russell <kbr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648728}
+
+(cherry picked from commit feb103bc1c01d1a1e62383f906346d23bb725fb1)
+
+Bug: 525661769,523591974
+Change-Id: I17239a547a16d8d2b2a754c9141f37b7f0012956
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7975811
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3693}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index f7f9308134684e798324c2197d24aec3fcb7ea52..701926aeb24683a82d7db550f933bc70bc313397 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -12310,11 +12310,16 @@ bool GLES2DecoderImpl::ClearLevelUsingGL(Texture* texture,
+     result = true;
+   }
+   RestoreClearState();
+-  api()->glDeleteFramebuffersEXTFn(1, &fb);
++  // Restore the previous framebuffer binding *before* deleting the temporary
++  // FBO. Some Imagination/PowerVR drivers retain an internal reference to the
++  // previously-bound FBO across bind transitions; deleting it while bound and
++  // then rebinding can dereference freed driver state. See the
++  // ensure_previous_framebuffer_not_deleted workaround.
+   Framebuffer* framebuffer = GetFramebufferInfoForTarget(fb_target);
+   GLuint fb_service_id =
+       framebuffer ? framebuffer->service_id() : GetBackbufferServiceId();
+   BindFramebuffer(fb_target, fb_service_id);
++  api()->glDeleteFramebuffersEXTFn(1, &fb);
+   return result;
+ }
+ 
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+index 874098118b2ddf4e02218818ce28e4b71b030484..9e4d6e3bf3c6788ad3984dd46bcdb1d2b7ec3866 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_base.h
+@@ -543,6 +543,7 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+   }
+ 
+  protected:
++  virtual void SetupMockGLBehaviors();
+   static const int kBackBufferWidth = 128;
+   static const int kBackBufferHeight = 64;
+ 
+@@ -787,7 +788,6 @@ class GLES2DecoderTestBase : public ::testing::TestWithParam<bool>,
+     GLuint bound_vertex_array_object_;
+   };  // class MockGLStates
+ 
+-  void SetupMockGLBehaviors();
+ 
+   GpuPreferences gpu_preferences_;
+   ShaderTranslatorCache shader_translator_cache_;
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+index 6c63c9d323e2ac3a449224b585a586069afb997b..6835fab59acecb64881781bc9281d83b956488bc 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder_unittest_textures.cc
+@@ -3171,6 +3171,171 @@ TEST_P(GLES2DecoderManualInitTest, GenerateMipmapDepthTexture) {
+   EXPECT_EQ(GL_INVALID_OPERATION, GetGLError());
+ }
+ 
++class GLES2DecoderEnsurePrevFboWorkaroundTest
++    : public GLES2DecoderManualInitTest {
++ public:
++  GLES2DecoderEnsurePrevFboWorkaroundTest() = default;
++
++  void SetupMockGLBehaviors() override {
++    GLES2DecoderManualInitTest::SetupMockGLBehaviors();
++    if (enable_workaround_expectations_) {
++      EXPECT_CALL(*gl_, GenTextures(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboTextureId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindTexture(GL_TEXTURE_2D, kCompleteFboTextureId))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA,
++                                   GL_UNSIGNED_BYTE, nullptr))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++          .WillOnce(SetArgPointee<1>(kCompleteFboId))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++          .Times(3)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, FramebufferTexture2DEXT(
++                            GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
++                            kCompleteFboTextureId, 0))
++          .Times(1)
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++          .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++          .RetiresOnSaturation();
++      EXPECT_CALL(*gl_, DeleteTextures(1, Pointee(kCompleteFboTextureId)))
++          .Times(1)
++          .RetiresOnSaturation();
++    }
++  }
++
++ protected:
++  bool enable_workaround_expectations_ = false;
++  static constexpr GLuint kCompleteFboTextureId = 999;
++  static constexpr GLuint kCompleteFboId = 998;
++};
++
++// The test uses a depth texture to force GLES2DecoderImpl::ClearLevel to use
++// the ClearLevelUsingGL path, which is required to trigger the FBO restoration
++// workaround logic. For color textures, ClearLevel may fallback to the
++// TexSubImage2D clear path which does not use a temporary FBO.
++TEST_P(GLES2DecoderEnsurePrevFboWorkaroundTest, ClearLevelUsingGLOrder) {
++  enable_workaround_expectations_ = true;
++  gpu::GpuDriverBugWorkarounds workarounds;
++  workarounds.ensure_previous_framebuffer_not_deleted = true;
++  InitState init;
++  init.extensions = "GL_ANGLE_depth_texture";
++  init.gl_version = "OpenGL ES 2.0";
++  init.has_depth = true;
++  init.request_depth = true;
++  InitDecoderWithWorkarounds(init, workarounds);
++
++  // Set up texture
++  DoBindTexture(GL_TEXTURE_2D, client_texture_id_, kServiceTextureId);
++  DoTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, 1, 1, 0,
++               GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0);
++
++  TextureRef* texture_ref =
++      group().texture_manager()->GetTexture(client_texture_id_);
++  ASSERT_TRUE(texture_ref != nullptr);
++  Texture* texture = texture_ref->texture();
++
++  // Expectations for ClearLevel
++  const GLuint kTempFboId = 777;
++  InSequence seq;
++
++  // 1. Gen temp FBO
++  EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++      .WillOnce(SetArgPointee<1>(kTempFboId))
++      .RetiresOnSaturation();
++
++  // 2. Bind temp FBO (wrapper triggers complete_fbo bind first)
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kTempFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 3. Attach texture
++  EXPECT_CALL(*gl_,
++              FramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
++                                      GL_TEXTURE_2D, kServiceTextureId, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 4. Check status
++  EXPECT_CALL(*gl_, CheckFramebufferStatusEXT(GL_FRAMEBUFFER))
++      .WillOnce(Return(GL_FRAMEBUFFER_COMPLETE))
++      .RetiresOnSaturation();
++
++  // 5. Clear calls
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, ColorMask(true, true, true, true))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++    EXPECT_CALL(*gl_, StencilMaskSeparate(GL_BACK, 0xFFFFFFFF))
++        .Times(1)
++        .RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  if (GetParam()) {
++    EXPECT_CALL(*gl_, DepthMask(true)).Times(1).RetiresOnSaturation();
++  }
++  EXPECT_CALL(*gl_, Enable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Scissor(0, 0, 1, 1)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Clear(GL_DEPTH_BUFFER_BIT)).Times(1).RetiresOnSaturation();
++
++  // 6. Restore state
++  EXPECT_CALL(*gl_, ClearColor(0.0f, 0.0f, 0.0f, 0.0f))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearStencil(0)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, ClearDepth(1.0f)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_, Disable(GL_SCISSOR_TEST)).Times(1).RetiresOnSaturation();
++  EXPECT_CALL(*gl_,
++              Scissor(0, 0, 128, 64))  // 128x64 is the default backbuffer size
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 7. Restore FBO binding (CRITICAL: Must happen BEFORE delete)
++  // Wrapper triggers complete_fbo bind first
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kCompleteFboId))
++      .Times(1)
++      .RetiresOnSaturation();
++  EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, 0))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // 8. Delete temp FBO
++  EXPECT_CALL(*gl_, DeleteFramebuffersEXT(1, Pointee(kTempFboId)))
++      .Times(1)
++      .RetiresOnSaturation();
++
++  // Call ClearLevel
++  EXPECT_TRUE(decoder_->ClearLevel(texture, GL_TEXTURE_2D, 0,
++                                   GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0, 0, 1,
++                                   1));
++
++  DoDeleteTexture(client_texture_id_, kServiceTextureId);
++}
++
++// The boolean parameter controls whether ignore_cached_state_for_test is
++// enabled in the base fixture GLES2DecoderTestBase. This forces GL state
++// restoration and helps test state-dirtying paths.
++INSTANTIATE_TEST_SUITE_P(Service,
++                         GLES2DecoderEnsurePrevFboWorkaroundTest,
++                         ::testing::Bool());
++
+ TEST_P(GLES2DecoderManualInitTest, DrawWithGLImageExternal) {
+   InitState init;
+   init.extensions = "GL_OES_EGL_image_external";

--- a/patches/chromium/cherry-pick-067fd777c0d1.patch
+++ b/patches/chromium/cherry-pick-067fd777c0d1.patch
@@ -1,0 +1,394 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Russell <kbr@chromium.org>
+Date: Wed, 17 Jun 2026 16:06:49 -0700
+Subject: [M148] Add workaround reattaching depth/stencil attachments.
+
+When a depth/stencil attachment to an FBO (bound or unbound) is
+redefined, this workaround first unbinds it from all FBOs and then
+reattaches it afterward. Apply this to certain vendors' GPUs.
+
+Disable the previous recreate_fbo_upon_flush workaround, as it has
+been demonstrated to be ineffective. Do not remove the code yet as the
+new approach must be tested first.
+
+Added tests ensuring the workaround has no unexpected side-effects.
+
+Co-authored with jetski-cli.
+
+(cherry picked from commit 092d0d9b5333e7d68a01f7e0dc44fd3c4f8a5b32)
+
+Bug: 520656244
+Fixed: 524507992
+Change-Id: Ibf9e6e428774b36a249bcb275e68da41dde4a9ba
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7959417
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4380}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/gpu/command_buffer/service/framebuffer_manager.cc b/gpu/command_buffer/service/framebuffer_manager.cc
+index f1f2154a5d39569d8b6c62c7a988bb3e24277229..cf2533629e016c209225fbcd9d4f595e7921072d 100644
+--- a/gpu/command_buffer/service/framebuffer_manager.cc
++++ b/gpu/command_buffer/service/framebuffer_manager.cc
+@@ -58,6 +58,7 @@ class RenderbufferAttachment
+   GLuint object_name() const override { return renderbuffer_->client_id(); }
+ 
+   GLint level() const override { NOTREACHED(); }
++  GLenum target() const override { return GL_RENDERBUFFER; }
+ 
+   bool cleared() const override { return renderbuffer_->cleared(); }
+ 
+@@ -135,6 +136,10 @@ class RenderbufferAttachment
+   scoped_refptr<Renderbuffer> renderbuffer_;
+ };
+ 
++GLint Framebuffer::Attachment::layer() const {
++  return 0;
++}
++
+ class TextureAttachment
+     : public Framebuffer::Attachment {
+  public:
+@@ -185,9 +190,9 @@ class TextureAttachment
+ 
+   GLsizei samples() const override { return samples_; }
+ 
+-  GLint layer() const { return layer_; }
++  GLint layer() const override { return layer_; }
+ 
+-  GLenum target() const { return target_; }
++  GLenum target() const override { return target_; }
+ 
+   GLint level() const override { return level_; }
+ 
+@@ -1160,5 +1165,46 @@ bool FramebufferManager::IsComplete(const Framebuffer* framebuffer) {
+       framebuffer_state_change_count_;
+ }
+ 
++std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++FramebufferManager::GetBindingFramebuffersForTexture(TextureRef* texture_ref) {
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> result;
++  if (!texture_ref) {
++    return result;
++  }
++  for (const auto& pair : framebuffers_) {
++    Framebuffer* framebuffer = pair.second.get();
++    for (GLenum attachment_point :
++         {GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}) {
++      const Framebuffer::Attachment* attachment =
++          framebuffer->GetAttachment(attachment_point);
++      if (attachment && attachment->IsTexture(texture_ref)) {
++        result.push_back({pair.second, attachment_point});
++      }
++    }
++  }
++  return result;
++}
++
++std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++FramebufferManager::GetBindingFramebuffersForRenderbuffer(
++    Renderbuffer* renderbuffer) {
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> result;
++  if (!renderbuffer) {
++    return result;
++  }
++  for (const auto& pair : framebuffers_) {
++    Framebuffer* framebuffer = pair.second.get();
++    for (GLenum attachment_point :
++         {GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}) {
++      const Framebuffer::Attachment* attachment =
++          framebuffer->GetAttachment(attachment_point);
++      if (attachment && attachment->IsRenderbuffer(renderbuffer)) {
++        result.push_back({pair.second, attachment_point});
++      }
++    }
++  }
++  return result;
++}
++
+ }  // namespace gles2
+ }  // namespace gpu
+diff --git a/gpu/command_buffer/service/framebuffer_manager.h b/gpu/command_buffer/service/framebuffer_manager.h
+index 7517a3302dc0acdae96148e23d1d68081f6e6f7a..cd0ae1d672db03f5c276b92677ac9211878ae50e 100644
+--- a/gpu/command_buffer/service/framebuffer_manager.h
++++ b/gpu/command_buffer/service/framebuffer_manager.h
+@@ -44,6 +44,7 @@ class GPU_GLES2_EXPORT Framebuffer : public base::RefCounted<Framebuffer> {
+     virtual GLsizei samples() const = 0;
+     virtual GLuint object_name() const = 0;
+     virtual GLint level() const = 0;
++    virtual GLenum target() const = 0;
+     virtual bool cleared() const = 0;
+     virtual void SetCleared(
+         RenderbufferManager* renderbuffer_manager,
+@@ -56,6 +57,7 @@ class GPU_GLES2_EXPORT Framebuffer : public base::RefCounted<Framebuffer> {
+     virtual bool IsRenderbuffer(Renderbuffer* renderbuffer) const = 0;
+     virtual bool IsSameAttachment(const Attachment* attachment) const = 0;
+     virtual bool Is3D() const = 0;
++    virtual GLint layer() const;
+ 
+     // If it's a 3D texture attachment, return true if
+     // FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER is smaller than the number of
+@@ -374,6 +376,12 @@ class GPU_GLES2_EXPORT FramebufferManager {
+ 
+   bool IsComplete(const Framebuffer* framebuffer);
+ 
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++  GetBindingFramebuffersForTexture(TextureRef* texture_ref);
++
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>>
++  GetBindingFramebuffersForRenderbuffer(Renderbuffer* renderbuffer);
++
+   void IncFramebufferStateChangeCount() {
+     // make sure this is never 0.
+     framebuffer_state_change_count_ =
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index 94de198c00fa78f6a569b2e051cb94f8fd5d5246..f7f9308134684e798324c2197d24aec3fcb7ea52 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -740,6 +740,7 @@ class GLES2DecoderImpl : public GLES2Decoder,
+   friend class ScopedFramebufferCopyBinder;
+   friend class BackFramebuffer;
+   friend class BackTexture;
++  friend class ScopedDepthStencilReattacher;
+ 
+   enum FramebufferOperation {
+     kFramebufferDiscard,
+@@ -2560,6 +2561,157 @@ ScopedGLErrorSuppressor::~ScopedGLErrorSuppressor() {
+   ERRORSTATE_CLEAR_REAL_GL_ERRORS(error_state_, function_name_);
+ }
+ 
++class ScopedDepthStencilReattacher {
++ public:
++  ScopedDepthStencilReattacher(GLES2DecoderImpl* decoder,
++                               TextureRef* texture_ref);
++  ScopedDepthStencilReattacher(GLES2DecoderImpl* decoder,
++                               Renderbuffer* renderbuffer);
++  ~ScopedDepthStencilReattacher();
++
++ private:
++  struct SavedAttachmentInfo {
++    scoped_refptr<Framebuffer> framebuffer;
++    GLenum attachment_point;
++    GLenum texture_target = 0;
++    GLint texture_level = 0;
++    GLsizei texture_samples = 0;
++    GLint texture_layer = 0;
++    bool is_texture = false;
++    bool is_renderbuffer = false;
++  };
++
++  void Initialize();
++
++  raw_ptr<GLES2DecoderImpl> decoder_;
++  raw_ptr<TextureRef> texture_ref_ = nullptr;
++  raw_ptr<Renderbuffer> renderbuffer_ = nullptr;
++  std::vector<SavedAttachmentInfo> saved_attachments_;
++  scoped_refptr<Framebuffer> old_read_fbo_;
++  scoped_refptr<Framebuffer> old_draw_fbo_;
++};
++
++ScopedDepthStencilReattacher::ScopedDepthStencilReattacher(
++    GLES2DecoderImpl* decoder,
++    TextureRef* texture_ref)
++    : decoder_(decoder), texture_ref_(texture_ref) {
++  Initialize();
++}
++
++ScopedDepthStencilReattacher::ScopedDepthStencilReattacher(
++    GLES2DecoderImpl* decoder,
++    Renderbuffer* renderbuffer)
++    : decoder_(decoder), renderbuffer_(renderbuffer) {
++  Initialize();
++}
++
++void ScopedDepthStencilReattacher::Initialize() {
++  if (!decoder_->workarounds().reattach_fbo_depth_stencil_on_reallocation) {
++    return;
++  }
++
++  std::vector<std::pair<scoped_refptr<Framebuffer>, GLenum>> detached_fbos;
++  if (texture_ref_) {
++    detached_fbos =
++        decoder_->framebuffer_manager()->GetBindingFramebuffersForTexture(
++            texture_ref_);
++  } else if (renderbuffer_) {
++    detached_fbos =
++        decoder_->framebuffer_manager()->GetBindingFramebuffersForRenderbuffer(
++            renderbuffer_);
++  }
++
++  if (detached_fbos.empty()) {
++    return;
++  }
++
++  // Save old bindings to restore them later.
++  old_read_fbo_ = decoder_->framebuffer_state_.bound_read_framebuffer;
++  old_draw_fbo_ = decoder_->framebuffer_state_.bound_draw_framebuffer;
++
++  // Save attachment details and detach.
++  for (const auto& pair : detached_fbos) {
++    Framebuffer* fbo = pair.first.get();
++    GLenum attachment_point = pair.second;
++    const Framebuffer::Attachment* attachment =
++        fbo->GetAttachment(attachment_point);
++    if (!attachment) {
++      continue;
++    }
++
++    SavedAttachmentInfo info;
++    info.framebuffer = pair.first;
++    info.attachment_point = attachment_point;
++
++    if (attachment->IsTextureAttachment()) {
++      info.is_texture = true;
++      info.texture_target = attachment->target();
++      info.texture_level = attachment->level();
++      info.texture_samples = attachment->samples();
++      info.texture_layer = attachment->layer();
++    } else if (attachment->IsRenderbufferAttachment()) {
++      info.is_renderbuffer = true;
++    }
++
++    saved_attachments_.push_back(info);
++
++    // Detach in driver.
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, fbo->service_id());
++    if (info.is_texture) {
++      decoder_->api()->glFramebufferTexture2DEXTFn(
++          GL_FRAMEBUFFER, attachment_point, info.texture_target, 0, 0);
++    } else if (info.is_renderbuffer) {
++      decoder_->api()->glFramebufferRenderbufferEXTFn(
++          GL_FRAMEBUFFER, attachment_point, GL_RENDERBUFFER, 0);
++    }
++  }
++}
++
++ScopedDepthStencilReattacher::~ScopedDepthStencilReattacher() {
++  if (saved_attachments_.empty()) {
++    return;
++  }
++
++  // Reattach.
++  for (const auto& info : saved_attachments_) {
++    Framebuffer* fbo = info.framebuffer.get();
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, fbo->service_id());
++    if (info.is_texture) {
++      if (info.texture_layer == 0) {
++        if (info.texture_samples == 0) {
++          decoder_->api()->glFramebufferTexture2DEXTFn(
++              GL_FRAMEBUFFER, info.attachment_point, info.texture_target,
++              texture_ref_->service_id(), info.texture_level);
++        } else {
++          decoder_->api()->glFramebufferTexture2DMultisampleEXTFn(
++              GL_FRAMEBUFFER, info.attachment_point, info.texture_target,
++              texture_ref_->service_id(), info.texture_level,
++              info.texture_samples);
++        }
++      } else {
++        decoder_->api()->glFramebufferTextureLayerFn(
++            GL_FRAMEBUFFER, info.attachment_point, texture_ref_->service_id(),
++            info.texture_level, info.texture_layer);
++      }
++    } else if (info.is_renderbuffer) {
++      decoder_->api()->glFramebufferRenderbufferEXTFn(
++          GL_FRAMEBUFFER, info.attachment_point, GL_RENDERBUFFER,
++          renderbuffer_->service_id());
++    }
++  }
++
++  // Restore bindings.
++  if (old_read_fbo_ == old_draw_fbo_) {
++    GLuint service_id = old_read_fbo_ ? old_read_fbo_->service_id() : 0;
++    decoder_->api()->glBindFramebufferEXTFn(GL_FRAMEBUFFER, service_id);
++  } else {
++    GLuint read_id = old_read_fbo_ ? old_read_fbo_->service_id() : 0;
++    GLuint draw_id = old_draw_fbo_ ? old_draw_fbo_->service_id() : 0;
++    decoder_->api()->glBindFramebufferEXTFn(GL_READ_FRAMEBUFFER, read_id);
++    decoder_->api()->glBindFramebufferEXTFn(GL_DRAW_FRAMEBUFFER, draw_id);
++  }
++}
++
+ static void RestoreCurrentTextureBindings(ContextState* state,
+                                           GLenum target,
+                                           GLuint texture_unit) {
+@@ -7909,6 +8061,8 @@ void GLES2DecoderImpl::RenderbufferStorageMultisampleWithWorkaround(
+     GLsizei width,
+     GLsizei height,
+     ForcedMultisampleMode mode) {
++  ScopedDepthStencilReattacher reattacher(this,
++                                          state_.bound_renderbuffer.get());
+   RegenerateRenderbufferIfNeeded(state_.bound_renderbuffer.get());
+   EnsureRenderbufferBound();
+   RenderbufferStorageMultisampleHelper(target, samples, internal_format, width,
+@@ -12953,6 +13107,9 @@ error::Error GLES2DecoderImpl::HandleTexImage2D(uint32_t immediate_data_size,
+   // Set as failed for now, but if it successed, this will be set to not failed.
+   texture_state_.tex_image_failed = true;
+   GLenum target = static_cast<GLenum>(c.target);
++  TextureRef* texture_ref =
++      texture_manager()->GetTextureInfoForTarget(&state_, target);
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   GLint level = static_cast<GLint>(c.level);
+   GLenum internal_format = static_cast<GLenum>(c.internalformat);
+   GLsizei width = static_cast<GLsizei>(c.width);
+@@ -13051,6 +13208,9 @@ error::Error GLES2DecoderImpl::HandleTexImage3D(uint32_t immediate_data_size,
+   // Set as failed for now, but if it successed, this will be set to not failed.
+   texture_state_.tex_image_failed = true;
+   GLenum target = static_cast<GLenum>(c.target);
++  TextureRef* texture_ref =
++      texture_manager()->GetTextureInfoForTarget(&state_, target);
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   GLint level = static_cast<GLint>(c.level);
+   GLenum internal_format = static_cast<GLenum>(c.internalformat);
+   GLsizei width = static_cast<GLsizei>(c.width);
+@@ -13359,6 +13519,7 @@ void GLES2DecoderImpl::DoCopyTexImage2D(
+         GL_INVALID_OPERATION, func_name, "unknown texture for target");
+     return;
+   }
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   Texture* texture = texture_ref->texture();
+   if (texture->IsImmutable()) {
+     LOCAL_SET_GL_ERROR(
+@@ -15975,6 +16136,7 @@ void GLES2DecoderImpl::TexStorageImpl(GLenum target,
+                        "unknown texture for target");
+     return;
+   }
++  ScopedDepthStencilReattacher reattacher(this, texture_ref);
+   Texture* texture = texture_ref->texture();
+   // The glTexStorage entry points require width, height, and depth to be
+   // at least 1, but the other texture entry points (those which use
+diff --git a/gpu/config/gpu_driver_bug_list.json b/gpu/config/gpu_driver_bug_list.json
+index 3cc48e4a79576f93bfa22b8f8d1b74e5ba5baae7..a97d53efada5690f7aa505ac6860a2c7f9bd2ca2 100644
+--- a/gpu/config/gpu_driver_bug_list.json
++++ b/gpu/config/gpu_driver_bug_list.json
+@@ -3854,6 +3854,19 @@
+       "features": [
+         "validate_max_per_stage_uniform_blocks_at_compile_time"
+       ]
++    },
++    {
++      "id": 480,
++      "cr_bugs": [520656244],
++      "description": "Reattach FBO depth/stencil attachments when they are reallocated on Qualcomm GPUs",
++      "gl_vendor": "Qualcomm.*",
++      "driver_version": {
++        "op": "<",
++        "value": "878"
++      },
++      "features": [
++        "reattach_fbo_depth_stencil_on_reallocation"
++      ]
+     }
+   ]
+ }
+diff --git a/gpu/config/gpu_workaround_list.txt b/gpu/config/gpu_workaround_list.txt
+index 6d43d0b1937cd1eeaa044fb9949a52ba2e07d446..0ed6e500c2d2a5362ad46f4c3ed368ac56b88883 100644
+--- a/gpu/config/gpu_workaround_list.txt
++++ b/gpu/config/gpu_workaround_list.txt
+@@ -109,6 +109,7 @@ no_downscaled_overlay_promotion
+ pack_parameters_workaround_with_pack_buffer
+ prefer_draw_to_copy
+ r8_egl_images_broken
++reattach_fbo_depth_stencil_on_reallocation
+ rely_on_implicit_sync_for_swap_buffers
+ remove_dynamic_indexing_of_swizzled_vector
+ round_down_uniform_bind_buffer_range_size

--- a/patches/chromium/cherry-pick-0babc641d95e.patch
+++ b/patches/chromium/cherry-pick-0babc641d95e.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ken Buchanan <kenrb@chromium.org>
+Date: Thu, 11 Jun 2026 14:53:26 -0700
+Subject: [M148] [WebAuthn] Guard for AuthenticatorCommonImpl destruction
+ during cleanup
+
+Original change's description:
+> [WebAuthn] Guard for AuthenticatorCommonImpl destruction during cleanup
+>
+> There might be rare cases where the WebContents can be destroyed
+> synchronously during clearing of a WebAuthn request's state, as a
+> consequence of it dismissing UI.
+>
+> This change adds a guard to the `Cleanup()` method that ensures
+> continued liveness of the `AuthenticatorCommonImpl` during
+> request cleanup.
+>
+> Fixed: 521495992
+> Change-Id: I2f93b31b37e007302a7d9fb7ca3e5b8c76fb2b3b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7921707
+> Commit-Queue: Ken Buchanan <kenrb@chromium.org>
+> Reviewed-by: Martin Kreichgauer <martinkr@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1644920}
+
+(cherry picked from commit 43731ada00e8a3a9bcd8fc8eafe91d0940914cab)
+
+Bug: 522600829,521495992
+Change-Id: I2f93b31b37e007302a7d9fb7ca3e5b8c76fb2b3b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7921702
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4327}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/webauth/authenticator_common_impl.cc b/content/browser/webauth/authenticator_common_impl.cc
+index f7dc703ba4f526832c490e96d341ee6489dada6e..0b9a200705c8b330df8756f95941e5d162d09c3e 100644
+--- a/content/browser/webauth/authenticator_common_impl.cc
++++ b/content/browser/webauth/authenticator_common_impl.cc
+@@ -3113,7 +3113,15 @@ void AuthenticatorCommonImpl::CompleteReportRequest(
+ 
+ void AuthenticatorCommonImpl::Cleanup() {
+   CHECK(!req_state_ || req_state_->request_key.value() == next_request_key_);
++  // `req_state_.reset()` destroys the embedder request delegate which can
++  // synchronously close UI which (via activation observers) may destroy the
++  // hosting WebContents and therefore `this`. See https://crbug.com/521495992.
++  base::WeakPtr<AuthenticatorCommonImpl> weak_this = weak_factory_.GetWeakPtr();
+   req_state_.reset();
++  if (!weak_this) {
++    return;
++  }
++
+   next_request_key_++;
+   CHECK(next_request_key_);  // crash on overflow. Only 2^64 WebAuthn requests
+                              // per instance of this object are supported.

--- a/patches/chromium/cherry-pick-1285ece45c13.patch
+++ b/patches/chromium/cherry-pick-1285ece45c13.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rakina Zata Amni <rakina@chromium.org>
+Date: Wed, 17 Jun 2026 03:07:03 -0700
+Subject: [M148] Only kill renderer on DidCommit while BFCached if ACKed, evict
+ otherwise
+
+Original change's description:
+> Only kill renderer on DidCommit while BFCached if ACKed, evict otherwise
+>
+> The previous approach of killing the renderer on all DidCommits might
+> be killing legitimate DidCommit calls that were sent from the renderer
+> from before the document is actually BFCached. This CL makes it so that
+> we kill only calls coming from the renderers that already ACKed the
+> BFCaching. For renderers that haven't we simply just evict the RFH from
+> BFCache. In both cases we return early and don't continue processing
+> the DidCommit.
+>
+> Bug: 520443189, 517148260
+> Change-Id: I4e3f1518e0d86c506127ee19a709aa5a28bc347c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7901822
+> Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+> Reviewed-by: Fergal Daly <fergal@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1643048}
+
+(cherry picked from commit 80366988eaf9e38a0bf32220fa757e66ff95e8e2)
+
+Bug: 520435989,520443189,517148260
+Change-Id: I4e3f1518e0d86c506127ee19a709aa5a28bc347c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7921672
+Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4372}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 76b72173831ba2f573d03c8283104cc5a9c23538..2c4ab147b6431efb6cfaa87cf4972d1ac223d0db 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -16673,8 +16673,18 @@ void RenderFrameHostImpl::DidCommitNavigation(
+   // kInBackForwardCache state. Trigger a renderer kill if we receive an
+   // unexpected DidCommit message.
+   if (IsInBackForwardCache()) {
+-    bad_message::ReceivedBadMessage(
+-        GetProcess(), bad_message::RFH_DID_COMMIT_NAVIGATION_WHILE_BFCACHED);
++    if (render_view_host()->DidReceiveBackForwardCacheAck()) {
++      bad_message::ReceivedBadMessage(
++          GetProcess(), bad_message::RFH_DID_COMMIT_NAVIGATION_WHILE_BFCACHED);
++    } else {
++      // The renderer might not have realized that it's in BFCache when it sent
++      // the DidCommitNavigation call, since we haven't received the BFCache
++      // ACK. In this case, just evict from BFCache instead of killing the
++      // renderer.
++      IsInactiveAndDisallowActivation(
++          DisallowActivationReasonId::kDidCommitNavigation);
++    }
++    // Return early in any case.
+     return;
+   }
+ 
+diff --git a/content/public/browser/disallow_activation_reason.h b/content/public/browser/disallow_activation_reason.h
+index 27d10cf7128391e377f9c9d5b5ccaf0bcad1e1bc..0f19be93af34ae13572c6d6a264c7e9804591b69 100644
+--- a/content/public/browser/disallow_activation_reason.h
++++ b/content/public/browser/disallow_activation_reason.h
+@@ -64,6 +64,7 @@ enum DisallowActivationReasonId : uint64_t {
+   kIndexedDBTransactionIsStartingWhileBlockingOthers = 40,
+   kIndexedDBTransactionIsOngoingAndBlockingOthers = 41,
+   kBrowserInitiatedErrorPage = 42,
++  kDidCommitNavigation = 44,
+   // New entries go above here. New entries should be added to
+   // tools/metrics/histograms/enums.xml .
+   kMinEmbedderDisallowActivationReason = 2 << 16,

--- a/patches/chromium/cherry-pick-30a20a1cc67a.patch
+++ b/patches/chromium/cherry-pick-30a20a1cc67a.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alvin Ji <alvinji@chromium.org>
+Date: Fri, 19 Jun 2026 10:34:54 -0700
+Subject: [M148] Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel
+
+Original change's description:
+> Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel
+>
+> Prevent synchronous destruction of BluetoothSocketMac when releasing the
+> channel by moving connect and receive callbacks to local variables. This
+> ensures the socket remains alive until ReleaseChannel finishes
+> execution, avoiding use-after-free when accessing other member
+> variables.
+>
+> Change-Id: I872d682b6a4d0887b8f93e118db54e51f57321f5
+> Bug: 523704570
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7948137
+> Commit-Queue: Alvin Ji <alvinji@chromium.org>
+> Reviewed-by: Matt Reynolds <mattreynolds@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1648713}
+
+(cherry picked from commit 30838188f5ff65357672bcd00dfaff982ca7ca25)
+
+Bug: 525660690,523704570
+Change-Id: I872d682b6a4d0887b8f93e118db54e51f57321f5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7966147
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4392}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/device/bluetooth/bluetooth_socket_mac.mm b/device/bluetooth/bluetooth_socket_mac.mm
+index e5901d22e80d6b3992935ef88662056d43fe672f..19ef880eaa359646e833537e6ca5f9924bbbeed1 100644
+--- a/device/bluetooth/bluetooth_socket_mac.mm
++++ b/device/bluetooth/bluetooth_socket_mac.mm
+@@ -931,9 +931,12 @@ bool VerifyL2capService(const std::optional<int>& requested_psm,
+   DCHECK(thread_checker_.CalledOnValidThread());
+   channel_.reset();
+ 
+-  // Closing the channel above prevents the callback delegate from being called
+-  // so it is now safe to release all callback state.
+-  connect_callbacks_.reset();
++  // Move connect_callbacks_ to a local variable to prevent synchronous
++  // destruction of 'this' if it holds the last reference to the socket.
++  // This keeps 'this' alive until the end of this method.
++  std::unique_ptr<ConnectCallbacks> temp_connect =
++      std::move(connect_callbacks_);
++
+   receive_callbacks_.reset();
+   empty_queue(receive_queue_);
+   empty_queue(send_queue_);

--- a/patches/chromium/cherry-pick-449a1ea22a42.patch
+++ b/patches/chromium/cherry-pick-449a1ea22a42.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brandon Jones <bajones@chromium.org>
+Date: Tue, 16 Jun 2026 14:30:01 -0700
+Subject: [M149] Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
+
+Original change's description:
+> Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
+>
+> One Android path in CopyTextureCHROMIUM uses a glReadPixels call
+> to a client buffer, but doesn't clear the PIXEL_PACK_BUFFER
+> before doing the read. If the page sets the PIXEL_PACK_BUFFER
+> in a WebGL 2 context prior to this method being called it could
+> interfere with the data being read, leading the client buffer to
+> potentially contain uninitialized memory.
+>
+> This change ensures the PIXEL_PACK_BUFFER is always set to 0
+> before performing the client read.
+>
+> Fixed: 522840723
+> Change-Id: I95c3ad176a2759b490b0b36555c186489fe9153d
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7927868
+> Commit-Queue: Brandon Jones <bajones@chromium.org>
+> Reviewed-by: Kenneth Russell <kbr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1646051}
+
+(cherry picked from commit 92b7a3ad4869e940d79019996d0751f739e1a842)
+
+Bug: 523531700,522840723
+Change-Id: I95c3ad176a2759b490b0b36555c186489fe9153d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7944906
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Brandon Jones <bajones@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3297}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc b/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
+index 98f476de9e4d423b6ec86f2a69638e43bd0fb423..ebf7848c2416cb790291c51936a647a963ed9963 100644
+--- a/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
++++ b/gpu/command_buffer/service/gles2_cmd_copy_texture_chromium.cc
+@@ -696,6 +696,7 @@ void PrepareUnpackBuffer(GLuint buffer[2],
+     // GLCopyTextureCHROMIUMES3Test.FormatCombinations in gl_tests. This is seen
+     // on Nexus 5 but not Nexus 4. Read pixels to client memory, then upload to
+     // pixel unpack buffer with glBufferData.
++    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+     auto pixels = base::HeapArray<uint8_t>::Uninit(width * height * 4);
+     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+     auto data = base::HeapArray<float>::Uninit(width * height * 3);

--- a/patches/chromium/cherry-pick-4febc44304bf.patch
+++ b/patches/chromium/cherry-pick-4febc44304bf.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anna Tsvirchkova <atsvirchkova@google.com>
+Date: Mon, 22 Jun 2026 04:21:52 -0700
+Subject: [M148] Fix leak of grouped credentials to renderer
+
+Original change's description:
+> Fix leak of grouped credentials to renderer
+>
+> If there are multiple matches e. g. the preferred match is an exact
+> match and the additional one is a grouped match (or PSL), there is a
+> possibility that the additional one will be leaked to the renderer
+> process though the filling on page load flow. On the rederer side, all
+> matches with non-empty realm are not used for filling anyway
+> (https://source.chromium.org/chromium/chromium/src/+/main:components/autofill/content/renderer/password_autofill_agent.cc;l=229;bpv=0;bpt=1),
+> so this fix clears the passwords for non-empty realm credentials to
+> avoid the leak.
+>
+> Bug: 523699355
+> Change-Id: I341cbb03752537c1ebc67b005d29de065eeca53c
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7941892
+> Commit-Queue: Anna Tsvirchkova <atsvirchkova@google.com>
+> Reviewed-by: Maria Kazinova <kazinova@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1648968}
+
+(cherry picked from commit 0be87b4e25bf905accc522efa61a431de40a2ae9)
+
+Bug: 525661291,523699355
+Change-Id: I341cbb03752537c1ebc67b005d29de065eeca53c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7978359
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4398}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/components/autofill/core/common/password_form_fill_data.cc b/components/autofill/core/common/password_form_fill_data.cc
+index 4feda24ca8a16017dd15d7251c04e44c89edaaf3..57c0a06cc86c454adb26f5f74281b73a9f85b314 100644
+--- a/components/autofill/core/common/password_form_fill_data.cc
++++ b/components/autofill/core/common/password_form_fill_data.cc
+@@ -94,14 +94,19 @@ PasswordFormFillData MaybeClearPasswordValues(
+   // field), credentials from |additional_logins| could be used for filling
+   // on load. So in case of filling on load nor |password_field| nor
+   // |additional_logins| can't be cleared
+-  bool is_fallback = data.password_element_renderer_id.is_null();
+-  if (!data.wait_for_username && !is_fallback) {
+-    return data;
+-  }
++  bool no_fill_on_page_load =
++      data.wait_for_username || data.password_element_renderer_id.is_null();
+   PasswordFormFillData result(data);
+-  result.preferred_login.password_value.clear();
++  if (no_fill_on_page_load) {
++    result.preferred_login.password_value.clear();
++  }
+   for (auto& credentials : result.additional_logins) {
+-    credentials.password_value.clear();
++    // Realm is only set for credentials initially associated with a different
++    // domain. For security reasons, such credentials are never filled on page
++    // load and should not be passed to the renderer.
++    if (!credentials.realm.empty() || no_fill_on_page_load) {
++      credentials.password_value.clear();
++    }
+   }
+   return result;
+ }

--- a/patches/chromium/cherry-pick-806fda7e35f3.patch
+++ b/patches/chromium/cherry-pick-806fda7e35f3.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dave Tapuska <dtapuska@chromium.org>
+Date: Wed, 17 Jun 2026 09:03:28 -0700
+Subject: [M148] Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
+
+Original change's description:
+> Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
+>
+> Add a weak pointer check after calling client_->OrientationChanged() because this call can cause the WidgetBase object to be destroyed.
+>
+> Bug: 523308824, 523711130
+> Change-Id: If70c28a4a616b4909dade238d8c39b001956fd05
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7930273
+> Reviewed-by: Vladimir Levin <vmpstr@chromium.org>
+> Commit-Queue: Vladimir Levin <vmpstr@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1646821}
+
+(cherry picked from commit 6b6931e5c44fc5fe912a04d4c67503a770b07e3d)
+
+Bug: 524508385,523308824,523711130
+Change-Id: If70c28a4a616b4909dade238d8c39b001956fd05
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7957259
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Dave Tapuska <dtapuska@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4375}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/platform/widget/widget_base.cc b/third_party/blink/renderer/platform/widget/widget_base.cc
+index 0896ed985458e0dc15a62e81b3053a7586d71f56..d329652964dbe2f59940df9b401d768dfc778527 100644
+--- a/third_party/blink/renderer/platform/widget/widget_base.cc
++++ b/third_party/blink/renderer/platform/widget/widget_base.cc
+@@ -1052,7 +1052,11 @@ void WidgetBase::UpdateVisualState() {
+       ShouldRecordBeginMainFrameMetrics()
+           ? DocumentUpdateReason::kBeginMainFrame
+           : DocumentUpdateReason::kTest;
++  auto weak_this = weak_ptr_factory_.GetWeakPtr();
+   client_->UpdateLifecycle(WebLifecycleUpdate::kAll, lifecycle_reason);
++  if (!weak_this) {
++    return;
++  }
+   client_->SetSuppressFrameRequestsWorkaroundFor704763Only(false);
+ }
+ 
+@@ -1733,8 +1737,13 @@ void WidgetBase::UpdateSurfaceAndScreenInfo(
+         screen_infos_.current().display_color_spaces);
+   }
+ 
+-  if (orientation_changed)
++  if (orientation_changed) {
++    auto weak_this = weak_ptr_factory_.GetWeakPtr();
+     client_->OrientationChanged();
++    if (!weak_this) {
++      return;
++    }
++  }
+ 
+   client_->DidUpdateSurfaceAndScreen(previous_original_screen_infos);
+ }

--- a/patches/chromium/cherry-pick-814cb4953ecb.patch
+++ b/patches/chromium/cherry-pick-814cb4953ecb.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Jensen <pauljensen@chromium.org>
+Date: Tue, 16 Jun 2026 14:55:55 -0700
+Subject: [M148] Protected Audience: Ignore non-finite interest group
+ priorities
+
+Original change's description:
+> Protected Audience: Ignore non-finite interest group priorities
+>
+> Non-finite values are not permitted in priority vectors submitted
+> via JSON or WebIDL so this likely indicates aberrant priority
+> calculations that went out of bounds.
+>
+> Fixed: 523677844
+> Change-Id: Ie201fafc7b11c34b236595afc369ac74f317b128
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7941151
+> Reviewed-by: Russ Hamilton <behamilton@google.com>
+> Auto-Submit: Paul Jensen <pauljensen@chromium.org>
+> Commit-Queue: Russ Hamilton <behamilton@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1646794}
+
+(cherry picked from commit 8ecc3fa50aad399fe7a40b5daba71615196cf4ec)
+
+Bug: 524507077,523677844
+Change-Id: Ie201fafc7b11c34b236595afc369ac74f317b128
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7952422
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4367}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/interest_group/interest_group_priority_util.cc b/content/browser/interest_group/interest_group_priority_util.cc
+index d4d40fd43022c127e7ef6486c189c8d9b5150aad..e12981009c84a3436f1e6141b17256dd25dd3ea7 100644
+--- a/content/browser/interest_group/interest_group_priority_util.cc
++++ b/content/browser/interest_group/interest_group_priority_util.cc
+@@ -89,6 +89,12 @@ double CalculateInterestGroupPriority(
+       break;
+     }
+   }
++
++  // Ignore non-finite results.
++  if (!std::isfinite(caclulated_priority)) {
++    return -1;
++  }
++
+   return caclulated_priority;
+ }
+ 

--- a/patches/chromium/cherry-pick-b9b2f0b7eca8.patch
+++ b/patches/chromium/cherry-pick-b9b2f0b7eca8.patch
@@ -1,0 +1,197 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Wilken=20D=C3=B6rrie?= <jdoerrie@chromium.org>
+Date: Fri, 19 Jun 2026 01:38:37 -0700
+Subject: [M148] [dbsc] Use final URL for registration validation checks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Original change's description:
+> [dbsc] Use final URL for registration validation checks
+>
+> This change updates the registration fetcher to use the final URL after
+> redirects for registration validation checks.
+>
+> Bug: 511776603
+> Change-Id: Ibacb0c22deddd9a1b6104690a70d7dd06a6a6964
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7852498
+> Commit-Queue: Jan Wilken Dörrie <jdoerrie@chromium.org>
+> Reviewed-by: Alex Ilin <alexilin@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1633609}
+
+(cherry picked from commit 159631e99b1d8828210daff47f6afe5a67a0fca5)
+
+Bug: 519051209,511776603
+Change-Id: Ibacb0c22deddd9a1b6104690a70d7dd06a6a6964
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7953464
+Reviewed-by: Alex Ilin <alexilin@chromium.org>
+Commit-Queue: Jan Wilken Dörrie <jdoerrie@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4390}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/net/device_bound_sessions/registration_fetcher.cc b/net/device_bound_sessions/registration_fetcher.cc
+index 0567a53e4ab95cd6c54e1ad0b8a40c38badb6996..34d0e4480fab80e95efd5cace3b5a3d358e8a911 100644
+--- a/net/device_bound_sessions/registration_fetcher.cc
++++ b/net/device_bound_sessions/registration_fetcher.cc
+@@ -375,6 +375,8 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+       return SessionError::kSessionProviderWellKnownHasProviderOrigin;
+     }
+ 
++    // TODO(crbug.com/511776603): Evaluate whether to use the final redirect URL
++    // instead of the original URL here in a follow-up.
+     std::string target_origin =
+         url::Origin::Create(fetcher_endpoint_).Serialize();
+     if (!maybe_params->relying_origins.has_value() ||
+@@ -430,6 +432,8 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+       return SessionError::kRelyingPartyWellKnownHasRelyingOrigins;
+     }
+ 
++    // TODO(crbug.com/511776603): Evaluate whether to use the final redirect URL
++    // instead of the original URL here in a follow-up.
+     if (!maybe_params->provider_origin.has_value() ||
+         url::Origin::Create(provider_url_).Serialize() !=
+             *maybe_params->provider_origin) {
+@@ -640,11 +644,15 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+       return;
+     }
+ 
++    // Use the final URL after redirects for validation checks to ensure we
++    // validate the origin that actually served the response.
++    GURL final_registration_url = url_fetcher_->request().url();
++
+     // Re-process challenge headers now that a session exists so that cached
+     // challenges work for the registration case as well.
+     auto challenge_params =
+         device_bound_sessions::SessionChallengeParam::CreateIfValid(
+-            fetcher_endpoint_, headers);
++            final_registration_url, headers);
+     for (const SessionChallengeParam& challenge_param : challenge_params) {
+       if (challenge_param.session_id() == *(*session_or_error)->id()) {
+         (*session_or_error)->set_cached_challenge(challenge_param.challenge());
+@@ -671,7 +679,7 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+         // Skip all validations if the fetcher endpoint is not a subdomain but
+         // rather the top-level site (which matches the origin when including
+         // the site).
+-        fetcher_endpoint_.GetHost() != (*session_or_error)->origin().host()) {
++        final_registration_url.host() != (*session_or_error)->origin().host()) {
+       GURL::Replacements replacements;
+       replacements.SetPathStr("/.well-known/device-bound-sessions");
+       replacements.SetHostStr((*session_or_error)->origin().host());
+@@ -688,7 +696,8 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+       url_fetcher_->Start(
+           base::BindOnce(&RegistrationFetcherImpl::
+                              OnSubdomainRegistrationWellKnownRequestComplete,
+-                         GetWeakPtr(), std::move(*session_or_error)));
++                         GetWeakPtr(), std::move(final_registration_url),
++                         std::move(*session_or_error)));
+       return;
+     }
+ 
+@@ -697,13 +706,15 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+   }
+ 
+   void OnSubdomainRegistrationWellKnownRequestComplete(
++      GURL final_registration_url,
+       std::unique_ptr<Session> session) {
+     RunCallback(OnSubdomainRegistrationWellKnownRequestCompleteInternal(
+-        std::move(session)));
++        std::move(final_registration_url), std::move(session)));
+     // `this` may be deleted.
+   }
+ 
+   RegistrationResult OnSubdomainRegistrationWellKnownRequestCompleteInternal(
++      GURL final_registration_url,
+       std::unique_ptr<Session> session) {
+     HttpResponseHeaders* headers = url_fetcher_->request().response_headers();
+     const int response_code = headers ? headers->response_code() : 0;
+@@ -730,7 +741,7 @@ class RegistrationFetcherImpl : public RegistrationFetcher {
+ 
+     if (!maybe_params->registering_origins.has_value() ||
+         !base::Contains(*maybe_params->registering_origins,
+-                        url::Origin::Create(fetcher_endpoint_).Serialize())) {
++                        url::Origin::Create(final_registration_url).Serialize())) {
+       return RegistrationResult(
+           SessionError{SessionError::kSubdomainRegistrationUnauthorized});
+     }
+diff --git a/net/device_bound_sessions/registration_fetcher_unittest.cc b/net/device_bound_sessions/registration_fetcher_unittest.cc
+index 02811966e0aab48e284a44f8a628ee4dc24fb9f7..65ea240d296fc12f1253bf517e8c1a71953f0fdc 100644
+--- a/net/device_bound_sessions/registration_fetcher_unittest.cc
++++ b/net/device_bound_sessions/registration_fetcher_unittest.cc
+@@ -15,6 +15,7 @@
+ #include "base/json/json_writer.h"
+ #include "base/run_loop.h"
+ #include "base/strings/string_util.h"
++#include "base/test/bind.h"
+ #include "base/test/gmock_callback_support.h"
+ #include "base/test/metrics/histogram_tester.h"
+ #include "base/test/scoped_feature_list.h"
+@@ -2578,6 +2579,68 @@ TEST_F(RegistrationTest, RegistrationBySubdomain_MultipleAllowed) {
+   }
+ }
+ 
++TEST_F(RegistrationTest, RegistrationRedirectToSubdomain) {
++  crypto::ScopedFakeUnexportableKeyProvider scoped_fake_key_provider;
++  bool well_known_fetched = false;
++
++  // 1. Redirect request
++  server_.RegisterRequestHandler(base::BindLambdaForTesting(
++      [&](const test_server::HttpRequest& request)
++          -> std::unique_ptr<test_server::HttpResponse> {
++        if (request.relative_url != "/") {
++          return nullptr;
++        }
++        auto response = std::make_unique<test_server::BasicHttpResponse>();
++        response->set_code(HTTP_FOUND);
++        response->AddCustomHeader(
++            "Location", server_.GetURL("subdomain.a.test", "/dbsc").spec());
++        return response;
++      }));
++
++  // 2. Return config
++  server_.RegisterRequestHandler(base::BindLambdaForTesting(
++      [&](const test_server::HttpRequest& request)
++          -> std::unique_ptr<test_server::HttpResponse> {
++        if (request.relative_url != "/dbsc") {
++          return nullptr;
++        }
++        return ReturnResponse(HTTP_OK, kBasicValidJson, request);
++      }));
++
++  // 3. Monitor well-known requests
++  server_.RegisterRequestHandler(base::BindLambdaForTesting(
++      [&](const test_server::HttpRequest& request)
++          -> std::unique_ptr<test_server::HttpResponse> {
++        if (request.relative_url != "/.well-known/device-bound-sessions") {
++          return nullptr;
++        }
++        well_known_fetched = true;
++        return ReturnResponse(HTTP_NOT_FOUND, "", request);
++      }));
++
++  ASSERT_TRUE(server_.Start());
++
++  GURL registration_url = server_.GetURL("a.test", "/");
++  RecordingNetLogObserver net_log_observer;
++  TestRegistrationCallback callback;
++
++  auto param = GetBasicParam(registration_url);
++  std::unique_ptr<RegistrationFetcher> fetcher =
++      RegistrationFetcher::CreateFetcher(
++          param, session_service(), unexportable_key_service(), context_.get(),
++          IsolationInfo::CreateTransient(/*nonce=*/std::nullopt),
++          /*net_log_source=*/std::nullopt,
++          /*original_request_initiator=*/std::nullopt);
++  fetcher->StartCreateTokenAndFetch(param, CreateAlgArray(),
++                                    callback.callback());
++  callback.WaitForCall();
++
++  // Verify well-known check is triggered and registration fails.
++  EXPECT_TRUE(well_known_fetched);
++  EXPECT_EQ(callback.outcome().SessionErrorForTesting()->type,
++            SessionError::kSubdomainRegistrationWellKnownUnavailable);
++}
++
+ TEST_F(RegistrationTest, FederatedSuccess) {
+   crypto::ScopedFakeUnexportableKeyProvider scoped_fake_key_provider;
+ 

--- a/patches/chromium/cherry-pick-d7593e5c3f70.patch
+++ b/patches/chromium/cherry-pick-d7593e5c3f70.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rakina Zata Amni <rakina@chromium.org>
+Date: Tue, 16 Jun 2026 23:38:04 -0700
+Subject: [M148] Kill renderer if we receive DidCommitNavigation from BFCached
+ RFH
+
+Original change's description:
+> Kill renderer if we receive DidCommitNavigation from BFCached RFH
+>
+> We don't allow bfcaching pages with pending commit navigations, so
+> kill the renderer if it claims it committed one.
+>
+> Fixed: 517148260
+> Change-Id: Idd69d28c908c55911dc72dde4fd6237d173dda0e
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7893390
+> Reviewed-by: Mark Pearson <mpearson@chromium.org>
+> Reviewed-by: Fergal Daly <fergal@chromium.org>
+> Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1641477}
+
+(cherry picked from commit ee35b8de30bc2ba497ebc165d1e878af53865b75)
+
+Bug: 520435989,517148260
+Change-Id: Idd69d28c908c55911dc72dde4fd6237d173dda0e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7921359
+Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+Reviewed-by: Fergal Daly <fergal@chromium.org>
+Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+Owners-Override: Rakina Zata Amni <rakina@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4370}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/content/browser/bad_message.h b/content/browser/bad_message.h
+index 66c416f414d92012c9fa893a1222102ddd9ab23a..c39b2f450a4fe3632ebab009d3844996b0e45e5a 100644
+--- a/content/browser/bad_message.h
++++ b/content/browser/bad_message.h
+@@ -358,6 +358,7 @@ enum BadMessageReason {
+   RFH_CRASH_REPORT_STORAGE_SIZE_TOO_LARGE = 330,
+   RFH_CRASH_REPORT_STORAGE_ALREADY_INITIALIZED = 331,
+   RFH_INVALID_DOCUMENT_SEQUENCE_NUMBER = 332,
++  RFH_DID_COMMIT_NAVIGATION_WHILE_BFCACHED = 354,
+ 
+   // Please add new elements here. The naming convention is abbreviated class
+   // name (e.g. RenderFrameHost becomes RFH) plus a unique description of the
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 368c8fa0d6de2eb0461c391a70826a42525bc524..76b72173831ba2f573d03c8283104cc5a9c23538 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -16670,8 +16670,13 @@ void RenderFrameHostImpl::DidCommitNavigation(
+   // BackForwardCache (see the check IsInactiveAndDisallowActivation in
+   // RFH::DidCommitSameDocumentNavigation() and RFH::BeginNavigation()) so it
+   // isn't possible to get a DidCommitNavigation IPC from the renderer in
+-  // kInBackForwardCache state.
+-  DCHECK(!IsInBackForwardCache());
++  // kInBackForwardCache state. Trigger a renderer kill if we receive an
++  // unexpected DidCommit message.
++  if (IsInBackForwardCache()) {
++    bad_message::ReceivedBadMessage(
++        GetProcess(), bad_message::RFH_DID_COMMIT_NAVIGATION_WHILE_BFCACHED);
++    return;
++  }
+ 
+   // TODO(https://crbug.com/445585641): Make this enforceable on Android.
+ #if !BUILDFLAG(IS_ANDROID)
+diff --git a/tools/metrics/histograms/metadata/stability/enums.xml b/tools/metrics/histograms/metadata/stability/enums.xml
+index 5e5c61f6e76d5e723885b07bbaecb18eaa02c196..460b1fcf85524782fb70f5b9da4648d290af10f7 100644
+--- a/tools/metrics/histograms/metadata/stability/enums.xml
++++ b/tools/metrics/histograms/metadata/stability/enums.xml
+@@ -498,6 +498,7 @@ Called by update_bad_message_reasons.py.-->
+   <int value="330" label="RFH_CRASH_REPORT_STORAGE_SIZE_TOO_LARGE"/>
+   <int value="331" label="RFH_CRASH_REPORT_STORAGE_ALREADY_INITIALIZED"/>
+   <int value="332" label="RFH_INVALID_DOCUMENT_SEQUENCE_NUMBER"/>
++  <int value="354" label="RFH_DID_COMMIT_NAVIGATION_WHILE_BFCACHED"/>
+ </enum>
+ 
+ <enum name="BadMessageReasonExtensions">

--- a/patches/chromium/cherry-pick-f583b94a1374.patch
+++ b/patches/chromium/cherry-pick-f583b94a1374.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sunny Sachanandani <sunnyps@chromium.org>
+Date: Thu, 18 Jun 2026 13:41:43 -0700
+Subject: [M149] [gpu] Check GL error before marking GLTexture/EGLImage cleared
+
+Original change's description:
+> [gpu] Check GL error before marking GLTexture/EGLImage cleared
+>
+> GLTextureImageBacking and EGLImageBacking currently mark the backing as
+> cleared unconditionally when initial pixel data is provided, even if the
+> subsequent upload via glTexSubImage2D fails (e.g. under resource
+> pressure / GL_OUT_OF_MEMORY). This bypasses the IsCleared() check,
+> potentially exposing uninitialized VRAM allocator residue during
+> readback.
+>
+> This CL checks for GL errors before calling SetCleared(). If a GL error
+> is detected, the backing remains uncleared so subsequent read access is
+> refused.
+>
+> Landing a shared image unittest for this wasn't feasible since it needs
+> patching GL function pointers which won't work well in any parallel test
+> setup. However, I was able to verify the fix locally with a unit test.
+>
+> Fixed: 517080836
+> Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7909296
+> Commit-Queue: Sunny Sachanandani <sunnyps@chromium.org>
+> Auto-Submit: Sunny Sachanandani <sunnyps@chromium.org>
+> Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1647933}
+
+(cherry picked from commit 7f4181fabb329920be950c95b76e69d1ad296cda)
+
+Bug: 525281583,517080836
+Change-Id: If9ac7f2cb1742601418db52ad163742d6a6a6964
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7962562
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7827@{#3415}
+Cr-Branched-From: 9f3e9aaccba63bd2ec30334e45e0bfd07ebcc8f1-refs/heads/main@{#1625079}
+
+diff --git a/gpu/command_buffer/service/shared_image/egl_image_backing.cc b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+index 4ebd02291c2301fea96cfe5076d3acbf94c23a85..6be895d9479165ff1ff375a95e4ccb9ee7a83769 100644
+--- a/gpu/command_buffer/service/shared_image/egl_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/egl_image_backing.cc
+@@ -454,6 +454,17 @@ gl::ScopedEGLImage EGLImageBacking::GenEGLImageSibling(
+                         pixel_data.data());
+   }
+ 
++  // The storage allocation of the sibling texture allocates undefined-content
++  // storage on a context without robust-resource-init. If the following upload
++  // upload failed (e.g. GL_OUT_OF_MEMORY) the storage is still uninitialized.
++  // Return an invalid image so that we don't call SetCleared() on the backing.
++  const GLenum error = api->glGetErrorFn();
++  if (error != GL_NO_ERROR) {
++    LOG(ERROR) << "EGLImageBacking: initial pixel upload failed (GL error 0x"
++               << std::hex << error << ")";
++    return gl::ScopedEGLImage();
++  }
++
+   // Use service id of the texture as a source to create the EGLImage.
+   const EGLint egl_attrib_list[] = {
+       EGL_GL_TEXTURE_LEVEL_KHR, 0, EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE};
+@@ -480,6 +491,12 @@ EGLImageBacking::GenEGLImageSiblings(base::span<const uint8_t> pixel_data) {
+     AutoLock auto_lock(this);
+     create_egl_images = egl_images_.empty();
+     if (create_egl_images) {
++      // Drain any pre-existing GL errors so the post-allocation check below in
++      // GenEGLImageSibling is attributable to the storage call. Silently
++      // squelching these errors is unfortunate, but is done in order to mirror
++      // other allocation checks done in the command decoder.
++      while (api->glGetErrorFn() != GL_NO_ERROR) {
++      }
+       for (int plane = 0; plane < num_planes; plane++) {
+         gl::ScopedEGLImage egl_image =
+             GenEGLImageSibling(pixel_data, service_ids, plane);
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+index 4a21a1109771ca9aca1fb732c8102217b16da77e..7e1b5f09299173d18e75a39685ef6e4470c5bb2c 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+@@ -221,10 +221,12 @@ void GLTextureHolder::Initialize(
+       // that it can be used in other ES2 contexts, and so we have to pass
+       // gl_format as the internal format in the LevelInfo.
+       // https://crbug.com/628064
+-      texture_->SetLevelInfo(format_desc_.target, 0, format_desc_.data_format,
+-                             size_.width(), size_.height(), /*depth=*/1, 0,
+-                             format_desc_.data_format, format_desc_.data_type,
+-                             /*cleared_rect=*/gfx::Rect());
++      const gfx::Rect cleared_rect =
++          !pixel_data.empty() ? gfx::Rect(size_) : gfx::Rect();
++      texture_->SetLevelInfo(
++          format_desc_.target, /*level=*/0, format_desc_.data_format,
++          size_.width(), size_.height(), /*depth=*/1, /*border=*/0,
++          format_desc_.data_format, format_desc_.data_type, cleared_rect);
+       texture_->SetImmutable(true, format_info.supports_storage);
+     } else {
+       LOG(ERROR) << "GLTextureHolder: native storage allocation failed";
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+index f33eb49688d7cfd0cc79e898366fcc76ad7a8cf3..86d66d157d44118ea59aed372d1e273db5f3eef8 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_image_backing.cc
+@@ -454,6 +454,14 @@ void GLTextureImageBacking::InitializeGLTexture(
+     base::span<const uint8_t> pixel_data,
+     gl::ProgressReporter* progress_reporter,
+     bool framebuffer_attachment_angle) {
++  // Drain any pre-existing GL errors so the post-allocation check below is
++  // attributable to the storage call. Silently squelching these errors is
++  // unfortunate, but is done in order to mirror other allocation checks done in
++  // the command decoder.
++  gl::GLApi* const api = gl::g_current_gl_context;
++  while (api->glGetErrorFn() != GL_NO_ERROR) {
++  }
++
+   const std::string debug_label =
+       "GLSharedImage_" + SharedImageBacking::debug_label();
+   int num_planes = format().NumberOfPlanes();
+@@ -467,8 +475,23 @@ void GLTextureImageBacking::InitializeGLTexture(
+                                 debug_label);
+   }
+ 
+-  if (!pixel_data.empty()) {
+-    SetCleared();
++  // Update the cleared state for passthrough textures if the pixel data upload
++  // was successful. We don't need to update the cleared state for validating
++  // decoder textures because we track the cleared state in the decoder texture
++  // objects whose cleared state is set in TextureHolder::Initialize above.
++  if (is_passthrough_ && !pixel_data.empty()) {
++    // The storage allocation allocates undefined-content storage on a context
++    // without robust-resource-init. If the subsequent upload failed (e.g.
++    // GL_OUT_OF_MEMORY) the storage is still uninitialised; only mark the
++    // backing cleared if no GL error was raised.
++    GLenum error = api->glGetErrorFn();
++    if (error == GL_NO_ERROR) {
++      SetCleared();
++    } else {
++      LOG(ERROR)
++          << "GLTextureImageBacking: initial pixel upload failed (GL error 0x"
++          << std::hex << error << ")";
++    }
+   }
+ }
+ 


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`067fd777c0d1`](https://chromium-review.googlesource.com/c/chromium/src/+/7959417) from chromium — [M148] Add workaround reattaching depth/stencil attachments.
* [`04f66fb96767`](https://chromium-review.googlesource.com/c/chromium/src/+/7975811) from chromium — [M149] Rebind original FBO earlier in ClearLevelUsingGL.
* [`814cb4953ecb`](https://chromium-review.googlesource.com/c/chromium/src/+/7952422) from chromium — [M148] Protected Audience: Ignore non-finite interest group priorities
* [`b9b2f0b7eca8`](https://chromium-review.googlesource.com/c/chromium/src/+/7953464) from chromium — [M148] [dbsc] Use final URL for registration validation checks
* [`f583b94a1374`](https://chromium-review.googlesource.com/c/chromium/src/+/7962562) from chromium — [M149] [gpu] Check GL error before marking GLTexture/EGLImage cleared
* [`d7593e5c3f70`](https://chromium-review.googlesource.com/c/chromium/src/+/7921359) from chromium — [M148] Kill renderer if we receive DidCommitNavigation from BFCached RFH
* [`1285ece45c13`](https://chromium-review.googlesource.com/c/chromium/src/+/7921672) from chromium — [M148] Only kill renderer on DidCommit while BFCached if ACKed, evict otherwise
* [`0babc641d95e`](https://chromium-review.googlesource.com/c/chromium/src/+/7921702) from chromium — [M148] [WebAuthn] Guard for AuthenticatorCommonImpl destruction during cleanup
* [`449a1ea22a42`](https://chromium-review.googlesource.com/c/chromium/src/+/7944906) from chromium — [M149] Clear PIXEL_PACK_BUFFER in CopyTextureCHROMIUM
* [`806fda7e35f3`](https://chromium-review.googlesource.com/c/chromium/src/+/7957259) from chromium — [M148] Prevent use-after-free in WidgetBase::UpdateSurfaceAndScreen.
* [`4febc44304bf`](https://chromium-review.googlesource.com/c/chromium/src/+/7978359) from chromium — [M148] Fix leak of grouped credentials to renderer
* [`30a20a1cc67a`](https://chromium-review.googlesource.com/c/chromium/src/+/7966147) from chromium — [M148] Fix Use-After-Free in BluetoothSocketMac::ReleaseChannel

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium.
