### PR TITLE
fix: show LSTypeIsPackage bundles in macOS open dialog filters

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -99,6 +99,28 @@ DialogSettings::~DialogSettings() = default;
 
 namespace {
 
+UTType* UTTypeForExtension(const std::string& ext) {
+  NSString* extension = @(ext.c_str());
+
+  if (ext == "app") {
+    UTType* super_type =
+        [UTType typeWithIdentifier:@"com.apple.application-bundle"];
+    return [UTType typeWithFilenameExtension:@"app"
+                            conformingToType:super_type];
+  }
+
+  UTType* package_supertype = [UTType typeWithIdentifier:@"com.apple.package"];
+  UTType* package_type =
+      [UTType typeWithFilenameExtension:extension
+                       conformingToType:package_supertype];
+  // Package conformance can synthesize dynamic types for ordinary extensions
+  // like .txt; prefer Launch Services-known package types only.
+  if (package_type && ![package_type isDynamic])
+    return package_type;
+
+  return [UTType typeWithFilenameExtension:extension];
+}
+
 void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   NSMutableArray* file_types_list = [NSMutableArray array];
   NSMutableArray* filter_names = [NSMutableArray array];
@@ -122,20 +144,8 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
       if (ext == "*") {
         [content_types_set addObject:[UTType typeWithFilenameExtension:@"*"]];
         break;
-      } else if (ext == "app") {
-        // This handles a bug on macOS where the "app" extension by default
-        // maps to "com.apple.application-file", which is for an Application
-        // file (older single-file carbon based apps), and not modern
-        // Application Bundles (multi file packages as you'd see for all modern
-        // applications).
-        UTType* superType =
-            [UTType typeWithIdentifier:@"com.apple.application-bundle"];
-        if (UTType* utt = [UTType typeWithFilenameExtension:@"app"
-                                           conformingToType:superType]) {
-          [content_types_set addObject:utt];
-        }
       } else {
-        if (UTType* utt = [UTType typeWithFilenameExtension:@(ext.c_str())])
+        if (UTType* utt = UTTypeForExtension(ext))
           [content_types_set addObject:utt];
       }
     }


### PR DESCRIPTION
#### Description of Change

Fixes a regression on macOS where `dialog.showOpenDialog()` filters using `allowedContentTypes` failed to show custom package bundles (extensions with `LSTypeIsPackage = true`, e.g. `.rtfd`, `.lspkg`).

Root cause: `UTType typeWithFilenameExtension:` without package conformance does not match macOS package directories in filtered open dialogs (Electron 36.2.0+).

This change adds `UTTypeForExtension()` which:
1. Keeps the existing `.app` → `com.apple.application-bundle` mapping.
2. Tries `com.apple.package` conformance first for other extensions.
3. Uses the package UTType only when Launch Services knows it (`!isDynamic`), avoiding false positives for regular files like `.txt`.
4. Falls back to the default extension lookup.

Closes https://github.com/electron/electron/issues/48191

**Manual test plan (macOS):**
1. In TextEdit, create a Rich Text document, drag in an image, save as `.rtfd`.
2. Run the [repro gist](https://gist.github.com/3afd1a232bdd7c2595ddb2cc885dcc98) on this branch.
3. `showOpenDialog` with `extensions: ['rtf', 'rtfd']` should list and allow selecting the `.rtfd` package.

cc @codebytere @jjeff

#### Checklist

- [ ] I have built and tested this change on macOS
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are changed or added
- [ ] relevant API documentation updated
- [x] PR release notes describe the change

#### Release Notes

Notes: Fixed macOS `dialog.showOpenDialog` filters to include file packages (such as `.rtfd`) when filtering by extension on the 36-x-y release line.