### PR TITLE
fix: restore top 1px client area on Win11 frameless windows

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -12,6 +12,8 @@
 #include <dwmapi.h>
 #include <memory>
 
+#include "base/win/windows_version.h"
+
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/win_caption_button_container.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -302,8 +304,14 @@ gfx::Insets WinFrameView::RestoredFrameBorderInsets() const {
   // TODO(mitchchn): despite the name, this method gives the correct
   // DPI-adjusted insets for the sides, not the top, when restored.
   const int thickness = FrameTopBorderThickness(/*restored=*/true);
-  // Inverse of ResizingBorderHitTest: resize insets go on sides but not top.
-  return gfx::Insets::TLBR(0, thickness, thickness, thickness);
+  // On Windows 11, DWM draws a 1px system border overlapping all 4 sides of
+  // the client area, so include a 1px top inset to match the left/right/bottom
+  // behavior and correctly account for the DWM border in Views layout.
+  // On Windows 10 the top is left at 0 (unchanged behavior).
+  const auto* os_info = base::win::OSInfo::GetInstance();
+  const int top_inset =
+      os_info->version() >= base::win::Version::WIN11 ? 1 : 0;
+  return gfx::Insets::TLBR(top_inset, thickness, thickness, thickness);
 }
 
 BEGIN_METADATA(WinFrameView)

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -127,7 +127,17 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
       // windows with standard frames. Non-resizable windows still get input
       // insets for stable bounds and so they can be dragged from outer edges,
       // also like in windows with standard frames.
-      *insets = gfx::Insets::TLBR(0, frame_thickness, frame_thickness,
+      //
+      // On Windows 11, DWM draws a 1px system border on all 4 sides of the
+      // window, overlapping 1px of client content on each edge. The
+      // left/right/bottom are already covered by frame_thickness insets above.
+      // Add a matching 1px top inset on Win11 so the top edge of web content
+      // is not clipped by the DWM border. Windows 10 is unaffected: its system
+      // border only overlaps edges that have non-zero insets.
+      const auto* os_info = base::win::OSInfo::GetInstance();
+      const int top_inset =
+          os_info->version() >= base::win::Version::WIN11 ? 1 : 0;
+      *insets = gfx::Insets::TLBR(top_inset, frame_thickness, frame_thickness,
                                   frame_thickness);
       return true;
     }


### PR DESCRIPTION
On Windows 11, DWM draws the WS_THICKFRAME system border on all 4 sides of the window, overlapping 1px of client content on each edge. The left/right/bottom were already covered by frame_thickness insets introduced in the frameless-insets feature, but the top was left at 0 to avoid triggering Windows's standard titlebar rendering.

On Windows 10 the system border only draws on edges with non-zero insets, so the top was never affected there. On Windows 11 the DWM border draws on all edges regardless, clipping the topmost pixel of web content in restored frameless thick-frame windows.

Fix this by adding a 1px top client-area inset on Windows 11 in:
  - GetClientAreaInsets() (electron_desktop_window_tree_host_win.cc) so WM_NCCALCSIZE reports a 1px top inset to the OS.
  - RestoredFrameBorderInsets() (win_frame_view.cc) so the Views layout system accounts for the same inset.

Windows 10, maximized windows, fullscreen windows, and windows with thickFrame:false are all unaffected.

Fixes: https://github.com/electron/electron/issues/XXXXX

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
