### PR TITLE
docs: use Chromium over Chrome

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -446,10 +446,10 @@ because it was crashed or killed. It does not include renderer processes.
 Returns:
 
 * `event` Event
-* `accessibilitySupportEnabled` boolean - `true` when Chrome's accessibility
+* `accessibilitySupportEnabled` boolean - `true` when Chromium's accessibility
   support is enabled, `false` otherwise.
 
-Emitted when Chrome's accessibility support changes. This event fires when
+Emitted when Chromium's accessibility support changes. This event fires when
 assistive technologies, such as screen readers, are enabled or disabled.
 See https://www.chromium.org/developers/design-documents/accessibility for more
 details.
@@ -1478,7 +1478,7 @@ For more information about setting different services as login items on macOS 13
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 
-Returns `boolean` - `true` if Chrome's accessibility support is enabled,
+Returns `boolean` - `true` if Chromium's accessibility support is enabled,
 `false` otherwise. This API will return `true` if the use of assistive
 technologies, such as screen readers, has been detected. See
 https://www.chromium.org/developers/design-documents/accessibility for more
@@ -1488,7 +1488,7 @@ details.
 
 * `enabled` boolean - Enable or disable [accessibility tree](https://developers.google.com/web/fundamentals/accessibility/semantics-builtin/the-accessibility-tree) rendering
 
-Manually enables Chrome's accessibility support, allowing to expose accessibility switch to users in application settings. See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more
+Manually enables Chromium's accessibility support, allowing to expose accessibility switch to users in application settings. See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more
 details. Disabled by default.
 
 This API must be called after the `ready` event is emitted.
@@ -1748,7 +1748,7 @@ app.setClientCertRequestPasswordHandler(async ({ hostname, tokenName, isRetry })
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_
 
-A `boolean` property that's `true` if Chrome's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chrome's accessibility support, allowing developers to expose accessibility switch to users in application settings.
+A `boolean` property that's `true` if Chromium's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chromium's accessibility support, allowing developers to expose accessibility switch to users in application settings.
 
 See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more details. Disabled by default.
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -72,7 +72,7 @@ requests according to the specified protocol scheme in the `options` object.
 Returns `Promise<GlobalResponse>` - see [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 Sends a request, similarly to how `fetch()` works in the renderer, using
-Chrome's network stack. This differs from Node's `fetch()`, which uses
+Chromium's network stack. This differs from Node's `fetch()`, which uses
 Node.js's HTTP stack.
 
 Example:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -821,7 +821,7 @@ Returns `Promise<void>` - Resolves when all connections are closed.
 Returns `Promise<GlobalResponse>` - see [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 Sends a request, similarly to how `fetch()` works in the renderer, using
-Chrome's network stack. This differs from Node's `fetch()`, which uses
+Chromium's network stack. This differs from Node's `fetch()`, which uses
 Node.js's HTTP stack.
 
 Example:

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -12,7 +12,7 @@ useful for app sub-windows that act as preference panels, or similar, as the
 parent can render to the sub-window directly, as if it were a `div` in the
 parent. This is the same behavior as in the browser.
 
-Electron pairs this native Chrome `Window` with a BrowserWindow under the hood.
+Electron pairs this native Chromium `Window` with a BrowserWindow under the hood.
 You can take advantage of all the customization available when creating a
 BrowserWindow in the main process by using `webContents.setWindowOpenHandler()`
 for renderer-created windows.

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -12,7 +12,7 @@ useful for app sub-windows that act as preference panels, or similar, as the
 parent can render to the sub-window directly, as if it were a `div` in the
 parent. This is the same behavior as in the browser.
 
-Electron pairs this native Chromium `Window` with a BrowserWindow under the hood.
+Electron pairs this native DOM `Window` with a BrowserWindow under the hood.
 You can take advantage of all the customization available when creating a
 BrowserWindow in the main process by using `webContents.setWindowOpenHandler()`
 for renderer-created windows.

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -43,7 +43,7 @@ standalone Node.js process (e.g. a SQLite server process).
 
 The `cookieEncryption` fuse toggles whether the cookie store on disk is encrypted using OS level
 cryptography keys. By default, the SQLite database that Chromium uses to store cookies stores the
-values in plaintext. If you wish to ensure your app's cookies are encrypted in the same way Chrome
+values in plaintext. If you wish to ensure your app's cookies are encrypted in the same way Chromium
 does, then you should enable this fuse. Please note it is a one-way transition—if you enable this
 fuse, existing unencrypted cookies will be encrypted-on-write, but subsequently disabling the fuse
 later will make your cookie store corrupt and useless. Most apps can safely enable this fuse.

--- a/docs/tutorial/performance.md
+++ b/docs/tutorial/performance.md
@@ -276,7 +276,7 @@ variant.
 
 ### 4. Blocking the renderer process
 
-Since Electron ships with a current version of Chrome, you can make use of the
+Since Electron ships with a current version of Chromium, you can make use of the
 latest and greatest features the Web Platform offers to defer or offload heavy
 operations in a way that keeps your app smooth and responsive.
 

--- a/docs/tutorial/sandbox.md
+++ b/docs/tutorial/sandbox.md
@@ -31,7 +31,7 @@ Electron has a few additional concepts to consider because it interfaces with No
 ### Renderer processes
 
 When renderer processes in Electron are sandboxed, they behave in the same way as a
-regular Chrome renderer would. A sandboxed renderer won't have a Node.js
+regular Chromium renderer would. A sandboxed renderer won't have a Node.js
 environment initialized.
 
 Therefore, when the sandbox is enabled, renderer processes can only perform privileged


### PR DESCRIPTION
#### Description of Change

This was feedback from a long time ago, but we should be better about using "Chromium" instead of "Chrome" whenever it's relevant.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
