### PR TITLE
chore: cherry-pick 6 changes from chromium and v8

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -330,3 +330,8 @@ cherry-pick-45d7457ac585.patch
 cherry-pick-7aea889dfa2f.patch
 cherry-pick-e6468cc124d6.patch
 cherry-pick-873978ddc92b.patch
+cherry-pick-e74ba1a76dd5.patch
+cherry-pick-d559d5018b66.patch
+cherry-pick-094448afb6ab.patch
+cherry-pick-e3cd72e404a5.patch
+cherry-pick-64f023ac1648.patch

--- a/patches/chromium/cherry-pick-094448afb6ab.patch
+++ b/patches/chromium/cherry-pick-094448afb6ab.patch
@@ -1,0 +1,118 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Maks Orlovich <morlovich@chromium.org>
+Date: Wed, 15 Jul 2026 09:05:33 -0700
+Subject: [M150] SimpleCache: fix problems with self-deletion in post-doom
+ callbacks
+
+Original change's description:
+> SimpleCache: fix problems with self-deletion in post-doom callbacks
+>
+> Fixed: 533446300
+> Change-Id: I130245edb091f1d48437d74a59aa012667a6227b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8074044
+> Reviewed-by: Josh Karlin <jkarlin@chromium.org>
+> Commit-Queue: Maks Orlovich <morlovich@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1661113}
+
+(cherry picked from commit 7b15c3bbc9632e9868e4c10a32133cd82a024f12;
+ merge seems to have introduced conflicts by pulling in tests that are
+ not in 150 (https://chromiumdash.appspot.com/commit/4373dfc5ccebd3829ad0f0d0b1ebd93550dd321a), not sure why)
+
+Bug: 534618158,533446300
+Change-Id: I130245edb091f1d48437d74a59aa012667a6227b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8091747
+Reviewed-by: Josh Karlin <jkarlin@chromium.org>
+Commit-Queue: Maks Orlovich <morlovich@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#3473}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/net/disk_cache/backend_unittest.cc b/net/disk_cache/backend_unittest.cc
+index 40d20bfea85841c3eeeb097b66cf1683cd8c40a9..45b00beb9cdb91c884052a6817f0df88b0830e4b 100644
+--- a/net/disk_cache/backend_unittest.cc
++++ b/net/disk_cache/backend_unittest.cc
+@@ -5968,6 +5968,67 @@ TEST_P(DiskCacheGenericBackendTest, BackendDoomNonExistentEntry) {
+   }
+ }
+ 
++TEST_P(DiskCacheGenericBackendTest, DeleteBackendWithMassDoom) {
++  if (backend_to_test() == BackendToTest::kMemory) {
++    // Uninteresting w/memory since the delete is synchronous.
++    return;
++  }
++
++  SetCacheType(net::APP_CACHE);  // no optimistic ops.
++
++  InitCache();
++  for (int i = 0; i < 100; ++i) {
++    disk_cache::Entry* entry = nullptr;
++    ASSERT_THAT(CreateEntry(base::NumberToString(i), &entry), IsOk());
++    entry->Close();
++  }
++  // Get closes to actually close.
++  FlushQueueForTest();
++  net::TestCompletionCallback cb;
++
++  // Kick off a doom.
++  int rv = cache_->DoomAllEntries(cb.callback());
++  EXPECT_EQ(net::ERR_IO_PENDING, rv);
++  // We need to go to event loop since DoomAllEntries in Simple has async index
++  // readiness hop, but we don't want to flush all the threads.
++  base::RunLoop().RunUntilIdle();
++
++  base::RunLoop run_loop;
++
++  // Try to open a couple of entries, and delete it in the first callback that
++  // gets invoked. The second open should be safe since we don't go to event
++  // loop between the calls, so the callback can't be delivered yet. Also only
++  // one of the callbacks should be invoked per the cancellation semantics.
++  EntryResult result0 = cache_->OpenEntry(
++      "0", net::HIGHEST, base::BindLambdaForTesting([&](EntryResult result) {
++        EXPECT_EQ(net::ERR_FAILED, result.net_error());
++        TakeCache();
++        run_loop.Quit();
++      }));
++  if (result0.net_error() == net::ERR_FAILED) {
++    // If the delete finished already to the point the open fails synchronously,
++    // we can't really test anything, so don't proceed.
++    return;
++  }
++  EXPECT_EQ(result0.net_error(), net::ERR_IO_PENDING);
++
++  EntryResult result1 = cache_->OpenEntry(
++      "1", net::HIGHEST, base::BindLambdaForTesting([&](EntryResult result) {
++        EXPECT_EQ(net::ERR_FAILED, result.net_error());
++        TakeCache();
++        run_loop.Quit();
++      }));
++  if (result1.net_error() == net::ERR_FAILED) {
++    // If the delete finished already to the point the open fails synchronously,
++    // we can't really test anything, so don't proceed.
++    return;
++  }
++  EXPECT_EQ(result1.net_error(), net::ERR_IO_PENDING);
++
++  EXPECT_EQ(net::OK, cb.GetResult(rv));
++  run_loop.Run();
++}
++
+ INSTANTIATE_TEST_SUITE_P(
+     /* no name */,
+     DiskCacheGenericBackendTest,
+diff --git a/net/disk_cache/simple/simple_backend_impl.cc b/net/disk_cache/simple/simple_backend_impl.cc
+index b83b96bdca1cb7b59396cea23568c91cec8da821..d51628718ccf74956a1e0f73fad4ff52c9f1a2b3 100644
+--- a/net/disk_cache/simple/simple_backend_impl.cc
++++ b/net/disk_cache/simple/simple_backend_impl.cc
+@@ -915,8 +915,12 @@ void SimpleBackendImpl::DoomEntriesComplete(
+     std::unique_ptr<std::vector<uint64_t>> entry_hashes,
+     CompletionOnceCallback callback,
+     int result) {
++  // Save `post_doom_waiting_` locally in case something invoked from us
++  // deletes `this`.
++  scoped_refptr<SimplePostOperationWaiterTable> post_doom_waiting =
++      post_doom_waiting_;
+   for (const uint64_t& entry_hash : *entry_hashes)
+-    post_doom_waiting_->OnOperationComplete(entry_hash);
++    post_doom_waiting->OnOperationComplete(entry_hash);
+   std::move(callback).Run(result);
+ }
+ 

--- a/patches/chromium/cherry-pick-64f023ac1648.patch
+++ b/patches/chromium/cherry-pick-64f023ac1648.patch
@@ -1,0 +1,204 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Tue, 14 Jul 2026 10:22:15 -0700
+Subject: [M150] [aura] Guard against root window destruction in
+ ScopedCursorHider
+
+Original change's description:
+> [aura] Guard against root window destruction in ScopedCursorHider
+>
+> Avoid Use-After-Free during device scale factor changes on Linux/X11 by
+> using an aura::WindowTracker inside
+> ScopedCursorHider::~ScopedCursorHider(). Previously,
+> display::Screen::Get()->GetDisplayNearestWindow() could synchronously
+> dispatch events that tear down the root window and the CursorClient. By
+> tracking window destruction, the window is verified to be alive after
+> returning from display queries before making calls on the CursorClient.
+>
+> Fixed: 532970574
+> Change-Id: I495fa5f12bf0a58fb047009d792366879e75521b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8072900
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Reviewed-by: Colin Blundell <blundell@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1661444}
+
+(cherry picked from commit d5f0488a4d6a4a7fd8d4941d748b5d6112bb40c9)
+
+Bug: 534618099,532970574
+Change-Id: I495fa5f12bf0a58fb047009d792366879e75521b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8092250
+Reviewed-by: Avi Drissman <avi@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#3417}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/ui/aura/window.cc b/ui/aura/window.cc
+index 00f951491f7d0e32aa5fa25ce5dbdfe7e282372d..2c08b169b4c79b6a62b7046e49f0859748b9f598 100644
+--- a/ui/aura/window.cc
++++ b/ui/aura/window.cc
+@@ -148,18 +148,31 @@ class ScopedCursorHider {
+   ScopedCursorHider& operator=(const ScopedCursorHider&) = delete;
+ 
+   ~ScopedCursorHider() {
+-    if (!window_->IsRootWindow())
++    // Store the raw window pointer in a local variable and clear the `window_`
++    // raw_ptr to nullptr before carrying out the rest of the destructor. Since
++    // the window can be synchronously destroyed inside display query sink calls
++    // below, clearing the raw_ptr while the window is still alive prevents
++    // Chromium's dangling raw_ptr checks from triggering on destruction.
++    Window* window = window_;
++    window_ = nullptr;
++
++    if (!window->IsRootWindow()) {
+       return;
++    }
+ 
+     // Update the device scale factor of the cursor client only when the last
+     // mouse location is on this root window.
+     if (hid_cursor_) {
+-      client::CursorClient* cursor_client = client::GetCursorClient(window_);
+-      if (cursor_client) {
+-        const display::Display& display =
+-            display::Screen::Get()->GetDisplayNearestWindow(window_);
+-        cursor_client->SetDisplay(display);
+-        cursor_client->ShowCursor();
++      aura::WindowTracker tracker;
++      tracker.Add(window);
++      const display::Display& display =
++          display::Screen::Get()->GetDisplayNearestWindow(window);
++      if (tracker.Contains(window)) {
++        client::CursorClient* cursor_client = client::GetCursorClient(window);
++        if (cursor_client) {
++          cursor_client->SetDisplay(display);
++          cursor_client->ShowCursor();
++        }
+       }
+     }
+   }
+diff --git a/ui/aura/window_unittest.cc b/ui/aura/window_unittest.cc
+index c59b14ef0962a847d5cd1f446bbc653dca3fdcfa..0c21e77e810f5680b8af352fda08673565906969 100644
+--- a/ui/aura/window_unittest.cc
++++ b/ui/aura/window_unittest.cc
+@@ -22,6 +22,7 @@
+ #include "cc/trees/layer_tree_frame_sink.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "ui/aura/client/capture_client.h"
++#include "ui/aura/client/cursor_client.h"
+ #include "ui/aura/client/focus_change_observer.h"
+ #include "ui/aura/client/visibility_client.h"
+ #include "ui/aura/client/window_parenting_client.h"
+@@ -30,6 +31,7 @@
+ #include "ui/aura/scoped_window_event_targeting_blocker.h"
+ #include "ui/aura/test/aura_test_base.h"
+ #include "ui/aura/test/aura_test_utils.h"
++#include "ui/aura/test/test_cursor_client.h"
+ #include "ui/aura/test/test_window_delegate.h"
+ #include "ui/aura/test/test_windows.h"
+ #include "ui/aura/test/window_test_api.h"
+@@ -4078,6 +4080,106 @@ TEST_P(WindowActualScreenBoundsTest, VerifyWindowActualBoundsDuringAnimation) {
+   bounds_checker.WaitForAnimationCompletion();
+ }
+ 
++class ReentrantDisplayScreen : public display::Screen {
++ public:
++  explicit ReentrantDisplayScreen(display::Screen* original_screen,
++                                  base::RepeatingClosure on_get_display)
++      : original_screen_(original_screen),
++        on_get_display_(std::move(on_get_display)) {
++    set_shutdown(true);
++  }
++
++  ReentrantDisplayScreen(const ReentrantDisplayScreen&) = delete;
++  ReentrantDisplayScreen& operator=(const ReentrantDisplayScreen&) = delete;
++
++  ~ReentrantDisplayScreen() override = default;
++
++  // Overridden from display::Screen:
++  gfx::Point GetCursorScreenPoint() override {
++    return original_screen_->GetCursorScreenPoint();
++  }
++  bool IsWindowUnderCursor(gfx::NativeWindow window) override {
++    return original_screen_->IsWindowUnderCursor(window);
++  }
++  gfx::NativeWindow GetWindowAtScreenPoint(const gfx::Point& point) override {
++    return original_screen_->GetWindowAtScreenPoint(point);
++  }
++  gfx::NativeWindow GetLocalProcessWindowAtPoint(
++      const gfx::Point& point,
++      const std::set<gfx::NativeWindow>& ignore) override {
++    return original_screen_->GetLocalProcessWindowAtPoint(point, ignore);
++  }
++  int GetNumDisplays() const override {
++    return original_screen_->GetNumDisplays();
++  }
++  const std::vector<display::Display>& GetAllDisplays() const override {
++    return original_screen_->GetAllDisplays();
++  }
++  display::Display GetDisplayNearestWindow(
++      gfx::NativeWindow window) const override {
++    on_get_display_.Run();
++    return original_screen_->GetDisplayNearestWindow(window);
++  }
++  display::Display GetDisplayNearestPoint(
++      const gfx::Point& point) const override {
++    return original_screen_->GetDisplayNearestPoint(point);
++  }
++  display::Display GetDisplayMatching(
++      const gfx::Rect& match_rect) const override {
++    return original_screen_->GetDisplayMatching(match_rect);
++  }
++  display::Display GetPrimaryDisplay() const override {
++    return original_screen_->GetPrimaryDisplay();
++  }
++  void AddObserver(display::DisplayObserver* observer) override {
++    original_screen_->AddObserver(observer);
++  }
++  void RemoveObserver(display::DisplayObserver* observer) override {
++    original_screen_->RemoveObserver(observer);
++  }
++
++ private:
++  raw_ptr<display::Screen> original_screen_;
++  base::RepeatingClosure on_get_display_;
++};
++
++TEST_F(WindowTest, ScopedCursorHiderCursorClientFreedDuringGetDisplay) {
++  display::Screen* original_screen = display::Screen::Get();
++
++  std::unique_ptr<Window> test_root = std::make_unique<Window>(nullptr);
++  test_root->Init(ui::LAYER_NOT_DRAWN);
++  test_root->set_host(host());
++  test_root->SetBounds(gfx::Rect(0, 0, 800, 600));
++
++  TestCursorClient cursor_client(root_window());
++  client::SetCursorClient(root_window(), nullptr);
++  client::SetCursorClient(test_root.get(), &cursor_client);
++
++  Env::GetInstance()->SetLastMouseLocation(gfx::Point(10, 10));
++
++  cursor_client.ShowCursor();
++  EXPECT_TRUE(cursor_client.IsCursorVisible());
++
++  ReentrantDisplayScreen reentrant_screen(
++      original_screen,
++      base::BindLambdaForTesting([&]() { test_root.reset(); }));
++
++  display::Screen::SetScreenInstance(&reentrant_screen);
++
++  // This call synchronously destroys `test_root` during the nested display
++  // nearest window query. With the fix, the ScopedCursorHider destructor
++  // detects this destruction via `WindowTracker` and avoids dereferencing the
++  // freed `CursorClient` pointer or `test_root`, so this call should complete
++  // without crashing.
++  test_root->OnDeviceScaleFactorChanged(1.0f, 2.0f);
++
++  display::Screen::SetScreenInstance(nullptr);
++  display::Screen::SetScreenInstance(original_screen);
++
++  // Restore cursor client.
++  client::SetCursorClient(root_window(), &cursor_client);
++}
++
+ }  // namespace
+ }  // namespace test
+ }  // namespace aura

--- a/patches/chromium/cherry-pick-d559d5018b66.patch
+++ b/patches/chromium/cherry-pick-d559d5018b66.patch
@@ -1,0 +1,335 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tzarial <zork@google.com>
+Date: Tue, 14 Jul 2026 10:54:37 -0700
+Subject: [M150] [agy][gpu] Fix active transform feedback buffer tracking
+
+Original change's description:
+> [agy][gpu] Fix active transform feedback buffer tracking
+>
+> An active (even if paused/unbound) transform feedback object continues
+> to reference its attached buffers in the driver until
+> glEndTransformFeedback. If a different transform feedback object is
+> bound, the previous one becomes unbound but remains active, and its
+> attached buffers should still be considered busy and locked.
+>
+> This CL refactors IndexedBufferBindingHost and TransformFeedback to use
+> AreBuffersBound() instead of is_bound_ directly. For
+> TransformFeedback, AreBuffersBound() is defined as (is_bound_ ||
+> active_). This preserves symmetric SetIsBound(true/false) calls on
+> TransformFeedback while correctly tracking buffer bindings on active
+> (but paused/unbound) transform feedback objects.
+>
+> Additionally, this CL addresses destruction edge cases by:
+> 1. Adding ForceUnbindBuffers() to prevent a buffer binding state leak
+>    on destruction of an active but unbound transform feedback object.
+> 2. Restricting glEndTransformFeedback() inside the destructor to only
+>    run when the object is currently bound, matching GL requirements.
+>
+> Fixed: 523750584
+> Test: gpu_unittests --gtest_filter=TransformFeedbackManagerTest.*
+> Change-Id: I4d9f0f133e18e54f57a14e15b9c5d70a36a099a7
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8015317
+> Reviewed-by: Kai Ninomiya <kainino@chromium.org>
+> Commit-Queue: Kai Ninomiya <kainino@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1659202}
+
+(cherry picked from commit 6b5adcce6f6241dcd610a980aa27cb2228d7fbca)
+
+Bug: 533271014,523750584
+Change-Id: I4d9f0f133e18e54f57a14e15b9c5d70a36a099a7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8088235
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Tzarial <zork@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3418}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/gpu/command_buffer/service/indexed_buffer_binding_host.cc b/gpu/command_buffer/service/indexed_buffer_binding_host.cc
+index 4d6f643d1c346eb3fa9f29bae12684a392f65495..fb0b3c0507c26a21a25343fc548c0b38062867ac 100644
+--- a/gpu/command_buffer/service/indexed_buffer_binding_host.cc
++++ b/gpu/command_buffer/service/indexed_buffer_binding_host.cc
+@@ -99,11 +99,14 @@ void IndexedBufferBindingHost::DoBindBufferBase(GLuint index, Buffer* buffer) {
+   GLuint service_id = buffer ? buffer->service_id() : 0;
+   glBindBufferBase(target_, index, service_id);
+ 
+-  if (buffer_bindings_[index].buffer && is_bound_) {
++  // AttachedBuffersAreLocked() is checked here (and in DoBindBufferRange)
++  // rather than DCHECK-ing because these methods are also called during
++  // RestoreBindings() when the host is not yet marked as bound.
++  if (buffer_bindings_[index].buffer && AttachedBuffersAreLocked()) {
+     buffer_bindings_[index].buffer->OnUnbind(target_, true);
+   }
+   buffer_bindings_[index].SetBindBufferBase(buffer);
+-  if (buffer && is_bound_) {
++  if (buffer && AttachedBuffersAreLocked()) {
+     buffer->OnBind(target_, true);
+   }
+   UpdateMaxNonNullBindingIndex(index);
+@@ -123,11 +126,14 @@ void IndexedBufferBindingHost::DoBindBufferRange(GLuint index,
+     glBindBufferRange(target_, index, service_id, offset, size);
+   }
+ 
+-  if (buffer_bindings_[index].buffer && is_bound_) {
++  // AttachedBuffersAreLocked() is checked here rather than DCHECK-ing because
++  // these methods are also called during RestoreBindings() when the host is not
++  // yet marked as bound.
++  if (buffer_bindings_[index].buffer && AttachedBuffersAreLocked()) {
+     buffer_bindings_[index].buffer->OnUnbind(target_, true);
+   }
+   buffer_bindings_[index].SetBindBufferRange(buffer, offset, size);
+-  if (buffer && is_bound_) {
++  if (buffer && AttachedBuffersAreLocked()) {
+     buffer->OnBind(target_, true);
+   }
+   UpdateMaxNonNullBindingIndex(index);
+@@ -244,11 +250,14 @@ void IndexedBufferBindingHost::SetIsBound(bool is_bound) {
+     }
+   }
+ 
+-  if (is_bound != is_bound_) {
+-    is_bound_ = is_bound;
++  bool was_bound = AttachedBuffersAreLocked();
++  is_bound_ = is_bound;
++  bool is_now_bound = AttachedBuffersAreLocked();
++
++  if (was_bound != is_now_bound) {
+     for (auto& bb : buffer_bindings_) {
+       if (bb.buffer) {
+-        if (is_bound_) {
++        if (is_now_bound) {
+           bb.buffer->OnBind(target_, true);
+         } else {
+           bb.buffer->OnUnbind(target_, true);
+@@ -258,6 +267,18 @@ void IndexedBufferBindingHost::SetIsBound(bool is_bound) {
+   }
+ }
+ 
++bool IndexedBufferBindingHost::AttachedBuffersAreLocked() const {
++  return is_bound_;
++}
++
++void IndexedBufferBindingHost::ForceUnbindBuffers() {
++  for (auto& bb : buffer_bindings_) {
++    if (bb.buffer) {
++      bb.buffer->OnUnbind(target_, true);
++    }
++  }
++}
++
+ Buffer* IndexedBufferBindingHost::GetBufferBinding(GLuint index) const {
+   DCHECK_LT(index, buffer_bindings_.size());
+   return buffer_bindings_[index].buffer.get();
+diff --git a/gpu/command_buffer/service/indexed_buffer_binding_host.h b/gpu/command_buffer/service/indexed_buffer_binding_host.h
+index fc8921524af8a5d7aa29c5cd58581b0280efe386..57e0356b559a469848e47b30976b732ea623d7e6 100644
+--- a/gpu/command_buffer/service/indexed_buffer_binding_host.h
++++ b/gpu/command_buffer/service/indexed_buffer_binding_host.h
+@@ -50,6 +50,8 @@ class GPU_GLES2_EXPORT IndexedBufferBindingHost
+ 
+   void SetIsBound(bool bound);
+ 
++  virtual bool AttachedBuffersAreLocked() const;
++
+   Buffer* GetBufferBinding(GLuint index) const;
+   // Returns |size| set by glBindBufferRange; 0 if set by glBindBufferBase.
+   GLsizeiptr GetBufferSize(GLuint index) const;
+@@ -72,6 +74,8 @@ class GPU_GLES2_EXPORT IndexedBufferBindingHost
+ 
+   virtual ~IndexedBufferBindingHost();
+ 
++  void ForceUnbindBuffers();
++
+   // Whether this object is currently bound into the context.
+   bool is_bound_;
+ 
+diff --git a/gpu/command_buffer/service/transform_feedback_manager.cc b/gpu/command_buffer/service/transform_feedback_manager.cc
+index 0c9dd74963a5d636a1da44efad23a6aecbe7b6af..534ff94e778c281e3ae50aea0c3f5ef0a414ee36 100644
+--- a/gpu/command_buffer/service/transform_feedback_manager.cc
++++ b/gpu/command_buffer/service/transform_feedback_manager.cc
+@@ -34,10 +34,20 @@ TransformFeedback::TransformFeedback(TransformFeedbackManager* manager,
+ 
+ TransformFeedback::~TransformFeedback() {
+   if (!manager_->lost_context()) {
+-    if (active_)
++    if (active_ && is_bound_) {
+       glEndTransformFeedback();
++    }
+     glDeleteTransformFeedbacks(1, &service_id_);
+   }
++  // ForceUnbindBuffers() manages purely CPU-side state tracking/refcounting of
++  // the attached buffers. We must run it even if the context is lost (unlike
++  // the GL driver calls above) to ensure that the buffer reference counts are
++  // correctly decremented, preventing state leaks or triggering BufferManager
++  // DCHECKs upon destruction of an active but unbound transform feedback
++  // object.
++  if (active_ && !is_bound_) {
++    ForceUnbindBuffers();
++  }
+ }
+ 
+ void TransformFeedback::DoBindTransformFeedback(
+@@ -71,6 +81,10 @@ void TransformFeedback::DoBindTransformFeedback(
+   }
+ }
+ 
++bool TransformFeedback::AttachedBuffersAreLocked() const {
++  return is_bound_ || active_;
++}
++
+ void TransformFeedback::DoBeginTransformFeedback(GLenum primitive_mode) {
+   DCHECK(!active_);
+   DCHECK(primitive_mode == GL_POINTS ||
+diff --git a/gpu/command_buffer/service/transform_feedback_manager.h b/gpu/command_buffer/service/transform_feedback_manager.h
+index 0eb5014dadd29cc2e588f32c8dbbf9004fc6b649..9252d0e14fd451fdc645a8a27cdf1b0e6ae85363 100644
+--- a/gpu/command_buffer/service/transform_feedback_manager.h
++++ b/gpu/command_buffer/service/transform_feedback_manager.h
+@@ -58,6 +58,8 @@ class GPU_GLES2_EXPORT TransformFeedback : public IndexedBufferBindingHost {
+     return paused_;
+   }
+ 
++  bool AttachedBuffersAreLocked() const override;
++
+   GLenum primitive_mode() const {
+     return primitive_mode_;
+   }
+diff --git a/gpu/command_buffer/service/transform_feedback_manager_unittest.cc b/gpu/command_buffer/service/transform_feedback_manager_unittest.cc
+index 406407da90f5bedf6af8b2bcbfde7c998f25a5cd..440c53cd7c5cc637a1f696f65c986f5a13114e34 100644
+--- a/gpu/command_buffer/service/transform_feedback_manager_unittest.cc
++++ b/gpu/command_buffer/service/transform_feedback_manager_unittest.cc
+@@ -2,15 +2,18 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
++#include "gpu/command_buffer/service/transform_feedback_manager.h"
++
+ #include <memory>
+ 
++#include "gpu/command_buffer/service/buffer_manager.h"
+ #include "gpu/command_buffer/service/gpu_service_test.h"
+ #include "gpu/command_buffer/service/test_helper.h"
+-#include "gpu/command_buffer/service/transform_feedback_manager.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "ui/gl/gl_mock.h"
+ 
+ using ::testing::_;
++using ::testing::AnyNumber;
+ 
+ namespace gpu {
+ namespace gles2 {
+@@ -58,5 +61,117 @@ TEST_F(TransformFeedbackManagerTest, LifeTime) {
+   transform_feedback = nullptr;
+ }
+ 
++TEST_F(TransformFeedbackManagerTest, BufferBindingTrackedWhilePaused) {
++  const GLuint kBufferClientId = 11;
++  const GLuint kBufferServiceId = 1011;
++  const GLuint kClientId2 = 77;
++  const GLuint kServiceId2 = 1077;
++
++  EXPECT_CALL(*gl_, BindTransformFeedback(_, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BindBuffer(_, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BindBufferBase(_, _, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BeginTransformFeedback(_)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, PauseTransformFeedback()).Times(AnyNumber());
++  EXPECT_CALL(*gl_, EndTransformFeedback()).Times(AnyNumber());
++  EXPECT_CALL(*gl_, DeleteTransformFeedbacks(1, _)).Times(AnyNumber());
++
++  BufferManager buffer_manager(nullptr, nullptr);
++  buffer_manager.CreateBuffer(kBufferClientId, kBufferServiceId);
++  scoped_refptr<Buffer> buffer = buffer_manager.GetBuffer(kBufferClientId);
++  ASSERT_TRUE(buffer.get());
++
++  scoped_refptr<TransformFeedback> tf1 = manager_->CreateTransformFeedback(
++      kTransformFeedbackClientId, kTransformFeedbackServiceId);
++  scoped_refptr<TransformFeedback> tf2 =
++      manager_->CreateTransformFeedback(kClientId2, kServiceId2);
++
++  tf1->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, nullptr, nullptr);
++  tf1->DoBindBufferBase(0, buffer.get());
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  tf1->DoBeginTransformFeedback(GL_POINTS);
++  tf1->DoPauseTransformFeedback();
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  // Switching to another transform feedback object while the previous one is
++  // still active (paused) must not drop the buffer's transform feedback
++  // binding state, otherwise it could be re-specified before it is resumed.
++  tf2->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tf1.get(), nullptr);
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  tf1->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tf2.get(), nullptr);
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++  EXPECT_FALSE(buffer->IsDoubleBoundForTransformFeedback());
++
++  tf1->DoEndTransformFeedback();
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  tf2->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tf1.get(), nullptr);
++  EXPECT_FALSE(buffer->IsBoundForTransformFeedback());
++
++  manager_->Destroy();
++  tf1 = nullptr;
++  tf2 = nullptr;
++  buffer = nullptr;
++  buffer_manager.MarkContextLost();
++  buffer_manager.Destroy();
++}
++
++TEST_F(TransformFeedbackManagerTest,
++       BufferBindingTrackedWhenActiveTfDestroyedUnbound) {
++  const GLuint kBufferClientId = 11;
++  const GLuint kBufferServiceId = 1011;
++  const GLuint kClientId2 = 77;
++  const GLuint kServiceId2 = 1077;
++
++  // Expect glDeleteTransformFeedbacks when destroying the unbound active TF
++  // tf1. Importantly, we do NOT expect glEndTransformFeedback to be called on
++  // tf1 since it was unbound when destroyed.
++  EXPECT_CALL(*gl_, BindTransformFeedback(_, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BindBuffer(_, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BindBufferBase(_, _, _)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, BeginTransformFeedback(_)).Times(AnyNumber());
++  EXPECT_CALL(*gl_, PauseTransformFeedback()).Times(AnyNumber());
++  EXPECT_CALL(*gl_, DeleteTransformFeedbacks(1, _)).Times(AnyNumber());
++  // glEndTransformFeedback must not be called!
++  EXPECT_CALL(*gl_, EndTransformFeedback()).Times(0);
++
++  BufferManager buffer_manager(nullptr, nullptr);
++  buffer_manager.CreateBuffer(kBufferClientId, kBufferServiceId);
++  scoped_refptr<Buffer> buffer = buffer_manager.GetBuffer(kBufferClientId);
++  ASSERT_TRUE(buffer.get());
++
++  scoped_refptr<TransformFeedback> tf1 = manager_->CreateTransformFeedback(
++      kTransformFeedbackClientId, kTransformFeedbackServiceId);
++  scoped_refptr<TransformFeedback> tf2 =
++      manager_->CreateTransformFeedback(kClientId2, kServiceId2);
++
++  tf1->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, nullptr, nullptr);
++  tf1->DoBindBufferBase(0, buffer.get());
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  tf1->DoBeginTransformFeedback(GL_POINTS);
++  tf1->DoPauseTransformFeedback();
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  // Bind to tf2. Now tf1 is unbound but remains active (paused).
++  tf2->DoBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tf1.get(), nullptr);
++  EXPECT_TRUE(buffer->IsBoundForTransformFeedback());
++
++  // Destroy tf1 while active and unbound.
++  // This must unbind the buffers attached to it (OnUnbind should be called),
++  // reducing transform_feedback_indexed_binding_count_ to 0.
++  // In addition, glEndTransformFeedback must not be called in the driver.
++  manager_->RemoveTransformFeedback(kTransformFeedbackClientId);
++  tf1 = nullptr;
++  EXPECT_FALSE(buffer->IsBoundForTransformFeedback());
++
++  manager_->Destroy();
++  tf2 = nullptr;
++  buffer = nullptr;
++  buffer_manager.MarkContextLost();
++  buffer_manager.Destroy();
++}
++
+ }  // namespace gles2
+ }  // namespace gpu

--- a/patches/chromium/cherry-pick-e3cd72e404a5.patch
+++ b/patches/chromium/cherry-pick-e3cd72e404a5.patch
@@ -1,0 +1,159 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kramer Ge <fangzhoug@chromium.org>
+Date: Tue, 14 Jul 2026 09:25:04 -0700
+Subject: [M150] [Ozone/Wayland]Add window manager GetAllWindowsAsWeakPtr()
+
+Original change's description:
+> [Ozone/Wayland]Add window manager GetAllWindowsAsWeakPtr()
+>
+> A class of uaf are caused by direct/indirect delegate OnStatusUpdate()
+> calls. Notably iterating on GetAllWindows() while the delegate may
+> destroy the window and its descendant windows.
+>
+> Add GetAllWindowsAsWeakPtr() for callers that need to check for
+> potential window destruction.
+>
+> Bug: 532925350
+> Change-Id: I06109f25e6a1d9588fb55e930bc5ba81e82f6267
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8072281
+> Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+> Commit-Queue: Kramer Ge <fangzhoug@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1661337}
+
+(cherry picked from commit c9c9c645ab28e5a002c926a456f10a36ac36029c)
+
+Bug: 534617840,532925350
+Change-Id: I06109f25e6a1d9588fb55e930bc5ba81e82f6267
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8092609
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3414}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_buffer_manager_host.cc b/ui/ozone/platform/wayland/host/wayland_buffer_manager_host.cc
+index c67677137c1c186a280b61b19696fe43084857f7..a7506130a0dcc6084193cf808801da26ff6804f8 100644
+--- a/ui/ozone/platform/wayland/host/wayland_buffer_manager_host.cc
++++ b/ui/ozone/platform/wayland/host/wayland_buffer_manager_host.cc
+@@ -81,8 +81,14 @@ void WaylandBufferManagerHost::OnChannelDestroyed() {
+ 
+   buffer_backings_.clear();
+   dma_buffers_.clear();
+-  for (auto* window : connection_->window_manager()->GetAllWindows())
+-    window->OnChannelDestroyed();
++  for (auto window : connection_->window_manager()->GetAllWindowsAsWeakPtr()) {
++    // OnChannelDestroyed() may RequestState() from window delegate and close
++    // its child windows. This can happen if `should_ack_swap_without_commit_`
++    // in the frame manager.
++    if (window) {
++      window->OnChannelDestroyed();
++    }
++  }
+ 
+   buffer_manager_gpu_associated_.reset();
+   receiver_.reset();
+diff --git a/ui/ozone/platform/wayland/host/wayland_output_manager.cc b/ui/ozone/platform/wayland/host/wayland_output_manager.cc
+index 28b7bfab21be3d0ecadb5c6adb1d13e9975cd658..c3564a0fe8b9a6428a19441af5a2c3712cdcd2e1 100644
+--- a/ui/ozone/platform/wayland/host/wayland_output_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_output_manager.cc
+@@ -70,8 +70,13 @@ void WaylandOutputManager::RemoveWaylandOutput(WaylandOutput::Id output_id) {
+   // 2. from `WaylandScreen::display_list_`
+   // 3. from `WaylandOutputManager::output_list_`
+   auto* wayland_window_manager = connection_->window_manager();
+-  for (auto* window : wayland_window_manager->GetAllWindows())
+-    window->RemoveEnteredOutput(output_id);
++  for (auto window : wayland_window_manager->GetAllWindowsAsWeakPtr()) {
++    // RemoveEnteredOutput() may RequestState() from window delegate and close
++    // its child windows.
++    if (window) {
++      window->RemoveEnteredOutput(output_id);
++    }
++  }
+ 
+   if (wayland_screen_)
+     wayland_screen_->OnOutputRemoved(output_id);
+@@ -174,7 +179,12 @@ void WaylandOutputManager::OnOutputHandleMetrics(
+   const bool is_primary =
+       wayland_screen_ &&
+       metrics.display_id == wayland_screen_->GetPrimaryDisplay().id();
+-  for (auto* window : connection_->window_manager()->GetAllWindows()) {
++  for (auto window : connection_->window_manager()->GetAllWindowsAsWeakPtr()) {
++    // RemoveEnteredOutput() may RequestState() from window delegate and close
++    // its child windows.
++    if (!window) {
++      continue;
++    }
+     auto entered_output = window->GetPreferredEnteredOutputId();
+     if (entered_output == metrics.output_id ||
+         (!entered_output && is_primary)) {
+diff --git a/ui/ozone/platform/wayland/host/wayland_window_manager.cc b/ui/ozone/platform/wayland/host/wayland_window_manager.cc
+index 50db3bd8e6060d2e7326b33e1fb51cabbdf6abec..82bf07642c644414445a972310ac96e730349080 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window_manager.cc
+@@ -335,6 +335,16 @@ std::vector<WaylandWindow*> WaylandWindowManager::GetAllWindows() const {
+   return result;
+ }
+ 
++std::vector<base::WeakPtr<WaylandWindow>>
++WaylandWindowManager::GetAllWindowsAsWeakPtr() const {
++  std::vector<base::WeakPtr<WaylandWindow>> result;
++  result.reserve(window_map_.size());
++  for (auto& entry : window_map_) {
++    result.push_back(entry.second->AsWeakPtr());
++  }
++  return result;
++}
++
+ bool WaylandWindowManager::IsWindowValid(const WaylandWindow* window) const {
+   for (auto& pair : window_map_) {
+     if (pair.second == window)
+@@ -348,8 +358,10 @@ void WaylandWindowManager::SetFontScale(float new_font_scale) {
+     return;
+   }
+   font_scale_ = new_font_scale;
+-  for (WaylandWindow* window : GetAllWindows()) {
+-    window->OnFontScaleFactorChanged();
++  for (auto window : GetAllWindowsAsWeakPtr()) {
++    if (window) {
++      window->OnFontScaleFactorChanged();
++    }
+   }
+ }
+ 
+diff --git a/ui/ozone/platform/wayland/host/wayland_window_manager.h b/ui/ozone/platform/wayland/host/wayland_window_manager.h
+index 7735975074d667ab2b8ff13dc385bc0ec3432272..5568396d2d0a06edfd142f292dc6883415e14b8b 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window_manager.h
++++ b/ui/ozone/platform/wayland/host/wayland_window_manager.h
+@@ -10,6 +10,7 @@
+ 
+ #include "base/containers/flat_map.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "base/observer_list.h"
+ #include "ui/gfx/geometry/size_f.h"
+ #include "ui/gfx/native_ui_types.h"
+@@ -115,6 +116,10 @@ class WaylandWindowManager {
+   // Returns all stored windows.
+   std::vector<WaylandWindow*> GetAllWindows() const;
+ 
++  // Same as above, but for callers that may destroy windows while iterating on
++  // them.
++  std::vector<base::WeakPtr<WaylandWindow>> GetAllWindowsAsWeakPtr() const;
++
+   // Returns true if the |window| still exists.
+   bool IsWindowValid(const WaylandWindow* window) const;
+ 
+diff --git a/ui/ozone/platform/wayland/host/wayland_window_manager_unittest.cc b/ui/ozone/platform/wayland/host/wayland_window_manager_unittest.cc
+index 17c2192e8d978e5b9f6032876a302c5cba7aa433..6306d513cbcc9563355986081889ff888ae26961 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window_manager_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window_manager_unittest.cc
+@@ -184,6 +184,9 @@ TEST_P(WaylandWindowManagerTest, GetAllWindows) {
+ 
+   windows = manager_->GetAllWindows();
+   EXPECT_EQ(2u, windows.size());
++
++  auto weak_windows = manager_->GetAllWindowsAsWeakPtr();
++  EXPECT_EQ(2u, weak_windows.size());
+ }
+ 
+ INSTANTIATE_TEST_SUITE_P(XdgVersionStableTest,

--- a/patches/chromium/cherry-pick-e74ba1a76dd5.patch
+++ b/patches/chromium/cherry-pick-e74ba1a76dd5.patch
@@ -1,0 +1,160 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sangwhan Moon <sxm@google.com>
+Date: Tue, 14 Jul 2026 14:13:31 -0700
+Subject: [M150] [mac] Fix use-after-free in VideoCaptureDeviceApple Mojo
+ callback
+
+Original change's description:
+> [mac] Fix use-after-free in VideoCaptureDeviceApple Mojo callback
+>
+> AVFoundation invokes OnPhotoTaken and OnPhotoError on an arbitrary
+> background queue. VideoCaptureDeviceApple::OnPhotoTaken was previously
+> executing std::move(photo_callback_).Run(...) directly on that
+> background thread, which causes threading violations and potential
+> use-after-free/double-free issues if the VideoCaptureDeviceApple
+> instance is destroyed concurrently, or if photo_callback_ is accessed
+> while being modified on the main task runner.
+>
+> Bug: 516987782
+> Change-Id: Ibefa689f22116a4e5e3d89da7a3476af36c55251
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7912588
+> Reviewed-by: Ilya Nikolaevskiy <ilnik@chromium.org>
+> Commit-Queue: Sangwhan Moon <sxm@google.com>
+> Auto-Submit: Sangwhan Moon <sxm@google.com>
+> Reviewed-by: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1656796}
+
+(cherry picked from commit b2c70fcd2ebf3fef59465251277e6105c9f5f5a3)
+
+Bug: 532002527,516987782
+Change-Id: Ibefa689f22116a4e5e3d89da7a3476af36c55251
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8093424
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3423}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/media/capture/video/apple/video_capture_device_apple.h b/media/capture/video/apple/video_capture_device_apple.h
+index 657443a1c49993c089712eab040eb6466e1e70ae..37f9d1a9c6c4dc9da9e1a3f569e3b0c1c48c69c0 100644
+--- a/media/capture/video/apple/video_capture_device_apple.h
++++ b/media/capture/video/apple/video_capture_device_apple.h
+@@ -113,6 +113,8 @@ class CAPTURE_EXPORT VideoCaptureDeviceApple
+ 
+   VideoFrameMetadata GetVideoFrameMetadata();
+ 
++  void OnPhotoResultOnMainThread(mojom::BlobPtr blob);
++
+   // Flag indicating the internal state.
+   enum InternalState { kNotInitialized, kIdle, kCapturing, kError };
+ 
+diff --git a/media/capture/video/apple/video_capture_device_apple.mm b/media/capture/video/apple/video_capture_device_apple.mm
+index 9710c204398340b6baa49bc99bffb8cc140d27af..7af99cbf1e4a282e187ce62d45e35430c3303710 100644
+--- a/media/capture/video/apple/video_capture_device_apple.mm
++++ b/media/capture/video/apple/video_capture_device_apple.mm
+@@ -267,21 +267,43 @@
+ void VideoCaptureDeviceApple::OnPhotoTaken(const uint8_t* image_data,
+                                            size_t image_length,
+                                            const std::string& mime_type) {
+-  DCHECK(photo_callback_);
+-  if (!image_data || !image_length) {
+-    OnPhotoError();
+-    return;
++  // Note: While OnPhotoTaken() is called on an AVFoundation background queue by
++  // VideoCaptureDeviceAVFoundation, it is guaranteed that `this` is not deleted
++  // because VideoCaptureDeviceAVFoundation holds `_lock` while calling
++  // `_frameReceiver->OnPhotoTaken(...)`, and StopAndDeAllocate() acquires
++  // `_lock` when setting `_frameReceiver = nil` before destruction on the main
++  // thread. Therefore, accessing `task_runner_` here is safe.
++  mojom::BlobPtr blob;
++  if (image_data && image_length) {
++    blob = mojom::Blob::New();
++    blob->data.assign(image_data, image_data + image_length);
++    blob->mime_type = mime_type;
+   }
+-
+-  mojom::BlobPtr blob = mojom::Blob::New();
+-  blob->data.assign(image_data, image_data + image_length);
+-  blob->mime_type = mime_type;
+-  std::move(photo_callback_).Run(std::move(blob));
++  task_runner_->PostTask(
++      FROM_HERE,
++      base::BindOnce(&VideoCaptureDeviceApple::OnPhotoResultOnMainThread,
++                     weak_factory_.GetWeakPtr(), std::move(blob)));
+ }
+ 
+ void VideoCaptureDeviceApple::OnPhotoError() {
+   VLOG(1) << __func__ << " error taking picture";
+-  photo_callback_.Reset();
++  task_runner_->PostTask(
++      FROM_HERE,
++      base::BindOnce(&VideoCaptureDeviceApple::OnPhotoResultOnMainThread,
++                     weak_factory_.GetWeakPtr(), nullptr));
++}
++
++void VideoCaptureDeviceApple::OnPhotoResultOnMainThread(mojom::BlobPtr blob) {
++  DCHECK(task_runner_->BelongsToCurrentThread());
++  if (!photo_callback_) {
++    return;
++  }
++  if (!blob) {
++    VLOG(1) << __func__ << " error taking picture";
++    photo_callback_.Reset();
++    return;
++  }
++  std::move(photo_callback_).Run(std::move(blob));
+ }
+ 
+ void VideoCaptureDeviceApple::ReceiveError(VideoCaptureError error,
+diff --git a/media/capture/video/apple/video_capture_device_apple_unittest.mm b/media/capture/video/apple/video_capture_device_apple_unittest.mm
+index 35a03dc9c3452adbf6e08ff8b7e4341bcda3654c..b719b48f38713e8684dd69a0f0ef62cf2e285160 100644
+--- a/media/capture/video/apple/video_capture_device_apple_unittest.mm
++++ b/media/capture/video/apple/video_capture_device_apple_unittest.mm
+@@ -8,8 +8,10 @@
+ #import "base/memory/ref_counted.h"
+ #import "base/memory/scoped_refptr.h"
+ #import "base/run_loop.h"
++#include "base/synchronization/waitable_event.h"
+ #include "base/test/bind.h"
+ #include "base/test/gmock_callback_support.h"
++#include "base/threading/thread.h"
+ #include "media/capture/video/apple/test/fake_av_capture_device_format.h"
+ #import "media/capture/video/apple/test/video_capture_test_utils.h"
+ #include "media/capture/video/apple/video_capture_device_avfoundation_utils.h"
+@@ -134,6 +136,36 @@
+   EXPECT_EQ(result, fmt_640_480_2vuy_30);
+ }
+ 
++// OnPhotoTaken() and OnPhotoError() are documented as safe to call from any
++// thread. Exercise OnPhotoError() concurrently from the device task runner and
++// a background thread to ensure the in-flight TakePhoto callback is accessed
++// safely without data races or sequence checker violations.
++TEST(VideoCaptureDeviceMacTest, ConcurrentOnPhotoErrorIsThreadSafe) {
++  RunTestCase(base::BindOnce([] {
++    constexpr int kIterations = 1000;
++    VideoCaptureDeviceDescriptor descriptor;
++    auto device = std::make_unique<VideoCaptureDeviceApple>(descriptor);
++    VideoCaptureDeviceAVFoundationFrameReceiver* frame_receiver = device.get();
++
++    base::Thread other_thread("OnPhotoErrorTestThread");
++    ASSERT_TRUE(other_thread.Start());
++
++    base::WaitableEvent done;
++    other_thread.task_runner()->PostTask(
++        FROM_HERE, base::BindLambdaForTesting([&] {
++          for (int i = 0; i < kIterations; ++i) {
++            frame_receiver->OnPhotoError();
++          }
++          done.Signal();
++        }));
++    for (int i = 0; i < kIterations; ++i) {
++      frame_receiver->OnPhotoError();
++    }
++    done.Wait();
++    other_thread.Stop();
++  }));
++}
++
+ class MockImageCaptureClient
+     : public base::RefCountedThreadSafe<MockImageCaptureClient> {
+  public:

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -12,3 +12,4 @@ cherry-pick-c6bfbe7c4e84.patch
 cherry-pick-3c3aab471d2b.patch
 cherry-pick-4ffaf99fae0d.patch
 cherry-pick-b9013994f341.patch
+cherry-pick-a90507bd38f7.patch

--- a/patches/v8/cherry-pick-a90507bd38f7.patch
+++ b/patches/v8/cherry-pick-a90507bd38f7.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Victor Gomes <victorgomes@chromium.org>
+Date: Tue, 7 Jul 2026 11:24:29 +0200
+Subject: [M150] [turbofan] Keep safe-integer check in ToNumber Word32 lowering
+
+Original change's description:
+> [turbofan] Keep safe-integer check in ToNumber Word32 lowering
+>
+> Fixed: 531503216
+> Change-Id: Icd80dc73acffe448922c6d3a33e7b750662223af
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8052504
+> Commit-Queue: Victor Gomes <victorgomes@chromium.org>
+> Auto-Submit: Victor Gomes <victorgomes@chromium.org>
+> Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#108479}
+
+(cherry picked from commit fba00590cb03c58aa01fe18dd8f0cfedf0e94077)
+
+Bug: 532408015,531503216
+Change-Id: Icd80dc73acffe448922c6d3a33e7b750662223af
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8091108
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/15.0@{#39}
+Cr-Branched-From: 0c6c73eea6994260f0a1d88469708360ea60c660-refs/heads/15.0.245@{#1}
+Cr-Branched-From: 03d64f40934c058cd1c6d7e5cead5b757a4faedd-refs/heads/main@{#107679}
+
+diff --git a/src/compiler/simplified-lowering.cc b/src/compiler/simplified-lowering.cc
+index aa7a81c9f536e03cbd294595591328ceed9ef1f4..3aa6a3b526560d21a93e1588f93e9bc5fa6044a5 100644
+--- a/src/compiler/simplified-lowering.cc
++++ b/src/compiler/simplified-lowering.cc
+@@ -2677,7 +2677,7 @@ class RepresentationSelector {
+             Type::BigInt(), Type::NumberOrOddball(), graph()->zone())));
+         VisitInputs<T>(node);
+         // TODO(bmeurer): Optimize somewhat based on input type?
+-        if (truncation.IsUsedAsWord32()) {
++        if (truncation.IsUsedAsWord32() && !truncation.check_safe_integer()) {
+           SetOutput<T>(node, MachineRepresentation::kWord32);
+           if (lower<T>())
+             lowering->DoJSToNumberOrNumericTruncatesToWord32(node, this);
+@@ -4336,7 +4336,8 @@ class RepresentationSelector {
+           if (lower<T>()) {
+             ChangeOp(node, simplified()->StringToNumber());
+           }
+-        } else if (truncation.IsUsedAsWord32()) {
++        } else if (truncation.IsUsedAsWord32() &&
++                   !truncation.check_safe_integer()) {
+           if (InputIs(node, Type::NumberOrOddball())) {
+             VisitUnop<T>(node, UseInfo::TruncatingWord32(),
+                          MachineRepresentation::kWord32);
+diff --git a/test/mjsunit/regress/regress-531503216.js b/test/mjsunit/regress/regress-531503216.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..2730be29dfeb3919a8574b154e41b96fa084ec8d
+--- /dev/null
++++ b/test/mjsunit/regress/regress-531503216.js
+@@ -0,0 +1,47 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++// When a PlainPrimitiveToNumber result feeds an additive-safe-integer add whose
++// result is truncated to word32, the conversion must keep the safe-integer
++// check: ToNumber(undefined) is NaN, so (NaN + C) | 0 must be 0. Truncating
++// undefined straight to word32 0 would drop the check and forge an integer.
++const C = 0x40101000;
++const TK = -0x40101000;
++
++function f(route, stop) {
++  let n = +(route ? TK : undefined);
++  if (stop) return 0;
++  return (n + C) | 0;
++}
++
++%PrepareFunctionForOptimization(f);
++// Warm the ToNumber with undefined once, returning before the add so the add
++// only ever sees in-range integers and keeps its additive-safe-integer type.
++f(false, true);
++for (let i = 0; i < 200; i++) f(true, false);
++%OptimizeFunctionOnNextCall(f);
++
++// undefined now flows into the add: the result must be 0, not a forged integer.
++assertEquals(0, f(false, false));
++
++// Same invariant for the sibling JSToNumber lowering: an effectful ToNumber
++// (object with valueOf) that yields NaN must keep the safe-integer check too.
++let vv = TK;
++const obj = { valueOf() { return vv; } };
++
++function g(route, stop) {
++  let n = +(route ? TK : obj);
++  if (stop) return 0;
++  return (n + C) | 0;
++}
++
++%PrepareFunctionForOptimization(g);
++g(false, true);
++for (let i = 0; i < 200; i++) g(true, false);
++%OptimizeFunctionOnNextCall(g);
++
++vv = NaN;
++assertEquals(0, g(false, false));


### PR DESCRIPTION
#### Description of Change

Backports the following changes:

* [`e74ba1a76dd5`](https://chromium-review.googlesource.com/c/chromium/src/+/8093424) from chromium — [mac] Fix use-after-free in VideoCaptureDeviceApple Mojo callback
* [`d559d5018b66`](https://chromium-review.googlesource.com/c/chromium/src/+/8088235) from chromium — [agy][gpu] Fix active transform feedback buffer tracking
* [`094448afb6ab`](https://chromium-review.googlesource.com/c/chromium/src/+/8091747) from chromium — SimpleCache: fix problems with self-deletion in post-doom callbacks
* [`e3cd72e404a5`](https://chromium-review.googlesource.com/c/chromium/src/+/8092609) from chromium — [Ozone/Wayland]Add window manager GetAllWindowsAsWeakPtr()
* [`64f023ac1648`](https://chromium-review.googlesource.com/c/chromium/src/+/8092250) from chromium — [aura] Guard against root window destruction in ScopedCursorHider
* [`a90507bd38f7`](https://chromium-review.googlesource.com/c/v8/v8/+/8091108) from v8 — [turbofan] Keep safe-integer check in ToNumber Word32 lowering

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Backported fixes from upstream Chromium and V8.
