### PR TITLE
docs: added documentation and a Fiddle for WCO breaking changes on Linux in Electron 43.x

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -41,6 +41,10 @@ When using `contextBridge` care must be taken to ensure that the [`clipboard API
 
 ## Planned Breaking API Changes (43.0)
 
+### Behavior Changed: WCO respects the native title bar layout on Linux
+
+Frameless windows with Window Controls Overlay (WCO) now adopt the native title bar layout and user settings on Linux. For example, controls will appear on the left side of the frame on RTL systems, and only the close button will be visible by default on GNOME. Depending on the user's desktop environment and configuration, buttons can appear on the left or right side of the frame (or both). To account for all possibilities, use the CSS variables `env(titlebar-area-x, 0px)` and `env(titlebar-area-width, 100%)` to constrain your app's title bar content to a safe area.
+
 ### Behavior Changed: `NativeImage.toBitmap()` now normalizes color space
 
 `NativeImage.toBitmap()` (and its deprecated alias `NativeImage.getBitmap()`) now normalizes pixel data to sRGB by default. Previously, raw pixel data was returned without color space conversion, which meant pixel values from images with different embedded color profiles (e.g., Display P3 on macOS) could differ for the same visual color.

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/index.html
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <link href="./styles.css" rel="stylesheet">
+    <title>Custom Titlebar App</title>
+  </head>
+  <body>
+	  <!-- mount your title bar at the top of you application's body tag -->
+    <div class="titlebar">Cool titlebar</div>
+  </body>
+</html>

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/main.js
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/main.js
@@ -1,0 +1,16 @@
+const { app, BrowserWindow } = require('electron')
+
+function createWindow () {
+  const win = new BrowserWindow({
+    // remove the default titlebar
+    titleBarStyle: 'hidden',
+    // expose window controls in Windows/Linux
+    ...(process.platform !== 'darwin' ? { titleBarOverlay: true } : {})
+  })
+
+  win.loadFile('index.html')
+}
+
+app.whenReady().then(() => {
+  createWindow()
+})

--- a/docs/fiddles/features/window-customization/custom-title-bar/safe-area/styles.css
+++ b/docs/fiddles/features/window-customization/custom-title-bar/safe-area/styles.css
@@ -1,0 +1,17 @@
+body {
+  margin: 0;
+}
+.titlebar {
+  background: blue;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  app-region: drag;
+  
+  margin-left: env(titlebar-area-x, 0);
+  width:       env(titlebar-area-width, 100%);
+  height:      env(titlebar-area-height, 30px);
+  box-sizing: border-box;
+  border: 1px dashed red;
+}

--- a/docs/tutorial/custom-title-bar.md
+++ b/docs/tutorial/custom-title-bar.md
@@ -62,6 +62,15 @@ bar to reposition our app window!
 For more information around how to manage drag regions defined by your electron application,
 see the [Custom draggable regions][] section below.
 
+One more step: we should make sure our title bar content doesn't overlap with the native
+window controls. Buttons can appear on the right or left side of the frame (or both) depending
+on RTL and the user's settings. We can create a safe area using the CSS variables
+`env(titlebar-area-x, 0px)` and `env(titlebar-area-width, 100%)`.
+
+```fiddle docs/fiddles/features/window-customization/custom-title-bar/safe-area
+
+```
+
 Congratulations, you've just implemented a basic custom title bar!
 
 ## Advanced window customization


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/52018.

See that PR for details.

Notes: none