### PR TITLE
chore: cherry-pick 1 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -165,3 +165,4 @@ cherry-pick-57f1f723d5d5.patch
 cherry-pick-f583b94a1374.patch
 cherry-pick-04f66fb96767.patch
 cherry-pick-449a1ea22a42.patch
+cherry-pick-54657772619c.patch

--- a/patches/chromium/cherry-pick-54657772619c.patch
+++ b/patches/chromium/cherry-pick-54657772619c.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Elly <ellyjones@chromium.org>
+Date: Mon, 22 Jun 2026 14:07:54 -0700
+Subject: [M148] mojo: don't overflow computation of channel read buffer size
+
+Original change's description:
+> mojo: don't overflow computation of channel read buffer size
+>
+> I am fairly confident this isn't exploitable (see rationale on the bug)
+> but to make the code more obviously correct, add a check for overflow
+> and error handling up the call stack.
+>
+> Fixed: 513138301
+> Change-Id: Ie2093dc08c2761951e4988ef283e21662de3bfd8
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7946296
+> Commit-Queue: Elly <ellyjones@chromium.org>
+> Reviewed-by: Fred Shih <ffred@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1647564}
+
+(cherry picked from commit 1598e0f1916030a6a9bd2ac6b878b48a696b35e5)
+
+Bug: 524889707,513138301
+Change-Id: Ie2093dc08c2761951e4988ef283e21662de3bfd8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7980378
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: Elly <ellyjones@chromium.org>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4403}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/mojo/core/channel.cc b/mojo/core/channel.cc
+index 12a65307693e71856e81e22abb55071d729654a5..f899d1630932cef47f19ecf56a62f413abd12ed0 100644
+--- a/mojo/core/channel.cc
++++ b/mojo/core/channel.cc
+@@ -938,7 +938,12 @@ class Channel::ReadBuffer {
+ 
+   // Ensures the ReadBuffer has enough contiguous space allocated to hold
+   // |num_bytes| more bytes; returns the address of the first available byte.
++  // If computing the new size overflows, returns nullptr.
+   char* Reserve(size_t num_bytes) {
++    const auto new_size = base::CheckAdd(num_bytes, size_);
++    if (!new_size.IsValid()) {
++      return nullptr;
++    }
+     if (num_occupied_bytes_ + num_bytes > size_) {
+       size_ = std::max(static_cast<size_t>(size_ * kGrowthFactor),
+                        num_occupied_bytes_ + num_bytes);
+diff --git a/mojo/core/channel_fuchsia.cc b/mojo/core/channel_fuchsia.cc
+index 05c57d9c6a8e7e00bc2dc0ed29da25dcad688da9..118bd085d198859d901ad314271dcdcbb613a14d 100644
+--- a/mojo/core/channel_fuchsia.cc
++++ b/mojo/core/channel_fuchsia.cc
+@@ -310,6 +310,13 @@ class ChannelFuchsia : public Channel,
+     do {
+       buffer_capacity = next_read_size;
+       char* buffer = GetReadBuffer(&buffer_capacity);
++      // A null buffer means the size computation for the new buffer overflowed
++      // so mark the connection as broken and bail.
++      if (!buffer) {
++        read_error = true;
++        validation_error = true;
++        break;
++      }
+       DCHECK_GT(buffer_capacity, 0u);
+ 
+       uint32_t bytes_read = 0;
+diff --git a/mojo/core/channel_posix.cc b/mojo/core/channel_posix.cc
+index 43df1bf2fb40e5025e169d787884296e1291c6cd..d016db98666e0597e68a70bb7e82f7251f172209 100644
+--- a/mojo/core/channel_posix.cc
++++ b/mojo/core/channel_posix.cc
+@@ -282,6 +282,13 @@ void ChannelPosix::OnFdReadable(int fd) {
+   do {
+     buffer_capacity = next_read_size;
+     char* buffer = GetReadBuffer(&buffer_capacity);
++    // A null buffer means that computing the read size overflowed, which means
++    // we received a malformed message; bail.
++    if (!buffer) {
++      read_error = true;
++      validation_error = true;
++      break;
++    }
+     DCHECK_GT(buffer_capacity, 0u);
+ 
+     std::vector<base::ScopedFD> incoming_fds;
+diff --git a/mojo/core/channel_win.cc b/mojo/core/channel_win.cc
+index a2e71b6b2572843438c5c4a2794fbd3d9c2f965a..f8b75a13c3c7039083d8a766d25ec2489ad1741d 100644
+--- a/mojo/core/channel_win.cc
++++ b/mojo/core/channel_win.cc
+@@ -306,6 +306,12 @@ class ChannelWin : public Channel,
+ 
+     size_t buffer_capacity = next_read_size_hint;
+     char* buffer = GetReadBuffer(&buffer_capacity);
++    // A null buffer means the size computation for the buffer overflowed;
++    // break the connection.
++    if (!buffer) {
++      OnError(Error::kDisconnected);
++      return;
++    }
+     DCHECK_GT(buffer_capacity, 0u);
+ 
+     BOOL ok =


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`54657772619c`](https://chromium-review.googlesource.com/c/chromium/src/+/7980378) from chromium — [M148] mojo: don't overflow computation of channel read buffer size

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium.
