### PR TITLE
fix: cache ObjectTemplate in frame_converter.cc to prevent V8 crash

### DIFF
--- a/shell/common/gin_converters/frame_converter.cc
+++ b/shell/common/gin_converters/frame_converter.cc
@@ -54,8 +54,20 @@ Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::ToV8(
   const int32_t process_id = rfh->GetProcess()->GetID().GetUnsafeValue();
   const int routing_id = rfh->GetRoutingID();
 
-  v8::Local<v8::ObjectTemplate> templ = v8::ObjectTemplate::New(isolate);
-  templ->SetInternalFieldCount(2);
+  // Cache the ObjectTemplate using v8::Eternal so it is created only once
+  // per isolate. Previously, a new ObjectTemplate was created on every IPC
+  // call, accumulating short-lived FunctionTemplateInfo objects in V8's old
+  // generation heap. After millions of IPC calls (e.g. from @electron/remote),
+  // this caused heap corruption during V8's idle-time Major GC
+  // (Mark-Compact with compaction), leading to a crash in
+  // InstantiateFunction(). See https://github.com/electron/electron/issues/52343
+  static v8::Eternal<v8::ObjectTemplate> cached_templ;
+  if (cached_templ.IsEmpty()) {
+    v8::Local<v8::ObjectTemplate> templ = v8::ObjectTemplate::New(isolate);
+    templ->SetInternalFieldCount(2);
+    cached_templ.Set(isolate, templ);
+  }
+  v8::Local<v8::ObjectTemplate> templ = cached_templ.Get(isolate);
 
   v8::Local<v8::Object> rfh_obj =
       templ->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();

--- a/spec/fixtures/crash-cases/ipc-object-template-leak/index.js
+++ b/spec/fixtures/crash-cases/ipc-object-template-leak/index.js
@@ -1,0 +1,47 @@
+// Regression test for https://github.com/electron/electron/issues/52343
+//
+// frame_converter.cc was creating a new v8::ObjectTemplate on every IPC call
+// via Converter<AccessorValue<RenderFrameHost*>>::ToV8(). Over millions of
+// calls this accumulated FunctionTemplateInfo objects in V8's old generation,
+// causing heap corruption and a crash in InstantiateFunction() during idle GC.
+//
+// The fix caches the ObjectTemplate using v8::Eternal<v8::ObjectTemplate>.
+// This test verifies that many rapid sendSync calls complete without crashing.
+
+const { app, BrowserWindow, ipcMain } = require('electron');
+
+const IPC_COUNT = 10_000;
+
+app.on('ready', async () => {
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  let count = 0;
+  ipcMain.on('ping', (event) => {
+    count++;
+    // Access senderFrame to exercise the AccessorValue<RFH*> converter path
+    // that was previously creating a new ObjectTemplate on every call.
+    void event.senderFrame;
+    event.returnValue = count;
+  });
+
+  ipcMain.on('done', () => {
+    if (count !== IPC_COUNT) {
+      process.exit(1);
+    }
+    app.quit();
+  });
+
+  await win.loadURL(`data:text/html,<script>
+    const { ipcRenderer } = require('electron');
+    for (let i = 0; i < ${IPC_COUNT}; i++) {
+      ipcRenderer.sendSync('ping');
+    }
+    ipcRenderer.send('done');
+  </script>`);
+});


### PR DESCRIPTION
`Converter<AccessorValue<RenderFrameHost*>>::ToV8()` in `frame_converter.cc` was creating a **new `v8::ObjectTemplate`** on every IPC call. Over millions of calls (e.g. from `@electron/remote`'s heavy `sendSync` usage), this accumulated short-lived `FunctionTemplateInfo` objects in V8's old generation heap. After 4–6 days of runtime, V8's idle-time Major GC (Mark-Compact with compaction) would corrupt a `FunctionTemplateInfo`'s bit fields, causing an `EXC_BREAKPOINT` crash in `InstantiateFunction()`.

The fix caches the `ObjectTemplate` using `v8::Eternal<v8::ObjectTemplate>` so it is created only once per isolate and reused on subsequent calls. This is safe because the template configuration is identical every time (`SetInternalFieldCount(2)` with no other properties), and is consistent with how other parts of Electron/Chromium cache templates.

Also adds a crash-case regression test that exercises the code path with 10,000 rapid `sendSync` calls.

### Call Path
```
ipcRenderer.sendSync()
  → ElectronApiIPCHandlerImpl::MessageSync()
    → MakeIPCEvent()
      → dict.SetGetter("senderFrame", frame)
        → Converter<AccessorValue<RFH*>>::ToV8()
          → ObjectTemplate::New(isolate)    ← was creating NEW template every time
          → templ->NewInstance(context)
            → V8 InstantiateFunction()      ← CRASH here after days
```

Fixes #52343

#### Description of Change

Cache the `v8::ObjectTemplate` in `Converter<AccessorValue<RenderFrameHost*>>::ToV8()` using a `static v8::Eternal<v8::ObjectTemplate>` to avoid creating a new template on every IPC call. The template is only configured with `SetInternalFieldCount(2)` and has no call-specific state, making it safe to reuse.

**Files changed:**
- `shell/common/gin_converters/frame_converter.cc` — Cache `ObjectTemplate` via `v8::Eternal`
- `spec/fixtures/crash-cases/ipc-object-template-leak/index.js` — Regression test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed a crash that occurred after days of runtime when using frequent synchronous IPC calls (e.g. via `@electron/remote`), caused by creating a new `v8::ObjectTemplate` on every IPC call in `frame_converter.cc`.
