### PR TITLE
fix: restore SelfKeepAlive in Menu

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -282,9 +282,11 @@ std::u16string Menu::GetAcceleratorTextAtForTesting(int index) const {
 
 void Menu::OnMenuWillClose() {
   Emit("menu-will-close");
+  keep_alive_.Clear();
 }
 
 void Menu::OnMenuWillShow() {
+  keep_alive_ = this;
   Emit("menu-will-show");
 }
 

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -12,6 +12,7 @@
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/self_keep_alive.h"
 #include "ui/base/mojom/menu_source_type.mojom-forward.h"
 #include "v8/include/cppgc/member.h"
 
@@ -133,6 +134,9 @@ class Menu : public gin::Wrappable<Menu>,
 
   std::unique_ptr<ElectronMenuModel> model_;
   cppgc::Member<Menu> parent_;
+
+  // Keep active menus alive even if they've been replaced.
+  gin_helper::SelfKeepAlive<Menu> keep_alive_{nullptr};
 };
 
 }  // namespace electron::api


### PR DESCRIPTION
#### Description of Change

This fixes #52247 by ensuring that a `Menu` instance will stay alive as long as the menu is open, even if its owner has cleared or replaced it.

It's a (very) partial revert of 9be03cbe54697, which removed this `keep_alive_` property because it was thought to be unnecessary.

Since 9be03cbe54697 didn't need to change any tests I'm assuming there are none for this aspect of the system, but I'd definitely be open to suggestions about where they could be added.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] `npm test` passes — there were a handful of unrelated-looking failures on my machine
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crash triggered by replacing an open application menu.