### PR TITLE
docs: document macOS APIs that require code signing

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1421,6 +1421,11 @@ Returns `Object`:
 
 ### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
+> [!IMPORTANT]
+> On macOS, your app should be [code signed and notarized](../tutorial/code-signing.md#macos-apis-that-require-code-signing)
+> for login item settings to work reliably. When an app isn't packaged, code signed,
+> and notarized, `openAtLogin` may silently fail to take effect.
+
 * `settings` Object
   * `openAtLogin` boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -27,8 +27,8 @@ update process. Apps that need to disable ATS can add the
 `NSAllowsArbitraryLoads` key to their app's plist.
 
 > [!IMPORTANT]
-> Your application must be signed for automatic updates on macOS.
-> This is a requirement of `Squirrel.Mac`.
+> Your application must be [signed](../tutorial/code-signing.md#macos-apis-that-require-code-signing)
+> for automatic updates on macOS. This is a requirement of `Squirrel.Mac`.
 
 ### Windows
 

--- a/docs/api/safe-storage.md
+++ b/docs/api/safe-storage.md
@@ -28,6 +28,12 @@ Note that on macOS, access to the system Keychain is required and
 these calls can block the current thread to collect user input.
 The same is true for Linux, if a password management tool is available.
 
+> [!IMPORTANT]
+> On macOS, your app should be [code signed](../tutorial/code-signing.md#macos-apis-that-require-code-signing)
+> for `safeStorage` to behave consistently. Without a valid, consistent signature,
+> macOS may not recognize different builds of your app as the same application,
+> which can cause the Keychain to re-prompt the user for permission on every update.
+
 ### Asynchronous API
 
 The asynchronous API uses pluggable key providers that vary by platform:

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -76,6 +76,27 @@ packager({
 
 See the [Mac App Store Guide][].
 
+## macOS APIs that require code signing
+
+A number of macOS APIs exposed by Electron rely on system frameworks (like Keychain
+Access and `Squirrel.Mac`) that only behave correctly once your app is code signed.
+When testing these APIs, keep in mind that an unsigned or ad-hoc signed app may behave
+inconsistently, and issues that look like Electron bugs are often resolved by properly
+signing (and notarizing) your app:
+
+- [`safeStorage`](../api/safe-storage.md) - Without a valid, consistent code signature,
+  macOS may be unable to tell that two builds of your unsigned app are "the same app",
+  which can cause the Keychain to prompt the user for permission again after every
+  update.
+- [`app.setLoginItemSettings()`](../api/app.md#appsetloginitemsettingssettings-macos-windows) -
+  Login items can behave incorrectly (e.g. silently failing to register) when the app is
+  not packaged, code signed, and notarized.
+- [The `cookieEncryption` fuse](./fuses.md#cookieencryption) - Cookie encryption uses
+  the same OS-level access to the Keychain as `safeStorage`, so it has the same code
+  signing requirement.
+- [`autoUpdater`](../api/auto-updater.md) - `Squirrel.Mac` requires the app to be
+  signed for automatic updates to work at all.
+
 ## Signing Windows builds
 
 ### Using Azure Artifact Signing

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -48,6 +48,11 @@ does, then you should enable this fuse. Please note it is a one-way transitionâ€
 fuse, existing unencrypted cookies will be encrypted-on-write, but subsequently disabling the fuse
 later will make your cookie store corrupt and useless. Most apps can safely enable this fuse.
 
+> [!IMPORTANT]
+> On macOS, this fuse relies on the same OS-level access to the Keychain as
+> [`safeStorage`](../api/safe-storage.md), so your app should be
+> [code signed](./code-signing.md#macos-apis-that-require-code-signing) for it to work correctly.
+
 ### `nodeOptions`
 
 **Default:** Enabled


### PR DESCRIPTION
#### Description of Change

Several macOS APIs rely on OS-level Keychain access or `Squirrel.Mac`, which only behave correctly once the app is code signed (and, for login items, notarized). This isn't documented anywhere today, and it's a recurring source of confusion — see #45672, #43233, and #45088.

This PR:

* Adds a new "macOS APIs that require code signing" section to the [code signing tutorial](https://github.com/electron/electron/blob/main/docs/tutorial/code-signing.md), summarizing why each API needs it.
* Cross-links that section from the docs for each affected API/feature:
  * `safeStorage`
  * `app.setLoginItemSettings()`
  * the `cookieEncryption` fuse
  * `autoUpdater` (already had a note; just linked it to the new section)

Fixes #45802

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are changed or added <!-- N/A, docs-only change -->
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

#### Release Notes

Notes: Documented which macOS APIs (`safeStorage`, `app.setLoginItemSettings()`, the `cookieEncryption` fuse, and `autoUpdater`) require the app to be code signed and/or notarized.