### PR TITLE
build: fail patch diff check on subprocess errors

### DIFF
--- a/script/check-patch-diff.ts
+++ b/script/check-patch-diff.ts
@@ -10,8 +10,19 @@ const proc = spawnSync('python3', [patchExportFnPath, configPath, '--dry-run'], 
   cwd: srcPath
 });
 
-// Fail if patch exporting returned 1, e.g dry run failed.
-if (proc.status === 1) {
-  console.log(proc.stderr.toString('utf8'));
+if (proc.error) {
+  console.error(proc.error.message);
   process.exit(1);
+}
+
+if (proc.signal) {
+  console.error(`Patch export terminated by signal ${proc.signal}`);
+  process.exit(1);
+}
+
+// Fail if patch exporting failed, e.g. dry run found changes.
+if (proc.status !== 0) {
+  console.log(proc.stdout.toString('utf8'));
+  console.error(proc.stderr.toString('utf8'));
+  process.exit(proc.status ?? 1);
 }


### PR DESCRIPTION
#### Description of Change

Updated `script/check-patch-diff.ts` to fail whenever the patch export subprocess fails, instead of only failing when it exits with status `1`.

The script now also handles spawn errors and signal termination, and preserves the subprocess exit status for non-zero exits.

This avoids false-positive successful runs when `export_all_patches.py` cannot be started or exits with another failure code.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
