### PR TITLE
fix: read asar contents through the archive's retained file handle

### DIFF
--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -145,21 +145,33 @@ class AsarURLLoader : public network::mojom::URLLoader {
       return;
     }
 
-    // Note that while the |Archive| already opens a |base::File|, we still need
-    // to create a new |base::File| here, as it might be accessed by multiple
-    // requests at the same time.
-    base::File file(info.unpacked ? real_path : archive->path(),
-                    base::File::FLAG_OPEN | base::File::FLAG_READ);
+    // Each request needs its own |base::File| as multiple requests may be
+    // streaming at the same time, but for packed files it must be a duplicate
+    // of the |Archive|'s retained handle rather than a fresh open by path:
+    // |info|'s offset and block hashes come from the cached header, and the
+    // archive on disk may have been replaced (e.g. by an app update) since
+    // that header was read. The retained handle always sees the bytes the
+    // header describes.
+    base::File file =
+        info.unpacked
+            ? base::File(real_path,
+                         base::File::FLAG_OPEN | base::File::FLAG_READ)
+            : archive->DuplicateFile();
+    // The validator reads skipped byte ranges itself, so it needs a handle of
+    // its own alongside the data source's.
+    base::File validator_file;
+    if (info.integrity.has_value())
+      validator_file = file.Duplicate();
     auto file_data_source =
-        std::make_unique<mojo::FileDataSource>(file.Duplicate());
-    std::unique_ptr<mojo::DataPipeProducer::DataSource> readable_data_source;
+        std::make_unique<mojo::FileDataSource>(std::move(file));
     mojo::FileDataSource* file_data_source_raw = file_data_source.get();
+    std::unique_ptr<mojo::DataPipeProducer::DataSource> readable_data_source;
     AsarFileValidator* file_validator_raw = nullptr;
     uint32_t block_size = 0;
     if (info.integrity.has_value()) {
       block_size = info.integrity.value().block_size;
       auto asar_validator = std::make_unique<AsarFileValidator>(
-          std::move(info.integrity.value()), std::move(file));
+          std::move(info.integrity.value()), std::move(validator_file));
       file_validator_raw = asar_validator.get();
       readable_data_source = std::make_unique<mojo::FilteredDataSource>(
           std::move(file_data_source), std::move(asar_validator));

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -152,11 +152,10 @@ class AsarURLLoader : public network::mojom::URLLoader {
     // archive on disk may have been replaced (e.g. by an app update) since
     // that header was read. The retained handle always sees the bytes the
     // header describes.
-    base::File file =
-        info.unpacked
-            ? base::File(real_path,
-                         base::File::FLAG_OPEN | base::File::FLAG_READ)
-            : archive->DuplicateFile();
+    base::File file = info.unpacked
+                          ? base::File(real_path, base::File::FLAG_OPEN |
+                                                      base::File::FLAG_READ)
+                          : archive->DuplicateFile();
     // The validator reads skipped byte ranges itself, so it needs a handle of
     // its own alongside the data source's.
     base::File validator_file;

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -389,6 +389,26 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
   return true;
 }
 
+bool Archive::ReadFileAt(uint64_t offset, base::span<uint8_t> buf) {
+  if (!file_.IsValid())
+    return false;
+
+  // Concurrent reads of |file_| are safe as long as every reader passes an
+  // explicit offset (POSIX uses pread(); on Windows the offset is passed via
+  // OVERLAPPED, though the shared file position still advances). All in-tree
+  // readers of this handle - here, ScopedTemporaryFile::InitFromFile(), and
+  // the fs wrapper reading GetUnsafeFD() - do so; the only current-position
+  // reads happen in Init(), before the archive is shared.
+  electron::ScopedAllowBlockingForElectron allow_blocking;
+  return file_.ReadAndCheck(offset, buf);
+}
+
+base::File Archive::DuplicateFile() {
+  // Duplicate() on an invalid file returns an invalid file.
+  electron::ScopedAllowBlockingForElectron allow_blocking;
+  return file_.Duplicate();
+}
+
 int Archive::GetUnsafeFD() const {
   return fd_;
 }

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -12,6 +12,7 @@
 
 #include <uv.h>
 
+#include "base/containers/span.h"
 #include "base/files/file.h"
 #include "base/files/file_path.h"
 #include "base/synchronization/lock.h"
@@ -91,13 +92,25 @@ class Archive {
   // For unpacked file, this method will return its real path.
   bool CopyFileOut(const base::FilePath& path, base::FilePath* out);
 
+  // Reads |buf.size()| bytes at |offset| from the archive's retained file
+  // handle. Reading through the retained handle (instead of re-opening the
+  // archive by path) keeps reads consistent with the header that was
+  // integrity-validated when the archive was first opened, even if the file
+  // on disk has since been atomically replaced (e.g. by an app update while
+  // the app is running).
+  bool ReadFileAt(uint64_t offset, base::span<uint8_t> buf);
+
+  // Returns a duplicate of the archive's retained file handle, for consumers
+  // that need exclusive ownership of a base::File (e.g. concurrent streaming
+  // reads). The duplicate refers to the same underlying file as |file_|, so
+  // like ReadFileAt() it is unaffected by the on-disk file being replaced.
+  base::File DuplicateFile();
+
   // Returns the file's fd.
   // Using this fd will not validate the integrity of any files
   // you read out of the ASAR manually.  Callers are responsible
   // for integrity validation after this fd is handed over.
   int GetUnsafeFD() const;
-
-  base::FilePath path() const { return path_; }
 
  private:
   bool initialized_ = false;

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -120,12 +120,14 @@ bool ReadFileToString(const base::FilePath& path, std::string* contents) {
     return base::ReadFileToString(real_path, contents);
   }
 
-  base::File src(asar_path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!src.IsValid())
-    return false;
-
+  // Read through the archive's retained file handle rather than re-opening
+  // the archive by path: |info|'s offset and integrity hash come from the
+  // cached header, and the file on disk may have been replaced (e.g. by an
+  // app update) since that header was read. The retained handle always sees
+  // the bytes the header describes.
   contents->resize(info.size);
-  if (!src.ReadAndCheck(info.offset, base::as_writable_byte_span(*contents)))
+  if (!archive->ReadFileAt(info.offset,
+                           base::as_writable_byte_span(*contents)))
     return false;
 
   if (info.integrity)

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -126,8 +126,7 @@ bool ReadFileToString(const base::FilePath& path, std::string* contents) {
   // app update) since that header was read. The retained handle always sees
   // the bytes the header describes.
   contents->resize(info.size);
-  if (!archive->ReadFileAt(info.offset,
-                           base::as_writable_byte_span(*contents)))
+  if (!archive->ReadFileAt(info.offset, base::as_writable_byte_span(*contents)))
     return false;
 
   if (info.integrity)


### PR DESCRIPTION
### Description of Change

Reads of packed asar contents re-opened the archive **by path** on every read, while using file offsets and per-file integrity hashes from the **cached header**. If the asar on disk is replaced while the app is running — enterprise MDM / updater software swapping the app bundle is the common case — the fresh open reads the *new* file's bytes at the *old* header's offsets. Depending on timing this presents as:

- a fatal browser-process crash in `asar::ValidateIntegrityOrDie` (via `asar::ReadFileToString` reading a preload script at `ReadyToCommitNavigation`), or
- a spurious `ENOENT: no such file or directory, open '.../app.asar/...'` preload error when the file is briefly missing mid-swap, or
- the equivalent block-hash `LOG(FATAL)` in `AsarFileValidator` for apps that serve their UI over `file://` from the asar.

The first two became much more visible after #51602 moved preload reads from main-process JS into C++: the JS read path (`asar-fs-wrapper.ts`) reads through the archive's retained fd and exits cleanly on mismatch, so the same race previously produced no crash reports.

This PR makes the C++ read paths behave like the JS path — read through the `base::File` the `Archive` has held open since its header was validated:

- `Archive::ReadFileAt()` — positional reads on the retained handle; `asar::ReadFileToString()` now uses it (covers the three preload startup-data readers and `nativeImage` file reads).
- `Archive::DuplicateFile()` — hands streaming consumers a duplicate of the retained handle; `AsarURLLoader` uses it for packed files instead of re-opening by path.
- The unused `Archive::path()` accessor is removed so by-path opens of archive contents can't be reintroduced accidentally.

Behavior after this change: reads stay consistent with the header that was integrity-validated at open time, so an app whose asar is swapped underneath it keeps serving the version it launched with until relaunch (the pre-#51602 behavior). Note this also means packed reads from a *deleted* archive now succeed from the retained handle instead of returning ENOENT — intentional, as the transient-deletion window during non-atomic updates was the source of the spurious preload errors.

Security: integrity enforcement is unchanged in strength — in-place tampering is still caught, because the retained handle sees the modified bytes and the hash check fails exactly as before. A swap can no longer produce a *false-positive* integrity failure, and an attacker who replaces the file gains nothing since the retained handle never observes the replacement.

Verified on macOS with a fused (`embeddedAsarIntegrityValidation`) packaged build: swapping the asar mid-run previously crashed with the reported `ValidateIntegrityOrDie` stack on the next navigation and now serves the original content cleanly; removing the asar mid-run previously produced the handled ENOENT preload error and now also serves the original content; a tampered-in-place asar still fails integrity validation fatally.

### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes locally
- [x] relevant documentation is changed or added (n/a — no API change)
- [x] PR title follows semantic commit guidelines

### Release Notes

Notes: Fixed a browser-process crash (`ValidateIntegrityOrDie`) and spurious preload `ENOENT` errors when an app's `app.asar` is replaced on disk (e.g. by an updater or MDM software) while the app is running.