### PR TITLE
fix: bind ipcRenderer for devtools_page extension subframes

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1620,9 +1620,25 @@ void ElectronBrowserClient::
       content::WebContents::FromRenderFrameHost(&render_frame_host);
   if (contents) {
     auto* prefs = WebContentsPreferences::From(contents);
+    // DevTools frontends and the DevTools pages of extensions run in
+    // subframes but still need the ipcRenderer bridge to bootstrap (they
+    // fetch their preload paths over it). Mirror the same policy as
+    // RendererClientBase::ShouldLoadPreload() and
+    // WebContents::MaybeSendRendererStartupData(), which already treat
+    // devtools:// and chrome-extension:// documents like main frames.
+    // GetLastCommittedURL() is empty at this point (the frame has not
+    // navigated yet), so key off the SiteInstance's site URL instead.
+    const GURL& site = render_frame_host.GetSiteInstance()
+                           ->GetSecurityPrincipal()
+                           .GetDeprecatedSiteURL();
+    bool is_devtools_like = site.SchemeIs(content::kChromeDevToolsScheme);
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+    is_devtools_like |= site.SchemeIs(extensions::kExtensionScheme);
+#endif
     if (render_frame_host.GetFrameTreeNodeId() ==
             contents->GetPrimaryMainFrame()->GetFrameTreeNodeId() ||
-        (prefs && prefs->AllowsNodeIntegrationInSubFrames())) {
+        (prefs && prefs->AllowsNodeIntegrationInSubFrames()) ||
+        is_devtools_like) {
       associated_registry.AddInterface<mojom::ElectronApiIPC>(
           base::BindRepeating(
               [](content::RenderFrameHost* render_frame_host,

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -664,6 +664,19 @@ describe('chrome extensions', () => {
       showLastDevToolsPanel(w);
       await winningMessage;
     });
+
+    // Regression test for https://github.com/electron/electron/issues/48705:
+    // when launched with --no-sandbox, the extension's devtools_page runs in a
+    // non-sandboxed renderer. Renderer init must not abort there, otherwise
+    // chrome.devtools.panels.create() never runs and the panel never appears.
+    // The fixture exits 0 once the panel runs, 1 on timeout. Must be a separate
+    // process because --no-sandbox is a process-wide switch.
+    ifit(process.platform !== 'win32' || process.arch !== 'arm64')('loads a devtools extension with --no-sandbox', async () => {
+      const appPath = path.join(__dirname, 'fixtures', 'apps', 'devtools-extension-no-sandbox');
+      const appProcess = spawn(process.execPath, [appPath, '--no-sandbox']);
+      const [code] = await once(appProcess, 'exit');
+      expect(code).to.equal(0);
+    });
   });
 
   describe('chrome extension content scripts', () => {

--- a/spec/fixtures/apps/devtools-extension-no-sandbox/main.js
+++ b/spec/fixtures/apps/devtools-extension-no-sandbox/main.js
@@ -1,0 +1,49 @@
+// Regression fixture for https://github.com/electron/electron/issues/48705.
+// When launched with --no-sandbox, the extension's devtools_page runs in a
+// non-sandboxed renderer. Renderer init must not abort there, otherwise
+// chrome.devtools.panels.create() never runs and the panel never appears.
+// Exits 0 when the extension panel runs (sends 'winning'), 1 on timeout.
+const { app, BrowserWindow, ipcMain, session } = require('electron');
+const http = require('node:http');
+const path = require('node:path');
+
+const extensionPath = path.join(__dirname, '..', '..', 'extensions', 'devtools-extension');
+
+const showLastDevToolsPanel = (w) => {
+  w.webContents.once('devtools-opened', () => {
+    const show = () => {
+      if (w == null || w.isDestroyed()) return;
+      const { devToolsWebContents } = w;
+      if (devToolsWebContents == null || devToolsWebContents.isDestroyed()) return;
+      const showLastPanel = () => {
+        const { EUI } = window;
+        const instance = EUI.InspectorView.InspectorView.instance();
+        const tabs = instance.tabbedPane.tabs;
+        instance.showPanel(tabs[tabs.length - 1].id);
+      };
+      devToolsWebContents.executeJavaScript(`(${showLastPanel})()`, false)
+        .then(() => setTimeout(show, 100))
+        .catch(() => setTimeout(show, 100));
+    };
+    setTimeout(show, 100);
+  });
+};
+
+app.whenReady().then(async () => {
+  const server = http.createServer((_req, res) => res.end('<title>host</title>'));
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${server.address().port}/`;
+
+  await session.defaultSession.extensions.loadExtension(extensionPath);
+
+  ipcMain.once('winning', () => app.exit(0));
+  setTimeout(() => app.exit(1), 30000);
+
+  const w = new BrowserWindow({
+    show: true,
+    webPreferences: { nodeIntegration: true, contextIsolation: false }
+  });
+  await w.loadURL(url);
+  w.webContents.openDevTools();
+  showLastDevToolsPanel(w);
+});

--- a/spec/fixtures/apps/devtools-extension-no-sandbox/package.json
+++ b/spec/fixtures/apps/devtools-extension-no-sandbox/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "devtools-extension-no-sandbox",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

Extension `devtools_page` documents (and the DevTools frontend) run in subframes. `ElectronApiIPC` was only bound for the main frame or `nodeIntegrationInSubFrames` subframes, so these frames had no receiver.

Under `--no-sandbox`, such a frame fetches its preload paths over `ipcRenderer` during renderer init. With no receiver bound, the sync IPC returns `null`, init throws (`object null is not iterable`), and `chrome.devtools.panels.create()` never runs — so the extension's DevTools panel tab never appears. Sandboxed renderers are unaffected because they receive preload data over a separate mojo interface.

This binds `ElectronApiIPC` for `devtools://` and `chrome-extension://` frames, mirroring the existing policy in `RendererClientBase::ShouldLoadPreload()` and `WebContents::MaybeSendRendererStartupData()`, which already treat these documents like main frames. The site URL is read from the `SiteInstance` because the frame's committed URL is empty at binder-registration time.

Regressed around the Chromium 131→132 roll (Electron 35); still reproduces on the latest release.

Fixes #48705

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)
- [x] relevant changes covered by tests (`spec/extensions-spec.ts` regression test running under `--no-sandbox`)

#### Disclosure

Investigated and drafted with AI assistance (Claude Code / Claude Opus 4.8); root cause, security review, and tests were human-reviewed and verified locally (fails without the fix, passes with it).

Notes: Fixed extension DevTools panels (`chrome.devtools.panels.create`) not appearing when running with `--no-sandbox`.
