### PR TITLE
feat: add color scheme override to web-contents

### DIFF
--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -49,6 +49,12 @@ Settings this property to `light` will have the following effects:
 * The [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS query will match `light` mode.
 * The `updated` event will be emitted
 
+To override the color scheme for an individual view without affecting native UI
+or other views, call [`webContents.setColorScheme`](web-contents.md#contentssetcolorschemecolorscheme)
+on the view's `webContents`. Use
+[`webContents.getColorScheme`](web-contents.md#contentsgetcolorscheme) to read its
+current override.
+
 The usage of this property should align with a classic "dark mode" state machine in your application
 where the user has three options.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2399,9 +2399,9 @@ added:
 ```
 -->
 
-* `colorScheme` string (optional) - Can be `system`, `light` or `dark`.
-  Defaults to `system` meaning that this `WebContents` will follow the value set
-  by [`nativeTheme.themeSource`](native-theme.md#nativethemethemesource).
+* `colorScheme` string (optional) - Can be `system`, `light` or `dark`. Defaults
+  to `system` meaning that this `WebContents` will follow the value set by
+  [`nativeTheme.themeSource`](native-theme.md#nativethemethemesource).
 
 Overrides the preferred color scheme for this WebContents. Calling this method
 without `colorScheme`, or setting it to `system`, removes the override.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2378,6 +2378,38 @@ changes:
 Controls whether or not this WebContents will throttle animations and timers
 when the page becomes backgrounded. This also affects the Page Visibility API.
 
+#### `contents.getColorScheme()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/52438
+```
+-->
+
+Returns `string` - The preferred color scheme override. Can be `system`, `light`
+or `dark`.
+
+#### `contents.setColorScheme([colorScheme])`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/52438
+```
+-->
+
+* `colorScheme` string (optional) - Can be `system`, `light` or `dark`.
+  Defaults to `system` meaning that this `WebContents` will follow the value set
+  by [`nativeTheme.themeSource`](native-theme.md#nativethemethemesource).
+
+Overrides the preferred color scheme for this WebContents. Calling this method
+without `colorScheme`, or setting it to `system`, removes the override.
+
+The override affects CSS media queries such as `prefers-color-scheme` without
+changing the preferred color scheme of other WebContents instances. It persists
+across navigations.
+
 #### `contents.getType()`
 
 Returns `string` - the type of the webContent. Can be `backgroundPage`, `window`, `browserView`, `remote`, `webview` or `offscreen`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2388,7 +2388,8 @@ added:
 -->
 
 Returns `string` - The preferred color scheme override. Can be `system`, `light`
-or `dark`.
+or `dark`. Defaults to `system` meaning that this `WebContents` will follow the
+value set by [`nativeTheme.themeSource`](native-theme.md#nativethemethemesource).
 
 #### `contents.setColorScheme([colorScheme])`
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2675,6 +2675,41 @@ void WebContents::SetBackgroundThrottling(bool allowed) {
   }
 }
 
+std::string WebContents::GetColorScheme() const {
+  if (!preferred_color_scheme_)
+    return "system";
+
+  return *preferred_color_scheme_ == blink::mojom::PreferredColorScheme::kDark
+             ? "dark"
+             : "light";
+}
+
+void WebContents::SetColorScheme(gin::Arguments* args) {
+  std::string color_scheme = "system";
+  if (args->Length() > 0 && !args->GetNext(&color_scheme)) {
+    args->ThrowTypeError(
+        "colorScheme must be one of 'system', 'light', or 'dark'");
+    return;
+  }
+
+  std::optional<blink::mojom::PreferredColorScheme> preferred_color_scheme;
+  if (color_scheme == "light") {
+    preferred_color_scheme = blink::mojom::PreferredColorScheme::kLight;
+  } else if (color_scheme == "dark") {
+    preferred_color_scheme = blink::mojom::PreferredColorScheme::kDark;
+  } else if (color_scheme != "system") {
+    args->ThrowTypeError(
+        "colorScheme must be one of 'system', 'light', or 'dark'");
+    return;
+  }
+
+  if (preferred_color_scheme_ == preferred_color_scheme)
+    return;
+
+  preferred_color_scheme_ = preferred_color_scheme;
+  web_contents()->NotifyPreferencesChanged();
+}
+
 int32_t WebContents::GetProcessID() const {
   return web_contents()
       ->GetPrimaryMainFrame()
@@ -4881,6 +4916,8 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
                  &WebContents::GetBackgroundThrottling)
       .SetMethod("setBackgroundThrottling",
                  &WebContents::SetBackgroundThrottling)
+      .SetMethod("getColorScheme", &WebContents::GetColorScheme)
+      .SetMethod("setColorScheme", &WebContents::SetColorScheme)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
       .SetMethod("clone", &WebContents::Clone)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2686,7 +2686,8 @@ std::string WebContents::GetColorScheme() const {
 
 void WebContents::SetColorScheme(gin::Arguments* args) {
   std::string color_scheme = "system";
-  if (args->Length() > 0 && !args->GetNext(&color_scheme)) {
+  if (args->Length() > 0 && !args->PeekNext()->IsUndefined() &&
+      !args->GetNext(&color_scheme)) {
     args->ThrowTypeError(
         "colorScheme must be one of 'system', 'light', or 'dark'");
     return;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -42,6 +42,7 @@
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "shell/common/gin_helper/wrappable.h"
+#include "third_party/blink/public/mojom/css/preferred_color_scheme.mojom.h"
 #include "third_party/skia/include/core/SkRegion.h"
 #include "ui/base/models/image_model.h"
 #include "v8/include/cppgc/persistent.h"
@@ -195,6 +196,12 @@ class WebContents final : public ExclusiveAccessContext,
   bool GetBackgroundThrottling() const override;
 
   void SetBackgroundThrottling(bool allowed);
+  std::string GetColorScheme() const;
+  void SetColorScheme(gin::Arguments* args);
+  const std::optional<blink::mojom::PreferredColorScheme>&
+  preferred_color_scheme() const {
+    return preferred_color_scheme_;
+  }
   int32_t GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
   [[nodiscard]] Type type() const { return type_; }
@@ -828,6 +835,8 @@ class WebContents final : public ExclusiveAccessContext,
 
   // Whether background throttling is disabled.
   bool background_throttling_ = true;
+
+  std::optional<blink::mojom::PreferredColorScheme> preferred_color_scheme_;
 
   // Whether to enable devtools.
   bool enable_devtools_ = true;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -367,6 +367,19 @@ void MaybeAppendSecureOriginsAllowlistSwitch(base::CommandLine* cmdline) {
   }
 }
 
+blink::mojom::PreferredColorScheme GetPreferredColorScheme(
+    content::WebContents* web_contents) {
+  if (auto* api_web_contents = api::WebContents::From(web_contents)) {
+    if (auto color_scheme = api_web_contents->preferred_color_scheme())
+      return *color_scheme;
+  }
+
+  return ui::NativeTheme::GetInstanceForNativeUi()->preferred_color_scheme() ==
+                 ui::NativeTheme::PreferredColorScheme::kDark
+             ? blink::mojom::PreferredColorScheme::kDark
+             : blink::mojom::PreferredColorScheme::kLight;
+}
+
 }  // namespace
 
 // static
@@ -465,11 +478,7 @@ void ElectronBrowserClient::OverrideWebPreferences(
   ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
   prefs->in_forced_colors = native_theme->forced_colors() !=
                             ui::ColorProviderKey::ForcedColors::kNone;
-  prefs->preferred_color_scheme =
-      native_theme->preferred_color_scheme() ==
-              ui::NativeTheme::PreferredColorScheme::kDark
-          ? blink::mojom::PreferredColorScheme::kDark
-          : blink::mojom::PreferredColorScheme::kLight;
+  prefs->preferred_color_scheme = GetPreferredColorScheme(web_contents);
 
   SetFontDefaults(prefs);
 
@@ -486,11 +495,7 @@ bool ElectronBrowserClient::WebPreferencesNeedUpdateForColorRelatedStateChanges(
   ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
   bool in_forced_colors = native_theme->forced_colors() !=
                           ui::ColorProviderKey::ForcedColors::kNone;
-  blink::mojom::PreferredColorScheme preferred_color_scheme =
-      native_theme->preferred_color_scheme() ==
-              ui::NativeTheme::PreferredColorScheme::kDark
-          ? blink::mojom::PreferredColorScheme::kDark
-          : blink::mojom::PreferredColorScheme::kLight;
+  auto preferred_color_scheme = GetPreferredColorScheme(&web_contents);
   return prefs.in_forced_colors != in_forced_colors ||
          prefs.preferred_color_scheme != preferred_color_scheme;
 }

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -7,7 +7,8 @@ import {
   BrowserView,
   WebContents,
   BaseWindow,
-  WebContentsView
+  WebContentsView,
+  nativeTheme
 } from 'electron/main';
 
 import { assert, expect } from 'chai';
@@ -2294,6 +2295,136 @@ describe('webContents module', () => {
 
       w.webContents.audioMuted = false;
       expect(w.webContents.audioMuted).to.be.false();
+    });
+  });
+
+  describe('color scheme', () => {
+    afterEach(async () => {
+      await closeAllWindows();
+      nativeTheme.themeSource = 'system';
+    });
+
+    const getEffectiveColorScheme = (contents: WebContents) => {
+      return contents.executeJavaScript(
+        "matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'"
+      ) as Promise<'dark' | 'light'>;
+    };
+
+    const waitForColorScheme = async (contents: WebContents, expected: 'dark' | 'light') => {
+      await waitUntil(async () => (await getEffectiveColorScheme(contents)) === expected);
+    };
+
+    it('gets the configured color scheme', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w.webContents.getColorScheme()).to.equal('system');
+
+      w.webContents.setColorScheme('dark');
+      expect(w.webContents.getColorScheme()).to.equal('dark');
+
+      w.webContents.setColorScheme('light');
+      expect(w.webContents.getColorScheme()).to.equal('light');
+
+      w.webContents.setColorScheme();
+      expect(w.webContents.getColorScheme()).to.equal('system');
+
+      w.webContents.setColorScheme('dark');
+      w.webContents.setColorScheme('system');
+      expect(w.webContents.getColorScheme()).to.equal('system');
+    });
+
+    it('overrides the color scheme for one WebContents', async () => {
+      const overridden = new BrowserWindow({ show: false });
+      const untouched = new BrowserWindow({ show: false });
+      await Promise.all([
+        overridden.loadURL('about:blank'),
+        untouched.loadURL('about:blank')
+      ]);
+
+      const systemColorScheme = await getEffectiveColorScheme(overridden.webContents);
+      expect(await getEffectiveColorScheme(untouched.webContents)).to.equal(systemColorScheme);
+
+      overridden.webContents.setColorScheme('dark');
+      await waitForColorScheme(overridden.webContents, 'dark');
+      expect(await getEffectiveColorScheme(untouched.webContents)).to.equal(systemColorScheme);
+
+      overridden.webContents.setColorScheme('light');
+      await waitForColorScheme(overridden.webContents, 'light');
+      expect(await getEffectiveColorScheme(untouched.webContents)).to.equal(systemColorScheme);
+
+      overridden.webContents.setColorScheme('system');
+      await waitForColorScheme(overridden.webContents, systemColorScheme);
+    });
+
+    it('takes precedence over nativeTheme.themeSource', async () => {
+      const overridden = new BrowserWindow({ show: false });
+      const followingGlobalTheme = new BrowserWindow({ show: false });
+      await Promise.all([
+        overridden.loadURL('about:blank'),
+        followingGlobalTheme.loadURL('about:blank')
+      ]);
+
+      nativeTheme.themeSource = 'light';
+      await Promise.all([
+        waitForColorScheme(overridden.webContents, 'light'),
+        waitForColorScheme(followingGlobalTheme.webContents, 'light')
+      ]);
+
+      overridden.webContents.setColorScheme('dark');
+      await waitForColorScheme(overridden.webContents, 'dark');
+
+      nativeTheme.themeSource = 'dark';
+      await waitForColorScheme(followingGlobalTheme.webContents, 'dark');
+
+      nativeTheme.themeSource = 'light';
+      await waitForColorScheme(followingGlobalTheme.webContents, 'light');
+      expect(await getEffectiveColorScheme(overridden.webContents)).to.equal('dark');
+
+      overridden.webContents.setColorScheme('system');
+      await waitForColorScheme(overridden.webContents, 'light');
+
+      nativeTheme.themeSource = 'dark';
+      await Promise.all([
+        waitForColorScheme(overridden.webContents, 'dark'),
+        waitForColorScheme(followingGlobalTheme.webContents, 'dark')
+      ]);
+    });
+
+    it('notifies media query listeners when the color scheme changes', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      const initialColorScheme = await getEffectiveColorScheme(w.webContents);
+      const expectedColorScheme = initialColorScheme === 'dark' ? 'light' : 'dark';
+      await w.webContents.executeJavaScript(`
+        window.colorSchemeChanges = [];
+        matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+          window.colorSchemeChanges.push(event.matches ? 'dark' : 'light');
+        });
+      `);
+
+      w.webContents.setColorScheme(expectedColorScheme);
+      await waitUntil(async () => {
+        const changes = await w.webContents.executeJavaScript('window.colorSchemeChanges');
+        return changes.includes(expectedColorScheme);
+      });
+    });
+
+    it('preserves the override across navigations', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.setColorScheme('dark');
+
+      await w.loadURL('data:text/html,first');
+      expect(await getEffectiveColorScheme(w.webContents)).to.equal('dark');
+
+      await w.loadURL('data:text/html,second');
+      expect(await getEffectiveColorScheme(w.webContents)).to.equal('dark');
+    });
+
+    it('throws for an invalid color scheme', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => w.webContents.setColorScheme('sepia' as any)).to.throw(
+        "colorScheme must be one of 'system', 'light', or 'dark'"
+      );
     });
   });
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2328,6 +2328,10 @@ describe('webContents module', () => {
       expect(w.webContents.getColorScheme()).to.equal('system');
 
       w.webContents.setColorScheme('dark');
+      w.webContents.setColorScheme(undefined);
+      expect(w.webContents.getColorScheme()).to.equal('system');
+
+      w.webContents.setColorScheme('dark');
       w.webContents.setColorScheme('system');
       expect(w.webContents.getColorScheme()).to.equal('system');
     });

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -2339,10 +2339,7 @@ describe('webContents module', () => {
     it('overrides the color scheme for one WebContents', async () => {
       const overridden = new BrowserWindow({ show: false });
       const untouched = new BrowserWindow({ show: false });
-      await Promise.all([
-        overridden.loadURL('about:blank'),
-        untouched.loadURL('about:blank')
-      ]);
+      await Promise.all([overridden.loadURL('about:blank'), untouched.loadURL('about:blank')]);
 
       const systemColorScheme = await getEffectiveColorScheme(overridden.webContents);
       expect(await getEffectiveColorScheme(untouched.webContents)).to.equal(systemColorScheme);
@@ -2362,10 +2359,7 @@ describe('webContents module', () => {
     it('takes precedence over nativeTheme.themeSource', async () => {
       const overridden = new BrowserWindow({ show: false });
       const followingGlobalTheme = new BrowserWindow({ show: false });
-      await Promise.all([
-        overridden.loadURL('about:blank'),
-        followingGlobalTheme.loadURL('about:blank')
-      ]);
+      await Promise.all([overridden.loadURL('about:blank'), followingGlobalTheme.loadURL('about:blank')]);
 
       nativeTheme.themeSource = 'light';
       await Promise.all([


### PR DESCRIPTION
#### Description of Change

Adds a per-`WebContents` preferred color scheme override, allowing applications with multiple views to render individual views in light or dark mode without changing the global [`nativeTheme.themeSource`](https://www.electronjs.org/docs/latest/api/native-theme).

This introduces `webContents.getColorScheme()` and `webContents.setColorScheme(colorScheme)`, accepting `inherit`, `light`, or `dark`. The override is applied when Electron populates and updates renderer web preferences. `inherit` is the default and follows `nativeTheme.themeSource`; calling `setColorScheme()` without an argument, or setting it to `inherit`, removes the override. Changes notify the renderer immediately, remain isolated to the target `WebContents`, and persist across navigations.

Tests cover the getter and setter, isolation between `WebContents` instances, precedence over `nativeTheme.themeSource`, media-query change notifications, navigation persistence, and invalid input. The `webContents` and `nativeTheme` API documentation has been updated accordingly.

Fixes #50581.

#### Checklist

- [x] I have built and tested this change on 43-x-y branch
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `webContents.getColorScheme()` and `webContents.setColorScheme()` to override the preferred color scheme for individual `WebContents` instances.