### PR TITLE
build: only run gn-typescript-definitions for default toolchain

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -185,17 +185,25 @@ config("electron_lib_config") {
   }
 }
 
-# We generate the definitions twice here, once in //electron/electron.d.ts
-# and once in $target_gen_dir
-# The one in $target_gen_dir is used for the actual TSC build later one
-# and the one in //electron/electron.d.ts is used by your IDE (vscode)
-# for typescript prompting
-npm_action("build_electron_definitions") {
-  script = "gn-typescript-definitions"
-  args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
-  inputs = auto_filenames.api_docs + [ "yarn.lock" ]
+# electron.d.ts is generated into the repo root (//electron/electron.d.ts) — a
+# single shared path consumed via the /// <reference> in
+# typings/internal-electron.d.ts — plus a per-toolchain gen-dir copy. Because
+# the repo-root write is a fixed shared path, instantiating this action in more
+# than one toolchain races two concurrent truncate-then-write generators on it.
+# Generate it once in the default toolchain and forward to that instance
+# everywhere else.
+if (current_toolchain == default_toolchain) {
+  npm_action("build_electron_definitions") {
+    script = "gn-typescript-definitions"
+    args = [ rebase_path("$target_gen_dir/tsc/typings/electron.d.ts") ]
+    inputs = auto_filenames.api_docs + [ "yarn.lock" ]
 
-  outputs = [ "$target_gen_dir/tsc/typings/electron.d.ts" ]
+    outputs = [ "$target_gen_dir/tsc/typings/electron.d.ts" ]
+  }
+} else {
+  group("build_electron_definitions") {
+    public_deps = [ ":build_electron_definitions($default_toolchain)" ]
+  }
 }
 
 webpack_build("electron_browser_bundle") {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

When cross-compiling, we can end up with two concurrent invocations of the `build_electron_definitions` GN action, both writing to `//electron/electron.d.ts`. If one wins the race and moves on to TypeScript compilation it may see a partially written `//electron/electron.d.ts` as the other concurrent invocation writes to disk, causing the TS compilation to fail. This was observed in [this `linux-arm64` CI job](https://github.com/electron/electron/actions/runs/28131482760/job/83308814079?pr=52113).

`$target_gen_dir/tsc/typings/electron.d.ts` isn't actually used for anything, the TS compilation uses `//electron/electron.d.ts` as seen by the CI job failure, and the contents of the file are architecture independent, so generate the content once for the default toolchain and any other toolchains can reference it there.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
