### PR TITLE
fix: allow custom macOS packages in dialog.showOpenDialog filters

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -137,6 +137,7 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [dialog setAllowedFileTypes:file_types];
+  [dialog setAllowsOtherFileTypes:YES];
 #pragma clang diagnostic pop
 
   if (count <= 1)


### PR DESCRIPTION
### Description of Change

Allows custom macOS package bundles (`LSTypeIsPackage`) to remain selectable when file filters are applied by setting `setAllowsOtherFileTypes:YES` on `NSSavePanel` / `NSOpenPanel`. Fixes #48191.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [x] `npm test` passes
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

### Release Notes

Notes: Fixed an issue where custom macOS package bundles were grayed out in `dialog.showOpenDialog` when file filters were active.