### PR TITLE
fix: use GTK UI theme for Linux message boxes

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -7,6 +7,7 @@
 
 #include "shell/browser/ui/message_box.h"
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
@@ -20,9 +21,11 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/gtk_util.h"
 #include "ui/base/glib/scoped_gsignal.h"
+#include "ui/color/system_theme.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gtk/gtk_ui.h"    // nogncheck
 #include "ui/gtk/gtk_util.h"  // nogncheck
+#include "ui/linux/linux_ui_factory.h"
 
 #if defined(USE_OZONE)
 #include "ui/base/ui_base_features.h"
@@ -43,10 +46,11 @@ base::flat_map<int, GtkWidget*>& GetDialogsMap() {
 }
 
 gtk::GtkUiPlatform* GetGtkUiPlatform() {
-  auto* linux_ui = ui::LinuxUi::instance();
-  auto* gtk_ui = static_cast<gtk::GtkUi*>(linux_ui);
+  auto* gtk_ui =
+      static_cast<gtk::GtkUi*>(ui::GetLinuxUiTheme(ui::SystemTheme::kGtk));
+  CHECK(gtk_ui);
   gtk::GtkUiPlatform* platform = gtk_ui->GetPlatform();
-  DCHECK(platform);
+  CHECK(platform);
   return platform;
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes electron/electron#51988.

Linux message boxes need the GTK `GtkUiPlatform`, but this helper was casting
the active `LinuxUi` singleton to `gtk::GtkUi`. When another Linux UI
implementation is active, that can use the wrong object for the GTK message box
path.

This change requests the GTK Linux UI theme directly with
`ui::GetLinuxUiTheme(ui::SystemTheme::kGtk)` before retrieving its platform, and
checks both the GTK UI and platform pointers before use.

Validation performed:

- `yarn lint:cpp --only -- shell/browser/ui/message_box_gtk.cc`
- `third_party/ninja/ninja -C out/LinuxTesting obj/electron/electron_lib/message_box_gtk.o`

For the object rebuild, the prior `message_box_gtk.o` and `message_box_gtk.dwo`
outputs were removed first so Ninja rebuilt the changed C++ file.

No tests or documentation were changed. This patch is limited to the internal
Linux GTK message box platform lookup and does not add or change public API
behavior.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when showing Linux message boxes while another Linux UI implementation was active.
