### PR TITLE
docs: update breaking changes to clarify v43 is last 32-bit

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -24,8 +24,8 @@ Electron headers CDN) are no longer published either.
 Older versions of Electron will continue to support these platforms, but Electron
 v44.0.0 and higher will only be published for 64-bit platforms.
 
-Once the v44 series reaches end of life in January 2027, Electron will no longer
-support these platforms completely.
+Once the v43 series reaches end of life in January 2027, these 32-bit platforms
+will no longer be supported.
 
 ### Removed: `clipboard` module is no longer available in the renderer process
 


### PR DESCRIPTION
#### Description of Change

- Followup to #52070.  While working on the blog post for v42.0.0, I realized that there was an incorrect statement in the breaking changes.  v43 (not v44) is the last Electron series to support 32-bit.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
