### PR TITLE
refactor: optimize context bridge, lazy modules, and texture cleanup

### DIFF
--- a/lib/browser/api/shared-texture.ts
+++ b/lib/browser/api/shared-texture.ts
@@ -25,50 +25,7 @@ ipcMain.handle(
   }
 );
 
-let checkManagedSharedTexturesInterval: NodeJS.Timeout | null = null;
 
-function scheduleCheckManagedSharedTextures() {
-  if (checkManagedSharedTexturesInterval === null) {
-    checkManagedSharedTexturesInterval = setInterval(checkManagedSharedTextures, 1000);
-  }
-}
-
-function unscheduleCheckManagedSharedTextures() {
-  if (checkManagedSharedTexturesInterval !== null) {
-    clearInterval(checkManagedSharedTexturesInterval);
-    checkManagedSharedTexturesInterval = null;
-  }
-}
-
-function checkManagedSharedTextures() {
-  const texturesToRemoveTracking = new Set<string>();
-  for (const [, wrapper] of managedSharedTextures) {
-    for (const [frameTreeNodeId, entry] of wrapper.rendererFrameReferences) {
-      const frame = entry.reference;
-      if (!frame || frame.isDestroyed()) {
-        console.error(
-          `The imported shared texture ${wrapper.texture.textureId} is referenced by a destroyed webContent/webFrameMain, this means a imported shared texture in renderer process is not released before the process is exited. Releasing that dangling reference now.`
-        );
-        wrapper.rendererFrameReferences.delete(frameTreeNodeId);
-      }
-    }
-
-    if (wrapper.rendererFrameReferences.size === 0 && !wrapper.mainReference) {
-      texturesToRemoveTracking.add(wrapper.texture.textureId);
-      wrapper.texture.subtle.release(() => {
-        wrapper.allReferencesReleased?.(wrapper.texture);
-      });
-    }
-  }
-
-  for (const id of texturesToRemoveTracking) {
-    managedSharedTextures.delete(id);
-  }
-
-  if (managedSharedTextures.size === 0) {
-    unscheduleCheckManagedSharedTextures();
-  }
-}
 
 function wrapperReleaseFromRenderer(id: string, frameTreeNodeId: number) {
   const wrapper = managedSharedTextures.get(id);
@@ -158,15 +115,28 @@ async function sendSharedTexture(options: Electron.SendSharedTextureOptions, ...
       wrapper.rendererFrameReferences.set(key, existing);
     } else {
       wrapper.rendererFrameReferences.set(key, { count: 1, reference: targetFrame });
+      targetFrame.once('destroyed', () => {
+        for (const [id, w] of managedSharedTextures) {
+          if (w.rendererFrameReferences.has(key)) {
+            console.error(
+              `The imported shared texture ${w.texture.textureId} is referenced by a destroyed webFrameMain, releasing dangling reference.`
+            );
+            w.rendererFrameReferences.delete(key);
+            if (w.rendererFrameReferences.size === 0 && !w.mainReference) {
+              managedSharedTextures.delete(id);
+              w.texture.subtle.release(() => {
+                w.allReferencesReleased?.(w.texture);
+              });
+            }
+          }
+        }
+      });
     }
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
     }
   }
-
-  // Schedule a check to see if any texture is referenced by any dangling renderer
-  scheduleCheckManagedSharedTextures();
 }
 
 function importSharedTexture(options: Electron.ImportSharedTextureOptions) {

--- a/lib/common/define-properties.ts
+++ b/lib/common/define-properties.ts
@@ -1,16 +1,21 @@
-const handleESModule = (loader: ElectronInternal.ModuleLoader) => () => {
-  const value = loader();
-  if (value.__esModule && value.default) return value.default;
-  return value;
-};
-
 // Attaches properties to |targetExports|.
-export function defineProperties(targetExports: Object, moduleList: ElectronInternal.ModuleEntry[]) {
+export function defineProperties(targetExports: any, moduleList: ElectronInternal.ModuleEntry[]) {
   const descriptors: PropertyDescriptorMap = {};
   for (const module of moduleList) {
     descriptors[module.name] = {
+      configurable: true,
       enumerable: true,
-      get: handleESModule(module.loader)
+      get() {
+        const raw = module.loader();
+        const value = (raw && raw.__esModule && raw.default) ? raw.default : raw;
+        Object.defineProperty(targetExports, module.name, {
+          value,
+          enumerable: true,
+          configurable: true,
+          writable: false
+        });
+        return value;
+      }
     };
   }
   return Object.defineProperties(targetExports, descriptors);

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -171,6 +171,7 @@ WebFrameMain::~WebFrameMain() {
 }
 
 void WebFrameMain::Destroyed() {
+  Emit("destroyed");
   if (FromFrameTreeNodeId(frame_tree_node_id_) == this) {
     // WebFrameMain initialized as detached doesn't support FTN lookup and
     // shouldn't erase the entry.

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -647,98 +647,98 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     BridgeErrorTarget error_target) {
   gin_helper::Dictionary api{source_isolate, api_object};
 
+  std::vector<std::pair<v8::Local<v8::Name>, v8::Local<v8::Value>>> properties;
+  std::vector<std::pair<v8::Local<v8::Name>, std::pair<v8::Local<v8::Value>, v8::Local<v8::Value>>>> accessors;
+
+  {
+    v8::Context::Scope source_context_scope(source_context);
+    auto maybe_keys = api.GetHandle()->GetOwnPropertyNames(
+        source_context, static_cast<v8::PropertyFilter>(v8::ONLY_ENUMERABLE));
+    if (!maybe_keys.IsEmpty()) {
+      auto keys = maybe_keys.ToLocalChecked();
+      uint32_t length = keys->Length();
+      properties.reserve(length);
+      for (uint32_t i = 0; i < length; i++) {
+        v8::Local<v8::Value> key_val;
+        if (!keys->Get(source_context, i).ToLocal(&key_val) || !key_val->IsName())
+          continue;
+        v8::Local<v8::Name> key = key_val.As<v8::Name>();
+
+        if (support_dynamic_properties) {
+          auto maybe_desc = api.GetHandle()->GetOwnPropertyDescriptor(
+              source_context, key);
+          v8::Local<v8::Value> desc_value;
+          if (maybe_desc.ToLocal(&desc_value) && desc_value->IsObject()) {
+            gin_helper::Dictionary desc(source_isolate, desc_value.As<v8::Object>());
+            if (desc.Has("get") || desc.Has("set")) {
+              v8::Local<v8::Value> getter;
+              v8::Local<v8::Value> setter;
+              desc.Get("get", &getter);
+              desc.Get("set", &setter);
+              accessors.push_back({key, {getter, setter}});
+              continue;
+            }
+          }
+        }
+
+        v8::Local<v8::Value> value;
+        if (api.Get(key, &value)) {
+          properties.push_back({key, value});
+        }
+      }
+    }
+  }
+
   {
     v8::Context::Scope destination_context_scope(destination_context);
     auto proxy = gin_helper::Dictionary::CreateEmpty(destination_isolate);
     object_cache->CacheProxiedObject(api.GetHandle(), proxy.GetHandle());
-    auto maybe_keys = api.GetHandle()->GetOwnPropertyNames(
-        source_context, static_cast<v8::PropertyFilter>(v8::ONLY_ENUMERABLE));
-    if (maybe_keys.IsEmpty())
-      return v8::MaybeLocal<v8::Object>(proxy.GetHandle());
-    auto keys = maybe_keys.ToLocalChecked();
 
-    uint32_t length = keys->Length();
-    for (uint32_t i = 0; i < length; i++) {
-      v8::Local<v8::Value> key =
-          keys->Get(destination_context, i).ToLocalChecked();
+    for (const auto& accessor : accessors) {
+      const auto& key = accessor.first;
+      const auto& getter = accessor.second.first;
+      const auto& setter = accessor.second.second;
 
-      if (support_dynamic_properties) {
-        v8::Context::Scope source_context_scope(source_context);
-        auto maybe_desc = api.GetHandle()->GetOwnPropertyDescriptor(
-            source_context, key.As<v8::Name>());
-        v8::Local<v8::Value> desc_value;
-        if (!maybe_desc.ToLocal(&desc_value) || !desc_value->IsObject())
-          continue;
-        gin_helper::Dictionary desc(api.isolate(), desc_value.As<v8::Object>());
-        if (desc.Has("get") || desc.Has("set")) {
-          v8::Local<v8::Value> getter;
-          v8::Local<v8::Value> setter;
-          desc.Get("get", &getter);
-          desc.Get("set", &setter);
+      v8::Local<v8::Value> getter_proxy;
+      v8::Local<v8::Value> setter_proxy;
 
-          {
-            v8::Context::Scope inner_destination_context_scope(
-                destination_context);
-            v8::Local<v8::Value> getter_proxy;
-            v8::Local<v8::Value> setter_proxy;
-            if (!getter.IsEmpty()) {
-              if (!PassValueToOtherContextInner(
-                       source_isolate, source_context, source_execution_context,
-                       destination_isolate, destination_context, getter,
-                       api.GetHandle(), object_cache,
-                       support_dynamic_properties, 1, error_target)
-                       .ToLocal(&getter_proxy))
-                continue;
-            }
-            if (!setter.IsEmpty()) {
-              if (!PassValueToOtherContextInner(
-                       source_isolate, source_context, source_execution_context,
-                       destination_isolate, destination_context, setter,
-                       api.GetHandle(), object_cache,
-                       support_dynamic_properties, 1, error_target)
-                       .ToLocal(&setter_proxy))
-                continue;
-            }
-
-            v8::PropertyDescriptor prop_desc(getter_proxy, setter_proxy);
-            std::ignore = proxy.GetHandle()->DefineProperty(
-                destination_context, key.As<v8::Name>(), prop_desc);
-          }
-          continue;
-        }
-      }
-
-      {
-        v8::Context::Scope source_context_scope(source_context);
-        v8::Local<v8::Value> value;
-        if (!api.Get(key, &value))
-          continue;
-
-        auto passed_value = PassValueToOtherContextInner(
+      if (!getter.IsEmpty() && !getter->IsUndefined()) {
+        auto passed = PassValueToOtherContextInner(
             source_isolate, source_context, source_execution_context,
-            destination_isolate, destination_context, value, api.GetHandle(),
-            object_cache, support_dynamic_properties, recursion_depth + 1,
-            error_target);
-        if (passed_value.IsEmpty())
-          return {};
-
-        {
-          v8::Context::Scope inner_destination_context_scope(
-              destination_context);
-          // Use CreateDataProperty (not Set) so that a key named "__proto__"
-          // becomes an own data property instead of invoking the inherited
-          // Object.prototype.__proto__ setter and mutating the prototype.
-          v8::Local<v8::Value> proxied_value = passed_value.ToLocalChecked();
-          if (key->IsName()) {
-            std::ignore = proxy.GetHandle()->CreateDataProperty(
-                destination_context, key.As<v8::Name>(), proxied_value);
-          } else {
-            std::ignore = proxy.GetHandle()->CreateDataProperty(
-                destination_context, key.As<v8::Uint32>()->Value(),
-                proxied_value);
-          }
-        }
+            destination_isolate, destination_context, getter,
+            api.GetHandle(), object_cache,
+            support_dynamic_properties, 1, error_target);
+        if (!passed.ToLocal(&getter_proxy)) continue;
       }
+      if (!setter.IsEmpty() && !setter->IsUndefined()) {
+        auto passed = PassValueToOtherContextInner(
+            source_isolate, source_context, source_execution_context,
+            destination_isolate, destination_context, setter,
+            api.GetHandle(), object_cache,
+            support_dynamic_properties, 1, error_target);
+        if (!passed.ToLocal(&setter_proxy)) continue;
+      }
+
+      v8::PropertyDescriptor prop_desc(getter_proxy, setter_proxy);
+      std::ignore = proxy.GetHandle()->DefineProperty(
+          destination_context, key, prop_desc);
+    }
+
+    for (const auto& prop : properties) {
+      const auto& key = prop.first;
+      const auto& value = prop.second;
+
+      auto passed_value = PassValueToOtherContextInner(
+          source_isolate, source_context, source_execution_context,
+          destination_isolate, destination_context, value, api.GetHandle(),
+          object_cache, support_dynamic_properties, recursion_depth + 1,
+          error_target);
+      if (passed_value.IsEmpty())
+        return {};
+
+      v8::Local<v8::Value> proxied_value = passed_value.ToLocalChecked();
+      std::ignore = proxy.GetHandle()->CreateDataProperty(
+          destination_context, key, proxied_value);
     }
 
     return proxy.GetHandle();


### PR DESCRIPTION
#### Description of Change

This PR implements core performance optimizations across C++ and TypeScript layers to reduce overhead in context-switching, lazy module resolution, and shared texture lifetime tracking:

1. **Context Bridge Context-Switching Optimization:** Restructured `CreateProxyForAPI` in `electron_api_context_bridge.cc` to batch property retrievals in the `source_context` and property definitions in the `destination_context`. This reduces the CPU overhead of repetitive `v8::Context::Scope` entering/exiting inside the property loop.
2. **Getter Redefinition for Lazy Loaded APIs:** Optimized `defineProperties` in `define-properties.ts` to redefine getter properties into static value properties on first access. This avoids executing the getter closure and running Node's internal `require` cache lookups on subsequent property accesses for `electron` APIs (e.g. `electron.app`, `electron.BrowserWindow`).
3. **Event-Driven Shared Texture Lifetime:** 
   * Added `Emit("destroyed")` to `WebFrameMain::Destroyed` right before the frame's wrapper is unpinned.
   * Restructured `shared-texture.ts` to clear referencing textures using an event-driven listener bound to the frame's `'destroyed'` event.
   * Completely removed the `setInterval` periodic checker timer (`checkManagedSharedTextures`) to save CPU wakeups and increase power efficiency.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Optimized internal performance of Context Bridge proxying, lazy module loading, and removed periodic polling timers for Shared Texture management.
