### PR TITLE
fix: use GTK UI theme for Linux message boxes

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -7,6 +7,7 @@
 
 #include "shell/browser/ui/message_box.h"
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
@@ -20,9 +21,11 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/gtk_util.h"
 #include "ui/base/glib/scoped_gsignal.h"
+#include "ui/color/system_theme.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gtk/gtk_ui.h"    // nogncheck
 #include "ui/gtk/gtk_util.h"  // nogncheck
+#include "ui/linux/linux_ui_factory.h"
 
 #if defined(USE_OZONE)
 #include "ui/base/ui_base_features.h"
@@ -43,10 +46,11 @@ base::flat_map<int, GtkWidget*>& GetDialogsMap() {
 }
 
 gtk::GtkUiPlatform* GetGtkUiPlatform() {
-  auto* linux_ui = ui::LinuxUi::instance();
-  auto* gtk_ui = static_cast<gtk::GtkUi*>(linux_ui);
+  auto* gtk_ui =
+      static_cast<gtk::GtkUi*>(ui::GetLinuxUiTheme(ui::SystemTheme::kGtk));
+  CHECK(gtk_ui);
   gtk::GtkUiPlatform* platform = gtk_ui->GetPlatform();
-  DCHECK(platform);
+  CHECK(platform);
   return platform;
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes electron/electron#51988.

Linux message boxes need the GTK `GtkUiPlatform`, but the helper was casting the active `LinuxUi` singleton to `gtk::GtkUi`. In environments where the active Linux UI implementation is not GTK, that can leave the message box path using the wrong UI object.

This changes the helper to request the GTK Linux UI theme directly with `ui::GetLinuxUiTheme(ui::SystemTheme::kGtk)` before retrieving the platform, and checks both the GTK UI and platform pointers before use.

#### Checklist

- [x] `yarn lint:cpp --only -- shell/browser/ui/message_box_gtk.cc`
- [x] `/work/src/third_party/ninja/ninja -C out/LinuxTesting -n electron`
- [x] `ELECTRON_OUT_DIR=LinuxTesting npm_config_match=dialog ./script/actions/run-tests.sh ./script/spec-runner.js --runners=main --skipYarnInstall --no-sandbox -g=showMessageBox`

The targeted dialog spec run passed 8 tests with 0 failures. macOS-only dialog interaction cases were skipped.
