### PR TITLE
fix: compilation errors due to Chromium API changes

### DIFF
--- a/shell/browser/ai/proxying_ai_manager.cc
+++ b/shell/browser/ai/proxying_ai_manager.cc
@@ -180,6 +180,20 @@ void ProxyingAIManager::CreateProofreader(
   NOTIMPLEMENTED();
 }
 
+void ProxyingAIManager::CanCreateClassifier(
+    blink::mojom::AIClassifierCreateOptionsPtr options,
+    CanCreateClassifierCallback callback) {
+  std::move(callback).Run(
+      blink::mojom::ModelAvailabilityCheckResult::kUnavailableUnknown);
+}
+
+void ProxyingAIManager::CreateClassifier(
+    mojo::PendingRemote<blink::mojom::AIManagerCreateClassifierClient> client,
+    blink::mojom::AIClassifierCreateOptionsPtr options,
+    mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor) {
+  NOTIMPLEMENTED();
+}
+
 void ProxyingAIManager::CanCreateSemanticEmbedder(
     CanCreateSemanticEmbedderCallback callback) {
   std::move(callback).Run(

--- a/shell/browser/ai/proxying_ai_manager.h
+++ b/shell/browser/ai/proxying_ai_manager.h
@@ -13,6 +13,7 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "third_party/blink/public/mojom/ai/ai_language_model.mojom.h"
+#include "third_party/blink/public/mojom/ai/ai_classifier.mojom.h"
 #include "third_party/blink/public/mojom/ai/ai_manager.mojom.h"
 #include "third_party/blink/public/mojom/ai/ai_proofreader.mojom-forward.h"
 #include "third_party/blink/public/mojom/ai/ai_rewriter.mojom-forward.h"
@@ -88,6 +89,14 @@ class ProxyingAIManager : public base::SupportsUserData::Data,
       mojo::PendingRemote<blink::mojom::AIManagerCreateProofreaderClient>
           client,
       blink::mojom::AIProofreaderCreateOptionsPtr options,
+      mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor)
+      override;
+  void CanCreateClassifier(blink::mojom::AIClassifierCreateOptionsPtr options,
+                           CanCreateClassifierCallback callback) override;
+  void CreateClassifier(
+      mojo::PendingRemote<blink::mojom::AIManagerCreateClassifierClient>
+          client,
+      blink::mojom::AIClassifierCreateOptionsPtr options,
       mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor)
       override;
   void CanCreateSemanticEmbedder(

--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -177,7 +177,7 @@ void NetLog::StartNetLogAfterCreateFile(net::NetLogCaptureMode capture_mode,
   }
   net_log_exporter_->Start(
       std::move(output_file), std::move(custom_constants), capture_mode,
-      net::NetLogFileFormat::kJson, max_file_size,
+      max_file_size,
       base::BindOnce(&NetLog::NetLogStarted, base::Unretained(this)));
 }
 

--- a/shell/utility/ai/utility_ai_manager.cc
+++ b/shell/utility/ai/utility_ai_manager.cc
@@ -540,6 +540,20 @@ void UtilityAIManager::CreateProofreader(
   NOTIMPLEMENTED();
 }
 
+void UtilityAIManager::CanCreateClassifier(
+    blink::mojom::AIClassifierCreateOptionsPtr options,
+    CanCreateClassifierCallback callback) {
+  std::move(callback).Run(
+      blink::mojom::ModelAvailabilityCheckResult::kUnavailableUnknown);
+}
+
+void UtilityAIManager::CreateClassifier(
+    mojo::PendingRemote<blink::mojom::AIManagerCreateClassifierClient> client,
+    blink::mojom::AIClassifierCreateOptionsPtr options,
+    mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor) {
+  NOTIMPLEMENTED();
+}
+
 void UtilityAIManager::CanCreateSemanticEmbedder(
     CanCreateSemanticEmbedderCallback callback) {
   std::move(callback).Run(

--- a/shell/utility/ai/utility_ai_manager.h
+++ b/shell/utility/ai/utility_ai_manager.h
@@ -17,6 +17,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "third_party/blink/public/common/tokens/tokens.h"
+#include "third_party/blink/public/mojom/ai/ai_classifier.mojom.h"
 #include "third_party/blink/public/mojom/ai/ai_language_model.mojom-forward.h"
 #include "third_party/blink/public/mojom/ai/ai_manager.mojom.h"
 #include "third_party/blink/public/mojom/ai/ai_proofreader.mojom-forward.h"
@@ -107,6 +108,14 @@ class UtilityAIManager : public blink::mojom::AIManager {
       mojo::PendingRemote<blink::mojom::AIManagerCreateProofreaderClient>
           client,
       blink::mojom::AIProofreaderCreateOptionsPtr options,
+      mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor)
+      override;
+  void CanCreateClassifier(blink::mojom::AIClassifierCreateOptionsPtr options,
+                           CanCreateClassifierCallback callback) override;
+  void CreateClassifier(
+      mojo::PendingRemote<blink::mojom::AIManagerCreateClassifierClient>
+          client,
+      blink::mojom::AIClassifierCreateOptionsPtr options,
       mojo::PendingRemote<on_device_model::mojom::DownloadObserver> monitor)
       override;
   void CanCreateSemanticEmbedder(


### PR DESCRIPTION
#### Description of Change

- Removed NetLogFileFormat argument from NetLogExporter::Start call
- Added stub CanCreateClassifier/CreateClassifier implementations to ProxyingAIManager and UtilityAIManager for new AI mojo interface
- Used full ai_classifier.mojom.h include instead of forward header

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

fixes:
```
../../third_party/libc++/src/include/__memory/unique_ptr.h:763:30: error: allocating an object of abstract class type 'electron::ProxyingAIManager'
  763 |   return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
      |                              ^
../../electron/shell/browser/electron_browser_client.cc:1740:14: note: in instantiation of function template specialization 'std::make_unique<electron::ProxyingAIManager, content::BrowserContext *&, content::RenderFrameHost *&, 0>' requested here
 1740 |         std::make_unique<ProxyingAIManager>(browser_context, rfh));
      |              ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:485:16: note: unimplemented pure virtual method 'CanCreateClassifier' in 'ProxyingAIManager'
  485 |   virtual void CanCreateClassifier(::blink::mojom::AIClassifierCreateOptionsPtr options, CanCreateClassifierCallback callback) = 0;
      |                ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:487:16: note: unimplemented pure virtual method 'CreateClassifier' in 'ProxyingAIManager'
  487 |   virtual void CreateClassifier(::mojo::PendingRemote<AIManagerCreateClassifierClient> client, ::blink::mojom::AIClassifierCreateOptionsPtr options, ::mojo::PendingRemote<::on_device_model::mojom::DownloadObserver> monitor) = 0;
      |                ^
1 error generated.
[62/293] CXX obj/electron/electron_lib/electron_api_web_contents.o

```
&
```
../../third_party/libc++/src/include/__memory/unique_ptr.h:763:30: error: allocating an object of abstract class type 'electron::UtilityAIManager'
  763 |   return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
      |                              ^
../../electron/shell/services/node/node_service.cc:284:12: note: in instantiation of function template specialization 'std::make_unique<electron::UtilityAIManager, std::optional<int> &, url::Origin &, base::TokenType<blink::LocalFrameTokenTypeMarker> &, int &, 0>' requested here
  284 |       std::make_unique<UtilityAIManager>(
      |            ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:485:16: note: unimplemented pure virtual method 'CanCreateClassifier' in 'UtilityAIManager'
  485 |   virtual void CanCreateClassifier(::blink::mojom::AIClassifierCreateOptionsPtr options, CanCreateClassifierCallback callback) = 0;
      |                ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:487:16: note: unimplemented pure virtual method 'CreateClassifier' in 'UtilityAIManager'
  487 |   virtual void CreateClassifier(::mojo::PendingRemote<AIManagerCreateClassifierClient> client, ::blink::mojom::AIClassifierCreateOptionsPtr options, ::mojo::PendingRemote<::on_device_model::mojom::DownloadObserver> monitor) = 0;
      |                ^
../../electron/shell/services/node/node_service.cc:294:9: error: no matching function for call to 'make_unique'
  294 |         std::make_unique<UtilityAIManager>(
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/libc++/src/include/__memory/unique_ptr.h:762:47: note: candidate template ignored: substitution failure [with _Tp = UtilityAIManager, _Args = <std::optional<int32_t> &, ::url::Origin &, ::blink::LocalFrameToken &, int32_t &>, $2 = 0]
  762 | _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(_Args&&... __args) {
      |                                               ^
../../third_party/libc++/src/include/__memory/unique_ptr.h:767:94: note: candidate function template not viable: requires single argument '__n', but 4 arguments were provided
  767 | [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(size_t __n) {
      |                                                                                              ^           ~~~~~~~~~~
../../third_party/libc++/src/include/__memory/unique_ptr.h:773:6: note: candidate template ignored: requirement '__is_bounded_array_v<electron::UtilityAIManager>' was not satisfied [with _Tp = UtilityAIManager, _Args = <std::optional<int32_t> &, ::url::Origin &, ::blink::LocalFrameToken &, int32_t &>]
  773 | void make_unique(_Args&&...) = delete;
      |      ^
2 errors generated.
[61/293] CXX obj/electron/electron_lib/electron_browser_client.o

```
&
```
../../electron/shell/browser/api/electron_api_net_log.cc:181:7: error: too many arguments to function call, expected 5, have 6
  178 |   net_log_exporter_->Start(
      |   ~~~~~~~~~~~~~~~~~~~~~~~~
  179 |       std::move(output_file), std::move(custom_constants), capture_mode,
  180 |       net::NetLogFileFormat::kJson, max_file_size,
  181 |       base::BindOnce(&NetLog::NetLogStarted, base::Unretained(this)));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gen/services/network/public/mojom/net_log.mojom.h:198:8: note: 'Start' declared here
  198 |   void Start(::base::File destination, ::base::DictValue extra_constants, ::net::NetLogCaptureMode capture_mode, uint64_t max_file_size, StartCallback callback) final;
      |        ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[40/293] CXX obj/electron/electron_lib/node_service.o
```
&
```
../../mojo/public/cpp/bindings/struct_forward.h:14:7: error: no viable destructor found for class 'InlinedStructPtr<blink::mojom::AIClassifierCreateOptions>'
   14 | class InlinedStructPtr;
      |       ^
../../electron/shell/browser/ai/proxying_ai_manager.cc:184:48: note: in instantiation of template class 'mojo::InlinedStructPtr<blink::mojom::AIClassifierCreateOptions>' requested here
  184 |     blink::mojom::AIClassifierCreateOptionsPtr options,
      |                                                ^
../../mojo/public/cpp/bindings/struct_ptr.h:159:3: note: candidate function not viable: constraints not satisfied
  159 |   ~InlinedStructPtr()
      |   ^
../../mojo/public/cpp/bindings/struct_ptr.h:160:14: note: because substituted constraint expression is ill-formed: constraint depends on a previously diagnosed expression
  160 |     requires(!std::is_trivially_destructible_v<Struct>)
      |              ^
3 errors generated.
[86/404] CXX obj/electron/electron_lib/electron_browser_client.o

```
&
```
../../third_party/libc++/src/include/__memory/unique_ptr.h:763:30: error: allocating an object of abstract class type 'electron::UtilityAIManager'
  763 |   return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
      |                              ^
../../electron/shell/services/node/node_service.cc:284:12: note: in instantiation of function template specialization 'std::make_unique<electron::UtilityAIManager, std::optional<int> &, url::Origin &, base::TokenType<blink::LocalFrameTokenTypeMarker> &, int &, 0>' requested here
  284 |       std::make_unique<UtilityAIManager>(
      |            ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:485:16: note: unimplemented pure virtual method 'CanCreateClassifier' in 'UtilityAIManager'
  485 |   virtual void CanCreateClassifier(::blink::mojom::AIClassifierCreateOptionsPtr options, CanCreateClassifierCallback callback) = 0;
      |                ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:487:16: note: unimplemented pure virtual method 'CreateClassifier' in 'UtilityAIManager'
  487 |   virtual void CreateClassifier(::mojo::PendingRemote<AIManagerCreateClassifierClient> client, ::blink::mojom::AIClassifierCreateOptionsPtr options, ::mojo::PendingRemote<::on_device_model::mojom::DownloadObserver> monitor) = 0;
      |                ^
../../electron/shell/services/node/node_service.cc:294:9: error: no matching function for call to 'make_unique'
  294 |         std::make_unique<UtilityAIManager>(
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/libc++/src/include/__memory/unique_ptr.h:762:47: note: candidate template ignored: substitution failure [with _Tp = UtilityAIManager, _Args = <std::optional<int32_t> &, ::url::Origin &, ::blink::LocalFrameToken &, int32_t &>, $2 = 0]
  762 | _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(_Args&&... __args) {
      |                                               ^
../../third_party/libc++/src/include/__memory/unique_ptr.h:767:94: note: candidate function template not viable: requires single argument '__n', but 4 arguments were provided
  767 | [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(size_t __n) {
      |                                                                                              ^           ~~~~~~~~~~
../../third_party/libc++/src/include/__memory/unique_ptr.h:773:6: note: candidate template ignored: requirement '__is_bounded_array_v<electron::UtilityAIManager>' was not satisfied [with _Tp = UtilityAIManager, _Args = <std::optional<int32_t> &, ::url::Origin &, ::blink::LocalFrameToken &, int32_t &>]
  773 | void make_unique(_Args&&...) = delete;
      |      ^
2 errors generated.

```
&
```
../../third_party/libc++/src/include/__memory/unique_ptr.h:763:30: error: allocating an object of abstract class type 'electron::ProxyingAIManager'
  763 |   return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
      |                              ^
../../electron/shell/browser/electron_browser_client.cc:1740:14: note: in instantiation of function template specialization 'std::make_unique<electron::ProxyingAIManager, content::BrowserContext *&, content::RenderFrameHost *&, 0>' requested here
 1740 |         std::make_unique<ProxyingAIManager>(browser_context, rfh));
      |              ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:485:16: note: unimplemented pure virtual method 'CanCreateClassifier' in 'ProxyingAIManager'
  485 |   virtual void CanCreateClassifier(::blink::mojom::AIClassifierCreateOptionsPtr options, CanCreateClassifierCallback callback) = 0;
      |                ^
gen/third_party/blink/public/mojom/ai/ai_manager.mojom.h:487:16: note: unimplemented pure virtual method 'CreateClassifier' in 'ProxyingAIManager'
  487 |   virtual void CreateClassifier(::mojo::PendingRemote<AIManagerCreateClassifierClient> client, ::blink::mojom::AIClassifierCreateOptionsPtr options, ::mojo::PendingRemote<::on_device_model::mojom::DownloadObserver> monitor) = 0;
      |                ^
1 error generated.
[157/560] CXX obj/electron/electron_lib/content_converter.o
```
&
```
../../electron/shell/browser/api/electron_api_net_log.cc:181:7: error: too many arguments to function call, expected 5, have 6
  178 |   net_log_exporter_->Start(
      |   ~~~~~~~~~~~~~~~~~~~~~~~~
  179 |       std::move(output_file), std::move(custom_constants), capture_mode,
  180 |       net::NetLogFileFormat::kJson, max_file_size,
  181 |       base::BindOnce(&NetLog::NetLogStarted, base::Unretained(this)));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gen/services/network/public/mojom/net_log.mojom.h:198:8: note: 'Start' declared here
  198 |   void Start(::base::File destination, ::base::DictValue extra_constants, ::net::NetLogCaptureMode capture_mode, uint64_t max_file_size, StartCallback callback) final;
      |        ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[135/695] CXX obj/electron/electron_lib/electron_api_web_contents.o

```

Notes: 
- We had ourselves a new dev machine, had to pull pull and build a fresh Electron. We were getting the errors above during compilation, apparently due to recent changes in Chromium's API. 
- This is a simple fix, no added features, just few added stubs to satisfy the API, and one removal to fix `NetLog` error
- that's it

Regards

<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
