### PR TITLE
fix: relative defaultPath producing an unusable dialog location on Linux

### DIFF
--- a/script/dbus_mock.py
+++ b/script/dbus_mock.py
@@ -27,6 +27,9 @@ def start():
 
         DBusTestCase.start_session_bus()
         DBusTestCase.spawn_server_template('notification_daemon', None, log)
+        DBusTestCase.spawn_server_template(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'dbusmock_xdg_file_chooser_portal.py'), None, log)
 
 
 if __name__ == '__main__':

--- a/script/dbusmock_xdg_file_chooser_portal.py
+++ b/script/dbusmock_xdg_file_chooser_portal.py
@@ -1,0 +1,67 @@
+"""python-dbusmock template for the xdg-desktop-portal FileChooser interface.
+
+Loaded onto the fake session bus by script/dbus_mock.py so that Linux tests
+exercise Chromium's portal-based file dialogs (SelectFileDialogLinuxPortal)
+instead of falling back to the GTK implementation. Every OpenFile/SaveFile
+request is automatically answered with a "user cancelled" Response so
+dialogs resolve instead of waiting for interaction; tests inspect the
+request options via the org.freedesktop.DBus.Mock interface (GetCalls).
+"""
+
+import dbus
+
+from dbusmock import mockobject
+from gi.repository import GLib
+
+BUS_NAME = 'org.freedesktop.portal.Desktop'
+MAIN_OBJ = '/org/freedesktop/portal/desktop'
+MAIN_IFACE = 'org.freedesktop.portal.FileChooser'
+SYSTEM_BUS = False
+
+REQUEST_IFACE = 'org.freedesktop.portal.Request'
+
+# https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
+RESPONSE_USER_CANCELLED = 1
+
+
+def load(mock, parameters):
+    """Set up the FileChooser interface on the mock object."""
+    mock.request_serial = 0
+    mock.AddProperty(MAIN_IFACE, 'version',
+                     dbus.UInt32(parameters.get('version', 4)))
+    mock.AddMethods(MAIN_IFACE, [
+        ('OpenFile', 'ssa{sv}', 'o', handle_file_chooser_call),
+        ('SaveFile', 'ssa{sv}', 'o', handle_file_chooser_call),
+    ])
+
+
+def handle_file_chooser_call(self, _parent_window, _title, _options):
+    """Create a Request object and cancel it shortly afterwards."""
+    self.request_serial += 1
+    request_path = f'{MAIN_OBJ}/request/mock/{self.request_serial}'
+    self.AddObject(request_path, REQUEST_IFACE, {},
+                   [('Close', '', '', 'self.response_pending = False')])
+    request = mockobject.objects[request_path]
+    request.response_pending = True
+
+    # The client sees that the returned request path differs from the one it
+    # derived from its handle_token and re-subscribes to the Response signal
+    # on the returned path, per the portal spec. Emit the signal on a delay
+    # so the re-subscription has completed, and repeat it a bounded number of
+    # times so a slow subscriber cannot miss it. The client Closes the
+    # request once it has processed a Response, which stops the emissions.
+    state = {'remaining': 25}
+
+    def emit_response():
+        if not request.response_pending:
+            return False
+        request.EmitSignal(
+            REQUEST_IFACE, 'Response', 'ua{sv}',
+            [dbus.UInt32(RESPONSE_USER_CANCELLED),
+             dbus.Dictionary({}, signature='sv')])
+        state['remaining'] -= 1
+        return state['remaining'] > 0
+
+    GLib.timeout_add(200, emit_response)
+
+    return dbus.ObjectPath(request_path)

--- a/script/dbusmock_xdg_file_chooser_portal.py
+++ b/script/dbusmock_xdg_file_chooser_portal.py
@@ -1,11 +1,9 @@
 """python-dbusmock template for the xdg-desktop-portal FileChooser interface.
 
-Loaded onto the fake session bus by script/dbus_mock.py so that Linux tests
-exercise Chromium's portal-based file dialogs (SelectFileDialogLinuxPortal)
-instead of falling back to the GTK implementation. Every OpenFile/SaveFile
-request is automatically answered with a "user cancelled" Response so
-dialogs resolve instead of waiting for interaction; tests inspect the
-request options via the org.freedesktop.DBus.Mock interface (GetCalls).
+Loaded onto the fake session bus by script/dbus_mock.py. Records every
+OpenFile/SaveFile request (inspectable via org.freedesktop.DBus.Mock
+GetCalls) and answers it with a "user cancelled" Response so dialogs
+resolve without interaction.
 """
 
 import dbus
@@ -44,12 +42,9 @@ def handle_file_chooser_call(self, _parent_window, _title, _options):
     request = mockobject.objects[request_path]
     request.response_pending = True
 
-    # The client sees that the returned request path differs from the one it
-    # derived from its handle_token and re-subscribes to the Response signal
-    # on the returned path, per the portal spec. Emit the signal on a delay
-    # so the re-subscription has completed, and repeat it a bounded number of
-    # times so a slow subscriber cannot miss it. The client Closes the
-    # request once it has processed a Response, which stops the emissions.
+    # Emit the Response on a delay so the client has re-subscribed to the
+    # returned request path, and repeat it until the client acknowledges by
+    # closing the request (a slow subscriber cannot miss it).
     state = {'remaining': 25}
 
     def emit_response():

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -60,6 +60,19 @@ ui::SelectFileDialog::FileTypeInfo GetFilterInfo(const Filters& filters) {
   return file_type_info;
 }
 
+// A relative defaultPath (e.g. a bare filename, which the docs permit) must
+// be anchored to an absolute directory: the file chooser derives its starting
+// folder from DirName(), which would otherwise be the unusable relative ".".
+// The macOS and Windows dialog implementations also special-case relative
+// paths with IsAbsolute() checks instead of passing them through.
+base::FilePath GetDefaultDialogPath(const DialogSettings& settings) {
+  if (settings.default_path.empty())
+    return electron::GetDefaultPath();
+  if (settings.default_path.IsAbsolute())
+    return settings.default_path;
+  return electron::GetDefaultPath().Append(settings.default_path);
+}
+
 void LogIfNeededAboutUnsupportedPortalFeature(const DialogSettings& settings) {
   if (!settings.default_path.empty() && IsPortalAvailable() &&
       GetPortalVersion() < 4) {
@@ -83,9 +96,7 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
     ui::SelectFileDialog::FileTypeInfo file_info =
         GetFilterInfo(settings.filters);
     ApplySettings(settings);
-    base::FilePath default_path = settings.default_path.empty()
-                                      ? electron::GetDefaultPath()
-                                      : settings.default_path;
+    base::FilePath default_path = GetDefaultDialogPath(settings);
 
     dialog_->SelectFile(ui::SelectFileDialog::SELECT_SAVEAS_FILE,
                         base::UTF8ToUTF16(settings.title), default_path,
@@ -114,9 +125,7 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
     ui::SelectFileDialog::FileTypeInfo file_info =
         GetFilterInfo(settings.filters);
     ApplySettings(settings);
-    base::FilePath default_path = settings.default_path.empty()
-                                      ? electron::GetDefaultPath()
-                                      : settings.default_path;
+    base::FilePath default_path = GetDefaultDialogPath(settings);
 
     dialog_->SelectFile(
         GetDialogType(settings.properties), base::UTF8ToUTF16(settings.title),

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -60,11 +60,9 @@ ui::SelectFileDialog::FileTypeInfo GetFilterInfo(const Filters& filters) {
   return file_type_info;
 }
 
-// A relative defaultPath (e.g. a bare filename, which the docs permit) must
-// be anchored to an absolute directory: the file chooser derives its starting
-// folder from DirName(), which would otherwise be the unusable relative ".".
-// The macOS and Windows dialog implementations also special-case relative
-// paths with IsAbsolute() checks instead of passing them through.
+// A relative defaultPath (e.g. a bare filename) would make the file chooser
+// open at the unusable relative directory ".", so anchor it to the default
+// directory instead.
 base::FilePath GetDefaultDialogPath(const DialogSettings& settings) {
   if (settings.default_path.empty())
     return electron::GetDefaultPath();

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -1039,14 +1039,9 @@ describe('dialog module', () => {
     }
   );
 
-  // For these tests script/dbus_mock.py hosts a mock xdg-desktop-portal
-  // FileChooser (script/dbusmock_xdg_file_chooser_portal.py) on the fake
-  // session bus, which Chromium's SelectFileDialogLinuxPortal talks to. The
-  // mock cancels every dialog automatically and records the request, so the
-  // tests can assert on the exact options sent over D-Bus.
-  //
-  // script/spec-runner.js spawns dbusmock, which sets
-  // DBUS_SESSION_BUS_ADDRESS.
+  // Asserts on the D-Bus requests received by the mock xdg-desktop-portal
+  // FileChooser that script/dbus_mock.py hosts on the fake session bus. The
+  // mock records each request and auto-cancels the dialog.
   ifdescribe(
     process.platform === 'linux' &&
       process.arch !== 'ia32' &&
@@ -1074,9 +1069,8 @@ describe('dialog module', () => {
       await clearCalls();
     });
 
-    // GetCalls entries are [timestamp, methodName, args] where the args of
-    // OpenFile/SaveFile are [parent_window, title, options]. Every logged
-    // arg and every a{sv} dict value is a [signature, [value]] variant pair.
+    // A call is [timestamp, methodName, [parent_window, title, options]];
+    // args and dict values are [signature, [value]] variant pairs.
     function getLoggedOptions(call: any) {
       const options: Record<string, any> = {};
       for (const entry of call[2][2][1][0]) {
@@ -1111,9 +1105,7 @@ describe('dialog module', () => {
         expect(getCurrentFolder(options)).to.equal(defaultDir);
       });
 
-      // A directory-less defaultPath must not produce a relative
-      // current_folder ("."), which portal backends cannot resolve. See
-      // https://github.com/electron/electron/issues/52051.
+      // https://github.com/electron/electron/issues/52051
       it('sends an absolute current_folder for a directory-less defaultPath', async () => {
         const { canceled } = await dialog.showSaveDialog({
           defaultPath: 'test.jpeg'

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -1,9 +1,11 @@
-import { dialog, BaseWindow, BrowserWindow } from 'electron/main';
+import { app, dialog, BaseWindow, BrowserWindow } from 'electron/main';
 
 import { expect } from 'chai';
+import * as dbus from 'dbus-native';
 
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import { promisify } from 'node:util';
 
 import { ifdescribe, ifit } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
@@ -1036,4 +1038,109 @@ describe('dialog module', () => {
       });
     }
   );
+
+  // For these tests script/dbus_mock.py hosts a mock xdg-desktop-portal
+  // FileChooser (script/dbusmock_xdg_file_chooser_portal.py) on the fake
+  // session bus, which Chromium's SelectFileDialogLinuxPortal talks to. The
+  // mock cancels every dialog automatically and records the request, so the
+  // tests can assert on the exact options sent over D-Bus.
+  //
+  // script/spec-runner.js spawns dbusmock, which sets
+  // DBUS_SESSION_BUS_ADDRESS.
+  ifdescribe(
+    process.platform === 'linux' &&
+      process.arch !== 'ia32' &&
+      !process.arch.startsWith('arm') &&
+      !!process.env.DBUS_SESSION_BUS_ADDRESS
+  )('file dialogs (Linux portal)', () => {
+    let bus: any;
+    let getCalls: () => Promise<any[]>;
+    let clearCalls: () => Promise<void>;
+
+    before(async () => {
+      bus = dbus.sessionBus();
+      const service = bus.getService('org.freedesktop.portal.Desktop');
+      const getInterface = promisify(service.getInterface.bind(service));
+      const mock: any = await getInterface('/org/freedesktop/portal/desktop', 'org.freedesktop.DBus.Mock');
+      getCalls = promisify(mock.GetCalls.bind(mock));
+      clearCalls = promisify(mock.ClearCalls.bind(mock));
+    });
+
+    after(() => {
+      bus?.connection.end();
+    });
+
+    beforeEach(async () => {
+      await clearCalls();
+    });
+
+    // GetCalls entries are [timestamp, methodName, args] where the args of
+    // OpenFile/SaveFile are [parent_window, title, options]. Every logged
+    // arg and every a{sv} dict value is a [signature, [value]] variant pair.
+    function getLoggedOptions(call: any) {
+      const options: Record<string, any> = {};
+      for (const entry of call[2][2][1][0]) {
+        options[entry[0]] = entry[1][1][0];
+      }
+      return options;
+    }
+
+    // current_folder is an 'ay' (null-terminated byte array).
+    function getCurrentFolder(options: Record<string, any>) {
+      const bytes = Buffer.from(options.current_folder);
+      const nul = bytes.indexOf(0);
+      return bytes.toString('utf8', 0, nul === -1 ? bytes.length : nul);
+    }
+
+    async function getSingleCall(method: string) {
+      const calls = (await getCalls()).filter((call) => call[1] === method);
+      expect(calls).to.have.lengthOf(1);
+      return calls[0];
+    }
+
+    describe('showSaveDialog', () => {
+      it('sends the defaultPath as current_folder and current_name', async () => {
+        const defaultDir = path.join(__dirname, 'fixtures');
+        const { canceled } = await dialog.showSaveDialog({
+          defaultPath: path.join(defaultDir, 'save-target.txt')
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('SaveFile'));
+        expect(options.current_name).to.equal('save-target.txt');
+        expect(getCurrentFolder(options)).to.equal(defaultDir);
+      });
+
+      // A directory-less defaultPath must not produce a relative
+      // current_folder ("."), which portal backends cannot resolve. See
+      // https://github.com/electron/electron/issues/52051.
+      it('sends an absolute current_folder for a directory-less defaultPath', async () => {
+        const { canceled } = await dialog.showSaveDialog({
+          defaultPath: 'test.jpeg'
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('SaveFile'));
+        expect(options.current_name).to.equal('test.jpeg');
+        const currentFolder = getCurrentFolder(options);
+        expect(currentFolder).to.satisfy(path.isAbsolute);
+        expect([app.getPath('downloads'), app.getPath('home')]).to.include(currentFolder);
+      });
+    });
+
+    describe('showOpenDialog', () => {
+      it('sends an absolute current_folder for a directory-less defaultPath', async () => {
+        const { canceled } = await dialog.showOpenDialog({
+          defaultPath: 'test.jpeg',
+          properties: ['openFile']
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('OpenFile'));
+        const currentFolder = getCurrentFolder(options);
+        expect(currentFolder).to.satisfy(path.isAbsolute);
+        expect([app.getPath('downloads'), app.getPath('home')]).to.include(currentFolder);
+      });
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/52051.

On Linux, `dialog.showSaveDialog()` / `dialog.showOpenDialog()` with a directory-less `defaultPath` forwarded the relative path unmodified to `SelectFile()`. Chromium's portal layer derives the chooser's starting folder from `DirName()`, so the xdg-desktop-portal `SaveFile`/`OpenFile` request carried `current_folder="."` — an unusable relative path. The dialog opens at a broken location (`file:.`), and stricter portal backends (e.g. LXQt) drop the suggested filename as well.

macOS and Windows both already special-case non-absolute paths with `IsAbsolute()` guards; Linux had no equivalent. This change anchors a relative `defaultPath` to the same default directory used when `defaultPath` is omitted (Downloads, falling back to home), so the portal receives an absolute `current_folder` plus the suggested filename. The GTK (non-portal) dialog benefits identically since the guard runs before `SelectFile()`.

#### Testing

The malformed request is only observable on the D-Bus wire, so this PR adds test infrastructure: `script/dbus_mock.py` now hosts a mock portal FileChooser (`script/dbusmock_xdg_file_chooser_portal.py`, a python-dbusmock template) on the fake session bus used by the Linux test suite. It records every `OpenFile`/`SaveFile` request and answers it with a "user cancelled" Response so dialogs resolve without interaction; new tests in `spec/api-dialog-spec.ts` assert on the exact options sent over D-Bus.

Verified against an unpatched nightly in the CI test image: the new directory-less `defaultPath` tests fail with `current_folder="."` (reproducing the issue exactly), the absolute-path test passes, and the rest of `api-dialog-spec.ts` plus `api-notification-dbus-spec.ts` are unaffected by the mock portal.

Note for reviewers: with the mock portal present, Linux CI dialogs now exercise Chromium's `SelectFileDialogLinuxPortal` (auto-cancelled by the mock) instead of falling back to leaked GTK dialogs.

Disclosure: I've relied heavily on Claude identifying the root cause and helping me fix the issue.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Fixed `dialog.showOpenDialog`/`dialog.showSaveDialog` opening at an unusable location on Linux when `defaultPath` is a bare filename without a directory.
