### PR TITLE
chore!: remove deprecated macOS login item API

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1406,8 +1406,8 @@ Returns `Integer` - The current value displayed in the counter badge.
 ### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
 * `options` Object (optional)
-  * `type` string (optional) _macOS_ - Can be `mainAppService`, `agentService`, `daemonService`, or `loginItemService`. Defaults to `mainAppService`. Only available on macOS 13 and up. See [app.setLoginItemSettings](app.md#appsetloginitemsettingssettings-macos-windows) for more information about each type.
-  * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default. Only available on macOS 13 and up.
+  * `type` string (optional) _macOS_ - Can be `mainAppService`, `agentService`, `daemonService`, or `loginItemService`. Defaults to `mainAppService`. See [app.setLoginItemSettings](app.md#appsetloginitemsettingssettings-macos-windows) for more information about each type.
+  * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default.
   * `path` string (optional) _Windows_ - The executable path to compare against. Defaults to `process.execPath`.
   * `args` string[] (optional) _Windows_ - The command-line arguments to compare against. Defaults to an empty array.
 
@@ -1417,10 +1417,7 @@ need to pass the same arguments here for `openAtLogin` to be set correctly.
 Returns `Object`:
 
 * `openAtLogin` boolean - `true` if the app is set to open at login.
-* `openAsHidden` boolean _macOS_ _Deprecated_ - `true` if the app is set to open as hidden at login. This does not work on macOS 13 and up.
 * `wasOpenedAtLogin` boolean _macOS_ - `true` if the app was opened at login automatically.
-* `wasOpenedAsHidden` boolean _macOS_ _Deprecated_ - `true` if the app was opened as a hidden login item. This indicates that the app should not open any windows at startup. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
-* `restoreState` boolean _macOS_ _Deprecated_ - `true` if the app was opened as a login item that should restore the state from the previous session. This indicates that the app should restore the windows that were open the last time the app was closed. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
 * `status` string _macOS_ - can be `not-registered`, `enabled`, `requires-approval`, or `not-found`.
 * `executableWillLaunchAtLogin` boolean _Windows_ - `true` if app is set to open at login and its run key is not deactivated. This differs from `openAtLogin` as it ignores the `args` option, this property will be true if the given executable would be launched at login with **any** arguments.
 * `launchItems` Object[] _Windows_
@@ -1440,13 +1437,12 @@ Returns `Object`:
 * `settings` Object
   * `openAtLogin` boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.
-  * `openAsHidden` boolean (optional) _macOS_ _Deprecated_ - `true` to open the app as hidden. Defaults to `false`. The user can edit this setting from the System Preferences so `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app is opened to know the current value. This setting is not available on [MAS builds][mas-builds] or on macOS 13 and up.
-  * `type` string (optional) _macOS_ - The type of service to add as a login item. Defaults to `mainAppService`. Only available on macOS 13 and up.
+  * `type` string (optional) _macOS_ - The type of service to add as a login item. Defaults to `mainAppService`.
     * `mainAppService` - The primary application.
     * `agentService` - The property list name for a launch agent. The property list name must correspond to a property list in the app’s `Contents/Library/LaunchAgents` directory.
     * `daemonService` string (optional) _macOS_ - The property list name for a launch agent. The property list name must correspond to a property list in the app’s `Contents/Library/LaunchDaemons` directory.
     * `loginItemService` string (optional) _macOS_ - The property list name for a login item service. The property list name must correspond to a property list in the app’s `Contents/Library/LoginItems` directory.
-  * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default. Only available on macOS 13 and up.
+  * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default.
   * `path` string (optional) _Windows_ - The executable to launch at login.
     Defaults to `process.execPath`.
   * `args` string[] (optional) _Windows_ - The command-line arguments to pass to
@@ -1482,7 +1478,7 @@ app.setLoginItemSettings({
 })
 ```
 
-For more information about setting different services as login items on macOS 13 and up, see [`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc).
+For more information about setting different services as login items on macOS, see [`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc).
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 
@@ -1805,7 +1801,6 @@ A `string` property that returns the app's [Toast Activator CLSID][toast-activat
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/documentation/coreservices/1441725-lscopydefaulthandlerforurlscheme?language=objc
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
-[mas-builds]: ../tutorial/mac-app-store-submission-guide.md
 [Squirrel-Windows]: https://github.com/Squirrel/Squirrel.Windows
 [JumpListBeginListMSDN]: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-icustomdestinationlist-beginlist
 [about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1405,6 +1405,14 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 ### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/52351
+    description: "Removed `openAsHidden`, `wasOpenedAsHidden` and `restoreState` fields from return value."
+```
+-->
+
 * `options` Object (optional)
   * `type` string (optional) _macOS_ - Can be `mainAppService`, `agentService`, `daemonService`, or `loginItemService`. Defaults to `mainAppService`. See [app.setLoginItemSettings](app.md#appsetloginitemsettingssettings-macos-windows) for more information about each type.
   * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default.
@@ -1428,6 +1436,14 @@ Returns `Object`:
   * `enabled` boolean _Windows_ - `true` if the app registry key is startup approved and therefore shows as `enabled` in Task Manager and Windows settings.
 
 ### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/52351
+    description: "Removed `openAsHidden` option."
+```
+-->
 
 > [!IMPORTANT]
 > On macOS, your app should be [code signed and notarized](../tutorial/code-signing.md#macos-apis-that-require-code-signing)

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -348,7 +348,7 @@ async function writeRTF (text, clipboardType) {
 }
 ```
 
-### Removed migration path from pre-macOS 13 login items to the new `SMAppService` API
+### Removed: Migration path from pre-macOS 13 login items to the new `SMAppService` API
 
 On macOS 12 and below, Electron used legacy APIs to power
 [`app.getLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions-macos-windows)
@@ -364,6 +364,15 @@ Electron no longer performs this migration automatically.
 Most end users should have been migrated by now. Thus, this change should have little
 impact. The benefits are fixing a deadlock in `app.getLoginItemSettings()` (see also PR
 [#48090](https://github.com/electron/electron/pull/48090)) and easier maintenance.
+
+### Removed: Pre-macOS 13 login item attributes
+
+Electron 44 removes the option `openAsHidden` from
+[`app.setLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appsetloginitemsettingssettings-macos-windows)
+and the fields `openAsHidden`, `wasOpenedAsHidden` and `restoreState` from the return value of
+[`app.getLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions-macos-windows).
+
+These only worked on macOS 12 and below. Support for macOS 12 has been dropped.
 
 ## Planned Breaking API Changes (43.0)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -348,6 +348,23 @@ async function writeRTF (text, clipboardType) {
 }
 ```
 
+### Removed migration path from pre-macOS 13 login items to the new `SMAppService` API
+
+On macOS 12 and below, Electron used legacy APIs to power
+[`app.getLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions-macos-windows)
+and [`app.setLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appsetloginitemsettingssettings-macos-windows).
+
+Now that support for macOS 12 has been dropped, Electron uses the new `SMAppService`
+API only.
+
+From Electron 29 to 43 (i.e., for over two years), Electron has been migrating login
+items created with the old API to the new API automatically. Starting in Electron 44,
+Electron no longer performs this migration automatically.
+
+Most end users should have been migrated by now. Thus, this change should have little
+impact. The benefits are fixing a deadlock in `app.getLoginItemSettings()` (see also PR
+[#48090](https://github.com/electron/electron/pull/48090)) and easier maintenance.
+
 ## Planned Breaking API Changes (43.0)
 
 ### Behavior Changed: Rounded corners on Linux

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -348,23 +348,6 @@ async function writeRTF (text, clipboardType) {
 }
 ```
 
-### Removed: Migration path from pre-macOS 13 login items to the new `SMAppService` API
-
-On macOS 12 and below, Electron used legacy APIs to power
-[`app.getLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions-macos-windows)
-and [`app.setLoginItemSettings()`](https://www.electronjs.org/docs/latest/api/app#appsetloginitemsettingssettings-macos-windows).
-
-Now that support for macOS 12 has been dropped, Electron uses the new `SMAppService`
-API only.
-
-From Electron 29 to 43 (i.e., for over two years), Electron has been migrating login
-items created with the old API to the new API automatically. Starting in Electron 44,
-Electron no longer performs this migration automatically.
-
-Most end users should have been migrated by now. Thus, this change should have little
-impact. The benefits are fixing a deadlock in `app.getLoginItemSettings()` (see also PR
-[#48090](https://github.com/electron/electron/pull/48090)) and easier maintenance.
-
 ### Removed: Pre-macOS 13 login item attributes
 
 Electron 44 removes the option `openAsHidden` from

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -67,10 +67,7 @@ struct LaunchItem {
 
 struct LoginItemSettings {
   bool open_at_login = false;
-  bool open_as_hidden = false;
-  bool restore_state = false;
   bool opened_at_login = false;
-  bool opened_as_hidden = false;
   std::u16string path;
   std::vector<std::u16string> args;
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -12,10 +12,9 @@
 
 #include "base/apple/bridging.h"
 #include "base/apple/bundle_locations.h"
+#include "base/apple/foundation_util.h"
 #include "base/apple/scoped_cftyperef.h"
 #include "base/i18n/rtl.h"
-#include "base/mac/mac_util.h"
-#include "base/mac/mac_util.mm"
 #include "base/strings/sys_string_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "electron/mas.h"
@@ -72,33 +71,6 @@ std::u16string GetAppDisplayNameForProtocol(NSString* app_path) {
       [[NSFileManager defaultManager] displayNameAtPath:app_path];
   return base::SysNSStringToUTF16(app_display_name);
 }
-
-#if !IS_MAS_BUILD()
-bool CheckLoginItemStatus(bool* is_hidden) {
-  base::mac::LoginItemsFileList login_items;
-  if (!login_items.Initialize())
-    return false;
-
-  base::apple::ScopedCFTypeRef<LSSharedFileListItemRef> item(
-      login_items.GetLoginItemForMainApp());
-  if (!item.get())
-    return false;
-
-  if (is_hidden)
-    *is_hidden = base::mac::IsHiddenLoginItem(item.get());
-
-  return true;
-}
-
-LoginItemSettings GetLoginItemSettingsDeprecated() {
-  LoginItemSettings settings;
-  settings.open_at_login = CheckLoginItemStatus(&settings.open_as_hidden);
-  settings.restore_state = base::mac::WasLaunchedAsLoginItemRestoreState();
-  settings.opened_at_login = base::mac::WasLaunchedAsLoginOrResumeItem();
-  settings.opened_as_hidden = base::mac::WasLaunchedAsHiddenLoginItem();
-  return settings;
-}
-#endif
 
 }  // namespace
 
@@ -407,7 +379,6 @@ void Browser::ApplyForcedRTL() {
 
 v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {
-  LoginItemSettings settings;
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
 
   if (options.type != "mainAppService" && options.service_name.empty()) {
@@ -416,31 +387,14 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
     return v8::Local<v8::Value>();
   }
 
-#if IS_MAS_BUILD()
   const std::string status =
       platform_util::GetLoginItemEnabled(options.type, options.service_name);
-  settings.open_at_login =
-      status == "enabled" || status == "enabled-deprecated";
+
+  LoginItemSettings settings;
+  settings.open_at_login = status == "enabled";
   settings.opened_at_login = was_launched_at_login_;
-  if (@available(macOS 13, *))
-    settings.status = status;
-#else
-  // If the app was previously set as a LoginItem with the deprecated API,
-  // we should report its LoginItemSettings via the old API.
-  if (@available(macOS 13, *)) {
-    const std::string status =
-        platform_util::GetLoginItemEnabled(options.type, options.service_name);
-    if (status == "enabled-deprecated") {
-      settings = GetLoginItemSettingsDeprecated();
-    } else {
-      settings.open_at_login = status == "enabled";
-      settings.opened_at_login = was_launched_at_login_;
-      settings.status = status;
-    }
-  } else {
-    settings = GetLoginItemSettingsDeprecated();
-  }
-#endif
+  settings.status = status;
+
   return gin::ConvertToV8(isolate, settings);
 }
 
@@ -450,34 +404,9 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
         .ThrowTypeError("'name' is required when type is not mainAppService");
     return;
   }
-#if IS_MAS_BUILD()
+
   platform_util::SetLoginItemEnabled(settings.type, settings.service_name,
                                      settings.open_at_login);
-#else
-  const base::FilePath bundle_path = base::apple::MainBundlePath();
-  if (@available(macOS 13, *)) {
-    // If the app was previously set as a LoginItem with the old API, remove it
-    // as a LoginItem via the old API before re-enabling with the new API.
-    const std::string status =
-        platform_util::GetLoginItemEnabled("mainAppService", "");
-    if (status == "enabled-deprecated") {
-      base::mac::RemoveFromLoginItems(bundle_path);
-      if (settings.open_at_login) {
-        platform_util::SetLoginItemEnabled(settings.type, settings.service_name,
-                                           settings.open_at_login);
-      }
-    } else {
-      platform_util::SetLoginItemEnabled(settings.type, settings.service_name,
-                                         settings.open_at_login);
-    }
-  } else {
-    if (settings.open_at_login) {
-      base::mac::AddToLoginItems(bundle_path, settings.open_as_hidden);
-    } else {
-      base::mac::RemoveFromLoginItems(bundle_path);
-    }
-  }
-#endif
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/shell/common/gin_converters/login_item_settings_converter.cc
+++ b/shell/common/gin_converters/login_item_settings_converter.cc
@@ -4,10 +4,6 @@
 
 #include "shell/common/gin_converters/login_item_settings_converter.h"
 
-#if BUILDFLAG(IS_MAC)
-#include "base/mac/mac_util.h"
-#endif
-
 #include "shell/browser/browser.h"
 #include "shell/common/gin_helper/dictionary.h"
 
@@ -51,7 +47,6 @@ bool Converter<electron::LoginItemSettings>::FromV8(
     return false;
 
   dict.Get("openAtLogin", &(out->open_at_login));
-  dict.Get("openAsHidden", &(out->open_as_hidden));
   dict.Get("path", &(out->path));
   dict.Get("args", &(out->args));
 #if BUILDFLAG(IS_WIN)
@@ -71,17 +66,13 @@ v8::Local<v8::Value> Converter<electron::LoginItemSettings>::ToV8(
 #if BUILDFLAG(IS_WIN)
   dict.Set("launchItems", val.launch_items);
 #elif BUILDFLAG(IS_MAC)
-  if (base::mac::MacOSMajorVersion() >= 13)
-    dict.Set("status", val.status);
+  dict.Set("status", val.status);
 #endif
   // Always emit `executableWillLaunchAtLogin` so callers don't see undefined
   // on non-Windows platforms; the value is only meaningful on Windows.
   dict.Set("executableWillLaunchAtLogin", val.executable_will_launch_at_login);
   dict.Set("openAtLogin", val.open_at_login);
-  dict.Set("openAsHidden", val.open_as_hidden);
-  dict.Set("restoreState", val.restore_state);
   dict.Set("wasOpenedAtLogin", val.opened_at_login);
-  dict.Set("wasOpenedAsHidden", val.opened_as_hidden);
   return dict.GetHandle();
 }
 

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -27,51 +27,41 @@
 
 namespace {
 
-NSString* GetLoginHelperBundleIdentifier() {
-  return [[[NSBundle mainBundle] bundleIdentifier]
-      stringByAppendingString:@".loginhelper"];
-}
-
 // https://developer.apple.com/documentation/servicemanagement/1561515-service_management_errors?language=objc
 std::string GetLaunchStringForError(NSError* error) {
-  if (@available(macOS 13, *)) {
-    switch ([error code]) {
-      case kSMErrorAlreadyRegistered:
-        return "The application is already registered";
-      case kSMErrorAuthorizationFailure:
-        return "The authorization requested failed";
-      case kSMErrorLaunchDeniedByUser:
-        return "The user denied the app's launch request";
-      case kSMErrorInternalFailure:
-        return "An internal failure has occurred";
-      case kSMErrorInvalidPlist:
-        return "The app's property list is invalid";
-      case kSMErrorInvalidSignature:
-        return "The app's code signature doesn't meet the requirements to "
-               "perform the operation";
-      case kSMErrorJobMustBeEnabled:
-        return "The specified job is not enabled";
-      case kSMErrorJobNotFound:
-        return "The system can't find the specified job";
-      case kSMErrorJobPlistNotFound:
-        return "The app's property list cannot be found";
-      case kSMErrorServiceUnavailable:
-        return "The service necessary to perform this operation is unavailable "
-               "or is no longer accepting requests";
-      case kSMErrorToolNotValid:
-        return "The specified path doesn't exist or the helper tool at the "
-               "specified path isn't valid";
-      default:
-        return base::SysNSStringToUTF8([error localizedDescription]);
-    }
+  switch ([error code]) {
+    case kSMErrorAlreadyRegistered:
+      return "The application is already registered";
+    case kSMErrorAuthorizationFailure:
+      return "The authorization requested failed";
+    case kSMErrorLaunchDeniedByUser:
+      return "The user denied the app's launch request";
+    case kSMErrorInternalFailure:
+      return "An internal failure has occurred";
+    case kSMErrorInvalidPlist:
+      return "The app's property list is invalid";
+    case kSMErrorInvalidSignature:
+      return "The app's code signature doesn't meet the requirements to "
+             "perform the operation";
+    case kSMErrorJobMustBeEnabled:
+      return "The specified job is not enabled";
+    case kSMErrorJobNotFound:
+      return "The system can't find the specified job";
+    case kSMErrorJobPlistNotFound:
+      return "The app's property list cannot be found";
+    case kSMErrorServiceUnavailable:
+      return "The service necessary to perform this operation is unavailable "
+             "or is no longer accepting requests";
+    case kSMErrorToolNotValid:
+      return "The specified path doesn't exist or the helper tool at the "
+             "specified path isn't valid";
+    default:
+      return base::SysNSStringToUTF8([error localizedDescription]);
   }
-
-  return "";
 }
 
 SMAppService* GetServiceForType(const std::string& type,
-                                const std::string& name)
-    API_AVAILABLE(macosx(13.0)) {
+                                const std::string& name) {
   NSString* service_name = [NSString stringWithUTF8String:name.c_str()];
   if (type == "mainAppService") {
     return [SMAppService mainAppService];
@@ -85,26 +75,6 @@ SMAppService* GetServiceForType(const std::string& type,
     LOG(ERROR) << "Unrecognized login item type";
     return nullptr;
   }
-}
-
-bool GetLoginItemEnabledDeprecated() {
-  BOOL enabled = NO;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // SMJobCopyDictionary does not work in sandbox (see rdar://13626319)
-  CFArrayRef jobs = SMCopyAllJobDictionaries(kSMDomainUserLaunchd);
-#pragma clang diagnostic pop
-  NSArray* jobs_ = CFBridgingRelease(jobs);
-  NSString* identifier = GetLoginHelperBundleIdentifier();
-  if (jobs_ && [jobs_ count] > 0) {
-    for (NSDictionary* job in jobs_) {
-      if ([identifier isEqualToString:[job objectForKey:@"Label"]]) {
-        enabled = [[job objectForKey:@"OnDemand"] boolValue];
-        break;
-      }
-    }
-  }
-  return enabled;
 }
 
 }  // namespace
@@ -220,60 +190,31 @@ void Beep() {
 
 std::string GetLoginItemEnabled(const std::string& type,
                                 const std::string& service_name) {
-  if (@available(macOS 13, *)) {
-    SMAppService* service = GetServiceForType(type, service_name);
-    SMAppServiceStatus status = [service status];
-    if (status == SMAppServiceStatusNotRegistered)
-      return "not-registered";
-    else if (status == SMAppServiceStatusEnabled)
-      return "enabled";
-    else if (status == SMAppServiceStatusRequiresApproval)
-      return "requires-approval";
-    else if (status == SMAppServiceStatusNotFound) {
-      // If the login item was enabled with the old API, return that.
-      return GetLoginItemEnabledDeprecated() ? "enabled-deprecated"
-                                             : "not-found";
-    }
-  }
-  return GetLoginItemEnabledDeprecated() ? "enabled" : "not-registered";
+  SMAppService* service = GetServiceForType(type, service_name);
+  SMAppServiceStatus status = [service status];
+  if (status == SMAppServiceStatusNotRegistered)
+    return "not-registered";
+  else if (status == SMAppServiceStatusEnabled)
+    return "enabled";
+  else if (status == SMAppServiceStatusRequiresApproval)
+    return "requires-approval";
+  else if (status == SMAppServiceStatusNotFound)
+    return "not-found";
+  else
+    return "not-registered";
 }
 
 bool SetLoginItemEnabled(const std::string& type,
                          const std::string& service_name,
                          bool enabled) {
-  if (@available(macOS 13, *)) {
-#if IS_MAS_BUILD()
-    // If the app was previously set as a LoginItem with the old API, remove it
-    // as a LoginItem via the old API before re-enabling with the new API.
-    if (GetLoginItemEnabledDeprecated() && enabled) {
-      NSString* identifier = GetLoginHelperBundleIdentifier();
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      // SMLoginItemSetEnabled is deprecated as of macOS 13, but it is used
-      // here intentionally to unregister login items registered by the old
-      // API before re-registering them with SMAppService.
-      SMLoginItemSetEnabled((__bridge CFStringRef)identifier, false);
-#pragma clang diagnostic pop
-    }
-#endif
-    SMAppService* service = GetServiceForType(type, service_name);
-    NSError* error = nil;
-    bool result = enabled ? [service registerAndReturnError:&error]
-                          : [service unregisterAndReturnError:&error];
-    if (error != nil)
-      LOG(ERROR) << "Unable to set login item: "
-                 << GetLaunchStringForError(error);
-    return result;
-  } else {
-    NSString* identifier = GetLoginHelperBundleIdentifier();
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    // SMLoginItemSetEnabled is deprecated as of macOS 13; this branch is
-    // unreachable now that macOS 13 is the minimum supported version, but
-    // the @available check above still compiles it.
-    return SMLoginItemSetEnabled((__bridge CFStringRef)identifier, enabled);
-#pragma clang diagnostic pop
-  }
+  SMAppService* service = GetServiceForType(type, service_name);
+  NSError* error = nil;
+  bool result = enabled ? [service registerAndReturnError:&error]
+                        : [service unregisterAndReturnError:&error];
+  if (error != nil)
+    LOG(ERROR) << "Unable to set login item: "
+               << GetLaunchStringForError(error);
+  return result;
 }
 
 }  // namespace platform_util

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow, Menu, session, net as electronNet, WebContents, utilityProcess } from 'electron/main';
 
 import { assert, expect } from 'chai';
-import * as semver from 'semver';
 
 import * as cp from 'node:child_process';
 import { once } from 'node:events';
@@ -730,8 +729,6 @@ describe('app module', () => {
       '/f',
       '/d'
     ];
-    const productVersion = isMac ? cp.execSync('sw_vers -productVersion').toString().trim() : '';
-    const isVenturaOrHigher = semver.gt(semver.coerce(productVersion) || '0.0.0', '13.0.0');
 
     beforeEach(() => {
       app.setLoginItemSettings({ openAtLogin: false });
@@ -750,21 +747,15 @@ describe('app module', () => {
 
       const settings = app.getLoginItemSettings();
       expect(settings.openAtLogin).to.equal(true);
-      expect(settings.openAsHidden).to.equal(false);
       expect(settings.wasOpenedAtLogin).to.equal(false);
-      expect(settings.wasOpenedAsHidden).to.equal(false);
-      expect(settings.restoreState).to.equal(false);
-      if (isVenturaOrHigher) expect(settings.status).to.equal('enabled');
+      expect(settings.status).to.equal('enabled');
     });
 
     ifit(isWin)('sets and returns the app as a login item (windows)', () => {
       app.setLoginItemSettings({ openAtLogin: true, enabled: true });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {
@@ -781,10 +772,7 @@ describe('app module', () => {
       app.setLoginItemSettings({ openAtLogin: true, enabled: false });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: false,
         launchItems: [
           {
@@ -793,41 +781,6 @@ describe('app module', () => {
             args: [],
             scope: 'user',
             enabled: false
-          }
-        ]
-      });
-    });
-
-    ifit(!isWin)('adds a login item that loads in hidden mode', () => {
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
-
-      const settings = app.getLoginItemSettings();
-      expect(settings.openAtLogin).to.equal(true);
-
-      const hasOpenAsHidden = process.platform === 'darwin' && !isVenturaOrHigher;
-      expect(settings.openAsHidden).to.equal(hasOpenAsHidden);
-      expect(settings.wasOpenedAtLogin).to.equal(false);
-      expect(settings.wasOpenedAsHidden).to.equal(false);
-      expect(settings.restoreState).to.equal(false);
-      if (isVenturaOrHigher) expect(settings.status).to.equal('enabled');
-    });
-
-    ifit(isWin)('adds a login item that loads in hidden mode (windows)', () => {
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
-      expect(app.getLoginItemSettings()).to.deep.equal({
-        openAtLogin: true,
-        openAsHidden: false,
-        wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
-        executableWillLaunchAtLogin: true,
-        launchItems: [
-          {
-            name: 'electron.app.Electron',
-            path: process.execPath,
-            args: [],
-            scope: 'user',
-            enabled: true
           }
         ]
       });
@@ -843,21 +796,8 @@ describe('app module', () => {
       expect(app.getLoginItemSettings().openAtLogin).to.equal(false);
     });
 
-    ifit(isMac)('correctly sets and unsets the LoginItem as hidden', () => {
-      expect(app.getLoginItemSettings().openAtLogin).to.equal(false);
-      expect(app.getLoginItemSettings().openAsHidden).to.equal(false);
-
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
-      expect(app.getLoginItemSettings().openAtLogin).to.equal(true);
-      expect(app.getLoginItemSettings().openAsHidden).to.equal(!isVenturaOrHigher);
-
-      app.setLoginItemSettings({ openAtLogin: true, openAsHidden: false });
-      expect(app.getLoginItemSettings().openAtLogin).to.equal(true);
-      expect(app.getLoginItemSettings().openAsHidden).to.equal(false);
-    });
-
     ifdescribe(isMac)('using SMAppService', () => {
-      ifit(isVenturaOrHigher)('can set a login item', () => {
+      it('can set a login item', () => {
         app.setLoginItemSettings({
           openAtLogin: true,
           type: 'mainAppService'
@@ -866,15 +806,12 @@ describe('app module', () => {
         expect(app.getLoginItemSettings()).to.deep.equal({
           status: 'enabled',
           openAtLogin: true,
-          openAsHidden: false,
-          restoreState: false,
           wasOpenedAtLogin: false,
-          wasOpenedAsHidden: false,
           executableWillLaunchAtLogin: false
         });
       });
 
-      ifit(isVenturaOrHigher)('throws when setting non-default type with no name', () => {
+      it('throws when setting non-default type with no name', () => {
         expect(() => {
           app.setLoginItemSettings({
             openAtLogin: true,
@@ -883,7 +820,7 @@ describe('app module', () => {
         }).to.throw(/'name' is required when type is not mainAppService/);
       });
 
-      ifit(isVenturaOrHigher)('throws when getting non-default type with no name', () => {
+      it('throws when getting non-default type with no name', () => {
         expect(() => {
           app.getLoginItemSettings({
             type: 'daemonService'
@@ -891,7 +828,7 @@ describe('app module', () => {
         }).to.throw(/'name' is required when type is not mainAppService/);
       });
 
-      ifit(isVenturaOrHigher)('can unset a login item', () => {
+      it('can unset a login item', () => {
         app.setLoginItemSettings({
           openAtLogin: true,
           type: 'mainAppService'
@@ -905,10 +842,7 @@ describe('app module', () => {
         expect(app.getLoginItemSettings()).to.deep.equal({
           status: 'not-registered',
           openAtLogin: false,
-          openAsHidden: false,
-          restoreState: false,
           wasOpenedAtLogin: false,
-          wasOpenedAsHidden: false,
           executableWillLaunchAtLogin: false
         });
       });
@@ -949,10 +883,7 @@ describe('app module', () => {
       app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: false });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {
@@ -975,10 +906,7 @@ describe('app module', () => {
       app.setLoginItemSettings({ openAtLogin: false, name: 'additionalEntry' });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {
@@ -997,10 +925,7 @@ describe('app module', () => {
       app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: false, args: ['arg2'] });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: false,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {
@@ -1024,10 +949,7 @@ describe('app module', () => {
     ifit(isWin)('finds launch items independent of path quotation or casing', () => {
       const expectation = {
         openAtLogin: false,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {
@@ -1077,10 +999,7 @@ describe('app module', () => {
       await once(appProcess, 'exit');
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: false,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: false,
         launchItems: [
           {
@@ -1097,10 +1016,7 @@ describe('app module', () => {
     ifit(isWin)('detects enabled by TaskManager', async () => {
       const expectation = {
         openAtLogin: false,
-        openAsHidden: false,
         wasOpenedAtLogin: false,
-        wasOpenedAsHidden: false,
-        restoreState: false,
         executableWillLaunchAtLogin: true,
         launchItems: [
           {

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -323,7 +323,7 @@ app.setJumpList([
 if (app.isAccessibilitySupportEnabled()) {
   console.log('a11y running');
 }
-app.setLoginItemSettings({ openAtLogin: true, openAsHidden: false });
+app.setLoginItemSettings({ openAtLogin: true });
 console.log(app.getLoginItemSettings().wasOpenedAtLogin);
 app.setAboutPanelOptions({
   applicationName: 'Test',


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/52334
Refs https://github.com/electron/electron/pull/48090

Electron 44 removes support for macOS 12.

This PR removes:

- The old macOS APIs that we used for login items on macOS 12 and below
- The related JavaScript attributes that only worked on macOS 12 and below.
- The migration logic that migrated old login items to the new macOS 13+ API ([unnecessary](https://github.com/electron/electron/pull/52351#issuecomment-5121161759), and we had it for two years).

One benefit of removing the old APIs is fixing a deadlock condition in `app.getLoginItemSettings` (see https://github.com/electron/electron/pull/48090 and [this Slack message](https://electronhq.slack.com/archives/CC80G2R6H/p1760129328638809)).

Past discussions: [#1](https://electronhq.slack.com/archives/CC80G2R6H/p1760129328638809), [#2](https://electronhq.slack.com/archives/CC80G2R6H/p1760129405452599), [#3](https://electronhq.slack.com/archives/CC80G2R6H/p1760193201948959)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:
* Removed `openAsHidden` option from `app.setLoginItemSettings()`.
* Removed `openAsHidden`, `wasOpenedAsHidden` and `restoreState` fields from return value of `app.getLoginItemSettings()`.
* Fixed potential deadlock inside `app.getLoginItemSettings()` on macOS.