### PR TITLE
fix: net module requests proceed without a client certificate when server requests one

### DIFF
--- a/shell/browser/net/url_loader_network_observer.cc
+++ b/shell/browser/net/url_loader_network_observer.cc
@@ -6,6 +6,7 @@
 
 #include "base/functional/bind.h"
 #include "content/public/browser/browser_thread.h"
+#include "mojo/public/cpp/bindings/remote.h"
 #include "services/network/public/mojom/shared_storage.mojom.h"
 #include "shell/browser/login_handler.h"
 
@@ -80,6 +81,18 @@ void URLLoaderNetworkObserver::OnAuthRequired(
         auth_challenge_responder) {
   new LoginHandlerDelegate(std::move(auth_challenge_responder), auth_info, url,
                            head_headers, process_id_, first_auth_attempt);
+}
+
+void URLLoaderNetworkObserver::OnCertificateRequested(
+    const std::optional<base::UnguessableToken>& window_id,
+    const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        client_cert_responder) {
+  // Proceed without a client certificate. Selection for net-module requests is
+  // not currently exposed; see https://github.com/electron/electron/issues/29984.
+  mojo::Remote<network::mojom::ClientCertificateResponder> responder(
+      std::move(client_cert_responder));
+  responder->ContinueWithoutCertificate();
 }
 
 void URLLoaderNetworkObserver::OnSSLCertificateError(

--- a/shell/browser/net/url_loader_network_observer.h
+++ b/shell/browser/net/url_loader_network_observer.h
@@ -65,7 +65,7 @@ class URLLoaderNetworkObserver
       const std::optional<base::UnguessableToken>& window_id,
       const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
       mojo::PendingRemote<network::mojom::ClientCertificateResponder>
-          client_cert_responder) override {}
+          client_cert_responder) override;
   void OnLocalNetworkAccessPermissionRequired(
       network::mojom::TransportType transport_type,
       network::mojom::IPAddressSpace ip_address_space,

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -460,6 +460,18 @@ void SimpleURLLoaderWrapper::OnAuthRequired(
   Emit("login", auth_info, std::move(cb));
 }
 
+void SimpleURLLoaderWrapper::OnCertificateRequested(
+    const std::optional<base::UnguessableToken>& window_id,
+    const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        client_cert_responder) {
+  // Proceed without a client certificate. Selection for net-module requests is
+  // not currently exposed; see https://github.com/electron/electron/issues/29984.
+  mojo::Remote<network::mojom::ClientCertificateResponder> responder(
+      std::move(client_cert_responder));
+  responder->ContinueWithoutCertificate();
+}
+
 void SimpleURLLoaderWrapper::OnSSLCertificateError(
     const GURL& url,
     int net_error,

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -102,7 +102,7 @@ class SimpleURLLoaderWrapper final
       const std::optional<base::UnguessableToken>& window_id,
       const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
       mojo::PendingRemote<network::mojom::ClientCertificateResponder>
-          client_cert_responder) override {}
+          client_cert_responder) override;
   void OnLocalNetworkAccessPermissionRequired(
       network::mojom::TransportType transport_type,
       network::mojom::IPAddressSpace ip_address_space,

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -6,6 +6,7 @@ import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as http2 from 'node:http2';
+import * as https from 'node:https';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
@@ -1823,6 +1824,50 @@ describe('net module', () => {
       }
     });
   }
+
+  describe('client certificate authentication', () => {
+    let server: https.Server;
+    let secureUrl: string;
+    const certPath = path.join(fixturesPath, 'certificates');
+    const ses = session.fromPartition('net-client-cert');
+
+    before(async () => {
+      ses.setCertificateVerifyProc((req, cb) => cb(0));
+      const options = {
+        key: fs.readFileSync(path.join(certPath, 'server.key')),
+        cert: fs.readFileSync(path.join(certPath, 'server.pem')),
+        ca: [
+          fs.readFileSync(path.join(certPath, 'rootCA.pem')),
+          fs.readFileSync(path.join(certPath, 'intermediateCA.pem'))
+        ],
+        requestCert: true,
+        rejectUnauthorized: false
+      };
+      server = https.createServer(options, (req, res) => {
+        if ((req as any).client.authorized) {
+          res.writeHead(200);
+          res.end('authorized');
+        } else {
+          res.writeHead(401);
+          res.end('denied');
+        }
+      });
+      secureUrl = (await listen(server)).url;
+    });
+
+    after(async () => {
+      ses.setCertificateVerifyProc(null);
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    });
+
+    it('does not abort net.fetch when the server requests an optional client certificate', async () => {
+      // Regression test for https://github.com/electron/electron/issues/29984:
+      // previously this rejected with ERR_SSL_CLIENT_AUTH_CERT_NEEDED.
+      const response = await ses.fetch(secureUrl);
+      expect(response.status).to.equal(401);
+      expect(await response.text()).to.equal('denied');
+    });
+  });
 
   ifdescribe(isTestingBindingAvailable())('Network Service crash recovery', () => {
     it('should recover net.fetch after Network Service crash (main process)', async () => {


### PR DESCRIPTION
#### Description of Change

See also #52162 for the full event-wiring approach.

`net.request` / `net.fetch` requests to a server that sends a TLS `CertificateRequest` (e.g. nginx `ssl_verify_client optional`) currently abort with `ERR_SSL_CLIENT_AUTH_CERT_NEEDED`. `SimpleURLLoaderWrapper::OnCertificateRequested` and `URLLoaderNetworkObserver::OnCertificateRequested` are empty stubs; dropping the `ClientCertificateResponder` mojo pipe causes the network service to treat the request as cancelled.

This change makes both observers respond with `ContinueWithoutCertificate()` so the TLS handshake proceeds without presenting a client certificate — the same behavior a renderer `fetch()` gets when no certificate is selected.

Client certificate selection for `net` module requests is tracked separately.

Refs #29984.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `net.request` and `net.fetch` failing with `ERR_SSL_CLIENT_AUTH_CERT_NEEDED` when the server requests an optional client certificate; requests now proceed without presenting a certificate.

