### PR TITLE
fix: don't create an autofill popup window for empty suggestion lists

### DIFF
--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -34,6 +34,14 @@ void AutofillDriver::ShowAutofillPopup(
     const gfx::RectF& bounds,
     const std::vector<std::u16string>& values,
     const std::vector<std::u16string>& labels) {
+  // The renderer only requests the popup for a non-empty suggestion list,
+  // and always sends one label per value. Don't let a compromised renderer
+  // create native popup windows for empty or malformed lists.
+  if (values.empty() || values.size() != labels.size()) {
+    HideAutofillPopup();
+    return;
+  }
+
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
   auto* web_contents = api::WebContents::From(

--- a/shell/renderer/electron_autofill_agent.cc
+++ b/shell/renderer/electron_autofill_agent.cc
@@ -171,6 +171,14 @@ void AutofillAgent::ShowSuggestions(const blink::WebFormControlElement& element,
     GetDataListSuggestions(input_element, &data_list_values, &data_list_labels);
   }
 
+  // With no suggestions there is nothing to show; hide any existing popup
+  // instead of asking the browser process to rebuild the native popup
+  // window for an empty list.
+  if (data_list_values.empty()) {
+    HidePopup();
+    return;
+  }
+
   ShowPopup(element, data_list_values, data_list_labels);
 }
 


### PR DESCRIPTION
#### Description of Change

Closes #52260.

Every keystroke that changes the value of a focused text control with the caret at the end sends `ShowAutofillPopup` to the browser process — even when there are zero datalist suggestions (always the case for `<textarea>` and any `<input>` without a `list`). The browser then destroys and recreates the native popup window before discovering there is nothing to show. On macOS 26 each window-ordering operation blocks `CrBrowserMain` in a synchronous WindowServer transaction for 50–350 ms, janking every window of the app while typing; CJK IME composition hits this on every keystroke.

- renderer: hide the popup instead of requesting one when there are no datalist suggestions
- browser: drop `ShowAutofillPopup` messages with empty or mismatched `values`/`labels`, so a compromised renderer can't force per-message window churn or crash the browser via out-of-range label access in `label_at()`

Measured with the repro from #52260 (50 synthetic IME composition updates into a suggestion-less `<textarea>`, macOS 26.5.2, arm64):

| | main-thread stalls >50 ms | NSWindow constructions while typing |
|---|---|---|
| before | 1–37 stalls, up to 4.9 s total | present (18 hits in a 4 s sample) |
| after | 0 | 0 |

Datalist popups with real suggestions are unaffected: keyboard selection (ArrowDown+Enter) still completes the value, and a prefix that filters all options out hides the popup.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Fixed a performance issue where every keystroke in a text field created and destroyed a native autofill popup window, causing app-wide input latency on macOS 26 (worst during CJK IME composition).
