### PR TITLE
feat: store Cache in proper location

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -405,7 +405,7 @@ int GetPathConstant(std::string_view name) {
 #if BUILDFLAG(IS_POSIX)
       {"cache", base::DIR_CACHE},
 #else
-      {"cache", base::DIR_ROAMING_APP_DATA},
+      {"cache", base::DIR_LOCAL_APP_DATA},
 #endif
       {"crashDumps", DIR_CRASH_DUMPS},
       {"desktop", base::DIR_USER_DESKTOP},
@@ -421,6 +421,7 @@ int GetPathConstant(std::string_view name) {
       {"recent", electron::DIR_RECENT},
 #endif
       {"sessionData", DIR_SESSION_DATA},
+      {"sessionCache", DIR_SESSION_CACHE},
       {"temp", base::DIR_TEMP},
       {"userCache", DIR_USER_CACHE},
       {"userData", chrome::DIR_USER_DATA},

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -673,8 +673,8 @@ std::string ElectronBrowserClient::GetGeolocationApiKey() {
 content::GeneratedCodeCacheSettings
 ElectronBrowserClient::GetGeneratedCodeCacheSettings(
     content::BrowserContext* context) {
-  // TODO(deepak1556): Use platform cache directory.
-  base::FilePath cache_path = context->GetPath();
+  const base::FilePath& cache_path =
+      static_cast<ElectronBrowserContext*>(context)->cache_path();
   // If we pass 0 for size, disk_cache will pick a default size using the
   // heuristics based on available disk size. These are implemented in
   // disk_cache::PreferredCacheSize in net/disk_cache/cache_util.cc.
@@ -1169,10 +1169,17 @@ void ElectronBrowserClient::OnNetworkServiceCreated(
 std::vector<base::FilePath>
 ElectronBrowserClient::GetNetworkContextsParentDirectory() {
   base::FilePath session_data;
+  base::FilePath session_cache;
   base::PathService::Get(DIR_SESSION_DATA, &session_data);
+  base::PathService::Get(DIR_SESSION_CACHE, &session_cache);
   DCHECK(!session_data.empty());
 
-  return {session_data};
+  // On some platforms, the cache is a child of the user_data_dir so only
+  // return the one path.
+  if (session_data.IsParent(session_cache))
+    return {session_data};
+  else
+    return {session_data, session_cache};
 }
 
 std::string ElectronBrowserClient::GetProduct() {

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -375,11 +375,14 @@ ElectronBrowserContext::ElectronBrowserContext(
   if (auto* path_value = std::get_if<std::reference_wrapper<const std::string>>(
           &partition_location)) {
     base::PathService::Get(DIR_SESSION_DATA, &path_);
+    base::PathService::Get(DIR_SESSION_CACHE, &cache_path_);
     const std::string& partition_loc = path_value->get();
     if (!in_memory && !partition_loc.empty()) {
-      path_ = path_.Append(FILE_PATH_LITERAL("Partitions"))
-                  .Append(base::FilePath::FromUTF8Unsafe(
-                      MakePartitionName(partition_loc)));
+      base::FilePath subdir = base::FilePath(FILE_PATH_LITERAL("Partitions"))
+                                  .Append(base::FilePath::FromUTF8Unsafe(
+                                      MakePartitionName(partition_loc)));
+      path_ = path_.Append(subdir);
+      cache_path_ = cache_path_.Append(subdir);
     }
   } else if (auto* filepath_partition =
                  std::get_if<std::reference_wrapper<const base::FilePath>>(

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -133,6 +133,7 @@ class ElectronBrowserContext : public content::BrowserContext {
   content::FileSystemAccessPermissionContext*
   GetFileSystemAccessPermissionContext() override;
 
+  const base::FilePath& cache_path() const { return cache_path_; }
   CookieChangeNotifier* cookie_change_notifier() const {
     return cookie_change_notifier_.get();
   }
@@ -216,6 +217,7 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   std::optional<std::string> user_agent_;
   base::FilePath path_;
+  base::FilePath cache_path_;
   bool in_memory_ = false;
   bool use_cache_ = true;
   int max_cache_size_ = 0;

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -92,7 +92,7 @@ void NetworkContextService::ConfigureNetworkContextParams(
     network_context_params->file_paths->trigger_migration =
         ShouldTriggerNetworkDataMigration();
     network_context_params->file_paths->http_cache_directory =
-        path.Append(chrome::kCacheDirname);
+        browser_context_->cache_path().Append(chrome::kCacheDirname);
 
     // Currently this just contains HttpServerProperties
     network_context_params->file_paths->http_server_properties_file_name =

--- a/shell/common/electron_paths.cc
+++ b/shell/common/electron_paths.cc
@@ -47,13 +47,15 @@ bool ElectronPathProvider(int key, base::FilePath* result) {
     case DIR_SESSION_DATA:
       // By default and for backward, equivalent to DIR_USER_DATA.
       return base::PathService::Get(chrome::DIR_USER_DATA, result);
+    case DIR_SESSION_CACHE:
+      return base::PathService::Get(DIR_USER_CACHE, result);
     case DIR_USER_CACHE: {
 #if BUILDFLAG(IS_POSIX)
       int parent_key = base::DIR_CACHE;
 #else
       // On Windows, there's no OS-level centralized location for caches, so
       // store the cache in the app data directory.
-      int parent_key = base::DIR_ROAMING_APP_DATA;
+      int parent_key = base::DIR_LOCAL_APP_DATA;
 #endif
       if (!base::PathService::Get(parent_key, &cur))
         return false;

--- a/shell/common/electron_paths.h
+++ b/shell/common/electron_paths.h
@@ -26,6 +26,7 @@ enum {
   DIR_USER_CACHE = PATH_START,  // Directory where user cache can be written.
   DIR_APP_LOGS,                 // Directory where app logs live.
   DIR_SESSION_DATA,             // Where cookies, localStorage are stored.
+  DIR_SESSION_CACHE,            // Where http cache, js code cache are stored.
 
 #if BUILDFLAG(IS_WIN)
   DIR_RECENT,  // Directory where recent files live


### PR DESCRIPTION
#### Description of Change

Using the work of https://github.com/electron/electron/pull/34337
Fixes https://github.com/electron/electron/issues/8124

Caches are now stored in LOCALAPPDATA and DIR_USER_CACHE instead of APPDATA and DIR_USER_DATA.

As APPDATA and XDG_CONFIG_HOME are supposed to be synced between devices or backed up to cloud, it is bad to store cache there, which can inflate the directories to gigabytes in size when there are multiple Electron apps.

TODO:
- [ ] `GPUCache`?

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Cache is now stored in proper locations.
