### PR TITLE
fix: guard NotifyUserActivation on live main frame.

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4262,7 +4262,7 @@ content::RenderFrameHost* WebContents::FocusedFrame() {
 
 void WebContents::NotifyUserActivation() {
   content::RenderFrameHost* frame = web_contents()->GetPrimaryMainFrame();
-  if (frame)
+  if (frame && frame->IsRenderFrameLive())
     frame->NotifyUserActivation(
         blink::mojom::UserActivationNotificationType::kInteraction);
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4201,7 +4201,7 @@ content::RenderFrameHost* WebContents::FocusedFrame() {
 
 void WebContents::NotifyUserActivation() {
   content::RenderFrameHost* frame = web_contents()->GetPrimaryMainFrame();
-  if (frame)
+  if (frame && frame->IsRenderFrameLive())
     frame->NotifyUserActivation(
         blink::mojom::UserActivationNotificationType::kInteraction);
 }

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1709,6 +1709,7 @@ describe('webContents module', () => {
     });
 
     it('can correctly convert accelerators to key codes', async () => {
+      await w.webContents.executeJavaScript('document.getElementById("input").focus()');
       const keyup = once(ipcMain, 'keyup');
       w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' });
       w.webContents.sendInputEvent({ keyCode: 'Space', type: 'char' });

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1847,6 +1847,7 @@ describe('webContents module', () => {
     });
 
     it('can correctly convert accelerators to key codes', async () => {
+      await w.webContents.executeJavaScript('document.getElementById("input").focus()');
       const keyup = once(ipcMain, 'keyup');
       w.webContents.sendInputEvent({ keyCode: 'Plus', type: 'char' });
       w.webContents.sendInputEvent({ keyCode: 'Space', type: 'char' });


### PR DESCRIPTION
#### Description of Change

I encountered several sporadic crash stack traces. 
callstack:
```
  *** Stack trace for last set context - .thread/.cxr resets it
 # Child-SP          RetAddr               Call Site
00 (Inline Function) --------`--------     RingCentral!blink::AssociatedInterfaceProvider::GetInterface+0x1b [] 
01 (Inline Function) --------`--------     RingCentral!content::RenderFrameHostImpl::GetAssociatedLocalFrame+0x30 [] 
02 0000003f`fd9fd180 00007ff6`448aca59     RingCentral!content::RenderFrameHostImpl::NotifyUserActivation+0x4d [] 
03 (Inline Function) --------`--------     RingCentral!electron::api::WebContents::NotifyUserActivation+0x3b [] 
04 0000003f`fd9fd1e0 00007ff6`448cc610     RingCentral!electron::api::WebContents::LoadURL+0x609 [] 
05 (Inline Function) --------`--------     RingCentral!base::RepeatingCallback<void (electron::api::WebContents *, const GURL &, const gin_helper::Dictionary &)>::Run+0x37 [] 
06 0000003f`fd9fd860 00007ff6`448cc388     RingCentral!gin_helper::Invoker<std::__Cr::integer_sequence<unsigned long long,0,1,2>,electron::api::WebContents *,const GURL &,const gin_helper::Dictionary &>::DispatchToCallback+0xa0 [] 
07 0000003f`fd9fd8d0 00007ff6`448cc237     RingCentral!gin_helper::Dispatcher<void (electron::api::WebContents *, const GURL &, const gin_helper::Dictionary &)>::DispatchToCallbackImpl+0x128 [] 
08 0000003f`fd9fd9e0 00007ff6`4dc559de     RingCentral!gin_helper::Dispatcher<void (electron::api::WebContents *, const GURL &, const gin_helper::Dictionary &)>::DispatchToCallback+0x47 [] 
09 0000003f`fd9fda30 00007ff6`4dc53c1e     RingCentral!Builtins_CallApiCallbackGeneric+0x9e
0a 0000003f`fd9fda88 00007ff6`4dc53c1e     RingCentral!Builtins_InterpreterEntryTrampoline+0x11e
0b 0000003f`fd9fdb40 00007ff6`4dc53c1e     RingCentral!Builtins_InterpreterEntryTrampoline+0x11e
0c 0000003f`fd9fdbc0 00007ff6`4dc962af     RingCentral!Builtins_InterpreterEntryTrampoline+0x11e
0d 0000003f`fd9fdcb8 00007ff6`4dd775ea     RingCentral!Builtins_AsyncFunctionAwaitResolveClosure+0x2f
0e 0000003f`fd9fdcf0 00007ff6`4dc84581     RingCentral!Builtins_PromiseFulfillReactionJob+0x2a
0f 0000003f`fd9fdd28 00007ff6`4dc516b3     RingCentral!Builtins_RunMicrotasks+0x2c1
10 0000003f`fd9fdd98 00007ff6`460ed291     RingCentral!Builtins_JSRunMicrotasksEntry+0xf3
11 0000003f`fd9fdec0 00007ff6`460edea5     RingCentral!v8::internal::`anonymous namespace'::Invoke+0x8b1 [] 
12 0000003f`fd9fe090 00007ff6`460ee0ab     RingCentral!v8::internal::`anonymous namespace'::InvokeWithTryCatch+0x65 [] 
13 0000003f`fd9fe120 00007ff6`46121228     RingCentral!v8::internal::Execution::TryRunMicrotasks+0x6b [] 
14 0000003f`fd9fe1a0 00007ff6`461219c3     RingCentral!v8::internal::MicrotaskQueue::RunMicrotasks+0xc8 [] 
15 (Inline Function) --------`--------     RingCentral!v8::internal::MicrotaskQueue::PerformCheckpointInternal+0x39 [] 
16 0000003f`fd9fe260 00007ff6`4a8e39c9     RingCentral!v8::internal::MicrotaskQueue::PerformCheckpoint+0x63 [] 
17 0000003f`fd9fe2c0 00007ff6`4dc559de     RingCentral!node::task_queue::RunMicrotasks+0xc9 [] 
18 0000003f`fd9fe320 00007ff6`add650a4     RingCentral!Builtins_CallApiCallbackGeneric+0x9e
```

And that likely cause is that IsRenderFrameLive() was not checked before sending the IPC.


RenderFrameHost::GetPrimaryMainFrame() can return an RFH object, but it does not guarantee that the RenderFrame in the renderer is already live.

The low risk change: avoid sending user activation notifications unless the primary main frame is live.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when notifying user activation before the primary main frame was live.
