### PR TITLE
chore: cherry-pick 8 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -321,3 +321,11 @@ cherry-pick-9800c213a58d.patch
 cherry-pick-fdf7bd93e6af.patch
 cherry-pick-64a1e167421c.patch
 cherry-pick-10c53ca4e2fb.patch
+cherry-pick-782c6b3e9bb4.patch
+cherry-pick-17a4e7216d1b.patch
+cherry-pick-1824adf21674.patch
+cherry-pick-086fe2cf7f7c.patch
+cherry-pick-45d7457ac585.patch
+cherry-pick-7aea889dfa2f.patch
+cherry-pick-e6468cc124d6.patch
+cherry-pick-873978ddc92b.patch

--- a/patches/chromium/cherry-pick-086fe2cf7f7c.patch
+++ b/patches/chromium/cherry-pick-086fe2cf7f7c.patch
@@ -1,0 +1,176 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Erik=20Spr=C3=A5ng?= <sprang@chromium.org>
+Date: Wed, 1 Jul 2026 13:30:17 -0700
+Subject: [M148] Add better handling of RtcVideoDecoderAdapter init timeout.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Original change's description:
+> Add better handling of RtcVideoDecoderAdapter init timeout.
+>
+> This CL introduced as new private `OnInitializeDone()` callback method
+> and uses the `weak_decoder_this_` instead of unreatined
+> `video_decoder_.get()`.
+>
+> Bug: 523712556
+> Change-Id: Icc2f8272b948dbc4fa65d5175dbcf60cea033462
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7992498
+> Reviewed-by: Guido Urdaneta <guidou@chromium.org>
+> Commit-Queue: Erik Språng <sprang@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1652310}
+
+(cherry picked from commit 18a41228c0a061c0a08d01c22e943e4862223f1e)
+
+Bug: 528195553,523712556
+Change-Id: Icc2f8272b948dbc4fa65d5175dbcf60cea033462
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8018763
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Erik Språng <sprang@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4443}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.cc b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.cc
+index ba089dfcd2c09e2462dedbf23e6e3ab976866aba..cc7ac7cb4bec0f6670259b1b8f84204b92cdc5ee 100644
+--- a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.cc
++++ b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.cc
+@@ -61,6 +61,8 @@ constexpr gfx::Size kDefaultSize(640, 480);
+ // Maximum number of buffers that we will queue in |pending_buffers_|.
+ constexpr int32_t kMaxPendingBuffers = 8;
+ 
++std::optional<base::TimeDelta> g_init_timeout_for_testing;
++
+ // Maximum number of timestamps that will be maintained in |decode_timestamps_|.
+ // Really only needs to be a bit larger than the maximum reorder distance (which
+ // is presumably 0 for WebRTC), but being larger doesn't hurt much.
+@@ -235,6 +237,9 @@ class RTCVideoDecoderAdapter::Impl {
+   void DecodePendingBuffers();
+   void OnDecodeDone(media::DecoderStatus status);
+   void OnOutput(scoped_refptr<media::VideoFrame> frame);
++  void OnInitializeDone(CrossThreadOnceFunction<void(bool)> init_cb,
++                        media::VideoDecoderType* decoder_type,
++                        media::DecoderStatus status);
+ 
+   const raw_ptr<media::GpuVideoAcceleratorFactories> gpu_factories_;
+   const scoped_refptr<WebRtcVideoFrameAdapter::SharedResources>
+@@ -292,22 +297,28 @@ void RTCVideoDecoderAdapter::Impl::Initialize(
+   media::VideoDecoder::OutputCB output_cb =
+       ConvertToBaseRepeatingCallback(CrossThreadBindRepeating(
+           &RTCVideoDecoderAdapter::Impl::OnOutput, weak_decoder_this_));
++  // Safe to use CrossThreadUnretained(decoder_type) because `decoder_type`
++  // points to the `RTCVideoDecoderAdapter::decoder_type_` member variable,
++  // which is guaranteed to outlive `Impl` since the adapter's destructor
++  // blocks synchronously on the media thread while destroying `Impl` in
++  // `Release()`.
+   video_decoder_->Initialize(
+-      config, /*low_delay=*/true,
+-      /*cdm_context=*/nullptr,
+-      base::BindOnce(
+-          [](base::OnceCallback<void(bool)> cb,
+-             media::VideoDecoderType* decoder_type,
+-             media::VideoDecoder* video_decoder, media::DecoderStatus status) {
+-            *decoder_type = video_decoder->GetDecoderType();
+-            std::move(cb).Run(status.is_ok());
+-          },
+-          ConvertToBaseOnceCallback(std::move(init_cb)),
+-          CrossThreadUnretained(decoder_type),
+-          CrossThreadUnretained(video_decoder_.get())),
++      config, /*low_delay=*/true, /*cdm_context=*/nullptr,
++      ConvertToBaseOnceCallback(CrossThreadBindOnce(
++          &RTCVideoDecoderAdapter::Impl::OnInitializeDone, weak_decoder_this_,
++          std::move(init_cb), CrossThreadUnretained(decoder_type))),
+       output_cb, base::DoNothing());
+ }
+ 
++void RTCVideoDecoderAdapter::Impl::OnInitializeDone(
++    CrossThreadOnceFunction<void(bool)> init_cb,
++    media::VideoDecoderType* decoder_type,
++    media::DecoderStatus status) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(media_sequence_checker_);
++  *decoder_type = video_decoder_->GetDecoderType();
++  std::move(init_cb).Run(status.is_ok());
++}
++
+ void RTCVideoDecoderAdapter::Impl::Decode(
+     scoped_refptr<media::DecoderBuffer> buffer,
+     base::WaitableEvent* waiter,
+@@ -629,8 +640,8 @@ bool RTCVideoDecoderAdapter::InitializeSync(
+                               weak_impl_, config, std::move(init_cb),
+                               start_time,
+                               CrossThreadUnretained(&decoder_type_)))) {
+-    // TODO(crbug.com/1076817) Remove if a root cause is found.
+-    if (!async_init_waiter_->TimedWait(base::Seconds(10))) {
++    if (!async_init_waiter_->TimedWait(
++            g_init_timeout_for_testing.value_or(base::Seconds(10)))) {
+       RecordInitializationLatency(base::TimeTicks::Now() - start_time);
+       return false;
+     }
+@@ -945,4 +956,9 @@ void RTCVideoDecoderAdapter::DecrementCurrentDecoderCountForTesting() {
+   g_num_decoders_--;
+ }
+ 
++void RTCVideoDecoderAdapter::SetInitializeSyncTimeoutForTesting(
++    std::optional<base::TimeDelta> timeout) {
++  g_init_timeout_for_testing = timeout;
++}
++
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.h b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.h
+index f2ddb9888a62ddb146d819adf8bc9aff4a348d37..d4c522ee76e657d442f31196745637f0a10554ed 100644
+--- a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.h
++++ b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter.h
+@@ -91,6 +91,8 @@ class PLATFORM_EXPORT RTCVideoDecoderAdapter : public webrtc::VideoDecoder {
+   static int GetCurrentDecoderCountForTesting();
+   static void IncrementCurrentDecoderCountForTesting();
+   static void DecrementCurrentDecoderCountForTesting();
++  static void SetInitializeSyncTimeoutForTesting(
++      std::optional<base::TimeDelta> timeout);
+ 
+   static std::atomic<int> g_num_decoders_;
+ 
+diff --git a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter_test.cc b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter_test.cc
+index 03c095747b9b501b410a89e9de282302057db5f8..68ea21cbe9e6305606263f41f074b7e4fbf92169 100644
+--- a/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter_test.cc
++++ b/third_party/blink/renderer/platform/peerconnection/rtc_video_decoder_adapter_test.cc
+@@ -21,6 +21,7 @@
+ #include "base/test/mock_callback.h"
+ #include "base/test/scoped_feature_list.h"
+ #include "base/test/task_environment.h"
++#include "base/threading/platform_thread.h"
+ #include "base/threading/thread.h"
+ #include "base/time/time.h"
+ #include "build/build_config.h"
+@@ -889,4 +890,32 @@ TEST_F(RTCVideoDecoderAdapterTest, CanReadSharedFrameBuffer) {
+   media_thread_.FlushForTesting();
+ }
+ 
++TEST_F(RTCVideoDecoderAdapterTest, InitializeSyncTimeoutRace) {
++  RTCVideoDecoderAdapter::SetInitializeSyncTimeoutForTesting(
++      base::Milliseconds(1));
++
++  base::WaitableEvent initialize_called;
++  media::VideoDecoder::InitCB saved_init_cb;
++
++  EXPECT_CALL(*video_decoder_, Initialize_)
++      .WillOnce(testing::WithArg<3>([&](media::VideoDecoder::InitCB& init_cb) {
++        saved_init_cb = std::move(init_cb);
++        initialize_called.Signal();
++      }));
++
++  ASSERT_FALSE(RTCVideoDecoderAdapterWrapper::Create(
++      &gpu_factories_,
++      webrtc::SdpVideoFormat(
++          webrtc::CodecTypeToPayloadString(webrtc::kVideoCodecVP9)),
++      true));
++
++  initialize_called.Wait();
++  media_thread_.task_runner()->PostTask(
++      FROM_HERE, base::BindOnce(std::move(saved_init_cb),
++                                media::DecoderStatus::Codes::kOk));
++  media_thread_.FlushForTesting();
++
++  RTCVideoDecoderAdapter::SetInitializeSyncTimeoutForTesting(std::nullopt);
++}
++
+ }  // namespace blink

--- a/patches/chromium/cherry-pick-17a4e7216d1b.patch
+++ b/patches/chromium/cherry-pick-17a4e7216d1b.patch
@@ -1,0 +1,206 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrea Orru <andreaorru@chromium.org>
+Date: Mon, 6 Jul 2026 18:20:55 -0700
+Subject: [M148] [Extensions] Fix UAF in AppWindow::SetNativeWindowFullscreen
+
+Original change's description:
+> [Extensions] Fix UAF in AppWindow::SetNativeWindowFullscreen
+>
+> If the window is destroyed during a nested message loop spun by the
+> platform fullscreen transition (e.g. on macOS), the AppWindow instance
+> is deleted, resulting in a UAF when execution returns to
+> SetNativeWindowFullscreen() and calls RestoreAlwaysOnTop().
+>
+> This change adds a dedicated weak pointer factory to AppWindow and
+> checks liveness before executing any logic following the platform
+> SetFullscreen call. We avoid reusing image_loader_ptr_factory_ as it
+> gets explicitly invalidated during favicon downloading.
+>
+> Fixed: 516948486
+> Change-Id: I371d778366eaaa9dac5e565b6ec00ee666833e03
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7902487
+> Reviewed-by: Toni Barzic <tbarzic@chromium.org>
+> Commit-Queue: Andrea Orru <andreaorru@chromium.org>
+> Reviewed-by: Solomon Kinard <solomonkinard@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1647781}
+
+(cherry picked from commit c73802e7eca02587d75cc2db56a1fc851ba5d76f)
+
+Bug: 524890377,516948486
+Change-Id: I371d778366eaaa9dac5e565b6ec00ee666833e03
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7997178
+Commit-Queue: Andrea Orru <andreaorru@chromium.org>
+Reviewed-by: Andrea Orru <andreaorru@chromium.org>
+Reviewed-by: Marc Treib <treib@chromium.org>
+Reviewed-by: Finnur Thorarinsson <finnur@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7778@{#4445}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/chrome/browser/apps/platform_apps/DEPS b/chrome/browser/apps/platform_apps/DEPS
+new file mode 100644
+index 0000000000000000000000000000000000000000..47ca473c62749a8ab1127bce421311ad14ff50a6
+--- /dev/null
++++ b/chrome/browser/apps/platform_apps/DEPS
+@@ -0,0 +1,5 @@
++specific_include_rules = {
++  "app_window_browsertest.cc": [
++    "+extensions/components/native_app_window/native_app_window_views.h",
++  ],
++}
+diff --git a/chrome/browser/apps/platform_apps/app_browsertest_util.cc b/chrome/browser/apps/platform_apps/app_browsertest_util.cc
+index f471b64fe4b990da200d0c50295b0c59f872bed0..4334c6f967e0954443c3e352eabbc0577b53aa50 100644
+--- a/chrome/browser/apps/platform_apps/app_browsertest_util.cc
++++ b/chrome/browser/apps/platform_apps/app_browsertest_util.cc
+@@ -284,6 +284,11 @@ void PlatformAppBrowserTest::CallAdjustBoundsToBeVisibleOnScreenForAppWindow(
+                                           bounds);
+ }
+ 
++void PlatformAppBrowserTest::SetNativeWindowFullscreenForTesting(
++    AppWindow* window) {
++  window->SetNativeWindowFullscreen();
++}
++
+ AppWindow* PlatformAppBrowserTest::CreateTestAppWindow(
+     const std::string& window_create_options) {
+   ExtensionTestMessageListener launched_listener("launched",
+diff --git a/chrome/browser/apps/platform_apps/app_browsertest_util.h b/chrome/browser/apps/platform_apps/app_browsertest_util.h
+index 5cff6b85c4af0616fb0299d9ca4e7382175b3c1f..b732814a0322f0e888b3a4bddcc1dda3b3f2c314 100644
+--- a/chrome/browser/apps/platform_apps/app_browsertest_util.h
++++ b/chrome/browser/apps/platform_apps/app_browsertest_util.h
+@@ -123,6 +123,9 @@ class PlatformAppBrowserTest : public MixinBasedExtensionApiTest {
+       const gfx::Size& minimum_size,
+       gfx::Rect* bounds);
+ 
++  // Call SetNativeWindowFullscreen of |window|.
++  void SetNativeWindowFullscreenForTesting(AppWindow* window);
++
+   // Load a simple test app and create a window. The window must be closed by
+   // the caller in order to terminate the test - use CloseAppWindow().
+   // |window_create_options| are the options that will be passed to
+diff --git a/chrome/browser/apps/platform_apps/app_window_browsertest.cc b/chrome/browser/apps/platform_apps/app_window_browsertest.cc
+index 1393919680bb2780854733f2fb66b64799b15df3..8adb63c0447c0fe19f351b8515275c96993a8598 100644
+--- a/chrome/browser/apps/platform_apps/app_window_browsertest.cc
++++ b/chrome/browser/apps/platform_apps/app_window_browsertest.cc
+@@ -2,6 +2,8 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
++#include "extensions/browser/app_window/app_window.h"
++
+ #include "base/memory/raw_ptr.h"
+ #include "base/run_loop.h"
+ #include "build/build_config.h"
+@@ -9,15 +11,18 @@
+ #include "chrome/browser/apps/app_service/app_service_proxy_factory.h"
+ #include "chrome/browser/apps/platform_apps/app_browsertest_util.h"
+ #include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/ui/apps/chrome_app_window_client.h"
+ #include "chrome/browser/ui/browser.h"
+ #include "components/services/app_service/public/cpp/app_launch_params.h"
+ #include "components/services/app_service/public/cpp/app_launch_util.h"
+ #include "content/public/test/browser_test.h"
+ #include "content/public/test/test_utils.h"
+ #include "extensions/browser/app_window/app_window_geometry_cache.h"
++#include "extensions/browser/app_window/native_app_window.h"
+ #include "extensions/common/constants.h"
+ #include "extensions/common/extension.h"
+ #include "extensions/common/extension_id.h"
++#include "extensions/components/native_app_window/native_app_window_views.h"
+ #include "extensions/test/extension_test_message_listener.h"
+ #include "extensions/test/result_catcher.h"
+ #include "ui/display/display_switches.h"
+@@ -273,3 +278,63 @@ IN_PROC_BROWSER_TEST_F(AppWindowAPITest, TestVisibleOnAllWorkspaces) {
+       RunAppWindowAPITestAndWaitForRoundTrip("testVisibleOnAllWorkspaces"))
+       << message_;
+ }
++
++namespace {
++
++class ClosingOnFullscreenTransitionWindow
++    : public native_app_window::NativeAppWindowViews {
++ public:
++  ClosingOnFullscreenTransitionWindow() = default;
++  ~ClosingOnFullscreenTransitionWindow() override = default;
++
++  void SetFullscreen(int fullscreen_types) override {
++    // Simulate window closure during fullscreen transition (e.g. as can happen
++    // on macOS when spinning a nested run loop).
++    widget()->CloseNow();
++  }
++};
++
++class TestAppWindowClient : public ChromeAppWindowClient {
++ public:
++  TestAppWindowClient() = default;
++  ~TestAppWindowClient() override = default;
++
++  std::unique_ptr<extensions::NativeAppWindow> CreateNativeAppWindow(
++      extensions::AppWindow* window,
++      extensions::AppWindow::CreateParams* params) override {
++    auto native_window =
++        std::make_unique<ClosingOnFullscreenTransitionWindow>();
++    native_window->Init(window, *params);
++    return native_window;
++  }
++};
++
++}  // namespace
++
++// Regression test for crbug.com/516948486.
++IN_PROC_BROWSER_TEST_F(AppWindowAPITest, UafInSetNativeWindowFullscreen) {
++  const extensions::Extension* extension = LoadExtension(
++      test_data_dir_.AppendASCII("platform_apps").AppendASCII("window_api"));
++  ASSERT_TRUE(extension);
++
++  TestAppWindowClient test_client;
++  // `AppWindowClient::Set()` has a DCHECK verifying that we don't overwrite a
++  // non-null client with another non-null client. We must clear the existing
++  // client (set during browser startup) before setting our test client.
++  extensions::AppWindowClient::Set(nullptr);
++  extensions::AppWindowClient::Set(&test_client);
++
++  extensions::AppWindow* window = CreateAppWindowFromParams(
++      browser()->profile(), extension, extensions::AppWindow::CreateParams());
++  ASSERT_TRUE(window);
++
++  // Trigger fullscreen transition. In our placeholder `SetFullscreen()`,
++  // `OnNativeClose()` will be called, deleting `window`. Without the weak
++  // pointer check in `SetNativeWindowFullscreen()`, this call would result in a
++  // Use-After-Free when `RestoreAlwaysOnTop()` is reached.
++  SetNativeWindowFullscreenForTesting(window);
++
++  // Clear our test client before restoring the production client.
++  extensions::AppWindowClient::Set(nullptr);
++  extensions::AppWindowClient::Set(ChromeAppWindowClient::GetInstance());
++}
+diff --git a/extensions/browser/app_window/app_window.cc b/extensions/browser/app_window/app_window.cc
+index e2115471c65e1c3914877945ca4a9616cabfaba9..ba9b728f28300c74f4e551ea7c1de38e21f34603 100644
+--- a/extensions/browser/app_window/app_window.cc
++++ b/extensions/browser/app_window/app_window.cc
+@@ -855,7 +855,14 @@ void AppWindow::DidDownloadFavicon(
+ }
+ 
+ void AppWindow::SetNativeWindowFullscreen() {
++  // `SetFullscreen()` can trigger window closure (e.g. on macOS when spinning a
++  // nested run loop), destroying `this`. Use a WeakPtr to avoid Use-After-Free
++  // when calling RestoreAlwaysOnTop(). See crbug.com/516948486.
++  base::WeakPtr<AppWindow> weak_this = weak_ptr_factory_.GetWeakPtr();
+   native_app_window_->SetFullscreen(fullscreen_types_);
++  if (!weak_this) {
++    return;
++  }
+ 
+   RestoreAlwaysOnTop();
+ }
+diff --git a/extensions/browser/app_window/app_window.h b/extensions/browser/app_window/app_window.h
+index bf59ce45114e99296f84693e329c7e238a351ab8..78276db2dba87f1e803d6d9b6c2b6529eddc51b0 100644
+--- a/extensions/browser/app_window/app_window.h
++++ b/extensions/browser/app_window/app_window.h
+@@ -601,6 +601,7 @@ class AppWindow : public content::WebContentsDelegate,
+   base::OnceClosure on_update_draggable_regions_callback_for_testing_;
+ 
+   base::WeakPtrFactory<AppWindow> image_loader_ptr_factory_{this};
++  base::WeakPtrFactory<AppWindow> weak_ptr_factory_{this};
+ };
+ 
+ }  // namespace extensions

--- a/patches/chromium/cherry-pick-1824adf21674.patch
+++ b/patches/chromium/cherry-pick-1824adf21674.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xuehui Chen <xuehuichen@google.com>
+Date: Fri, 26 Jun 2026 08:46:47 -0700
+Subject: [M148] [SPC] Guard SPC Controller destruction during dialog close.
+
+Original change's description:
+> [SPC] Guard SPC Controller destruction during dialog close.
+>
+> A `potential` UAF vulnerability exists in the browser process due to
+> synchronous reentrancy inside SecurePaymentConfirmationController.
+>
+> This can happen if platform-specific synchronous activation dispatch
+> from native_widget_->Close() that reaches
+> ExtensionPopup::OnWidgetDestroying() inside the same call stack. Or
+> CloseDialog() itself trigger a controller destruction.
+>
+> This change adds a guard to the `CloseDialog()` method that ensures the
+> call inside SecurePaymentConfirmationController will not continue to
+> prevent a memory crash.
+>
+> Fixed: 522568496
+> Change-Id: Ifc0eaaebc42db33bb309e850881722df13cad35d
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7959279
+> Reviewed-by: Slobodan Pejic <slobodan@chromium.org>
+> Reviewed-by: Darwin Yang <darwinyang@chromium.org>
+> Commit-Queue: Xuehui Chen <xuehuichen@google.com>
+> Cr-Commit-Position: refs/heads/main@{#1649831}
+
+(cherry picked from commit b87b4b251a81a1e17b4388046d56f93765b646b3)
+
+Bug: 525969298,522568496
+Change-Id: Ifc0eaaebc42db33bb309e850881722df13cad35d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8008507
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4428}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/components/payments/content/secure_payment_confirmation_controller.cc b/components/payments/content/secure_payment_confirmation_controller.cc
+index df9bc659e9c2f8225a3faafccab6d23624c9970b..b63f2e7685d469ecc3727bbbb54d27e7714b1346 100644
+--- a/components/payments/content/secure_payment_confirmation_controller.cc
++++ b/components/payments/content/secure_payment_confirmation_controller.cc
+@@ -130,7 +130,15 @@ void SecurePaymentConfirmationController::OnConfirm() {
+                                   SecurePaymentRequestOutcome::kAccept);
+ 
+     is_dialog_showing_ = false;
++    // CloseDialog() -> Widget::Close() can potentially synchronously trigger
++    // activation observers that destroy the payment window's WebContents.
++    // This self weak pointer guard can prevent potential UAF if controller is
++    // synchronously deleted inside CloseDialog().
++    auto weak_this = weak_ptr_factory_.GetWeakPtr();
+     CloseDialog();
++    if (!weak_this) {
++      return;
++    }
+ 
+     if (!request_) {
+       return;
+@@ -163,7 +171,13 @@ void SecurePaymentConfirmationController::OnAnotherWay() {
+                                 SecurePaymentRequestOutcome::kAnotherWay);
+ 
+   is_dialog_showing_ = false;
++
++  // CloseDialog() can potentially delete `this`. See OnConfirm() above.
++  auto weak_this = weak_ptr_factory_.GetWeakPtr();
+   CloseDialog();
++  if (!weak_this) {
++    return;
++  }
+ 
+   if (!request_) {
+     return;
+@@ -195,7 +209,12 @@ void SecurePaymentConfirmationController::OnCancel() {
+   }
+ 
+   is_dialog_showing_ = false;
++  // CloseDialog() can potentially delete `this`. See OnConfirm() above.
++  auto weak_this = weak_ptr_factory_.GetWeakPtr();
+   CloseDialog();
++  if (!weak_this) {
++    return;
++  }
+ 
+   if (!request_) {
+     return;
+@@ -215,7 +234,12 @@ void SecurePaymentConfirmationController::OnOptOut() {
+   }
+ 
+   is_dialog_showing_ = false;
++  // CloseDialog() can potentially delete `this`. See OnConfirm() above.
++  auto weak_this = weak_ptr_factory_.GetWeakPtr();
+   CloseDialog();
++  if (!weak_this) {
++    return;
++  }
+ 
+   if (!request_) {
+     return;

--- a/patches/chromium/cherry-pick-45d7457ac585.patch
+++ b/patches/chromium/cherry-pick-45d7457ac585.patch
@@ -1,0 +1,150 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Baron <dbaron@chromium.org>
+Date: Mon, 29 Jun 2026 13:14:51 -0700
+Subject: [M148] Recheck prerequisites when inserting multiple nodes into a
+ Document.
+
+Original change's description:
+> Recheck prerequisites when inserting multiple nodes into a Document.
+>
+> This moves the check of prerequisites earlier so that it also applies
+> when the parent node is a Document.  This is needed so that we check
+> that the nodes' parents are still all null.
+>
+> The added test is a simplified version of the AI-generated test provided
+> in the bug.  Without the fix it fails a DCHECK in DCHECK-enabled builds,
+> at third_party/blink/renderer/core/dom/container_node.cc:400:
+> DCHECK failed: !target_node->parentNode().
+>
+> Fixed: 523729553
+> Change-Id: I409e096d54150f97083a281e0b3dee5a203015ac
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7963938
+> Commit-Queue: David Baron <dbaron@chromium.org>
+> Reviewed-by: Mason Freed <masonf@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1650442}
+
+(cherry picked from commit cb26b6a1eb7999001e771a07944d4cb0e377341c)
+
+Bug: 526881727,523729553
+Change-Id: I409e096d54150f97083a281e0b3dee5a203015ac
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8020702
+Commit-Queue: David Baron <dbaron@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4439}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/core/dom/container_node.cc b/third_party/blink/renderer/core/dom/container_node.cc
+index e700d6eb6af5d768650c937245c65eae582d511e..fd52e6a12638059e2c5937e3dfaa692a11c77975 100644
+--- a/third_party/blink/renderer/core/dom/container_node.cc
++++ b/third_party/blink/renderer/core/dom/container_node.cc
+@@ -270,6 +270,20 @@ bool ContainerNode::EnsurePreInsertionValidity(
+     }
+   }
+ 
++  // Node::ConvertNodeUnionsIntoNodes behaves differently depending on
++  // whether there is one node or more than one, since it simulates
++  // insertion into a DocumentFragment for the latter case.  If it handled
++  // more than one node, then it already removed the children from their old
++  // parent.  Check here that those removals didn't do anything bad.  (We
++  // could potentially make this faster by using a DOMMutationDetector in
++  // ConvertNodeUnionsIntoNodes and storing whether we need to do this.)
++  if (new_children && new_children->size() != 1u &&
++      RuntimeEnabledFeatures::RecheckParentDuringNodeVectorInsertionEnabled() &&
++      !RecheckNodeInsertionStructuralPrereq(*new_children, next,
++                                            exception_state)) {
++    return false;
++  }
++
+   if (auto* document = DynamicTo<Document>(this)) {
+     // Step 2 is unnecessary. No one can have a Document child.
+     // Step 3:
+@@ -320,21 +334,6 @@ bool ContainerNode::EnsurePreInsertionValidity(
+         return false;
+       }
+     }
+-
+-    // Node::ConvertNodeUnionsIntoNodes behaves differently depending on
+-    // whether there is one node or more than one, since it simulates
+-    // insertion into a DocumentFragment for the latter case.  If it handled
+-    // more than one node, then it already removed the children from their old
+-    // parent.  Check here that those removals didn't do anything bad.  (We
+-    // could potentially make this faster by using a DOMMutationDetector in
+-    // ConvertNodeUnionsIntoNodes and storing whether we need to do this.)
+-    if (new_children->size() != 1u &&
+-        RuntimeEnabledFeatures::
+-            RecheckParentDuringNodeVectorInsertionEnabled() &&
+-        !RecheckNodeInsertionStructuralPrereq(*new_children, next,
+-                                              exception_state)) {
+-      return false;
+-    }
+   } else if (auto* child_fragment = DynamicTo<DocumentFragment>(new_child)) {
+     for (Node* node = child_fragment->firstChild(); node;
+          node = node->nextSibling()) {
+diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+index 0ebf7f1be37e0b0fccb594e83ecaacc3d4c6f510..44eff613fbfcdb5b7c725abb3694ebf2349c581c 100644
+--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
++++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -4375,7 +4375,7 @@
+       status: "stable",
+     },
+     {
+-      // Shipping in M148, so should be removed around M150.
++      // Shipping in M148, revised in M151, so should be removed around M153.
+       name: "RecheckParentDuringNodeVectorInsertion",
+       status: "stable",
+     },
+diff --git a/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..a96111455304c1349bf8a6d1b3e4c0358b8395a9
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html
+@@ -0,0 +1,41 @@
++<!DOCTYPE html>
++<html>
++<head><title>Document.append reentrancy tree corruption</title></head>
++<body>
++<script>
++
++// Create a container whose removal fires a synchronous JS callback.
++function makeTrigger(callback) {
++  const container = document.createElement('div');
++  const iframe = document.createElement('iframe');
++  container.appendChild(iframe);
++  document.body.appendChild(container);
++  let fired = false;
++  function listener() {
++    if (fired) {
++      return;
++    }
++    fired = true;
++    callback();
++  }
++  iframe.contentWindow.addEventListener('unload', listener);
++  iframe.contentWindow.addEventListener('pagehide', listener);
++  return container;
++}
++
++function bug() {
++  const doc = document.implementation.createDocument(null, null, null);
++  const div = document.createElement('div');
++  const node1 = document.createComment('victim');
++  const trig = makeTrigger(() => {
++    div.appendChild(node1);
++  });
++  try { doc.append(node1, trig); } catch (e) { }
++}
++
++window.onload = () => {
++  bug();
++};
++</script>
++</body>
++</html>
+diff --git a/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html.headers b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html.headers
+new file mode 100644
+index 0000000000000000000000000000000000000000..f1e8ace831407eccae03f62ff5e77ee7d1586005
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/dom/nodes/crashtests/multiple-append-mutated-in-unload-document.https.html.headers
+@@ -0,0 +1 @@
++Permissions-Policy: unload=*

--- a/patches/chromium/cherry-pick-782c6b3e9bb4.patch
+++ b/patches/chromium/cherry-pick-782c6b3e9bb4.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kramer Ge <fangzhoug@chromium.org>
+Date: Wed, 1 Jul 2026 11:42:19 -0700
+Subject: [M144-LTS][ozone/wayland]Handle window destruction during surface
+ configure
+
+ProcessPendingConfigureState() calls RequestStateFromServer(), which
+reaches the delegate's OnStateUpdate(). The views layer may
+synchronously close the widget and destroy the platform window inside
+that callout. The existing weak-ptr guard in
+MaybeApplyLatestStateRequest() returns early in that case, but
+ProcessPendingConfigureState() then continued to access members after
+the call returned.
+
+Add a weak-ptr liveness check around RequestStateFromServer(), mirroring
+the existing pattern used elsewhere in this file and in
+WaylandToplevelWindow::HandleToplevelConfigure().
+
+(cherry picked from commit 06d1bbdddd1f176c3443ca2ddb1f1d21dfe9a094)
+
+Fixed: 518006275
+Change-Id: I8812d780c4e46b42bc1a8302c69e4f2e8256b660
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7981871
+Commit-Queue: Kramer Ge <fangzhoug@chromium.org>
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1651724}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8006327
+Commit-Queue: Gyuyoung Kim (xWF) <qkim@google.com>
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Cr-Commit-Position: refs/branch-heads/7559@{#5060}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_window.cc b/ui/ozone/platform/wayland/host/wayland_window.cc
+index 862cc0ea11d7dc63b00535a93964db6a3439b4d3..96a49f37faa0099e4d337fed6a7b1df90b36a7f4 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -1315,7 +1315,13 @@ void WaylandWindow::ProcessPendingConfigureState(uint32_t serial) {
+     }
+   }
+ 
++  // RequestStateFromServer transitively calls delegate()->OnStateUpdate(),
++  // which may synchronously delete |this|.
++  auto weak_this = AsWeakPtr();
+   RequestStateFromServer(state, serial);
++  if (!weak_this) {
++    return;
++  }
+ 
+   // Reset values.
+   pending_configure_state_ = PendingConfigureState();
+diff --git a/ui/ozone/platform/wayland/host/wayland_window_unittest.cc b/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+index acbb98a204a396459ae6e1bd252a44cbb06c1abf..f43c842c5c8fe70cf4bc5f1605a65eca48599b90 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+@@ -473,6 +473,22 @@ TEST_P(WaylandWindowTest, Shutdown) {
+   window_->OnDragSessionClose(mojom::DragOperation::kNone);
+ }
+ 
++// Regression test for https://crbug.com/495948109.
++TEST_P(WaylandWindowTest, DeleteWindowFromOnStateUpdateDuringSurfaceConfigure) {
++  delegate_.set_on_state_update_callback(base::BindLambdaForTesting([&]() {
++    window_.reset();
++    return false;
++  }));
++
++  WaylandWindow* window = window_.get();
++  WaylandWindow::WindowStates window_states;
++  window_states.is_activated = true;
++  window->HandleToplevelConfigure(1024, 768, window_states);
++  window->HandleSurfaceConfigure(2);
++
++  EXPECT_FALSE(window_);
++}
++
+ TEST_P(WaylandWindowTest, SetTitle) {
+   window_->SetTitle(u"hello");
+   PostToServerAndWait([id = surface_id_](wl::TestWaylandServerThread* server) {

--- a/patches/chromium/cherry-pick-7aea889dfa2f.patch
+++ b/patches/chromium/cherry-pick-7aea889dfa2f.patch
@@ -1,0 +1,251 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Steve Becker <stevebe@microsoft.com>
+Date: Mon, 29 Jun 2026 15:41:38 -0700
+Subject: [M148] InspectorIndexedDBAgent must not use v8_session_ after
+ disposal
+
+Original change's description:
+> InspectorIndexedDBAgent must not use v8_session_ after disposal
+>
+> `v8_session_` is a `raw_ptr` member of `InspectorIndexedDBAgent`. To
+> prevent use after frees, this fix updates
+> `InspectorIndexedDBAgent::Dispose()` to set `v8_session_` to `nullptr`.
+> The change then adds null checks before each use of `v8_session_`.
+> `nullptr`.
+>
+> This fix follows the same pattern as `InspectorDOMAgent`:
+>
+> https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/inspector/inspector_dom_agent.cc;drc=284b36ac2742525000db2ca28f448f6cc8584f40;l=3416
+>
+> The change adds a test that repros 100% on ASAN builds.
+>
+> Bug: 503553615
+> Change-Id: Ifa540fb83556710d197ed4b3c942ab61c37de35b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8007837
+> Reviewed-by: Philip Pfaffe <pfaffe@chromium.org>
+> Commit-Queue: Steve Becker <stevebe@microsoft.com>
+> Cr-Commit-Position: refs/heads/main@{#1653288}
+
+(cherry picked from commit f507e6c6334f3791b4b0e808343ceb0e95832273)
+
+Bug: 528587984,503553615
+Change-Id: Ifa540fb83556710d197ed4b3c942ab61c37de35b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8020374
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7778@{#4441}
+Cr-Branched-From: 77f495ee216d4c3cc784d33658bad4778c0680ee-refs/heads/main@{#1610480}
+
+diff --git a/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.cc b/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.cc
+index 37d84a51ee5f40610b84372ceac41d06a35a7bff..32fca937b3def061abdf7f8faa5aa9cc7689c492 100644
+--- a/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.cc
++++ b/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.cc
+@@ -104,6 +104,8 @@ namespace {
+ 
+ const char kIndexedDBObjectGroup[] = "indexeddb";
+ const char kNoDocumentError[] = "No document for given frame found";
++const char kSessionDetachedDuringOperation[] =
++    "DevTools session detached during operation.";
+ const char kOriginMismatchError[] =
+     "Requested security origin does not match the target's origin.";
+ 
+@@ -680,9 +682,10 @@ class OpenCursorCallback final : public NativeEventListener {
+   ~OpenCursorCallback() override = default;
+ 
+   void Invoke(ExecutionContext*, Event* event) override {
+-    if (!agent_) {
+-      request_callback_->sendFailure(protocol::Response::ServerError(
+-          "DevTools session detached during operation."));
++    InspectorIndexedDBAgent* agent = agent_.Get();
++    if (!agent) {
++      request_callback_->sendFailure(
++          protocol::Response::ServerError(kSessionDetachedDuringOperation));
+       return;
+     }
+ 
+@@ -737,7 +740,12 @@ class OpenCursorCallback final : public NativeEventListener {
+       return;
+     }
+ 
+-    v8_inspector::V8InspectorSession* v8_session = agent_->v8_session();
++    v8_inspector::V8InspectorSession* v8_session = agent->v8_session();
++    if (!v8_session) {
++      request_callback_->sendFailure(
++          protocol::Response::ServerError(kSessionDetachedDuringOperation));
++      return;
++    }
+     ScriptState::Scope scope(script_state_);
+     v8::Local<v8::Context> context = script_state_->GetContext();
+     v8_inspector::StringView object_group =
+@@ -881,6 +889,20 @@ InspectorIndexedDBAgent::InspectorIndexedDBAgent(
+ 
+ InspectorIndexedDBAgent::~InspectorIndexedDBAgent() = default;
+ 
++void InspectorIndexedDBAgent::Dispose() {
++  ReleaseObjectGroup();
++  v8_session_ = nullptr;
++  InspectorBaseAgent<protocol::IndexedDB::Metainfo>::Dispose();
++}
++
++void InspectorIndexedDBAgent::ReleaseObjectGroup() {
++  if (!v8_session_) {
++    return;
++  }
++  v8_session_->releaseObjectGroup(
++      ToV8InspectorStringView(kIndexedDBObjectGroup));
++}
++
+ void InspectorIndexedDBAgent::Restore() {
+   if (enabled_.Get()) {
+     enable();
+@@ -889,8 +911,7 @@ void InspectorIndexedDBAgent::Restore() {
+ 
+ void InspectorIndexedDBAgent::DidCommitLoadForLocalFrame(LocalFrame* frame) {
+   if (frame == inspected_frames_->Root()) {
+-    v8_session_->releaseObjectGroup(
+-        ToV8InspectorStringView(kIndexedDBObjectGroup));
++    ReleaseObjectGroup();
+   }
+ }
+ 
+@@ -901,8 +922,7 @@ protocol::Response InspectorIndexedDBAgent::enable() {
+ 
+ protocol::Response InspectorIndexedDBAgent::disable() {
+   enabled_.Clear();
+-  v8_session_->releaseObjectGroup(
+-      ToV8InspectorStringView(kIndexedDBObjectGroup));
++  ReleaseObjectGroup();
+   return protocol::Response::Success();
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.h b/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.h
+index dd3f49a9433e25e9da7f945baa568af7604e0b3e..edef182542bed83a79d7333fde562eb0d7d4bccf 100644
+--- a/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.h
++++ b/third_party/blink/renderer/modules/indexeddb/inspector_indexed_db_agent.h
+@@ -57,6 +57,7 @@ class MODULES_EXPORT InspectorIndexedDBAgent final
+ 
+   v8_inspector::V8InspectorSession* v8_session() { return v8_session_; }
+ 
++  void Dispose() override;
+   void Restore() override;
+   void DidCommitLoadForLocalFrame(LocalFrame*) override;
+ 
+@@ -115,10 +116,13 @@ class MODULES_EXPORT InspectorIndexedDBAgent final
+       std::unique_ptr<DeleteDatabaseCallback>) override;
+ 
+  private:
++  void ReleaseObjectGroup();
++
+   // This is null while inspecting workers.
+   Member<InspectedFrames> inspected_frames_;
+   // This is null while inspecting frames.
+   Member<WorkerGlobalScope> worker_global_scope_;
++  // This is null after `InspectorIndexedDBAgent` is disposed.
+   raw_ptr<v8_inspector::V8InspectorSession, DanglingUntriaged> v8_session_;
+   InspectorAgentState::Boolean enabled_;
+ };
+diff --git a/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db-expected.txt b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db-expected.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..6e8509a66f74f7c0ca1116ae2c3b8bd161462fbd
+--- /dev/null
++++ b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db-expected.txt
+@@ -0,0 +1,4 @@
++Race IndexedDB requestData() with navigation using a large dataset.
++Round 0 completed without a crash.
++Round 1 completed without a crash.
++
+diff --git a/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db.js b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..f52afef721c5c3be47d4af983f5c80d92ebea115
+--- /dev/null
++++ b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/indexed-db-request-data-race-with-navigation-large-db.js
+@@ -0,0 +1,88 @@
++(async function(/** @type {import('test_runner').TestRunner} */ testRunner) {
++  const {page, session, dp} = await testRunner.startBlank(
++      'Race IndexedDB requestData() with navigation using a large dataset.');
++
++  const rounds = 2;
++  const valueCount = 64;
++  const valueSize = 8192;
++  const securityOrigin = await session.evaluate('location.origin');
++
++  await dp.Page.enable();
++  await dp.Runtime.enable();
++  await dp.IndexedDB.enable();
++
++  // Repeat the test multiple times to trigger the race.
++  for (let round = 0; round < rounds; ++round) {
++    const dbName = `RaceDB_${round}`;
++
++    // Navigate to an empty page to set up IndexedDB.
++    await dp.Page.navigate(
++        {url: securityOrigin + '/inspector-protocol/resources/empty.html'});
++    await dp.Page.onceLoadEventFired();
++
++    // Create a larger IndexedDB with KBs data to make requestData() take longer.
++    await session.evaluateAsync(`(async () => {
++      const dbName = ${JSON.stringify(dbName)};
++      const storeName = 'TestObjectStore';
++      const payload = 'X'.repeat(${valueSize});
++      await new Promise((resolve, reject) => {
++        const request = indexedDB.deleteDatabase(dbName);
++        request.onsuccess = () => resolve();
++        request.onerror = () => resolve();
++        request.onblocked = () => reject(String(request.error || 'delete blocked'));
++      });
++      await new Promise((resolve, reject) => {
++        const request = indexedDB.open(dbName, 1);
++        request.onupgradeneeded = event => {
++          const db = event.target.result;
++          const store = db.createObjectStore(storeName, {keyPath: 'id'});
++          for (let i = 0; i < ${valueCount}; ++i) {
++            store.put({id: i, label: 'row-' + i, value: payload + i});
++          }
++        };
++        request.onsuccess = () => {
++          request.result.close();
++          resolve();
++        };
++        request.onerror = () => reject(String(request.error || 'open failed'));
++      });
++      return 'done';
++    })()`);
++
++    // Start an async IndexedDB read.
++    dp.IndexedDB.requestData({
++      securityOrigin: securityOrigin,
++      databaseName: dbName,
++      objectStoreName: 'TestObjectStore',
++      skipCount: 0,
++      pageSize: valueCount,
++    });
++
++    // Navigate immediately to race against the pending requestData() callback.
++    dp.Page.navigate(
++        {url: 'data:text/html,<body>navigated<iframe></iframe></body>'});
++
++    // Allow time for teardown to execute while the requestData() callback may still fire.
++    await new Promise(resolve => setTimeout(resolve, 500));
++
++    testRunner.log(`Round ${round} completed without a crash.`);
++  }
++
++  // Clean up the databases.
++  await dp.Page.navigate(
++      {url: securityOrigin + '/inspector-protocol/resources/empty.html'});
++  await dp.Page.onceLoadEventFired();
++  await session.evaluateAsync(`(async () => {
++    for (let round = 0; round < ${rounds}; ++round) {
++      await new Promise(resolve => {
++        const request = indexedDB.deleteDatabase('RaceDB_' + round);
++        request.onsuccess = () => resolve();
++        request.onerror = () => resolve();
++        request.onblocked = () => resolve();
++      });
++    }
++    return 'done';
++  })()`);
++
++  testRunner.completeTest();
++})

--- a/patches/chromium/cherry-pick-873978ddc92b.patch
+++ b/patches/chromium/cherry-pick-873978ddc92b.patch
@@ -1,0 +1,301 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maks Orlovich <morlovich@chromium.org>
+Date: Wed, 8 Jul 2026 09:29:46 -0700
+Subject: [M144] FLEDGE: fix lifetime reportWin's deprecatedUrl handler.
+
+Original change's description:
+> FLEDGE: fix lifetime reportWin's deprecatedUrl handler.
+>
+> Other lazy fillers seem fine on read-through, but just in case:
+> 1) Reuse unused logger param from the config filler --- it gets
+>    it from ContextRecycler, and using the passed in one would
+>    cause trouble.
+> 2) Call the checkpoint after resetting the bindings and lazy fillers.
+>
+> Bug: 527406824
+> Change-Id: I570a1267be21d9d398c4e2102e21a6bb923345c2
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8006698
+> Reviewed-by: mmenke <mmenke@chromium.org>
+> Commit-Queue: Maks Orlovich <morlovich@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1653488}
+
+(cherry picked from commit 5a68bc6c97d97312ffa0f9ac04e2288f1cdadd13)
+(change in merge: don't need tags for v8::External in this version)
+
+Bug: 532492736,527406824
+Change-Id: I570a1267be21d9d398c4e2102e21a6bb923345c2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8063845
+Commit-Queue: Maks Orlovich <morlovich@chromium.org>
+Reviewed-by: mmenke <mmenke@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7559@{#5071}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/content/services/auction_worklet/bidder_worklet.cc b/content/services/auction_worklet/bidder_worklet.cc
+index 38f7021578dbf089a77af91600786cb2a5fef2f2..745cb87427d140b967b1e258ffa03d348e7ede22 100644
+--- a/content/services/auction_worklet/bidder_worklet.cc
++++ b/content/services/auction_worklet/bidder_worklet.cc
+@@ -1128,6 +1128,12 @@ void BidderWorklet::V8State::ReportWin(
+   AuctionV8Helper::FullIsolateScope isolate_scope(v8_helper_.get());
+   v8::Isolate* isolate = v8_helper_->isolate();
+ 
++  // Needs to outlast ContextRecyclerScope. See crbug.com/527406824.
++  DeprecatedUrlLazyFiller deprecated_render_url(
++      v8_helper_.get(), &browser_signal_render_url,
++      "browserSignals.renderUrl is deprecated."
++      " Please use browserSignals.renderURL instead.");
++
+   // Short lived context, to avoid leaking data at global scope between either
+   // repeated calls to this worklet, or to calls to any other worklet.
+   ContextRecycler context_recycler(v8_helper_.get());
+@@ -1180,10 +1186,6 @@ void BidderWorklet::V8State::ReportWin(
+ 
+   context_recycler.AddReportWinBrowserSignalsLazyFiller();
+ 
+-  DeprecatedUrlLazyFiller deprecated_render_url(
+-      v8_helper_.get(), &v8_logger, &browser_signal_render_url,
+-      "browserSignals.renderUrl is deprecated."
+-      " Please use browserSignals.renderURL instead.");
+   base::TimeDelta reporting_timeout =
+       browser_signal_reporting_timeout.has_value()
+           ? *browser_signal_reporting_timeout
+@@ -1242,6 +1244,8 @@ void BidderWorklet::V8State::ReportWin(
+   }
+   args.push_back(direct_from_seller_signals);
+ 
++  deprecated_render_url.SetLogger(&v8_logger);
++
+   // An empty return value indicates an exception was thrown. Any other return
+   // value indicates no exception.
+   v8_helper_->MaybeTriggerInstrumentationBreakpoint(
+@@ -1257,6 +1261,7 @@ void BidderWorklet::V8State::ReportWin(
+       v8_helper_->RunScript(context, unbound_worklet_script, debug_id_.get(),
+                             total_timeout.get(), errors_out);
+   if (result != AuctionV8Helper::Result::kSuccess) {
++    deprecated_render_url.SetLogger(nullptr);
+     TRACE_EVENT_END("fledge", perfetto::Track(trace_id));
+     PostReportWinCallbackToUserThread(
+         std::move(callback), /*report_url=*/std::nullopt,
+@@ -1297,6 +1302,7 @@ void BidderWorklet::V8State::ReportWin(
+   base::UmaHistogramTimes("Ads.InterestGroup.Auction.ReportWinTime", elapsed);
+ 
+   if (result != AuctionV8Helper::Result::kSuccess) {
++    deprecated_render_url.SetLogger(nullptr);
+     // Keep Private Aggregation API requests since `reportWin()` might use it to
+     // detect script timeout or failures.
+     PostReportWinCallbackToUserThread(
+@@ -1403,6 +1409,7 @@ void BidderWorklet::V8State::ReportWin(
+   }
+   // This covers both the case where a report URL was provided, and the case one
+   // was not.
++  deprecated_render_url.SetLogger(nullptr);
+   PostReportWinCallbackToUserThread(
+       std::move(callback), context_recycler.report_bindings()->report_url(),
+       context_recycler.register_ad_beacon_bindings()->TakeAdBeaconMap(),
+diff --git a/content/services/auction_worklet/bidder_worklet_unittest.cc b/content/services/auction_worklet/bidder_worklet_unittest.cc
+index 34d84d0bffdd8ef8a33a5ef061f78a5e23b4a463..b8005122f33e7727b8f4282a0fd0977d0771c093 100644
+--- a/content/services/auction_worklet/bidder_worklet_unittest.cc
++++ b/content/services/auction_worklet/bidder_worklet_unittest.cc
+@@ -8755,6 +8755,33 @@ TEST_F(BidderWorkletTest, ReportWinBrowserSignalRenderUrlDeprecationWarning) {
+   channel->ExpectNoMoreConsoleEvents();
+ }
+ 
++TEST_F(BidderWorkletTest, ReportWinBrowserSignalRenderUrlDeprecationAsync) {
++  // From https://crbug.com/527406824
++  const char kBody[] = R"(
++      globalThis.savedBrowserSignals = browserSignals;
++      Promise.resolve().then(() => {
++        void globalThis.savedBrowserSignals.renderUrl;
++      });
++
++      // Force reportWin timeout. V8's normal auto microtask checkpoint is
++      // skipped while execution is terminating; AuctionWorklet's
++      // ContextRecyclerScope then performs a later ResetForReuse() microtask
++      // checkpoint after stack unwind.
++      while (true) {}
++  )";
++  AddJavascriptResponse(&url_loader_factory_, interest_group_bidding_url_,
++                        CreateReportWinScript(kBody));
++  RunReportWinExpectingResult(
++      /*expected_report_url=*/std::nullopt,
++      /*expected_ad_beacon_map=*/{},
++      /*expected_ad_macro_map=*/{},
++      /*expected_pa_requests=*/{},
++      /*expected_pmt_request_data=*/nullptr,
++      /*expected_reporting_latency_timeout=*/true,
++      /*expected_errors=*/
++      {"https://url.test/ execution of `reportWin` timed out."});
++}
++
+ // Check that accessing `renderURL` of browserSignals does not display a
+ // warning.
+ //
+diff --git a/content/services/auction_worklet/context_recycler.cc b/content/services/auction_worklet/context_recycler.cc
+index 57d4275c9cc779d291962a90d4049ec9eabceea9..8d1e0ada7894e2b26ba112754d649d436117657c 100644
+--- a/content/services/auction_worklet/context_recycler.cc
++++ b/content/services/auction_worklet/context_recycler.cc
+@@ -190,12 +190,6 @@ v8::Local<v8::Context> ContextRecycler::GetContext() {
+ }
+ 
+ void ContextRecycler::ResetForReuse() {
+-  // Make sure that microtasks get flushed as they would not on timeout.
+-  {
+-    AuctionV8Helper::TimeLimitScope time_scope(v8_helper_->GetTimeLimit());
+-    v8_helper_->isolate()->PerformMicrotaskCheckpoint();
+-  }
+-
+   for (Bindings* bindings : bindings_list_) {
+     bindings->Reset();
+   }
+@@ -214,6 +208,12 @@ void ContextRecycler::ResetForReuse() {
+   for (const auto& auction_config_lazy_filler : auction_config_lazy_fillers_) {
+     auction_config_lazy_filler->Reset();
+   }
++
++  // Make sure that microtasks get flushed as they would not on timeout.
++  {
++    AuctionV8Helper::TimeLimitScope time_scope(v8_helper_->GetTimeLimit());
++    v8_helper_->isolate()->PerformMicrotaskCheckpoint();
++  }
+ }
+ 
+ ContextRecyclerScope::ContextRecyclerScope(ContextRecycler& context_recycler)
+diff --git a/content/services/auction_worklet/deprecated_url_lazy_filler.cc b/content/services/auction_worklet/deprecated_url_lazy_filler.cc
+index ee281f6b7cd0334c89ddf1535e81cf5e333df8b3..d3ddda07a5c8371a5080210e255567da53da00fc 100644
+--- a/content/services/auction_worklet/deprecated_url_lazy_filler.cc
++++ b/content/services/auction_worklet/deprecated_url_lazy_filler.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <string_view>
+ 
++#include "base/check.h"
+ #include "base/memory/raw_ptr.h"
+ #include "content/services/auction_worklet/auction_v8_helper.h"
+ #include "content/services/auction_worklet/auction_v8_logger.h"
+@@ -17,15 +18,16 @@
+ namespace auction_worklet {
+ 
+ DeprecatedUrlLazyFiller::DeprecatedUrlLazyFiller(AuctionV8Helper* v8_helper,
+-                                                 AuctionV8Logger* v8_logger,
+                                                  const GURL* url,
+                                                  const char* warning)
+     : LazyFiller(v8_helper),
+-      v8_logger_(v8_logger),
++      v8_logger_(nullptr),
+       url_(url),
+       warning_(warning) {}
+ 
+-DeprecatedUrlLazyFiller::~DeprecatedUrlLazyFiller() = default;
++DeprecatedUrlLazyFiller::~DeprecatedUrlLazyFiller() {
++  DCHECK_EQ(v8_logger_, nullptr);
++}
+ 
+ bool DeprecatedUrlLazyFiller::AddDeprecatedUrlGetter(
+     v8::Local<v8::Object> object,
+@@ -39,7 +41,9 @@ void DeprecatedUrlLazyFiller::HandleDeprecatedUrl(
+     v8::Local<v8::Name> name,
+     const v8::PropertyCallbackInfo<v8::Value>& info) {
+   DeprecatedUrlLazyFiller* self = GetSelf<DeprecatedUrlLazyFiller>(info);
+-  self->v8_logger_->LogConsoleWarning(self->warning_.get());
++  if (self->v8_logger_) {
++    self->v8_logger_->LogConsoleWarning(self->warning_.get());
++  }
+ 
+   AuctionV8Helper* v8_helper = self->v8_helper();
+   v8::Isolate* isolate = v8_helper->isolate();
+diff --git a/content/services/auction_worklet/deprecated_url_lazy_filler.h b/content/services/auction_worklet/deprecated_url_lazy_filler.h
+index a3541ef3802dc1ca2349194d9b676d131216482c..f252209e2f387c5b5c40575d62fc8077c378d094 100644
+--- a/content/services/auction_worklet/deprecated_url_lazy_filler.h
++++ b/content/services/auction_worklet/deprecated_url_lazy_filler.h
+@@ -31,12 +31,14 @@ class DeprecatedUrlLazyFiller : public LazyFiller {
+   // DeprecatedUrlLazyFiller. Additionally, `url` and `warning` must not be
+   // modified until the DeprecatedUrlLazyFiller is destroyed.
+   DeprecatedUrlLazyFiller(AuctionV8Helper* v8_helper,
+-                          AuctionV8Logger* v8_logger,
+                           const GURL* url,
+                           const char* warning);
+ 
+   ~DeprecatedUrlLazyFiller() override;
+ 
++  // v8_logger must outlast `this` (or should be cleared).
++  void SetLogger(AuctionV8Logger* v8_logger) { v8_logger_ = v8_logger; }
++
+   // Adds a getter to `object` that, when the `name` field is first accessed,
+   // will display a warning and return the URL `this` was created with, as a
+   // string. Subsequent accesses will not display a warning. Does nothing if
+@@ -51,7 +53,7 @@ class DeprecatedUrlLazyFiller : public LazyFiller {
+       v8::Local<v8::Name> name,
+       const v8::PropertyCallbackInfo<v8::Value>& info);
+ 
+-  const raw_ptr<AuctionV8Logger> v8_logger_;
++  raw_ptr<AuctionV8Logger> v8_logger_;
+   const raw_ptr<const GURL> url_;
+   const raw_ptr<const char> warning_;
+ };
+diff --git a/content/services/auction_worklet/seller_worklet.cc b/content/services/auction_worklet/seller_worklet.cc
+index 4f17ec9fafe127763453b165edb4d996b4599d97..6e868c142fb4e117bd5565ed4f37bf0df6aaf01a 100644
+--- a/content/services/auction_worklet/seller_worklet.cc
++++ b/content/services/auction_worklet/seller_worklet.cc
+@@ -171,7 +171,6 @@ bool IsValidBid(double bid) {
+ // (With many fields filled in on-demand by an AuctionConfigLazyFiller).
+ bool AppendAuctionConfig(
+     AuctionV8Helper* v8_helper,
+-    AuctionV8Logger* v8_logger,
+     v8::Local<v8::Context> context,
+     const url::Origin& seller,
+     base::optional_ref<const GURL> decision_logic_url,
+@@ -269,7 +268,7 @@ bool AppendAuctionConfig(
+     for (size_t pos = 0; pos < component_auctions.size(); ++pos) {
+       const auto& component_auction = component_auctions[pos];
+       if (!AppendAuctionConfig(
+-              v8_helper, v8_logger, context, component_auction.seller,
++              v8_helper, context, component_auction.seller,
+               component_auction.decision_logic_url,
+               component_auction.trusted_scoring_signals_url,
+               experiment_group_id,
+@@ -1147,8 +1146,6 @@ void SellerWorklet::V8State::ScoreAd(
+   v8::Local<v8::Context> context = context_recycler_scope.GetContext();
+   TRACE_EVENT_END("fledge", perfetto::Track(trace_id));  // "get_seller_context"
+ 
+-  AuctionV8Logger v8_logger(v8_helper_.get(), context);
+-
+   v8::LocalVector<v8::Value> args(isolate);
+   if (!v8_helper_->AppendJsonValue(context, ad_metadata_json, &args)) {
+     PostScoreAdCallbackToUserThreadOnError(
+@@ -1167,10 +1164,10 @@ void SellerWorklet::V8State::ScoreAd(
+   context_recycler->EnsureAuctionConfigLazyFillers(
+       1 + auction_ad_config_non_shared_params.component_auctions.size());
+   if (!AppendAuctionConfig(
+-          v8_helper_.get(), &v8_logger, context,
+-          url::Origin::Create(decision_logic_url_), decision_logic_url_,
+-          trusted_scoring_signals_url_, experiment_group_id_,
+-          send_creative_scanning_metadata_, auction_ad_config_non_shared_params,
++          v8_helper_.get(), context, url::Origin::Create(decision_logic_url_),
++          decision_logic_url_, trusted_scoring_signals_url_,
++          experiment_group_id_, send_creative_scanning_metadata_,
++          auction_ad_config_non_shared_params,
+           context_recycler->auction_config_lazy_fillers(),
+           /*auction_config_lazy_filler_pos=*/0, &args)) {
+     PostScoreAdCallbackToUserThreadOnError(
+@@ -1759,7 +1756,6 @@ void SellerWorklet::V8State::ReportResult(
+ 
+   ContextRecyclerScope context_recycler_scope(context_recycler);
+   v8::Local<v8::Context> context = context_recycler_scope.GetContext();
+-  AuctionV8Logger v8_logger(v8_helper_.get(), context);
+ 
+   // We want this before RunScript, both because it's meant to be visible
+   // to globals, and because we don't want to overwrite existing globals.
+@@ -1770,10 +1766,10 @@ void SellerWorklet::V8State::ReportResult(
+   context_recycler.EnsureAuctionConfigLazyFillers(
+       1 + auction_ad_config_non_shared_params.component_auctions.size());
+   if (!AppendAuctionConfig(
+-          v8_helper_.get(), &v8_logger, context,
+-          url::Origin::Create(decision_logic_url_), decision_logic_url_,
+-          trusted_scoring_signals_url_, experiment_group_id_,
+-          send_creative_scanning_metadata_, auction_ad_config_non_shared_params,
++          v8_helper_.get(), context, url::Origin::Create(decision_logic_url_),
++          decision_logic_url_, trusted_scoring_signals_url_,
++          experiment_group_id_, send_creative_scanning_metadata_,
++          auction_ad_config_non_shared_params,
+           context_recycler.auction_config_lazy_fillers(),
+           /*auction_config_lazy_filler_pos=*/0, &args)) {
+     PostReportResultCallbackToUserThread(std::move(callback),

--- a/patches/chromium/cherry-pick-e6468cc124d6.patch
+++ b/patches/chromium/cherry-pick-e6468cc124d6.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dana Fried <dfried@chromium.org>
+Date: Tue, 7 Jul 2026 06:06:04 -0700
+Subject: [M144-LTS] [Views] avoid possible UAF in FocusManager
+
+This replaces raw View* with ViewTracker in a couple of instances where
+it is (theoretically) possible for a View to disappear in the middle of
+a function, because events are potentially generated between capture and
+use.
+
+(cherry picked from commit b17402fd2c84ab1a58ff094c122a3c4f55c79b38)
+
+Fixed: 524045160
+Change-Id: I4f9c42ca0e706c5042e08aa451d3944367b98a83
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8015894
+Commit-Queue: Kaan Alsan <alsan@chromium.org>
+Commit-Queue: Dana Fried <dfried@chromium.org>
+Auto-Submit: Dana Fried <dfried@chromium.org>
+Reviewed-by: Kaan Alsan <alsan@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1654051}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8032002
+Reviewed-by: Fahad Mansoor <fahadmansoor@google.com>
+Reviewed-by: Dana Fried <dfried@chromium.org>
+Commit-Queue: Tiago Vignatti (xWF) <vignatti@google.com>
+Cr-Commit-Position: refs/branch-heads/7559@{#5066}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/ui/views/focus/focus_manager.cc b/ui/views/focus/focus_manager.cc
+index ec1ba3c3dd0a0cb0ddf66feb56b1366361e775b5..b69957ad823b6b4086791245e00559e4e0bcf13b 100644
+--- a/ui/views/focus/focus_manager.cc
++++ b/ui/views/focus/focus_manager.cc
+@@ -376,11 +376,12 @@ void FocusManager::SetFocusedView(View* view) {
+ 
+ void FocusManager::ClearFocus() {
+   // SetFocusedView(nullptr) is going to clear out the stored view to. We need
+-  // to persist it in this case.
+-  views::View* focused_view = GetStoredFocusView();
++  // to persist it in this case (assuming it survives the events sent out in the
++  // interim).
++  auto focused_view = std::make_unique<ViewTracker>(GetStoredFocusView());
+   SetFocusedView(nullptr);
+   ClearNativeFocus();
+-  SetStoredFocusView(focused_view);
++  view_tracker_for_stored_view_ = std::move(focused_view);
+ }
+ 
+ void FocusManager::AdvanceFocusIfNecessary() {
+@@ -401,14 +402,14 @@ void FocusManager::AdvanceFocusIfNecessary() {
+ }
+ 
+ void FocusManager::StoreFocusedView(bool clear_native_focus) {
+-  View* focused_view = focused_view_;
+   // Don't do anything if no focused view. Storing the view (which is nullptr),
+   // in this case, would clobber the view that was previously saved.
+   if (!focused_view_) {
+     return;
+   }
+ 
+-  View* v = focused_view_;
++  // This could go away when sending events below, so guard access.
++  ViewTracker old_view(focused_view_);
+ 
+   if (clear_native_focus) {
+     // Temporarily disable notification.  ClearFocus() will set the focus to the
+@@ -420,11 +421,11 @@ void FocusManager::StoreFocusedView(bool clear_native_focus) {
+     ClearFocus();
+   } else {
+     SetFocusedView(nullptr);
+-    SetStoredFocusView(focused_view);
++    SetStoredFocusView(old_view.view());
+   }
+ 
+-  if (v) {
+-    v->SchedulePaint();  // Remove focus border.
++  if (auto* const view = old_view.view()) {
++    view->SchedulePaint();  // Remove focus border.
+   }
+ }
+ 


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`782c6b3e9bb4`](https://chromium-review.googlesource.com/c/chromium/src/+/8006327) from chromium — [M144-LTS][ozone/wayland]Handle window destruction during surface configure
* [`17a4e7216d1b`](https://chromium-review.googlesource.com/c/chromium/src/+/7997178) from chromium — [M148] [Extensions] Fix UAF in AppWindow::SetNativeWindowFullscreen
* [`1824adf21674`](https://chromium-review.googlesource.com/c/chromium/src/+/8008507) from chromium — [M148] [SPC] Guard SPC Controller destruction during dialog close.
* [`086fe2cf7f7c`](https://chromium-review.googlesource.com/c/chromium/src/+/8018763) from chromium — [M148] Add better handling of RtcVideoDecoderAdapter init timeout.
* [`45d7457ac585`](https://chromium-review.googlesource.com/c/chromium/src/+/8020702) from chromium — [M148] Recheck prerequisites when inserting multiple nodes into a Document.
* [`7aea889dfa2f`](https://chromium-review.googlesource.com/c/chromium/src/+/8020374) from chromium — [M148] InspectorIndexedDBAgent must not use v8_session_ after disposal
* [`e6468cc124d6`](https://chromium-review.googlesource.com/c/chromium/src/+/8032002) from chromium — [M144-LTS] [Views] avoid possible UAF in FocusManager
* [`873978ddc92b`](https://chromium-review.googlesource.com/c/chromium/src/+/8063845) from chromium — [M144] FLEDGE: fix lifetime reportWin's deprecatedUrl handler.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium.
