### PR TITLE
fix: enable GlobalShortcutsPortalPreferredTrigger by default on Linux

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -32,6 +32,7 @@
 
 #if BUILDFLAG(IS_LINUX)
 #include "printing/printing_features.h"
+#include "ui/base/ui_base_features.h"
 #endif
 
 namespace electron {
@@ -81,6 +82,16 @@ void InitializeFeatureList() {
   // Refs https://issues.chromium.org/issues/373852607
   enable_features +=
       std::string(",") + chrome_pdf::features::kPdfUseShowSaveFilePicker.name;
+#endif
+
+#if BUILDFLAG(IS_LINUX)
+  // Without this, globalShortcut is a silent no-op on GNOME Wayland (the
+  // ozone factory returns no listener there). Chromium keeps it off due to
+  // https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/issues/185,
+  // but current GNOME persists bound shortcuts across sessions, so re-binds
+  // are silent. A user-passed --disable-features for this still wins.
+  enable_features +=
+      std::string(",") + features::kGlobalShortcutsPortalPreferredTrigger.name;
 #endif
 
   std::string platform_specific_enable_features =


### PR DESCRIPTION
#### Description of Change

Enables `GlobalShortcutsPortalPreferredTrigger` by default on Linux, so that `globalShortcut` works on GNOME Wayland out of the box. Inspired by a conversation with @mitchchn.

Chromium gates the GlobalShortcuts portal on GNOME behind `GlobalAcceleratorListener::GetInstance` added in [crrev.com/c/7620219](https://chromium-review.googlesource.com/c/chromium/src/+/7620219)). When the feature is off, every `globalShortcut.register()` call fails silently, from the app's perspective. On GNOME Wayland (the only GNOME session type on Ubuntu 26.04), that means `globalShortcut` is a no-op unless every Electron app author independently discovers a Chromium feature flag.

This is a no-op outside GNOME. Verified against a local build on Linux (headless Ozone, private session bus, simulated `XDG_CURRENT_DESKTOP=GNOME`):

- Before: `globalShortcut.register()` → `false` on GNOME with no flags (listener never created).
- After: `register()` → `true` on GNOME with no flags; portal session is created.
- After + `--disable-features=GlobalShortcutsPortalPreferredTrigger`: `register()` → `false` (user override wins).
- Non-GNOME: `true` before and after (unchanged).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes locally
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Fixed `globalShortcut` not working on GNOME Wayland by enabling Chromium's `GlobalShortcutsPortalPreferredTrigger` feature by default on Linux.
