### PR TITLE
fix: deliver macOS notification without icon when attachment creation fails

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -168,7 +168,13 @@ void CocoaNotification::Show(const NotificationOptions& options) {
                UNMutableNotificationContent* content,
                UNNotificationAttachment* attachment) {
               if (auto* notification = weak_self.get()) {
-                content.attachments = @[ attachment ];
+                if (attachment) {
+                  content.attachments = @[ attachment ];
+                } else if (electron::debug_notifications) {
+                  LOG(INFO)
+                      << "Notification icon attachment creation failed; "
+                         "delivering without icon";
+                }
                 auto* self = static_cast<CocoaNotification*>(notification);
                 self->ScheduleNotification(content);
               }


### PR DESCRIPTION
#### Description of Change

On macOS, when the notification icon cannot be persisted to `<user data>/Notification Resources/` (any I/O failure in `NotificationImageRetainer::RegisterTemporaryImage`) or `+[UNNotificationAttachment attachmentWithIdentifier:URL:options:error:]` returns an error, the attachment factory returns `nil` — and the UI-thread reply callback then crashed the browser process:

```objc
content.attachments = @[ attachment ];
// NSInvalidArgumentException: attempt to insert nil object from objects[0]
// → NSApplicationUncaughtExceptionHandler → SIGTRAP
```

This nil-guards the callback and falls back to delivering the notification without the icon attachment instead of crashing.

Regression from #47817 (first shipped in v42); the pre-rewrite `NSUserNotification` path used `setContentImage:` and had no attachment array.

Fixes #52295.

A deterministic repro is linked in the issue (occupy the `Notification Resources` path with a plain file so `base::CreateDirectory` fails, then show a notification with an icon): crashes with exit code 133 before this change; the same scenario delivers an icon-less notification after it. Also captured twice in production by a long-running app receiving a message notification in the background.

Note on tests: the failure requires injecting a native-layer I/O failure inside the image retainer, which is not reachable from the JS spec harness; verified with the deterministic repro above instead. Requesting backport to supported release lines (42+) since this is a crash regression affecting any app that shows notifications with icons on macOS.

#### Checklist

- [x] PR description included and stakeholders cc'd as appropriate.
- [x] I have read the [contribution documentation](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] `npm test` passes locally — change is a one-line native nil-guard; relying on CI as a full local Electron build was not feasible.
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md) — see note above on native-layer failure injection.

#### Release Notes

Notes: Fixed a macOS main-process crash when the notification icon attachment could not be created; the notification is now delivered without the icon instead.
