### PR TITLE
fix: don't show empty autofill popup

### DIFF
--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -34,8 +34,11 @@ void AutofillDriver::ShowAutofillPopup(
     const gfx::RectF& bounds,
     const std::vector<std::u16string>& values,
     const std::vector<std::u16string>& labels) {
-  if (values.empty()) {
-    autofill_popup_->Hide();
+  // The renderer only requests the popup for a non-empty suggestion list,
+  // and always sends one label per value. Don't let a compromised renderer
+  // create native popup windows for empty or malformed lists.
+  if (values.empty() || values.size() != labels.size()) {
+    HideAutofillPopup();
     return;
   }
 

--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -34,6 +34,11 @@ void AutofillDriver::ShowAutofillPopup(
     const gfx::RectF& bounds,
     const std::vector<std::u16string>& values,
     const std::vector<std::u16string>& labels) {
+  if (values.empty()) {
+    autofill_popup_->Hide();
+    return;
+  }
+
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
   auto* web_contents = api::WebContents::From(

--- a/shell/renderer/electron_autofill_agent.cc
+++ b/shell/renderer/electron_autofill_agent.cc
@@ -171,6 +171,9 @@ void AutofillAgent::ShowSuggestions(const blink::WebFormControlElement& element,
     GetDataListSuggestions(input_element, &data_list_values, &data_list_labels);
   }
 
+  // With no suggestions there is nothing to show; hide any existing popup
+  // instead of asking the browser process to rebuild the native popup
+  // window for an empty list.
   if (data_list_values.empty()) {
     HidePopup();
     return;

--- a/shell/renderer/electron_autofill_agent.cc
+++ b/shell/renderer/electron_autofill_agent.cc
@@ -171,6 +171,11 @@ void AutofillAgent::ShowSuggestions(const blink::WebFormControlElement& element,
     GetDataListSuggestions(input_element, &data_list_values, &data_list_labels);
   }
 
+  if (data_list_values.empty()) {
+    HidePopup();
+    return;
+  }
+
   ShowPopup(element, data_list_values, data_list_labels);
 }
 


### PR DESCRIPTION
#### Description of Change

Resolves #52260. This was written with the help of GPT-5.5 with the Codex CLI. Not sure if this needs release notes as it's unclear how impactful this bug has been.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed unnecessary autofill popup creation for fields without datalist suggestions, which could cause input latency on macOS.
