### PR TITLE
feat: add fontType option to MenuItem on macOS

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -34,7 +34,7 @@ See [`Menu`](menu.md) for examples.
   * `accessibilityLabel` string (optional) _macOS_
   * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
-  * `fontType` string (optional) _macOS_ - The font family variant to render the label with, can be `monospaced` or `monospacedDigit`. When left blank, the label uses the default menu font.
+  * `fontType` string (optional) _macOS_ - The system font variant to render the label with. Can be `monospaced` or `monospacedDigit`. When omitted, the label uses the default menu font. See [`menuItem.fontType`](#menuitemfonttype-macos).
   * `accelerator` string (optional) - An [Accelerator](../tutorial/keyboard-shortcuts.md#accelerators) string.
   * `icon` ([NativeImage](native-image.md) | string) (optional) - Can be a
     [NativeImage](native-image.md) or the file path of an icon.
@@ -148,8 +148,16 @@ A `string` indicating the item's hover text.
 
 #### `menuItem.fontType` _macOS_
 
-A `string` indicating the font family variant the item's label is rendered
-with. Can be `monospaced` or `monospacedDigit`.
+A `string` (optional) indicating the system font variant the item's label is rendered with. Can be
+`monospaced` or `monospacedDigit`. `monospacedDigit` only gives digits a fixed width, which keeps
+columns of numbers (such as times) aligned while otherwise matching the default menu font.
+
+This property can be dynamically changed; setting it to `undefined` restores the default menu font.
+
+> [!NOTE]
+> On macOS 14, an item with a `fontType` does not display its `sublabel`. Both are shown on
+> macOS 15 and later. See Apple's [`NSMenuItem.subtitle`](https://developer.apple.com/documentation/appkit/nsmenuitem/subtitle)
+> documentation.
 
 #### `menuItem.enabled`
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -34,6 +34,7 @@ See [`Menu`](menu.md) for examples.
   * `accessibilityLabel` string (optional) _macOS_
   * `sublabel` string (optional) _macOS_ - Available in macOS >= 14.4
   * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
+  * `fontType` string (optional) _macOS_ - The font family variant to render the label with, can be `monospaced` or `monospacedDigit`. When left blank, the label uses the default menu font.
   * `accelerator` string (optional) - An [Accelerator](../tutorial/keyboard-shortcuts.md#accelerators) string.
   * `icon` ([NativeImage](native-image.md) | string) (optional) - Can be a
     [NativeImage](native-image.md) or the file path of an icon.
@@ -144,6 +145,11 @@ This property can be dynamically changed.
 #### `menuItem.toolTip` _macOS_
 
 A `string` indicating the item's hover text.
+
+#### `menuItem.fontType` _macOS_
+
+A `string` indicating the font family variant the item's label is rendered
+with. Can be `monospaced` or `monospacedDigit`.
 
 #### `menuItem.enabled`
 

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -32,6 +32,15 @@ const validateBadge = (badge: any) => {
   }
 };
 
+const fontTypes = ['monospaced', 'monospacedDigit'];
+
+const validateFontType = (fontType: any) => {
+  if (fontType == null) return;
+  if (!fontTypes.includes(fontType)) {
+    throw new TypeError(`Invalid fontType '${fontType}': must be one of ${fontTypes.join(', ')}`);
+  }
+};
+
 const MenuItem = function (this: any, options: any) {
   // Preserve extra fields specified by user
   for (const key in options) {
@@ -61,12 +70,27 @@ const MenuItem = function (this: any, options: any) {
   this.overrideProperty('accessibilityLabel', '');
   this.overrideProperty('sublabel', '');
   this.overrideProperty('toolTip', '');
-  this.overrideProperty('fontType', '');
   this.overrideProperty('enabled', true);
   this.overrideProperty('visible', true);
   this.overrideProperty('checked', false);
   this.overrideProperty('acceleratorWorksWhenHidden', true);
   this.overrideProperty('registerAccelerator', roles.shouldRegisterAccelerator(this.role));
+
+  validateFontType(options.fontType);
+  let fontTypeValue = options.fontType ?? undefined;
+  Object.defineProperty(this, 'fontType', {
+    get: () => fontTypeValue,
+    set: (newValue) => {
+      validateFontType(newValue);
+      fontTypeValue = newValue ?? undefined;
+      // Push the change to the native item if this item is already in a menu.
+      if (this.menu) {
+        const index = this.menu.getIndexOfCommandId(this.commandId);
+        if (index !== -1) this.menu.setFontType(index, fontTypeValue ?? '');
+      }
+    },
+    enumerable: true
+  });
 
   if (process.platform === 'darwin') {
     validateBadge(options.badge);

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -61,6 +61,7 @@ const MenuItem = function (this: any, options: any) {
   this.overrideProperty('accessibilityLabel', '');
   this.overrideProperty('sublabel', '');
   this.overrideProperty('toolTip', '');
+  this.overrideProperty('fontType', '');
   this.overrideProperty('enabled', true);
   this.overrideProperty('visible', true);
   this.overrideProperty('checked', false);

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -175,6 +175,7 @@ Menu.prototype.insert = function (pos, item) {
 
   // set item properties
   if (item.toolTip) this.setToolTip(pos, item.toolTip);
+  if (item.fontType) this.setFontType(pos, item.fontType);
   if (item.icon) this.setIcon(pos, item.icon);
   if (item.role) this.setRole(pos, item.role);
   if (item.type === 'palette' || item.type === 'header') {

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -170,6 +170,10 @@ Menu.prototype.insert = function (pos, item) {
     throw new RangeError(`Position ${pos} cannot be greater than the total MenuItem count`);
   }
 
+  if (item.fontType && item.fontType !== 'monospaced' && item.fontType !== 'monospacedDigit') {
+    throw new TypeError("fontType must be one of 'monospaced' or 'monospacedDigit'");
+  }
+
   // insert item depending on its type
   insertItemByType.call(this, item, pos);
 

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -170,10 +170,6 @@ Menu.prototype.insert = function (pos, item) {
     throw new RangeError(`Position ${pos} cannot be greater than the total MenuItem count`);
   }
 
-  if (item.fontType && item.fontType !== 'monospaced' && item.fontType !== 'monospacedDigit') {
-    throw new TypeError("fontType must be one of 'monospaced' or 'monospacedDigit'");
-  }
-
   // insert item depending on its type
   insertItemByType.call(this, item, pos);
 

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -271,6 +271,10 @@ void Menu::SetToolTip(int index, const std::u16string& toolTip) {
   model_->SetToolTip(index, toolTip);
 }
 
+void Menu::SetFontType(int index, const std::u16string& fontType) {
+  model_->SetFontType(index, fontType);
+}
+
 void Menu::SetRole(int index, const std::u16string& role) {
   model_->SetRole(index, role);
 }
@@ -324,6 +328,7 @@ void Menu::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("insertSubMenu", &Menu::InsertSubMenuAt)
       .SetMethod("setIcon", &Menu::SetIcon)
       .SetMethod("setToolTip", &Menu::SetToolTip)
+      .SetMethod("setFontType", &Menu::SetFontType)
       .SetMethod("setRole", &Menu::SetRole)
       .SetMethod("setCustomType", &Menu::SetCustomType)
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -127,6 +127,7 @@ class Menu : public gin::Wrappable<Menu>,
   void SetIcon(int index, const gfx::Image& image);
   void SetSublabel(int index, const std::u16string& sublabel);
   void SetToolTip(int index, const std::u16string& toolTip);
+  void SetFontType(int index, const std::u16string& fontType);
   void SetRole(int index, const std::u16string& role);
   void SetCustomType(int index, const std::u16string& customType);
 #if BUILDFLAG(IS_MAC)

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -347,6 +347,30 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   return item;
 }
 
+// Renders the item's label via attributedTitle with the requested system font
+// variant, if any. Section headers are excluded, they carry their own distinct
+// system styling.
+- (void)applyFontTypeToMenuItem:(NSMenuItem*)item
+                      fromModel:(electron::ElectronMenuModel*)model
+                        atIndex:(NSInteger)index {
+  std::u16string fontType = model->GetFontTypeAt(index);
+  if (fontType != u"monospaced" && fontType != u"monospacedDigit")
+    return;
+  if (model->GetCustomTypeAt(index) == u"header")
+    return;
+
+  CGFloat font_size = [[NSFont menuFontOfSize:0] pointSize];
+  NSFont* font =
+      fontType == u"monospaced"
+          ? [NSFont monospacedSystemFontOfSize:font_size
+                                        weight:NSFontWeightRegular]
+          : [NSFont monospacedDigitSystemFontOfSize:font_size
+                                             weight:NSFontWeightRegular];
+  item.attributedTitle =
+      [[NSAttributedString alloc] initWithString:item.title
+                                      attributes:@{NSFontAttributeName : font}];
+}
+
 - (NSMenuItem*)makeMenuItemForIndex:(NSInteger)index
                           fromModel:(electron::ElectronMenuModel*)model {
   std::u16string label16 = model->GetLabelAt(index);
@@ -396,22 +420,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
       item.badge = CreateBadge(badge);
   }
 
-  // Render the label with a system font variant, if specified. Section
-  // headers are excluded, they carry their own distinct system styling.
-  std::u16string fontType = model->GetFontTypeAt(index);
-  if (customType != u"header" &&
-      (fontType == u"monospaced" || fontType == u"monospacedDigit")) {
-    CGFloat font_size = [[NSFont menuFontOfSize:0] pointSize];
-    NSFont* font =
-        fontType == u"monospaced"
-            ? [NSFont monospacedSystemFontOfSize:font_size
-                                          weight:NSFontWeightRegular]
-            : [NSFont monospacedDigitSystemFontOfSize:font_size
-                                               weight:NSFontWeightRegular];
-    item.attributedTitle = [[NSAttributedString alloc]
-        initWithString:item.title
-            attributes:@{NSFontAttributeName : font}];
-  }
+  [self applyFontTypeToMenuItem:item fromModel:model atIndex:index];
 
   if (role == u"services") {
     std::u16string title = u"Services";
@@ -559,6 +568,10 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   std::u16string accessibility_label16 = model->GetAccessibilityLabelAt(index);
   NSString* label = l10n_util::FixUpWindowsStyleLabel(label16);
   item.title = label;
+  // A set attributedTitle takes display precedence over title, so re-render
+  // it with the updated label.
+  if (item.attributedTitle)
+    [self applyFontTypeToMenuItem:item fromModel:model atIndex:index];
   if (!accessibility_label16.empty()) {
     NSString* accessibility_label =
         base::SysUTF16ToNSString(accessibility_label16);

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -347,28 +347,35 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   return item;
 }
 
-// Renders the item's label via attributedTitle with the requested system font
-// variant, if any. Section headers are excluded, they carry their own distinct
-// system styling.
+// Renders the item's label with the requested system font variant, if any,
+// by setting attributedTitle from the item's current title. attributedTitle
+// takes display precedence over title, so it is explicitly cleared when no
+// variant is requested; that restores plain title rendering (and, on
+// macOS 14, the subtitle, which AppKit hides while attributedTitle is set).
+// Section headers are excluded since they carry their own system styling.
 - (void)applyFontTypeToMenuItem:(NSMenuItem*)item
                       fromModel:(electron::ElectronMenuModel*)model
                         atIndex:(NSInteger)index {
-  std::u16string fontType = model->GetFontTypeAt(index);
-  if (fontType != u"monospaced" && fontType != u"monospacedDigit")
-    return;
-  if (model->GetCustomTypeAt(index) == u"header")
-    return;
+  NSFont* font = nil;
+  if (model->GetCustomTypeAt(index) != u"header") {
+    const std::u16string fontType = model->GetFontTypeAt(index);
+    const CGFloat font_size = [NSFont menuFontOfSize:0].pointSize;
+    if (fontType == u"monospaced") {
+      font = [NSFont monospacedSystemFontOfSize:font_size
+                                         weight:NSFontWeightRegular];
+    } else if (fontType == u"monospacedDigit") {
+      font = [NSFont monospacedDigitSystemFontOfSize:font_size
+                                              weight:NSFontWeightRegular];
+    }
+  }
 
-  CGFloat font_size = [[NSFont menuFontOfSize:0] pointSize];
-  NSFont* font =
-      fontType == u"monospaced"
-          ? [NSFont monospacedSystemFontOfSize:font_size
-                                        weight:NSFontWeightRegular]
-          : [NSFont monospacedDigitSystemFontOfSize:font_size
-                                             weight:NSFontWeightRegular];
-  item.attributedTitle =
-      [[NSAttributedString alloc] initWithString:item.title
-                                      attributes:@{NSFontAttributeName : font}];
+  if (font) {
+    item.attributedTitle = [[NSAttributedString alloc]
+        initWithString:item.title
+            attributes:@{NSFontAttributeName : font}];
+  } else {
+    item.attributedTitle = nil;
+  }
 }
 
 - (NSMenuItem*)makeMenuItemForIndex:(NSInteger)index
@@ -568,10 +575,9 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   std::u16string accessibility_label16 = model->GetAccessibilityLabelAt(index);
   NSString* label = l10n_util::FixUpWindowsStyleLabel(label16);
   item.title = label;
-  // A set attributedTitle takes display precedence over title, so re-render
-  // it with the updated label.
-  if (item.attributedTitle)
-    [self applyFontTypeToMenuItem:item fromModel:model atIndex:index];
+  // Re-apply (or clear) the font variant so attributedTitle tracks both the
+  // updated label and any change to the item's fontType.
+  [self applyFontTypeToMenuItem:item fromModel:model atIndex:index];
   if (!accessibility_label16.empty()) {
     NSString* accessibility_label =
         base::SysUTF16ToNSString(accessibility_label16);

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -396,6 +396,23 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
       item.badge = CreateBadge(badge);
   }
 
+  // Render the label with a system font variant, if specified. Section
+  // headers are excluded, they carry their own distinct system styling.
+  std::u16string fontType = model->GetFontTypeAt(index);
+  if (customType != u"header" &&
+      (fontType == u"monospaced" || fontType == u"monospacedDigit")) {
+    CGFloat font_size = [[NSFont menuFontOfSize:0] pointSize];
+    NSFont* font =
+        fontType == u"monospaced"
+            ? [NSFont monospacedSystemFontOfSize:font_size
+                                          weight:NSFontWeightRegular]
+            : [NSFont monospacedDigitSystemFontOfSize:font_size
+                                               weight:NSFontWeightRegular];
+    item.attributedTitle = [[NSAttributedString alloc]
+        initWithString:item.title
+            attributes:@{NSFontAttributeName : font}];
+  }
+
   if (role == u"services") {
     std::u16string title = u"Services";
     NSString* sub_label = l10n_util::FixUpWindowsStyleLabel(title);

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -46,6 +46,18 @@ std::u16string ElectronMenuModel::GetToolTipAt(size_t index) {
   return iter == std::end(toolTips_) ? std::u16string() : iter->second;
 }
 
+void ElectronMenuModel::SetFontType(size_t index,
+                                    const std::u16string& fontType) {
+  int command_id = GetCommandIdAt(index);
+  fontTypes_[command_id] = fontType;
+}
+
+std::u16string ElectronMenuModel::GetFontTypeAt(size_t index) {
+  const int command_id = GetCommandIdAt(index);
+  const auto iter = fontTypes_.find(command_id);
+  return iter == std::end(fontTypes_) ? std::u16string() : iter->second;
+}
+
 void ElectronMenuModel::SetCustomType(size_t index,
                                       const std::u16string& customType) {
   int command_id = GetCommandIdAt(index);

--- a/shell/browser/ui/electron_menu_model.cc
+++ b/shell/browser/ui/electron_menu_model.cc
@@ -48,8 +48,11 @@ std::u16string ElectronMenuModel::GetToolTipAt(size_t index) {
 
 void ElectronMenuModel::SetFontType(size_t index,
                                     const std::u16string& fontType) {
-  int command_id = GetCommandIdAt(index);
-  fontTypes_[command_id] = fontType;
+  const int command_id = GetCommandIdAt(index);
+  if (fontType.empty())
+    fontTypes_.erase(command_id);
+  else
+    fontTypes_[command_id] = fontType;
 }
 
 std::u16string ElectronMenuModel::GetFontTypeAt(size_t index) {

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -100,6 +100,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
 
   void SetToolTip(size_t index, const std::u16string& toolTip);
   std::u16string GetToolTipAt(size_t index);
+  void SetFontType(size_t index, const std::u16string& fontType);
+  std::u16string GetFontTypeAt(size_t index);
   void SetCustomType(size_t index, const std::u16string& customType);
   std::u16string GetCustomTypeAt(size_t index);
   std::u16string GetAccessibilityLabelAt(size_t index) const;
@@ -146,8 +148,9 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   base::flat_map<int, Badge> badges_;  // command id -> badge
 #endif
 
-  base::flat_map<int, std::u16string> toolTips_;  // command id -> tooltip
-  base::flat_map<int, std::u16string> roles_;     // command id -> role
+  base::flat_map<int, std::u16string> toolTips_;   // command id -> tooltip
+  base::flat_map<int, std::u16string> fontTypes_;  // command id -> font type
+  base::flat_map<int, std::u16string> roles_;      // command id -> role
   base::flat_map<int, std::u16string>
       customTypes_;  // command id -> custom type
   base::ObserverList<Observer> observers_;

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -69,6 +69,7 @@ describe('MenuItems', () => {
       expect(item).to.have.property('type').that.is.a('string').equal('normal');
       expect(item).to.have.property('commandId').that.is.a('number');
       expect(item).to.have.property('toolTip').that.is.a('string');
+      expect(item).to.have.property('fontType').that.is.a('string');
       expect(item).to.have.property('role').that.is.a('string');
       expect(item).to.have.property('icon');
     });

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -74,6 +74,14 @@ describe('MenuItems', () => {
       expect(item).to.have.property('icon');
     });
 
+    it('should throw when fontType is invalid without modifying the menu', () => {
+      const menu = new Menu();
+      expect(() => {
+        menu.append(new MenuItem({ label: '09:45', fontType: 'bold' as any }));
+      }).to.throw("fontType must be one of 'monospaced' or 'monospacedDigit'");
+      expect(menu.getItemCount()).to.equal(0);
+    });
+
     it('should have a default accelerator for certain roles', () => {
       const items: Record<string, Electron.MenuItem['accelerator']> = {
         undo: 'CommandOrControl+Z',

--- a/spec/api-menu-item-spec.ts
+++ b/spec/api-menu-item-spec.ts
@@ -69,17 +69,8 @@ describe('MenuItems', () => {
       expect(item).to.have.property('type').that.is.a('string').equal('normal');
       expect(item).to.have.property('commandId').that.is.a('number');
       expect(item).to.have.property('toolTip').that.is.a('string');
-      expect(item).to.have.property('fontType').that.is.a('string');
       expect(item).to.have.property('role').that.is.a('string');
       expect(item).to.have.property('icon');
-    });
-
-    it('should throw when fontType is invalid without modifying the menu', () => {
-      const menu = new Menu();
-      expect(() => {
-        menu.append(new MenuItem({ label: '09:45', fontType: 'bold' as any }));
-      }).to.throw("fontType must be one of 'monospaced' or 'monospacedDigit'");
-      expect(menu.getItemCount()).to.equal(0);
     });
 
     it('should have a default accelerator for certain roles', () => {
@@ -856,6 +847,49 @@ describe('MenuItems', () => {
         item.badge = { type: 'bogus' } as any;
       }).to.throw(/Invalid badge type/);
       expect(item.badge).to.be.undefined();
+    });
+  });
+
+  describe('MenuItem.fontType', () => {
+    it('should be undefined when not set', () => {
+      const item = new MenuItem({ label: 'test' });
+      expect(item.fontType).to.be.undefined();
+    });
+
+    it('should set fontType from constructor options', () => {
+      const monospaced = new MenuItem({ label: '09:45', fontType: 'monospaced' });
+      const monospacedDigit = new MenuItem({ label: '11:15', fontType: 'monospacedDigit' });
+      expect(monospaced.fontType).to.equal('monospaced');
+      expect(monospacedDigit.fontType).to.equal('monospacedDigit');
+    });
+
+    it('should set fontType on items added to a menu', () => {
+      const menu = Menu.buildFromTemplate([{ label: '09:45', fontType: 'monospacedDigit' }]);
+      expect(menu.items[0].fontType).to.equal('monospacedDigit');
+    });
+
+    it('should allow dynamic fontType updates', () => {
+      const item = new MenuItem({ label: '09:45', fontType: 'monospaced' });
+      item.fontType = 'monospacedDigit';
+      expect(item.fontType).to.equal('monospacedDigit');
+
+      const menu = Menu.buildFromTemplate([{ label: '11:15' }]);
+      menu.items[0].fontType = 'monospacedDigit';
+      expect(menu.items[0].fontType).to.equal('monospacedDigit');
+      menu.items[0].fontType = undefined;
+      expect(menu.items[0].fontType).to.be.undefined();
+    });
+
+    it('should throw on an invalid fontType', () => {
+      expect(() => new MenuItem({ label: '09:45', fontType: 'bold' as any })).to.throw(/Invalid fontType 'bold'/);
+      expect(() => new MenuItem({ label: '09:45', fontType: 0 as any })).to.throw(/Invalid fontType/);
+      expect(() => new MenuItem({ label: '09:45', fontType: false as any })).to.throw(/Invalid fontType/);
+
+      const menu = Menu.buildFromTemplate([{ label: '11:15', fontType: 'monospaced' }]);
+      expect(() => {
+        menu.items[0].fontType = 'bold' as any;
+      }).to.throw(/Invalid fontType 'bold'/);
+      expect(menu.items[0].fontType).to.equal('monospaced');
     });
   });
 });

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -207,6 +207,7 @@ declare namespace Electron {
     closePopupAt(id: number): void;
     setSublabel(index: number, label: string): void;
     setToolTip(index: number, tooltip: string): void;
+    setFontType(index: number, fontType: string): void;
     setIcon(index: number, image: string | NativeImage): void;
     setRole(index: number, role: string): void;
     setCustomType(index: number, customType: string): void;


### PR DESCRIPTION
#### Description of Change

Closes #52263.

On macOS, menu item labels are rendered with the system menu font, whose digits have proportional widths — so a menu showing a column of times comes out jagged (`11:15` renders narrower than `09:45`). There is currently no way around this from Electron.

This PR adds a `fontType` option to `MenuItem`, macOS-only like `toolTip`, accepting the same two values as the `fontType` option `tray.setTitle()` gained in #22363:

```js
new MenuItem({
  label: "11:15  Doctor's appointment",
  fontType: 'monospacedDigit'
})
```

When set, `ElectronMenuController` renders the label via `NSMenuItem.attributedTitle` with the corresponding system font variant (`monospacedSystemFontOfSize:` / `monospacedDigitSystemFontOfSize:`) at the standard menu font size. The `monospacedDigit` variant is otherwise identical to the default menu font, so labels align without looking out of place.

<img width="752" height="450" alt="Screenshot 2026-07-06 at 11 30 36 AM" src="https://github.com/user-attachments/assets/34977fc6-76bc-45fb-b571-559eca3e13f8" />

Just for comparison, this already exists:
<img width="811" height="501" alt="Screenshot 2026-07-06 at 11 30 40 AM" src="https://github.com/user-attachments/assets/417ea666-dcd4-45f3-9f0e-3203ce89f105" />

Implementation notes:

- Mirrors the per-item `toolTip` plumbing: a command-id map on `ElectronMenuModel`, a `setFontType` binding on the `Menu` wrapper, and per-item application in `electron_menu_controller.mm`.
- Since a set `attributedTitle` takes display precedence over `title`, the controller re-renders it in the `applyStateToMenuItem:` refresh path — dynamic label updates (the clock use case) stay visible.
- Invalid values throw a `TypeError`, matching `tray.setTitle()` behavior; validation runs before the native insert so a throwing `insert()`/`append()` leaves the menu untouched.
- Section headers (`type: 'header'`) are excluded — they carry their own distinct system styling.
- Based on the patch attached to #52263; this PR adds value validation, dynamic-label handling, internal typings, and specs on top, and was built and verified locally.

Disclosure: I've relied pretty heavily on Claude. The code looks good to me and I've obviously verified it locally.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a `fontType` option to `MenuItem`, allowing menu item labels on macOS to be rendered with the system monospaced or monospaced-digit font variants.
