### PR TITLE
feat: expose MemAvailable as `process.getSystemMemoryInfo().available`

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -211,6 +211,10 @@ Returns `Object`:
   system.
 * `free` Integer - The total amount of memory not being used by applications or disk
   cache.
+* `available` Integer _Linux_ - The kernel's estimate of the amount of memory
+  available for allocation without swapping, from `/proc/meminfo`
+  `MemAvailable`. Use this as the memory pressure signal on Linux; `free` there
+  is `MemFree`, which excludes page cache and other reclaimable memory.
 * `fileBacked` Integer _macOS_ - The amount of memory that currently has been paged out to storage.
   Includes memory for file caches, network buffers, and other system services.
 * `purgeable` Integer _macOS_ - The amount of memory that is marked as "purgeable". The system can reclaim it

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -185,6 +185,10 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 #endif
   dict.Set("free", free.InKiB());
 
+#if BUILDFLAG(IS_LINUX)
+  dict.Set("available", mem_info.available.InKiB());
+#endif
+
 #if BUILDFLAG(IS_MAC)
   dict.Set("fileBacked", mem_info.file_backed.InKiB());
   dict.Set("purgeable", mem_info.purgeable.InKiB());

--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -55,6 +55,9 @@ describe('process module', () => {
         const systemMemoryInfo = await invoke(() => process.getSystemMemoryInfo());
         expect(systemMemoryInfo.free).to.be.a('number');
         expect(systemMemoryInfo.total).to.be.a('number');
+        if (process.platform === 'linux') {
+          expect(systemMemoryInfo.available).to.be.a('number').greaterThan(0);
+        }
       });
     });
 


### PR DESCRIPTION
#### Description of Change

On Linux the returned free is `/proc/meminfo` MemFree - free pages only, excluding page cache and other reclaimable memory. Any long-uptime machine reads a few percent "free" with no real memory pressure, so free / total is useless as a pressure signal and apps end up parsing `/proc/meminfo` themselves.

Chromium already parses MemAvailable into `base::SystemMemoryInfo::available`; we just never exposed it. This adds it to the returned object as available, the kernel's estimate of memory available for allocation without swapping.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `available` to `process.getSystemMemoryInfo()` on Linux, exposing `proc/meminfo` MemAvailable.