### PR TITLE
fix: deflake crash spec and fullscreen startup

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -194,11 +194,25 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   options.Get(options::kFullScreenable, &fullscreenable);
   SetFullScreenable(fullscreenable);
 
+  bool resizable = true;
+  const bool has_resizable = options.Get(options::kResizable, &resizable);
+
+#if BUILDFLAG(IS_WIN)
+  if (fullscreen && has_resizable && !resizable)
+    SetResizable(resizable);
+#endif
+
   if (fullscreen)
     SetFullScreen(true);
 
-  if (bool val; options.Get(options::kResizable, &val))
-    SetResizable(val);
+  if (has_resizable) {
+#if !BUILDFLAG(IS_WIN)
+    SetResizable(resizable);
+#else
+    if (!fullscreen || resizable)
+      SetResizable(resizable);
+#endif
+  }
 
   if (bool val; options.Get(options::kSkipTaskbar, &val))
     SetSkipTaskbar(val);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -2375,6 +2375,19 @@ describe('BrowserWindow module', () => {
             expect(w.fullScreen).to.be.true();
           });
 
+          it('fills the display when fullscreen and non-resizable', () => {
+            const display = screen.getPrimaryDisplay();
+            const w = new BrowserWindow({
+              frame: false,
+              resizable: false,
+              fullscreen: true,
+              width: 0
+            });
+
+            expect(w.fullScreen).to.be.true();
+            expectBoundsEqual(w.getBounds(), display.bounds);
+          });
+
           it('can be changed', () => {
             w.fullScreen = false;
             expect(w.fullScreen).to.be.false();

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 import * as cp from 'node:child_process';
-import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -62,6 +61,22 @@ const shouldRunCase = (crashCase: string) => {
   }
 };
 
+const waitForChildExit = (child: cp.ChildProcessWithoutNullStreams) => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    child.once('exit', () => {
+      resolve();
+    });
+
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+    }
+  });
+};
+
 describe('crash cases', () => {
   afterEach(async () => {
     // A wedged crash-case fixture child can ignore the default SIGTERM and
@@ -70,8 +85,7 @@ describe('crash cases', () => {
     // shared `children` array (whose length only drops via that same handler).
     await Promise.all(
       children.map((child) => {
-        if (child.exitCode !== null || child.signalCode !== null) return null;
-        const exited = once(child, 'exit');
+        const exited = waitForChildExit(child);
         child.kill('SIGKILL');
         return exited;
       })


### PR DESCRIPTION
## Summary

This PR fixes two Windows-related issues:

- Adjusts fullscreen startup sizing for non-resizable frameless windows.
- Improves crash-spec teardown cleanup to avoid intermittent failures.

The implementation changes are limited to the affected code paths and the corresponding tests.

## Testing

- Built Electron locally.
- Ran the affected tests on Windows.
- Verified that the updated behavior is correct.

## Release Notes

Notes: Fixed Windows fullscreen startup sizing for non-resizable frameless windows and improved crash-spec teardown cleanup.