### PR TITLE
fix: avoid split DPI rounding for custom titlebar overlay height #52208

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -189,8 +189,12 @@ int WinFrameView::TitlebarHeight(int custom_height) const {
 
   int height = TitlebarMaximizedVisualHeight() +
                FrameTopBorderThickness(false) - WindowTopY();
+
+  // Custom overlay heights are already the full intended title bar height.
+  // Do not subtract WindowTopY(), otherwise the y and height are rounded
+  // separately at fractional DPI scales. See #52208.
   if (custom_height > TitlebarMaximizedVisualHeight())
-    height = custom_height - WindowTopY();
+    height = custom_height;
 
   return height;
 }
@@ -233,8 +237,20 @@ void WinFrameView::LayoutCaptionButtons() {
                            ? preferred_size.width()
                            : (IsMaximized() ? preferred_size.width()
                                             : preferred_size.width() - 1);
-  caption_button_container_->SetBounds(width() - preferred_size.width(),
-                                       WindowTopY(), variable_width, height);
+
+  // Keep custom overlay geometry as one rectangle starting at y = 0.
+  // Using WindowTopY() here would split the custom height into y + height,
+  // which can round to an extra physical pixel at fractional DPI scales.
+  // See #52208.
+  const bool has_custom_height =
+      custom_height > TitlebarMaximizedVisualHeight();
+  const int titlebar_y = has_custom_height ? 0 : WindowTopY();
+
+  caption_button_container_->SetBounds(
+      width() - preferred_size.width(),
+      titlebar_y,
+      variable_width,
+      height);
 
   // Needed for heights larger than default
   caption_button_container_->SetButtonSize(gfx::Size(0, height));

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -67,6 +67,16 @@ views::View* WinFrameView::TargetForRect(views::View* root,
     if (!window()->IsWindowControlsOverlayEnabled())
       return this;
 
+    // For custom overlay heights, the caption button container starts at y = 0
+    // to keep the requested height as a single rectangle and avoid the
+    // fractional-DPI rounding bug fixed in #52242. Keep the restored top-edge
+    // resize strip owned by the frame view so caption buttons do not receive
+    // hover or mouse events while the native hit-test is HTTOP.
+    if (window()->titlebar_overlay_height() > TitlebarMaximizedVisualHeight() &&
+        !IsMaximized() && rect.origin().y() < FrameTopBorderThickness(false)) {
+      return this;
+    }
+
     auto local_point = rect.origin();
     ConvertPointToTarget(parent(), caption_button_container_, &local_point);
     if (!caption_button_container_->HitTestPoint(local_point))
@@ -81,8 +91,17 @@ int WinFrameView::NonClientHitTest(const gfx::Point& point) {
     return frame_->client_view()->NonClientHitTest(point);
 
   if (window()->IsWindowControlsOverlayEnabled()) {
+    // For custom overlay heights, the caption button container starts at y = 0
+    // to keep the requested height as a single rectangle and avoid the
+    // fractional-DPI rounding bug fixed in #52242. Let the restored top-edge
+    // resize strip fall through to the existing frame hit-test below instead
+    // of allowing the caption buttons to consume that row.
+    const bool is_top_resize_strip =
+        window()->titlebar_overlay_height() > TitlebarMaximizedVisualHeight() &&
+        !IsMaximized() && point.y() < FrameTopBorderThickness(false);
+
     // See if the point is within any of the window controls.
-    if (caption_button_container_) {
+    if (caption_button_container_ && !is_top_resize_strip) {
       gfx::Point local_point = point;
 
       ConvertPointToTarget(parent(), caption_button_container_, &local_point);


### PR DESCRIPTION
#### Description of Change

On Windows, custom `titleBarOverlay.height` was split into two DIP values for caption button layout:

```
y = WindowTopY()
height = custom_height - WindowTopY()
```

At fractional display scales, those values are scaled and rounded separately. For some custom height and scale factor pairs, this can make the native caption button container one physical pixel taller than the intended overlay height, causing it to overlap the renderer title bar bottom border.

For custom overlay heights, lay out the caption button container as a single vertical rectangle instead:

```
y = 0
height = custom_height
```

The existing WindowTopY()-based layout is preserved for the default/system title bar height path.

Fixes #52208

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a Windows custom title bar overlay height rounding issue at fractional display scales.
