### PR TITLE
fix: release activation when hiding a focused window

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -634,6 +634,16 @@ void NativeWindowViews::Hide() {
   if (is_modal() && NativeWindow::parent())
     static_cast<NativeWindowViews*>(parent())->DecrementChildModals();
 
+  // Hiding the widget alone does not release activation: on Windows the
+  // widget is hidden with SWP_NOACTIVATE, so the invisible window stays the
+  // system foreground window and keeps reporting a focused accessibility
+  // state, stranding screen readers on a window the user can no longer see.
+  // Linux/at-spi has the equivalent problem. Deactivate first so the OS
+  // hands focus to the next window and emits the corresponding
+  // accessibility events.
+  if (widget()->IsActive())
+    widget()->Deactivate();
+
   widget()->Hide();
 
   NotifyWindowHide();

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -644,6 +644,24 @@ void NativeWindowViews::Hide() {
   if (is_modal() && NativeWindow::parent())
     static_cast<NativeWindowViews*>(parent())->DecrementChildModals();
 
+  // Hiding the widget alone does not release activation: on Windows the
+  // widget is hidden with SWP_NOACTIVATE, so the invisible window stays the
+  // system foreground window and keeps reporting a focused accessibility
+  // state, stranding screen readers on a window the user can no longer see.
+  // Linux/at-spi has the equivalent problem. Release activation first so the
+  // OS emits the corresponding accessibility events. Hand activation to the
+  // parent window explicitly when there is one: on Windows,
+  // Widget::Deactivate() activates whichever visible window happens to be
+  // next in the Z order, which is not guaranteed to be the owner.
+  if (widget()->IsActive()) {
+    auto* parent_window =
+        static_cast<NativeWindowViews*>(NativeWindow::parent());
+    if (parent_window && parent_window->IsVisible())
+      parent_window->widget()->Activate();
+    else
+      widget()->Deactivate();
+  }
+
   widget()->Hide();
 
   NotifyWindowHide();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1397,6 +1397,24 @@ describe('BrowserWindow module', () => {
         await blurred;
         expect(w.isFocused()).to.equal(false);
       });
+      it('restores focus to the parent when hiding a focused child window', async () => {
+        const focused = once(w, 'focus');
+        w.show();
+        await focused;
+
+        const child = new BrowserWindow({ show: false, parent: w });
+        const childFocused = once(child, 'focus');
+        child.show();
+        await childFocused;
+        expect(child.isFocused()).to.equal(true);
+
+        const parentFocused = once(w, 'focus');
+        child.hide();
+        await parentFocused;
+        expect(w.isFocused()).to.equal(true);
+
+        await closeWindow(child, { assertNotWindows: false });
+      });
     });
 
     describe('BrowserWindow.minimize()', () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1386,6 +1386,17 @@ describe('BrowserWindow module', () => {
         w.hide();
         expect(w.isFocused()).to.equal(false);
       });
+      it('releases focus when hiding a focused window', async () => {
+        const focused = once(w, 'focus');
+        w.show();
+        await focused;
+        expect(w.isFocused()).to.equal(true);
+
+        const blurred = once(w, 'blur');
+        w.hide();
+        await blurred;
+        expect(w.isFocused()).to.equal(false);
+      });
     });
 
     describe('BrowserWindow.minimize()', () => {


### PR DESCRIPTION
#### Description of Change

Hiding a focused `BrowserWindow` — the common hide-on-close pattern (intercept `close`, call `win.hide()`, keep running in the background) — strands foreground activation and accessibility focus on the now-invisible window.

On Windows, `NativeWindowViews::Hide()` → `views::Widget::Hide()` → `HWNDMessageHandler::Hide()`, which hides the window via `SetWindowPos(… SWP_HIDEWINDOW | SWP_NOACTIVATE …)`. Because activation is never released:

- `GetForegroundWindow()` still returns the hidden HWND
- the window fires `EVENT_OBJECT_HIDE` while still reporting `STATE_SYSTEM_FOCUSED`
- Windows never activates a successor window, so no `EVENT_SYSTEM_FOREGROUND` is emitted
- screen readers (Narrator, JAWS, NVDA) keep reading the hidden window with no path back to the real foreground

Linux/at-spi has the equivalent problem: hidden windows keep presenting themselves as active (#48268).

This PR deactivates the widget before hiding it, when (and only when) the window is currently active. `Widget::Deactivate()` hands foreground to the next visible window in the z-order (on Windows via `HWNDMessageHandler::Deactivate()` → `SetForegroundWindow()` on the next visible window), which emits the platform deactivation/foreground accessibility events that assistive technology follows. This matches the behavior the issue reporter verified: calling `win.blur()` before hiding fixes the stranded focus (confirmed 2/2 runs with Narrator on the repro gist), while `win.blurWebView()` does not (it only moves renderer-internal focus).

The `IsActive()` guard keeps the change away from the hazard called out in Chromium's `HWNDMessageHandler::Hide()` comment (activating another window while a deactivation is already in progress), and makes this a no-op when hiding an unfocused window. `NativeWindowViews::Hide()` is only reached from the public `win.hide()` API path (`BaseWindow::Hide()`), so internal Chromium hide paths are unaffected.

This also resolves the long-standing focus-restoration bug with secondary windows: hiding a focused child window now hands foreground back to its parent, since Windows keeps owned windows directly above their owner in the z-order and `Deactivate()` activates the next visible window below. A regression test covering that scenario (from #28451) is included.

Fixes #52124
Fixes #48268
Fixes #28451

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes locally — not run locally (no Electron build environment); added a regression test: hiding a focused window must emit `blur` and report `isFocused() === false` (previously on Windows it stayed `true` after `hide()`)
- [x] relevant documentation is changed or added — no API change; behavior now matches the existing `hide()` docs ("Hides the window")
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples)

#### Release Notes

Notes: Fixed hidden windows retaining system foreground activation and accessibility focus on Windows and Linux, which caused screen readers to keep reading windows that were hidden on close.

