### PR TITLE
feat(web-contents): add bypassCache option to navigationHistory.restore

### DIFF
--- a/docs/api/navigation-history.md
+++ b/docs/api/navigation-history.md
@@ -97,6 +97,7 @@ This API allows you to create common flows that aim to restore, recreate, or clo
 * `options` Object
   * `entries` [NavigationEntry[]](structures/navigation-entry.md) - Result of a prior `getAllEntries()` call
   * `index` Integer (optional) - Index of the stack that should be loaded. If you set it to `0`, the webContents will load the first (oldest) entry. If you leave it undefined, Electron will automatically load the last (newest) entry.
+  * `bypassCache` boolean (optional) - When `true`, the restored entry is loaded directly from the network instead of the cache. By default a restored navigation is served from the cache without contacting the server, so any condition that depends on a live network request is not re-evaluated. Bypassing the cache forces a fresh load, so errors such as an invalid certificate (for example one that has expired or changed since the page was cached, surfaced through the [`certificate-error`](web-contents.md#event-certificate-error) event) or other network failures are reported. Note that this requires network connectivity to restore the navigation. Defaults to `false`.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading the selected navigation entry
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -546,7 +546,7 @@ WebContents.prototype._init = function () {
       getEntryAtIndex: this._getNavigationEntryAtIndex.bind(this),
       removeEntryAtIndex: this._removeNavigationEntryAtIndex.bind(this),
       getAllEntries: this._getHistory.bind(this),
-      restore: ({ index, entries }: { index?: number; entries: NavigationEntry[] }) => {
+      restore: ({ index, entries, bypassCache = false }: { index?: number; entries: NavigationEntry[]; bypassCache?: boolean }) => {
         if (index === undefined) {
           index = entries.length - 1;
         }
@@ -561,7 +561,7 @@ WebContents.prototype._init = function () {
         p.catch(() => {});
 
         try {
-          this._restoreHistory(index, entries);
+          this._restoreHistory(index, entries, bypassCache);
         } catch (error) {
           return Promise.reject(error);
         }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2927,7 +2927,8 @@ void WebContents::RestoreHistory(
     v8::Isolate* isolate,
     gin_helper::ErrorThrower thrower,
     int index,
-    const std::vector<v8::Local<v8::Value>>& entries) {
+    const std::vector<v8::Local<v8::Value>>& entries,
+    bool bypass_cache) {
   if (!web_contents()
            ->GetController()
            .GetLastCommittedEntry()
@@ -2967,7 +2968,19 @@ void WebContents::RestoreHistory(
     web_contents()->SetUserAgentOverride(ua_override, false);
     web_contents()->GetController().Restore(
         index, content::RestoreType::kRestored, &navigation_entries);
-    web_contents()->GetController().LoadIfNecessary();
+    if (bypass_cache) {
+      // Load the restored entry directly from the network instead of the
+      // cache. A cached navigation is served without contacting the server, so
+      // any condition that depends on a live network request is not
+      // re-evaluated. Bypassing the cache forces a fresh load so errors such as
+      // an invalid TLS certificate (for example one that expired or changed
+      // since the page was cached) or other network failures surface through
+      // their corresponding events (for example "certificate-error").
+      web_contents()->GetController().Reload(
+          content::ReloadType::BYPASSING_CACHE, /*check_for_repost=*/false);
+    } else {
+      web_contents()->GetController().LoadIfNecessary();
+    }
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -227,7 +227,8 @@ class WebContents final : public ExclusiveAccessContext,
   void RestoreHistory(v8::Isolate* isolate,
                       gin_helper::ErrorThrower thrower,
                       int index,
-                      const std::vector<v8::Local<v8::Value>>& entries);
+                      const std::vector<v8::Local<v8::Value>>& entries,
+                      bool bypass_cache);
   int GetHistoryLength() const;
   const std::string GetWebRTCIPHandlingPolicy() const;
   void SetWebRTCIPHandlingPolicy(const std::string& webrtc_ip_handling_policy);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1121,6 +1121,93 @@ describe('webContents module', () => {
       });
     });
 
+    describe('navigationHistory.restore() bypassCache option', () => {
+      let server: http.Server;
+      let serverUrl: string;
+      let requestCount = 0;
+
+      before(async () => {
+        server = http.createServer((req, res) => {
+          // Only the top-level document navigation is relevant for these
+          // assertions. Ignore any other request (e.g. /favicon.ico) so the
+          // request counts stay deterministic.
+          if (req.url !== '/') {
+            res.statusCode = 404;
+            res.end();
+            return;
+          }
+          requestCount++;
+          res.setHeader('Content-Type', 'text/html');
+          res.setHeader('Cache-Control', 'max-age=3600');
+          res.end(
+            '<html><head><title>Cacheable</title></head><body>cacheable</body></html>'
+          );
+        });
+        serverUrl = (await listen(server)).url;
+      });
+
+      after(async () => {
+        if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+        server = null as any;
+      });
+
+      beforeEach(() => {
+        requestCount = 0;
+      });
+
+      // Primes the cache by loading the page once, then restores the captured
+      // entries in a fresh window that shares the same on-disk cache. Returns
+      // whether the restored main-frame navigation was served from the cache
+      // along with the number of server hits the restore triggered.
+      const restoreAndObserveCache = async (partition: string, bypassCache: boolean) => {
+        const ses = session.fromPartition(partition);
+
+        const primer = new BrowserWindow({ show: false, webPreferences: { partition } });
+        await primer.loadURL(serverUrl);
+        const entries = primer.webContents.navigationHistory.getAllEntries();
+        primer.destroy();
+
+        const countAfterInitialLoad = requestCount;
+        expect(countAfterInitialLoad, 'initial load should hit the server once').to.equal(1);
+
+        let mainFrameFromCache: boolean | undefined;
+        ses.webRequest.onResponseStarted((details) => {
+          if (details.resourceType === 'mainFrame') {
+            mainFrameFromCache = details.fromCache;
+          }
+        });
+
+        const restored = new BrowserWindow({ show: false, webPreferences: { partition } });
+        try {
+          await restored.webContents.navigationHistory.restore({ index: 0, entries, bypassCache });
+        } finally {
+          ses.webRequest.onResponseStarted(null);
+        }
+
+        return { mainFrameFromCache, restoreRequests: requestCount - countAfterInitialLoad };
+      };
+
+      it('serves the restored entry from the cache by default', async () => {
+        const partition = `restore-bypasscache-default-${Date.now()}`;
+        const { mainFrameFromCache, restoreRequests } = await restoreAndObserveCache(partition, false);
+
+        // The response is cacheable, so restoring without bypassCache is served
+        // from the cache and must not contact the server again.
+        expect(mainFrameFromCache, 'restore should be served from cache').to.equal(true);
+        expect(restoreRequests, 'restore should not hit the server').to.equal(0);
+      });
+
+      it('loads the restored entry from the network when bypassCache is true', async () => {
+        const partition = `restore-bypasscache-network-${Date.now()}`;
+        const { mainFrameFromCache, restoreRequests } = await restoreAndObserveCache(partition, true);
+
+        // bypassCache forces a fresh network request even though the response is
+        // cacheable.
+        expect(mainFrameFromCache, 'restore should bypass the cache').to.equal(false);
+        expect(restoreRequests, 'restore should hit the server once').to.equal(1);
+      });
+    });
+
     it('should restore an overridden user agent', async () => {
       const partition = 'persist:wcvtest';
       const testUA = 'MyCustomUA';

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -133,7 +133,7 @@ declare namespace Electron {
     _goToIndex(index: number): void;
     _removeNavigationEntryAtIndex(index: number): boolean;
     _getHistory(): Electron.NavigationEntry[];
-    _restoreHistory(index: number, entries: Electron.NavigationEntry[]): void;
+    _restoreHistory(index: number, entries: Electron.NavigationEntry[], bypassCache: boolean): void;
     _clearHistory(): void;
     destroy(): void;
     // <webview>


### PR DESCRIPTION
#### Description of Change

`navigationHistory.restore()` currently loads the restored entry via `LoadIfNecessary()`, which serves the page from the HTTP cache without contacting the server. This means that conditions requiring a live network request — such as an expired or changed TLS certificate — are not re-evaluated and the corresponding events (e.g. [`certificate-error`](https://www.electronjs.org/docs/latest/api/web-contents#event-certificate-error)) are never fired.

This PR adds an optional `bypassCache` boolean parameter (default `false`) to `navigationHistory.restore()`. When set to `true`, the restored entry is loaded via `content::ReloadType::BYPASSING_CACHE` instead of `LoadIfNecessary()`, forcing a fresh network request so that certificate errors and other network failures surface normally.

**Before:**
```js
await contents.navigationHistory.restore({ entries, index });
// TLS certificate is never re-checked — certificate-error won't fire
```

**After:**
```js
await contents.navigationHistory.restore({ entries, index, bypassCache: true });
// Forces a network request — certificate-error fires if cert is invalid/expired
```

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `bypassCache` option to `navigationHistory.restore()` to force a fresh network request when restoring navigation history, allowing certificate errors and other network failures to surface normally.