### PR TITLE
feat: emit select-client-certificate for net module requests

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -326,7 +326,7 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
 Returns:
 
 * `event` Event
-* `webContents` [WebContents](web-contents.md)
+* `webContents` [WebContents](web-contents.md) | null
 * `url` URL
 * `certificateList` [Certificate[]](structures/certificate.md)
 * `callback` Function
@@ -338,6 +338,10 @@ The `url` corresponds to the navigation entry requesting the client certificate
 and `callback` can be called with an entry filtered from the list. Using
 `event.preventDefault()` prevents the application from using the first
 certificate from the store.
+
+`webContents` is `null` when the request does not originate from a renderer
+process, for example when using [`net.request`](net.md#netrequestoptions),
+[`net.fetch`](net.md#netfetchinput-init), or a [utility process](utility-process.md).
 
 ```js
 const { app } = require('electron')

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -340,8 +340,12 @@ and `callback` can be called with an entry filtered from the list. Using
 certificate from the store.
 
 `webContents` is `null` when the request does not originate from a renderer
-process, for example when using [`net.request`](net.md#netrequestoptions),
-[`net.fetch`](net.md#netfetchinput-init), or a [utility process](utility-process.md).
+process, for example when using [`net.request`](net.md#netrequestoptions) or
+[`net.fetch`](net.md#netfetchinput-init) in the main process, or from a
+[utility process](utility-process.md) created with
+`respondToAuthRequestsFromMainProcess: true`. For utility processes created
+without that flag, `net` requests proceed without a client certificate and this
+event is not emitted.
 
 ```js
 const { app } = require('electron')

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -326,7 +326,7 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
 Returns:
 
 * `event` Event
-* `webContents` [WebContents](web-contents.md) | null
+* `webContents` [WebContents](web-contents.md) (optional)
 * `url` URL
 * `certificateList` [Certificate[]](structures/certificate.md)
 * `callback` Function

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -56,9 +56,11 @@ Process: [Main](../glossary.md#main-process)<br />
     requests created via the [net module](net.md) will allow responding to them via the
     [`login`](#event-login) event on the `UtilityProcess` instance when a `session` is provided, or via
     the [`app#login`](app.md#event-login) event in the main process when using the default system network
-    context. Without this flag, auth challenges are handled by the default
-    [`login`](client-request.md#event-login) event on the [`ClientRequest`](client-request.md) object. Default is
-    `false`.
+    context. This flag also routes client-certificate selection to the
+    [`app#select-client-certificate`](app.md#event-select-client-certificate) event in the main process; without
+    it, `net` requests from the utility process proceed without a client certificate. Without this flag, auth
+    challenges are handled by the default [`login`](client-request.md#event-login) event on the
+    [`ClientRequest`](client-request.md) object. Default is `false`.
 
 Returns [`UtilityProcess`](utility-process.md#class-utilityprocess)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -22,6 +22,12 @@ created with `respondToAuthRequestsFromMainProcess: true`. For these requests th
 `webContents` argument is `null`. Previously the event was only emitted for requests
 originating from a `WebContents` and the argument was always non-null.
 
+As with `WebContents` requests, when the event is not handled (or `event.preventDefault()`
+is not called) Electron uses the first matching client certificate from the platform
+certificate store. Previously `net` requests to a server that requested a client
+certificate failed with `ERR_SSL_CLIENT_AUTH_CERT_NEEDED`. To opt out, handle the event
+and call `callback()` with no argument to continue without a client certificate.
+
 ```js
 // Before
 app.on('select-client-certificate', (event, webContents, url, list, callback) => {

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,26 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (44.0)
 
+### Behavior Changed: `webContents` may be `null` in `select-client-certificate`
+
+The `app` `'select-client-certificate'` event is now also emitted for requests made
+via the [`net` module](api/net.md) and for [utility processes](api/utility-process.md)
+created with `respondToAuthRequestsFromMainProcess: true`. For these requests the
+`webContents` argument is `null`. Previously the event was only emitted for requests
+originating from a `WebContents` and the argument was always non-null.
+
+```js
+// Before
+app.on('select-client-certificate', (event, webContents, url, list, callback) => {
+  console.log(webContents.id)
+})
+
+// After
+app.on('select-client-certificate', (event, webContents, url, list, callback) => {
+  if (webContents) console.log(webContents.id)
+})
+```
+
 ### Removed: macOS 12 support
 
 macOS 12 (Monterey) is no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/7907086).

--- a/filenames.gni
+++ b/filenames.gni
@@ -449,6 +449,8 @@ filenames = {
     "shell/browser/net/asar/asar_url_loader_factory.h",
     "shell/browser/net/cert_verifier_client.cc",
     "shell/browser/net/cert_verifier_client.h",
+    "shell/browser/net/client_certificate_responder_delegate.cc",
+    "shell/browser/net/client_certificate_responder_delegate.h",
     "shell/browser/net/electron_url_loader_factory.cc",
     "shell/browser/net/electron_url_loader_factory.h",
     "shell/browser/net/network_context_service.cc",

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -112,7 +112,8 @@ if (process.platform === 'linux') {
 const events = ['certificate-error', 'select-client-certificate'];
 for (const name of events) {
   app.on(name as 'certificate-error', (event, webContents, ...args: any[]) => {
-    webContents.emit(name, event, ...args);
+    // webContents is null for net module / utility process requests.
+    if (webContents) webContents.emit(name, event, ...args);
   });
 }
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -469,14 +469,8 @@ void OnClientCertificateSelected(
     std::shared_ptr<content::ClientCertificateDelegate> delegate,
     std::shared_ptr<net::ClientCertIdentityList> identities,
     gin::Arguments* const args) {
-  if (args->Length() == 2) {
-    delegate->ContinueWithCertificate(nullptr, nullptr);
-    return;
-  }
-
   v8::Local<v8::Value> val;
-  args->GetNext(&val);
-  if (val->IsNull()) {
+  if (!args->GetNext(&val) || val.IsEmpty() || val->IsNullOrUndefined()) {
     delegate->ContinueWithCertificate(nullptr, nullptr);
     return;
   }

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -787,8 +787,9 @@ base::OnceClosure App::SelectClientCertificate(
            base::BindOnce(&OnClientCertificateSelected, isolate,
                           shared_delegate, shared_identities));
 
-  // Default to first certificate from the platform store.
-  if (!prevent_default) {
+  // Default to first certificate from the platform store. The JS callback may
+  // have already run synchronously and moved the identity out, so guard for it.
+  if (!prevent_default && (*shared_identities)[0]) {
     scoped_refptr<net::X509Certificate> cert =
         (*shared_identities)[0]->certificate();
     net::ClientCertIdentity::SelfOwningAcquirePrivateKey(

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -778,9 +778,8 @@ base::OnceClosure App::SelectClientCertificate(
   // |web_contents| is null for requests that did not originate from a renderer
   // (e.g. net.fetch / utilityProcess); surface those with a null WebContents.
   v8::Local<v8::Value> web_contents_value =
-      web_contents
-          ? WebContents::FromOrCreate(isolate, web_contents).ToV8()
-          : v8::Null(isolate).As<v8::Value>();
+      web_contents ? WebContents::FromOrCreate(isolate, web_contents).ToV8()
+                   : v8::Null(isolate).As<v8::Value>();
   bool prevent_default =
       Emit("select-client-certificate", web_contents_value,
            cert_request_info->host_and_port.ToString(), std::move(client_certs),

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -781,9 +781,14 @@ base::OnceClosure App::SelectClientCertificate(
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
+  // |web_contents| is null for requests that did not originate from a renderer
+  // (e.g. net.fetch / utilityProcess); surface those with a null WebContents.
+  v8::Local<v8::Value> web_contents_value =
+      web_contents
+          ? WebContents::FromOrCreate(isolate, web_contents).ToV8()
+          : v8::Null(isolate).As<v8::Value>();
   bool prevent_default =
-      Emit("select-client-certificate",
-           WebContents::FromOrCreate(isolate, web_contents),
+      Emit("select-client-certificate", web_contents_value,
            cert_request_info->host_and_port.ToString(), std::move(client_certs),
            base::BindOnce(&OnClientCertificateSelected, isolate,
                           shared_delegate, shared_identities));

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -141,6 +141,18 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 
   content::PlatformNotificationService* GetPlatformNotificationService();
 
+  // content::ContentBrowserClient overrides exposed for net-module client
+  // certificate handling (see ClientCertificateResponderDelegate).
+  base::OnceClosure SelectClientCertificate(
+      content::BrowserContext* browser_context,
+      int process_id,
+      content::WebContents* web_contents,
+      net::SSLCertRequestInfo* cert_request_info,
+      net::ClientCertIdentityList client_certs,
+      std::unique_ptr<content::ClientCertificateDelegate> delegate) override;
+  std::unique_ptr<net::ClientCertStore> CreateClientCertStore(
+      content::BrowserContext* browser_context) override;
+
  protected:
   void RenderProcessWillLaunch(content::RenderProcessHost* host) override;
   content::SpeechRecognitionManagerDelegate*
@@ -170,13 +182,6 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       bool strict_enforcement,
       base::OnceCallback<void(content::CertificateRequestResultType)> callback)
       override;
-  base::OnceClosure SelectClientCertificate(
-      content::BrowserContext* browser_context,
-      int process_id,
-      content::WebContents* web_contents,
-      net::SSLCertRequestInfo* cert_request_info,
-      net::ClientCertIdentityList client_certs,
-      std::unique_ptr<content::ClientCertificateDelegate> delegate) override;
   bool CanCreateWindow(content::RenderFrameHost* opener,
                        const GURL& opener_url,
                        const GURL& opener_top_level_frame_url,
@@ -205,8 +210,6 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       std::vector<std::string>* additional_schemes) override;
   void GetAdditionalWebUISchemes(
       std::vector<std::string>* additional_schemes) override;
-  std::unique_ptr<net::ClientCertStore> CreateClientCertStore(
-      content::BrowserContext* browser_context) override;
   std::unique_ptr<device::LocationProvider> OverrideSystemLocationProvider()
       override;
   void ConfigureNetworkContextParams(

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 GitHub, Inc.
+// Copyright (c) 2026 Anthropic, PBC.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -43,15 +43,15 @@ class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
     // `ssl_private_key_` may abandon the callback (https://crbug.com/40651689).
     callback = mojo::WrapCallbackWithDefaultInvokeIfNotRun(
         std::move(callback), int32_t{net::ERR_FAILED}, std::vector<uint8_t>());
-    ssl_private_key_->Sign(
-        algorithm, input,
-        base::BindOnce(
-            [](SignCallback callback, net::Error net_error,
-               const std::vector<uint8_t>& signature) {
-              std::move(callback).Run(static_cast<int32_t>(net_error),
-                                      signature);
-            },
-            std::move(callback)));
+    ssl_private_key_->Sign(algorithm, input,
+                           base::BindOnce(
+                               [](SignCallback callback, net::Error net_error,
+                                  const std::vector<uint8_t>& signature) {
+                                 std::move(callback).Run(
+                                     static_cast<int32_t>(net_error),
+                                     signature);
+                               },
+                               std::move(callback)));
   }
 
  private:
@@ -66,9 +66,9 @@ class ClientCertificateResponderDelegate
   explicit ClientCertificateResponderDelegate(
       mojo::PendingRemote<network::mojom::ClientCertificateResponder> responder)
       : responder_(std::move(responder)) {
-    responder_.set_disconnect_handler(base::BindOnce(
-        &ClientCertificateResponderDelegate::OnDisconnect,
-        base::Unretained(this)));
+    responder_.set_disconnect_handler(
+        base::BindOnce(&ClientCertificateResponderDelegate::OnDisconnect,
+                       base::Unretained(this)));
   }
 
   ~ClientCertificateResponderDelegate() override {

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/client_certificate_delegate.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -24,9 +24,8 @@ namespace electron {
 
 namespace {
 
-// Bridges net::SSLPrivateKey to the network::mojom::SSLPrivateKey interface so
-// the network service can sign with a key that lives in the browser process.
-// Mirrors content::SSLPrivateKeyImpl (content/browser/ssl_private_key_impl.h).
+// Mirrors content/browser/ssl_private_key_impl.h (not public) so the network
+// service can sign with a key that lives in the browser process.
 class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
  public:
   explicit SSLPrivateKeyImpl(scoped_refptr<net::SSLPrivateKey> ssl_private_key)
@@ -54,9 +53,8 @@ class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
   scoped_refptr<net::SSLPrivateKey> ssl_private_key_;
 };
 
-// Adapts a network::mojom::ClientCertificateResponder to the
-// content::ClientCertificateDelegate interface that
-// ElectronBrowserClient::SelectClientCertificate expects.
+// Adapts the mojo responder to the content::ClientCertificateDelegate
+// interface that ElectronBrowserClient::SelectClientCertificate expects.
 class ClientCertificateResponderDelegate
     : public content::ClientCertificateDelegate {
  public:

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -11,8 +11,10 @@
 #include "base/functional/bind.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/client_certificate_delegate.h"
+#include "mojo/public/cpp/bindings/callback_helpers.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
+#include "net/base/net_errors.h"
 #include "net/ssl/client_cert_identity.h"
 #include "net/ssl/client_cert_store.h"
 #include "net/ssl/ssl_cert_request_info.h"
@@ -38,6 +40,9 @@ class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
   void Sign(uint16_t algorithm,
             const std::vector<uint8_t>& input,
             SignCallback callback) override {
+    // `ssl_private_key_` may abandon the callback (https://crbug.com/40651689).
+    callback = mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+        std::move(callback), int32_t{net::ERR_FAILED}, std::vector<uint8_t>());
     ssl_private_key_->Sign(
         algorithm, input,
         base::BindOnce(

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/net/client_certificate_responder_delegate.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "content/public/browser/client_certificate_delegate.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "mojo/public/cpp/bindings/self_owned_receiver.h"
+#include "net/ssl/client_cert_identity.h"
+#include "net/ssl/client_cert_store.h"
+#include "net/ssl/ssl_cert_request_info.h"
+#include "net/ssl/ssl_private_key.h"
+#include "services/network/public/mojom/url_loader_network_service_observer.mojom.h"
+#include "shell/browser/electron_browser_client.h"
+
+namespace electron {
+
+namespace {
+
+// Bridges net::SSLPrivateKey to the network::mojom::SSLPrivateKey interface so
+// the network service can sign with a key that lives in the browser process.
+class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
+ public:
+  explicit SSLPrivateKeyImpl(scoped_refptr<net::SSLPrivateKey> ssl_private_key)
+      : ssl_private_key_(std::move(ssl_private_key)) {}
+
+  SSLPrivateKeyImpl(const SSLPrivateKeyImpl&) = delete;
+  SSLPrivateKeyImpl& operator=(const SSLPrivateKeyImpl&) = delete;
+
+  // network::mojom::SSLPrivateKey:
+  void Sign(uint16_t algorithm,
+            const std::vector<uint8_t>& input,
+            SignCallback callback) override {
+    ssl_private_key_->Sign(
+        algorithm, input,
+        base::BindOnce(
+            [](SignCallback callback, net::Error net_error,
+               const std::vector<uint8_t>& signature) {
+              std::move(callback).Run(static_cast<int32_t>(net_error),
+                                      signature);
+            },
+            std::move(callback)));
+  }
+
+ private:
+  scoped_refptr<net::SSLPrivateKey> ssl_private_key_;
+};
+
+// Adapts a network::mojom::ClientCertificateResponder to the
+// content::ClientCertificateDelegate interface that
+// ElectronBrowserClient::SelectClientCertificate expects.
+class ClientCertificateResponderDelegate
+    : public content::ClientCertificateDelegate {
+ public:
+  explicit ClientCertificateResponderDelegate(
+      mojo::PendingRemote<network::mojom::ClientCertificateResponder> responder)
+      : responder_(std::move(responder)) {
+    responder_.set_disconnect_handler(base::BindOnce(
+        &ClientCertificateResponderDelegate::OnDisconnect,
+        base::Unretained(this)));
+  }
+
+  ~ClientCertificateResponderDelegate() override {
+    if (!responded_ && responder_)
+      responder_->CancelRequest();
+  }
+
+  ClientCertificateResponderDelegate(
+      const ClientCertificateResponderDelegate&) = delete;
+  ClientCertificateResponderDelegate& operator=(
+      const ClientCertificateResponderDelegate&) = delete;
+
+  // content::ClientCertificateDelegate:
+  void ContinueWithCertificate(
+      scoped_refptr<net::X509Certificate> cert,
+      scoped_refptr<net::SSLPrivateKey> private_key) override {
+    if (responded_ || !responder_)
+      return;
+    responded_ = true;
+    if (!cert || !private_key) {
+      responder_->ContinueWithoutCertificate();
+      return;
+    }
+    mojo::PendingRemote<network::mojom::SSLPrivateKey> ssl_private_key;
+    mojo::MakeSelfOwnedReceiver(
+        std::make_unique<SSLPrivateKeyImpl>(private_key),
+        ssl_private_key.InitWithNewPipeAndPassReceiver());
+    responder_->ContinueWithCertificate(
+        std::move(cert), private_key->GetProviderName(),
+        private_key->GetAlgorithmPreferences(), std::move(ssl_private_key));
+  }
+
+ private:
+  void OnDisconnect() { responder_.reset(); }
+
+  bool responded_ = false;
+  mojo::Remote<network::mojom::ClientCertificateResponder> responder_;
+};
+
+void OnGotClientCerts(
+    std::unique_ptr<net::ClientCertStore> cert_store,
+    std::unique_ptr<content::ClientCertificateDelegate> delegate,
+    content::BrowserContext* browser_context,
+    scoped_refptr<net::SSLCertRequestInfo> cert_info,
+    net::ClientCertIdentityList identities) {
+  // ElectronBrowserClient handles both the empty-list case (continue without a
+  // certificate) and routing to the `select-client-certificate` app event.
+  ElectronBrowserClient::Get()->SelectClientCertificate(
+      browser_context, /*process_id=*/0, /*web_contents=*/nullptr,
+      cert_info.get(), std::move(identities), std::move(delegate));
+}
+
+}  // namespace
+
+void SelectClientCertificateForResponder(
+    content::BrowserContext* browser_context,
+    scoped_refptr<net::SSLCertRequestInfo> cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        cert_responder) {
+  auto delegate = std::make_unique<ClientCertificateResponderDelegate>(
+      std::move(cert_responder));
+
+  std::unique_ptr<net::ClientCertStore> cert_store =
+      ElectronBrowserClient::Get()->CreateClientCertStore(browser_context);
+  if (!cert_store) {
+    delegate->ContinueWithCertificate(nullptr, nullptr);
+    return;
+  }
+
+  // The store must outlive the async lookup; bind it into the callback.
+  auto* cert_store_ptr = cert_store.get();
+  cert_store_ptr->GetClientCerts(
+      cert_info,
+      base::BindOnce(&OnGotClientCerts, std::move(cert_store),
+                     std::move(delegate), browser_context, cert_info));
+}
+
+}  // namespace electron

--- a/shell/browser/net/client_certificate_responder_delegate.cc
+++ b/shell/browser/net/client_certificate_responder_delegate.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/client_certificate_delegate.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
@@ -25,6 +26,7 @@ namespace {
 
 // Bridges net::SSLPrivateKey to the network::mojom::SSLPrivateKey interface so
 // the network service can sign with a key that lives in the browser process.
+// Mirrors content::SSLPrivateKeyImpl (content/browser/ssl_private_key_impl.h).
 class SSLPrivateKeyImpl : public network::mojom::SSLPrivateKey {
  public:
   explicit SSLPrivateKeyImpl(scoped_refptr<net::SSLPrivateKey> ssl_private_key)
@@ -123,6 +125,7 @@ void SelectClientCertificateForResponder(
     scoped_refptr<net::SSLCertRequestInfo> cert_info,
     mojo::PendingRemote<network::mojom::ClientCertificateResponder>
         cert_responder) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   auto delegate = std::make_unique<ClientCertificateResponderDelegate>(
       std::move(cert_responder));
 

--- a/shell/browser/net/client_certificate_responder_delegate.h
+++ b/shell/browser/net/client_certificate_responder_delegate.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_NET_CLIENT_CERTIFICATE_RESPONDER_DELEGATE_H_
+#define ELECTRON_SHELL_BROWSER_NET_CLIENT_CERTIFICATE_RESPONDER_DELEGATE_H_
+
+#include "base/memory/scoped_refptr.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "services/network/public/mojom/url_loader_network_service_observer.mojom-forward.h"
+
+namespace content {
+class BrowserContext;
+}
+
+namespace net {
+class SSLCertRequestInfo;
+}
+
+namespace electron {
+
+// Handles a client-certificate request that arrived over the network-service
+// observer mojo pipe (i.e. from a non-WebContents URLLoader such as net.fetch
+// or a utilityProcess request). Fetches matching identities from the platform
+// store and routes the selection through ElectronBrowserClient so the
+// `select-client-certificate` app event fires with a null WebContents.
+void SelectClientCertificateForResponder(
+    content::BrowserContext* browser_context,
+    scoped_refptr<net::SSLCertRequestInfo> cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        cert_responder);
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_NET_CLIENT_CERTIFICATE_RESPONDER_DELEGATE_H_

--- a/shell/browser/net/client_certificate_responder_delegate.h
+++ b/shell/browser/net/client_certificate_responder_delegate.h
@@ -19,10 +19,8 @@ class SSLCertRequestInfo;
 
 namespace electron {
 
-// Handles a client-certificate request that arrived over the network-service
-// observer mojo pipe (i.e. from a non-WebContents URLLoader such as net.fetch
-// or a utilityProcess request). Fetches matching identities from the platform
-// store and routes the selection through ElectronBrowserClient so the
+// Handles a client-certificate request from a non-WebContents URLLoader
+// (net.fetch / utilityProcess): routes through ElectronBrowserClient so the
 // `select-client-certificate` app event fires with a null WebContents.
 void SelectClientCertificateForResponder(
     content::BrowserContext* browser_context,

--- a/shell/browser/net/client_certificate_responder_delegate.h
+++ b/shell/browser/net/client_certificate_responder_delegate.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 GitHub, Inc.
+// Copyright (c) 2026 Anthropic, PBC.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 

--- a/shell/browser/net/url_loader_network_observer.cc
+++ b/shell/browser/net/url_loader_network_observer.cc
@@ -8,6 +8,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "services/network/public/mojom/shared_storage.mojom.h"
 #include "shell/browser/login_handler.h"
+#include "shell/browser/net/client_certificate_responder_delegate.h"
 
 namespace electron {
 
@@ -80,6 +81,15 @@ void URLLoaderNetworkObserver::OnAuthRequired(
         auth_challenge_responder) {
   new LoginHandlerDelegate(std::move(auth_challenge_responder), auth_info, url,
                            head_headers, process_id_, first_auth_attempt);
+}
+
+void URLLoaderNetworkObserver::OnCertificateRequested(
+    const std::optional<base::UnguessableToken>& window_id,
+    const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        client_cert_responder) {
+  SelectClientCertificateForResponder(/*browser_context=*/nullptr, cert_info,
+                                      std::move(client_cert_responder));
 }
 
 void URLLoaderNetworkObserver::OnSSLCertificateError(

--- a/shell/browser/net/url_loader_network_observer.h
+++ b/shell/browser/net/url_loader_network_observer.h
@@ -65,7 +65,7 @@ class URLLoaderNetworkObserver
       const std::optional<base::UnguessableToken>& window_id,
       const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
       mojo::PendingRemote<network::mojom::ClientCertificateResponder>
-          client_cert_responder) override {}
+          client_cert_responder) override;
   void OnLocalNetworkAccessPermissionRequired(
       network::mojom::TransportType transport_type,
       network::mojom::IPAddressSpace ip_address_space,

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -41,6 +41,7 @@
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/net/asar/asar_url_loader_factory.h"
+#include "shell/browser/net/client_certificate_responder_delegate.h"
 #include "shell/browser/net/proxying_url_loader_factory.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/common/gin_converters/callback_converter.h"
@@ -459,6 +460,23 @@ void SimpleURLLoaderWrapper::OnAuthRequired(
       },
       std::move(auth_responder));
   Emit("login", auth_info, std::move(cb));
+}
+
+void SimpleURLLoaderWrapper::OnCertificateRequested(
+    const std::optional<base::UnguessableToken>& window_id,
+    const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        client_cert_responder) {
+  // In the utility process this observer is only bound when the host did not
+  // provide one; routing to the app event requires the browser process.
+  if (!electron::IsBrowserProcess()) {
+    mojo::Remote<network::mojom::ClientCertificateResponder> responder(
+        std::move(client_cert_responder));
+    responder->ContinueWithoutCertificate();
+    return;
+  }
+  SelectClientCertificateForResponder(browser_context_, cert_info,
+                                      std::move(client_cert_responder));
 }
 
 void SimpleURLLoaderWrapper::OnSSLCertificateError(

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -102,7 +102,7 @@ class SimpleURLLoaderWrapper final
       const std::optional<base::UnguessableToken>& window_id,
       const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
       mojo::PendingRemote<network::mojom::ClientCertificateResponder>
-          client_cert_responder) override {}
+          client_cert_responder) override;
   void OnLocalNetworkAccessPermissionRequired(
       network::mojom::TransportType transport_type,
       network::mojom::IPAddressSpace ip_address_space,

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1903,18 +1903,24 @@ describe('net module', () => {
     // guard.
     it('emits select-client-certificate on app with a null webContents', async () => {
       let eventWebContents: unknown = 'unset';
-      app.once('select-client-certificate', (event, webContents, url, list, callback) => {
+      const handler = (event: Electron.Event, webContents: Electron.WebContents, _url: string,
+        _list: Electron.Certificate[], callback: (cert?: Electron.Certificate) => void) => {
         event.preventDefault();
         eventWebContents = webContents;
         callback();
-      });
-      const response = await ses.fetch(secureUrl);
-      expect(response.status).to.equal(401);
-      expect(await response.text()).to.equal('denied');
-      // The event only fires if the platform cert store has matching
-      // identities; when it does, webContents must be null for net requests.
-      if (eventWebContents !== 'unset') {
-        expect(eventWebContents).to.be.null();
+      };
+      app.once('select-client-certificate', handler);
+      try {
+        const response = await ses.fetch(secureUrl);
+        expect(response.status).to.equal(401);
+        expect(await response.text()).to.equal('denied');
+        // The event only fires if the platform cert store has matching
+        // identities; when it does, webContents must be null for net requests.
+        if (eventWebContents !== 'unset') {
+          expect(eventWebContents).to.be.null();
+        }
+      } finally {
+        app.removeListener('select-client-certificate', handler);
       }
     });
 

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1897,6 +1897,10 @@ describe('net module', () => {
       expect(await response.text()).to.equal('denied');
     });
 
+    // Note: on CI hosts with no matching client identity in the keychain,
+    // ElectronBrowserClient short-circuits before emitting and this test
+    // passes without exercising the handler. The first test is the regression
+    // guard.
     it('emits select-client-certificate on app with a null webContents', async () => {
       let eventWebContents: unknown = 'unset';
       app.once('select-client-certificate', (event, webContents, url, list, callback) => {

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1886,7 +1886,7 @@ describe('net module', () => {
 
     after(async () => {
       ses.setCertificateVerifyProc(null);
-      await new Promise<void>(resolve => server.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
     });
 
     it('does not abort net.fetch when the server requests an optional client certificate', async () => {
@@ -1903,8 +1903,13 @@ describe('net module', () => {
     // guard.
     it('emits select-client-certificate on app with a null webContents', async () => {
       let eventWebContents: unknown = 'unset';
-      const handler = (event: Electron.Event, webContents: Electron.WebContents, _url: string,
-        _list: Electron.Certificate[], callback: (cert?: Electron.Certificate) => void) => {
+      const handler = (
+        event: Electron.Event,
+        webContents: Electron.WebContents,
+        _url: string,
+        _list: Electron.Certificate[],
+        callback: (cert?: Electron.Certificate) => void
+      ) => {
         event.preventDefault();
         eventWebContents = webContents;
         callback();

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1,4 +1,4 @@
-import { net, session, ClientRequest, ClientRequestConstructorOptions, utilityProcess } from 'electron/main';
+import { app, net, session, ClientRequest, ClientRequestConstructorOptions, utilityProcess } from 'electron/main';
 
 import { expect } from 'chai';
 
@@ -6,6 +6,7 @@ import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as http2 from 'node:http2';
+import * as https from 'node:https';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
@@ -1849,6 +1850,74 @@ describe('net module', () => {
       }
     });
   }
+
+  // The select-client-certificate event only fires when the platform cert
+  // store yields at least one matching identity, which the test suite cannot
+  // guarantee on Linux (NSS) without app.importCertificate.
+  ifdescribe(process.platform !== 'linux')('client certificate authentication', () => {
+    let server: https.Server;
+    let secureUrl: string;
+    const certPath = path.join(fixturesPath, 'certificates');
+    const ses = session.fromPartition('net-client-cert');
+
+    before(async () => {
+      ses.setCertificateVerifyProc((req, cb) => cb(0));
+      const options = {
+        key: fs.readFileSync(path.join(certPath, 'server.key')),
+        cert: fs.readFileSync(path.join(certPath, 'server.pem')),
+        ca: [
+          fs.readFileSync(path.join(certPath, 'rootCA.pem')),
+          fs.readFileSync(path.join(certPath, 'intermediateCA.pem'))
+        ],
+        requestCert: true,
+        rejectUnauthorized: false
+      };
+      server = https.createServer(options, (req, res) => {
+        if ((req as any).client.authorized) {
+          res.writeHead(200);
+          res.end('authorized');
+        } else {
+          res.writeHead(401);
+          res.end('denied');
+        }
+      });
+      secureUrl = (await listen(server)).url;
+    });
+
+    after(async () => {
+      ses.setCertificateVerifyProc(null);
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    });
+
+    it('does not abort net.fetch when the server requests an optional client certificate', async () => {
+      // Regression test for https://github.com/electron/electron/issues/29984:
+      // previously this rejected with ERR_SSL_CLIENT_AUTH_CERT_NEEDED.
+      const response = await ses.fetch(secureUrl);
+      expect(response.status).to.equal(401);
+      expect(await response.text()).to.equal('denied');
+    });
+
+    it('emits select-client-certificate on app with a null webContents', async () => {
+      let eventWebContents: unknown = 'unset';
+      app.once('select-client-certificate', (event, webContents, url, list, callback) => {
+        event.preventDefault();
+        eventWebContents = webContents;
+        callback();
+      });
+      const response = await ses.fetch(secureUrl);
+      expect(response.status).to.equal(401);
+      expect(await response.text()).to.equal('denied');
+      // The event only fires if the platform cert store has matching
+      // identities; when it does, webContents must be null for net requests.
+      if (eventWebContents !== 'unset') {
+        expect(eventWebContents).to.be.null();
+      }
+    });
+
+    // TODO: add a test that selects a real client certificate once
+    // spec/fixtures/certificates/generate_certs.sh also emits client.pem and
+    // client.key alongside client.p12.
+  });
 
   ifdescribe(isTestingBindingAvailable())('Network Service crash recovery', () => {
     it('should recover net.fetch after Network Service crash (main process)', async () => {


### PR DESCRIPTION
#### Description of Change

Companion to #52160 (the minimal decline-only fix). This is the full implementation that also wires the `select-client-certificate` event for `net.request` / `net.fetch` / utility-process requests, so applications can choose a client certificate rather than always declining.

`SimpleURLLoaderWrapper::OnCertificateRequested` and `URLLoaderNetworkObserver::OnCertificateRequested` are implemented to fetch client identities via `ElectronBrowserClient::CreateClientCertStore()` and route through the existing `App::SelectClientCertificate` path with `webContents` as `null` (matching the existing `app` `'login'` event behavior for `net` module requests). When no matching identities exist, the request proceeds without a certificate. A shared `ClientCertificateResponderDelegate` adapter bridges `network::mojom::ClientCertificateResponder` ↔ `content::ClientCertificateDelegate`, and an `SSLPrivateKeyImpl` (mirroring `content::SSLPrivateKeyImpl`) handles the key wrapping.

Refs #29984.

Posting both this and #52160 as drafts so reviewers can compare the minimal fix vs. the full event wiring; happy to consolidate to whichever direction is preferred (or to a `session.setClientCertificateSelectHandler()` shape if that's a better fit — see #29984 discussion).

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `select-client-certificate` event support for `net.request` and `net.fetch`; requests to servers requesting a client certificate no longer fail with `ERR_SSL_CLIENT_AUTH_CERT_NEEDED`, and applications can now select a certificate to present.

