### PR TITLE
fix: honor webContents.print option names

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -453,6 +453,8 @@ constexpr char kMediaSize[] = "mediaSize";
 constexpr char kDpi[] = "dpi";
 constexpr char kMarginType[] = "marginType";
 constexpr char kMargins[] = "margins";
+constexpr char kPrintBackground[] = "printBackground";
+constexpr char kDuplexMode[] = "duplexMode";
 
 constexpr char kDpiHorizontal[] = "horizontal";
 constexpr char kDpiVertical[] = "vertical";
@@ -3460,7 +3462,10 @@ void WebContents::Print(gin::Arguments* const args) {
 
   settings.Set(
       printing::kSettingShouldPrintBackgrounds,
-      options.ValueOrDefault(printing::kSettingShouldPrintBackgrounds, false));
+      options.ValueOrDefault(
+          kPrintBackground,
+          options.ValueOrDefault(printing::kSettingShouldPrintBackgrounds,
+                                 false)));
 
   // Set custom margin settings
   auto margins = gin_helper::Dictionary::CreateEmpty(isolate);
@@ -3565,7 +3570,9 @@ void WebContents::Print(gin::Arguments* const args) {
 
   // Duplex type user wants to use.
   const auto duplex_mode = options.ValueOrDefault(
-      printing::kSettingDuplexMode, printing::mojom::DuplexMode::kSimplex);
+      kDuplexMode,
+      options.ValueOrDefault(printing::kSettingDuplexMode,
+                             printing::mojom::DuplexMode::kUnknownDuplexMode));
   settings.Set(printing::kSettingDuplexMode, static_cast<int>(duplex_mode));
 
   // Set custom media size if passed. If none is passed, the media size

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3460,12 +3460,11 @@ void WebContents::Print(gin::Arguments* const args) {
   // Set optional silent printing.
   settings.Set(kSilent, options.ValueOrDefault(kSilent, false));
 
-  settings.Set(
-      printing::kSettingShouldPrintBackgrounds,
-      options.ValueOrDefault(
-          kPrintBackground,
-          options.ValueOrDefault(printing::kSettingShouldPrintBackgrounds,
-                                 false)));
+  settings.Set(printing::kSettingShouldPrintBackgrounds,
+               options.ValueOrDefault(
+                   kPrintBackground,
+                   options.ValueOrDefault(
+                       printing::kSettingShouldPrintBackgrounds, false)));
 
   // Set custom margin settings
   auto margins = gin_helper::Dictionary::CreateEmpty(isolate);


### PR DESCRIPTION
#### Description of Change

Closes #52048.

`webContents.print()` receives public API option names from JS, but the native print settings parser was reading two options through Chromium internal print setting keys:

- `printBackground` was read as `shouldPrintBackgrounds`
- `duplexMode` was read as `duplex`

That caused `printBackground: true` to be ignored and `duplexMode` to fall back instead of honoring the caller option.

This updates `WebContents::Print` to read the public Electron option names first, while keeping the Chromium internal keys as a fallback for compatibility with any existing workaround code. When no duplex option is supplied, the setting now uses `kUnknownDuplexMode` so Chromium/platform printing can keep the printer default duplex behavior instead of forcing simplex.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic commit guidelines
- [x] PR release notes describe the change in a way relevant to app developers

#### Tests

- `git diff --check`
- `python3 script/run-clang-format.py -c shell/browser/api/electron_api_web_contents.cc`
- `npm run lint:clang-format`
- `npm test` was attempted locally. `create-typescript-definitions` completed, but the spec runner could not start because this machine has no local Electron build output: `No valid out directory found; use one of Testing,Release,Default,Debug or set process.env.ELECTRON_OUT_DIR`.

#### Release Notes

Notes: Fixed `webContents.print()` honoring `printBackground`, `duplexMode`, and printer default duplex settings.
