### PR TITLE
docs: fix command for clang-tidy usage

### DIFF
--- a/docs/development/clang-tidy.md
+++ b/docs/development/clang-tidy.md
@@ -10,12 +10,12 @@ files, you need to have built Electron so that it knows which compiler flags
 were used. There is one required option for the script `--output-dir`, which
 tells the script which build directory to pull the compilation information
 from. A typical usage would be:
-`npm run lint:clang-tidy --out-dir ../out/Testing`
+`npm run lint:clang-tidy -- --out-dir ../out/Testing`
 
 With no filenames provided, all C/C++/Objective-C files will be checked.
 You can provide a list of files to be checked by passing the filenames after
 the options:
-`npm run lint:clang-tidy --out-dir ../out/Testing shell/browser/api/electron_api_app.cc`
+`npm run lint:clang-tidy -- --out-dir ../out/Testing shell/browser/api/electron_api_app.cc`
 
 While `clang-tidy` has a
 [long list](https://clang.llvm.org/extra/clang-tidy/checks/list.html)


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

`npm run` needs an extra `--` to make sure the arguments are passed to the script, instead of npm itself.

```
$ npm run --help
Run arbitrary package scripts

Usage:
npm run <command> [-- <args>]
```

The example command fails with:
```
$ npm run lint:clang-tidy --out-dir ../out/Testing
npm warn "../out/Testing" is being parsed as a normal command line argument.
npm warn Unknown cli config "--out-dir". This will stop working in the next major version of npm.

> @electron-ci/dev-root@0.0.0-development lint:clang-tidy
> ts-node ./script/run-clang-tidy.ts ../out/Testing

--out-dir is a required argument
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
