### PR TITLE
fix: rename isMainFrame to isRequestForMainFrame

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -365,6 +365,7 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
   * `pid` number
+  * `isRequestForMainFrame` boolean - Indicates whether the request is for the main frame.
   * `isRequestForNavigation` boolean - Indicates whether the request is for a navigation.
   * `firstAuthAttempt` boolean - Indicates whether this is the first authentication attempt.
   * `responseHeaders` Record\<string, string | string[]\> (optional) - The headers returned in the response.

--- a/docs/api/utility-process.md
+++ b/docs/api/utility-process.md
@@ -197,6 +197,7 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
   * `pid` number
+  * `isRequestForMainFrame` boolean - Indicates whether the request is for the main frame.
   * `isRequestForNavigation` boolean - Indicates whether the request is for a navigation.
   * `firstAuthAttempt` boolean - Indicates whether this is the first authentication attempt.
   * `responseHeaders` Record\<string, string | string[]\> (optional) - The headers returned in the response.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -689,6 +689,7 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
   * `pid` number
+  * `isRequestForMainFrame` boolean - Indicates whether the request is for the main frame.
   * `isRequestForNavigation` boolean - Indicates whether the request is for a navigation.
   * `firstAuthAttempt` boolean - Indicates whether this is the first authentication attempt.
   * `responseHeaders` Record\<string, string | string[]\> (optional) - The headers returned in the response.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -694,6 +694,7 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
   * `pid` number
+  * `isRequestForMainFrame` boolean - Indicates whether the request is for the main frame.
   * `isRequestForNavigation` boolean - Indicates whether the request is for a navigation.
   * `firstAuthAttempt` boolean - Indicates whether this is the first authentication attempt.
   * `responseHeaders` Record\<string, string | string[]\> (optional) - The headers returned in the response.

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -85,13 +85,10 @@ void LoginHandler::EmitEvent(
   auto details = gin::Dictionary::CreateEmpty(isolate);
   details.Set("url", url);
   details.Set("pid", process_id);
+  details.Set("isRequestForMainFrame", is_request_for_primary_main_frame);
   details.Set("isRequestForNavigation", is_request_for_navigation);
   details.Set("firstAuthAttempt", first_auth_attempt);
   details.Set("responseHeaders", response_headers.get());
-
-  // This parameter isn't documented in the Electron API because:
-  // https://github.com/electron/electron/pull/46630#pullrequestreview-2862305353
-  details.Set("isMainFrame", is_request_for_primary_main_frame);
 
   auto weak_this = weak_factory_.GetWeakPtr();
   bool default_prevented = false;


### PR DESCRIPTION
#### Description of Change

Rename the `isMainFrame` authentication response detail to `isRequestForPrimaryMainFrame` to match the value it represents. This change is intentionally separated from the documentation update introduced in #46630.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Renamed the undocumented `authenticationResponseDetails.isMainFrame` property to `isRequestForMainFrame`.
