### PR TITLE
build: replace chalk with node:util styleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@types/temp": "^0.9.4",
     "@xmldom/xmldom": "^0.8.13",
     "buffer": "^6.0.3",
-    "chalk": "^4.1.0",
     "check-for-leaks": "^1.2.1",
     "events": "^3.2.0",
     "folder-hash": "^4.1.2",

--- a/script/gen-libc++-filenames.js
+++ b/script/gen-libc++-filenames.js
@@ -1,7 +1,6 @@
-const chalk = require('chalk');
-
 const fs = require('node:fs');
 const path = require('node:path');
+const { styleText } = require('node:util');
 
 const check = process.argv.includes('--check');
 
@@ -27,11 +26,11 @@ const diff = (array1, array2) => {
   const added = array1.filter((item) => !set2.has(item));
   const removed = array2.filter((item) => !set1.has(item));
 
-  console.log(chalk.white.bgGreen.bold('Files Added:'));
-  added.forEach((item) => console.log(chalk.green.bold(`+ ${item}`)));
+  console.log(styleText(['white', 'bgGreen', 'bold'], 'Files Added:'));
+  added.forEach((item) => console.log(styleText(['green', 'bold'], `+ ${item}`)));
 
-  console.log(chalk.white.bgRed.bold('Files Removed:'));
-  removed.forEach((item) => console.log(chalk.red.bold(`- ${item}`)));
+  console.log(styleText(['white', 'bgRed', 'bold'], 'Files Removed:'));
+  removed.forEach((item) => console.log(styleText(['red', 'bold'], `- ${item}`)));
 };
 
 const parseHeaders = (name, content) => {
@@ -70,9 +69,9 @@ ${prettyName}_licenses = [ "//third_party/${folder}/src/LICENSE.TXT" ]
     if (currentContent !== content) {
       const currentHeaders = parseHeaders(prettyName, currentContent);
 
-      console.error(chalk.bold(`${file} contents are not up to date:\n`));
+      console.error(styleText('bold', `${file} contents are not up to date:\n`));
       diff(currentHeaders, newHeaders);
-      console.error(chalk.bold(`\nRun node script/gen-libc++-filenames.js to regenerate ${file}`));
+      console.error(styleText('bold', `\nRun node script/gen-libc++-filenames.js to regenerate ${file}`));
       process.exit(1);
     }
   } else {

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,9 +1,8 @@
-const chalk = require('chalk');
-
 const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { styleText } = require('node:util');
 
 const ELECTRON_DIR = path.resolve(__dirname, '..', '..');
 const SRC_DIR = path.resolve(ELECTRON_DIR, '..');
@@ -11,8 +10,8 @@ const SRC_DIR = path.resolve(ELECTRON_DIR, '..');
 const CHROMIUM_VERSION_DEPS_REGEX = /chromium_version':\n +'(.+?)',/m;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const pass = chalk.green('✓');
-const fail = chalk.red('✗');
+const pass = styleText('green', '✓');
+const fail = styleText('red', '✗');
 
 function getElectronExec() {
   const OUT_DIR = getOutDir();

--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -2,7 +2,6 @@
 
 import { BlobServiceClient } from '@azure/storage-blob';
 import { Octokit } from '@octokit/rest';
-import * as chalk from 'chalk';
 import got from 'got';
 import { gte } from 'semver';
 import { track as trackTemp } from 'temp';
@@ -10,6 +9,7 @@ import { track as trackTemp } from 'temp';
 import { execSync, ExecSyncOptions } from 'node:child_process';
 import { statSync, createReadStream, writeFileSync, close } from 'node:fs';
 import { join } from 'node:path';
+import { styleText } from 'node:util';
 
 import { getElectronVersion } from '../lib/get-version';
 import { ELECTRON_DIR } from '../lib/utils';
@@ -19,8 +19,8 @@ import { ELECTRON_ORG, ELECTRON_REPO, ElectronReleaseRepo, NIGHTLY_REPO } from '
 
 const temp = trackTemp();
 
-const pass = chalk.green('✓');
-const fail = chalk.red('✗');
+const pass = styleText('green', '✓');
+const fail = styleText('red', '✗');
 
 const pkgVersion = `v${getElectronVersion()}`;
 

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -3,7 +3,6 @@
 const { ElectronVersions, Installer } = require('@electron/fiddle-core');
 
 const { DOMParser } = require('@xmldom/xmldom');
-const chalk = require('chalk');
 const { hashElement } = require('folder-hash');
 const minimist = require('minimist');
 
@@ -12,11 +11,12 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { styleText } = require('node:util');
 
 const unknownFlags = [];
 
-const pass = chalk.green('✓');
-const fail = chalk.red('✗');
+const pass = styleText('green', '✓');
+const fail = styleText('red', '✗');
 
 const FAILURE_STATUS_KEY = 'Electron_Spec_Runner_Failures';
 
@@ -86,7 +86,7 @@ async function main() {
     }
 
     const versionString = `v${args.electronVersion}`;
-    console.log(`Running against Electron ${chalk.green(versionString)}`);
+    console.log(`Running against Electron ${styleText('green', versionString)}`);
   }
 
   const [lastSpecHash, lastSpecInstallHash] = loadLastSpecHash();

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,7 +387,6 @@ __metadata:
     "@types/temp": "npm:^0.9.4"
     "@xmldom/xmldom": "npm:^0.8.13"
     buffer: "npm:^6.0.3"
-    chalk: "npm:^4.1.0"
     check-for-leaks: "npm:^1.2.1"
     events: "npm:^3.2.0"
     folder-hash: "npm:^4.1.2"


### PR DESCRIPTION
#### Description of Change

Removes the chalk devDependency in favor of the built-in styleText API from `node:util`, which is available in all Node versions used by the project's scripts and CI.

Closes https://github.com/electron/electron/pull/52225/

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
