### PR TITLE
feat: add webFrameMain.printToPDF()

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -831,6 +831,8 @@ source_set("electron_lib") {
 
   if (enable_printing) {
     sources += [
+      "shell/browser/printing/print_to_pdf.cc",
+      "shell/browser/printing/print_to_pdf.h",
       "shell/browser/printing/print_view_manager_electron.cc",
       "shell/browser/printing/print_view_manager_electron.h",
       "shell/browser/printing/printing_utils.cc",

--- a/docs/api/structures/print-to-pdf-margins.md
+++ b/docs/api/structures/print-to-pdf-margins.md
@@ -1,0 +1,6 @@
+# PrintToPDFMargins Object
+
+* `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
+* `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).
+* `left` number (optional) - Left margin in inches. Defaults to 1cm (~0.4 inches).
+* `right` number (optional) - Right margin in inches. Defaults to 1cm (~0.4 inches).

--- a/docs/api/structures/print-to-pdf-options.md
+++ b/docs/api/structures/print-to-pdf-options.md
@@ -1,0 +1,15 @@
+# PrintToPDFOptions Object
+
+* `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
+* `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
+* `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
+* `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
+* `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
+`A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
+* `margins` [PrintToPDFMargins](print-to-pdf-margins.md?inline) (optional)
+* `pageRanges` string (optional) - Page ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
+* `headerTemplate` string (optional) - HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: `date` (formatted print date), `title` (document title), `url` (document location), `pageNumber` (current page number) and `totalPages` (total pages in the document). For example, `<span class=title></span>` would generate span containing the title.
+* `footerTemplate` string (optional) - HTML template for the print footer. Should use the same format as the `headerTemplate`.
+* `preferCSSPageSize` boolean (optional) - Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
+* `generateTaggedPDF` boolean (optional) _Experimental_ - Whether or not to generate a tagged (accessible) PDF. Defaults to false. As this property is experimental, the generated PDF may not adhere fully to PDF/UA and WCAG standards.
+* `generateDocumentOutline` boolean (optional) _Experimental_ - Whether or not to generate a PDF document outline from content headers. Defaults to false.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1864,24 +1864,7 @@ win.webContents.print(options, (success, errorType) => {
 
 #### `contents.printToPDF(options)`
 
-* `options` Object
-  * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
-  * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
-  * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
-  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
-  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
-  * `margins` Object (optional)
-    * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
-    * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).
-    * `left` number (optional) - Left margin in inches. Defaults to 1cm (~0.4 inches).
-    * `right` number (optional) - Right margin in inches. Defaults to 1cm (~0.4 inches).
-  * `pageRanges` string (optional) - Page ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
-  * `headerTemplate` string (optional) - HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: `date` (formatted print date), `title` (document title), `url` (document location), `pageNumber` (current page number) and `totalPages` (total pages in the document). For example, `<span class=title></span>` would generate span containing the title.
-  * `footerTemplate` string (optional) - HTML template for the print footer. Should use the same format as the `headerTemplate`.
-  * `preferCSSPageSize` boolean (optional) - Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
-  * `generateTaggedPDF` boolean (optional) _Experimental_ - Whether or not to generate a tagged (accessible) PDF. Defaults to false. As this property is experimental, the generated PDF may not adhere fully to PDF/UA and WCAG standards.
-  * `generateDocumentOutline` boolean (optional) _Experimental_ - Whether or not to generate a PDF document outline from content headers. Defaults to false.
+* `options` [PrintToPDFOptions](structures/print-to-pdf-options.md?inline)
 
 Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -189,6 +189,67 @@ When executed on a video media element, copies the frame at (x, y) to the clipbo
 
 When executed on a video media element, shows a save dialog and saves the frame at (x, y) to disk.
 
+#### `frame.printToPDF(options)`
+
+* `options` Object
+  * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
+  * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
+  * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
+  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
+  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
+  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
+  * `margins` Object (optional)
+    * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
+    * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).
+    * `left` number (optional) - Left margin in inches. Defaults to 1cm (~0.4 inches).
+    * `right` number (optional) - Right margin in inches. Defaults to 1cm (~0.4 inches).
+  * `pageRanges` string (optional) - Page ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
+  * `headerTemplate` string (optional) - HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: `date` (formatted print date), `title` (document title), `url` (document location), `pageNumber` (current page number) and `totalPages` (total pages in the document). For example, `<span class=title></span>` would generate span containing the title.
+  * `footerTemplate` string (optional) - HTML template for the print footer. Should use the same format as the `headerTemplate`.
+  * `preferCSSPageSize` boolean (optional) - Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
+  * `generateTaggedPDF` boolean (optional) _Experimental_ - Whether or not to generate a tagged (accessible) PDF. Defaults to false. As this property is experimental, the generated PDF may not adhere fully to PDF/UA and WCAG standards.
+  * `generateDocumentOutline` boolean (optional) _Experimental_ - Whether or not to generate a PDF document outline from content headers. Defaults to false.
+
+Returns `Promise<Buffer>` - Resolves with the generated PDF data.
+
+Prints the frame's web page as PDF.
+
+Unlike [`webContents.printToPDF`](web-contents.md#contentsprinttopdfoptions),
+this method prints only the contents of the frame it is called on. This can be
+used to print an individual `<iframe>` from the main process.
+
+The `landscape` will be ignored if `@page` CSS at-rule is used in the web page.
+
+An example of printing an iframe to PDF:
+
+```js
+const { app, BrowserWindow } = require('electron')
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow()
+  win.loadFile('page-with-iframe.html')
+
+  win.webContents.on('did-finish-load', () => {
+    const pdfPath = path.join(os.homedir(), 'Desktop', 'iframe.pdf')
+    const iframe = win.webContents.mainFrame.frames[0]
+    iframe.printToPDF({}).then(data => {
+      fs.writeFile(pdfPath, data, (error) => {
+        if (error) throw error
+        console.log(`Wrote PDF successfully to ${pdfPath}`)
+      })
+    }).catch(error => {
+      console.log(`Failed to write PDF to ${pdfPath}: `, error)
+    })
+  })
+})
+```
+
+See [Page.printToPdf](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) for more information.
+
 ### Instance Properties
 
 #### `frame.ipc` _Readonly_

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -198,24 +198,7 @@ added:
 ```
 -->
 
-* `options` Object
-  * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
-  * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
-  * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
-  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
-  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
-  * `margins` Object (optional)
-    * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
-    * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).
-    * `left` number (optional) - Left margin in inches. Defaults to 1cm (~0.4 inches).
-    * `right` number (optional) - Right margin in inches. Defaults to 1cm (~0.4 inches).
-  * `pageRanges` string (optional) - Page ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
-  * `headerTemplate` string (optional) - HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: `date` (formatted print date), `title` (document title), `url` (document location), `pageNumber` (current page number) and `totalPages` (total pages in the document). For example, `<span class=title></span>` would generate span containing the title.
-  * `footerTemplate` string (optional) - HTML template for the print footer. Should use the same format as the `headerTemplate`.
-  * `preferCSSPageSize` boolean (optional) - Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
-  * `generateTaggedPDF` boolean (optional) _Experimental_ - Whether or not to generate a tagged (accessible) PDF. Defaults to false. As this property is experimental, the generated PDF may not adhere fully to PDF/UA and WCAG standards.
-  * `generateDocumentOutline` boolean (optional) _Experimental_ - Whether or not to generate a PDF document outline from content headers. Defaults to false.
+* `options` [PrintToPDFOptions](structures/print-to-pdf-options.md?inline)
 
 Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -191,6 +191,13 @@ When executed on a video media element, shows a save dialog and saves the frame 
 
 #### `frame.printToPDF(options)`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/52439
+```
+-->
+
 * `options` Object
   * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
   * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -596,24 +596,7 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 ### `<webview>.printToPDF(options)`
 
-* `options` Object
-  * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
-  * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
-  * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
-  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
-  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
-  `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
-  * `margins` Object (optional)
-    * `top` number (optional) - Top margin in inches. Defaults to 1cm (~0.4 inches).
-    * `bottom` number (optional) - Bottom margin in inches. Defaults to 1cm (~0.4 inches).
-    * `left` number (optional) - Left margin in inches. Defaults to 1cm (~0.4 inches).
-    * `right` number (optional) - Right margin in inches. Defaults to 1cm (~0.4 inches).
-  * `pageRanges` string (optional) - Page ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
-  * `headerTemplate` string (optional) - HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them: `date` (formatted print date), `title` (document title), `url` (document location), `pageNumber` (current page number) and `totalPages` (total pages in the document). For example, `<span class=title></span>` would generate span containing the title.
-  * `footerTemplate` string (optional) - HTML template for the print footer. Should use the same format as the `headerTemplate`.
-  * `preferCSSPageSize` boolean (optional) - Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
-  * `generateTaggedPDF` boolean (optional) _Experimental_ - Whether or not to generate a tagged (accessible) PDF. Defaults to false. As this property is experimental, the generated PDF may not adhere fully to PDF/UA and WCAG standards.
-  * `generateDocumentOutline` boolean (optional) _Experimental_ - Whether or not to generate a PDF document outline from content headers. Defaults to false.
+* `options` [PrintToPDFOptions](structures/print-to-pdf-options.md?inline)
 
 Returns `Promise<Uint8Array>` - Resolves with the generated PDF data.
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -658,6 +658,7 @@ auto_filenames = {
     "lib/browser/ipc-main-internal.ts",
     "lib/browser/message-port-main.ts",
     "lib/browser/parse-features-string.ts",
+    "lib/browser/print-to-pdf.ts",
     "lib/browser/rpc-server.ts",
     "lib/browser/web-view-events.ts",
     "lib/common/api/module-list.ts",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -139,6 +139,8 @@ auto_filenames = {
     "docs/api/structures/post-body.md",
     "docs/api/structures/preload-script-registration.md",
     "docs/api/structures/preload-script.md",
+    "docs/api/structures/print-to-pdf-margins.md",
+    "docs/api/structures/print-to-pdf-options.md",
     "docs/api/structures/printer-info.md",
     "docs/api/structures/process-memory-info.md",
     "docs/api/structures/process-metric.md",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -6,6 +6,7 @@ import {
 import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
 import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-utils';
 import { parseFeatures } from '@electron/internal/browser/parse-features-string';
+import { printToPDF } from '@electron/internal/browser/print-to-pdf';
 import * as deprecate from '@electron/internal/common/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
@@ -19,11 +20,6 @@ import * as url from 'url';
 // before the webContents module.
 // eslint-disable-next-line no-unused-expressions
 session;
-
-let nextId = 0;
-const getNextId = function () {
-  return ++nextId;
-};
 
 // Stock page sizes
 const PDFPageSizes: Record<string, ElectronInternal.MediaSize> = {
@@ -88,20 +84,6 @@ const PDFPageSizes: Record<string, ElectronInternal.MediaSize> = {
     name: 'ISO_A6',
     width_microns: 105000
   }
-} as const;
-
-const paperFormats: Record<string, ElectronInternal.PageSize> = {
-  letter: { width: 8.5, height: 11 },
-  legal: { width: 8.5, height: 14 },
-  tabloid: { width: 11, height: 17 },
-  ledger: { width: 17, height: 11 },
-  a0: { width: 33.1, height: 46.8 },
-  a1: { width: 23.4, height: 33.1 },
-  a2: { width: 16.54, height: 23.4 },
-  a3: { width: 11.7, height: 16.54 },
-  a4: { width: 8.27, height: 11.7 },
-  a5: { width: 5.83, height: 8.27 },
-  a6: { width: 4.13, height: 5.83 }
 } as const;
 
 // The minimum micron size Chromium accepts is that where:
@@ -199,81 +181,8 @@ WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (worldId
   );
 };
 
-function checkType<T>(value: T, type: 'number' | 'boolean' | 'string' | 'object', name: string): T {
-  // eslint-disable-next-line valid-typeof
-  if (typeof value !== type) {
-    throw new TypeError(`${name} must be a ${type}`);
-  }
-
-  return value;
-}
-
-function parsePageSize(pageSize: string | ElectronInternal.PageSize) {
-  if (typeof pageSize === 'string') {
-    const format = paperFormats[pageSize.toLowerCase()];
-    if (!format) {
-      throw new Error(`Invalid pageSize ${pageSize}`);
-    }
-
-    return { paperWidth: format.width, paperHeight: format.height };
-  } else if (typeof pageSize === 'object') {
-    if (typeof pageSize.width !== 'number' || typeof pageSize.height !== 'number') {
-      throw new TypeError('width and height properties are required for pageSize');
-    }
-
-    return { paperWidth: pageSize.width, paperHeight: pageSize.height };
-  } else {
-    throw new TypeError('pageSize must be a string or an object');
-  }
-}
-
-// Translate the options of printToPDF.
-
-const printToPDFQueues = new WeakMap<Electron.WebContents, Promise<unknown>>();
 WebContents.prototype.printToPDF = async function (options) {
-  const margins = checkType(options.margins ?? {}, 'object', 'margins');
-  const pageSize = parsePageSize(options.pageSize ?? 'letter');
-
-  const { top, bottom, left, right } = margins;
-  const validHeight = [top, bottom].every((u) => u === undefined || u <= pageSize.paperHeight);
-  const validWidth = [left, right].every((u) => u === undefined || u <= pageSize.paperWidth);
-
-  if (!validHeight || !validWidth) {
-    throw new Error('margins must be less than or equal to pageSize');
-  }
-
-  const printSettings = {
-    requestID: getNextId(),
-    landscape: checkType(options.landscape ?? false, 'boolean', 'landscape'),
-    displayHeaderFooter: checkType(options.displayHeaderFooter ?? false, 'boolean', 'displayHeaderFooter'),
-    headerTemplate: checkType(options.headerTemplate ?? '', 'string', 'headerTemplate'),
-    footerTemplate: checkType(options.footerTemplate ?? '', 'string', 'footerTemplate'),
-    printBackground: checkType(options.printBackground ?? false, 'boolean', 'printBackground'),
-    scale: checkType(options.scale ?? 1.0, 'number', 'scale'),
-    marginTop: checkType(margins.top ?? 0.4, 'number', 'margins.top'),
-    marginBottom: checkType(margins.bottom ?? 0.4, 'number', 'margins.bottom'),
-    marginLeft: checkType(margins.left ?? 0.4, 'number', 'margins.left'),
-    marginRight: checkType(margins.right ?? 0.4, 'number', 'margins.right'),
-    pageRanges: checkType(options.pageRanges ?? '', 'string', 'pageRanges'),
-    preferCSSPageSize: checkType(options.preferCSSPageSize ?? false, 'boolean', 'preferCSSPageSize'),
-    generateTaggedPDF: checkType(options.generateTaggedPDF ?? false, 'boolean', 'generateTaggedPDF'),
-    generateDocumentOutline: checkType(options.generateDocumentOutline ?? false, 'boolean', 'generateDocumentOutline'),
-    ...pageSize
-  };
-
-  if (!this._printToPDF) {
-    throw new Error('Printing feature is disabled');
-  }
-
-  const prev = printToPDFQueues.get(this) ?? Promise.resolve();
-  const next = prev.catch(() => {}).then(() => this._printToPDF(printSettings));
-  printToPDFQueues.set(this, next);
-  next
-    .finally(() => {
-      if (printToPDFQueues.get(this) === next) printToPDFQueues.delete(this);
-    })
-    .catch(() => {});
-  return next;
+  return printToPDF(this, options);
 };
 
 // TODO(codebytere): deduplicate argument sanitization by moving rest of

--- a/lib/browser/api/web-frame-main.ts
+++ b/lib/browser/api/web-frame-main.ts
@@ -1,5 +1,6 @@
 import { IpcMainImpl } from '@electron/internal/browser/ipc-main-impl';
 import { MessagePortMain } from '@electron/internal/browser/message-port-main';
+import { printToPDF } from '@electron/internal/browser/print-to-pdf';
 
 const { WebFrameMain, fromId, fromFrameToken } = process._linkedBinding('electron_browser_web_frame_main');
 
@@ -33,6 +34,10 @@ WebFrameMain.prototype._sendInternal = function (channel, ...args) {
   } catch (e) {
     console.error('Error sending from webFrameMain: ', e);
   }
+};
+
+WebFrameMain.prototype.printToPDF = async function (options) {
+  return printToPDF(this, options);
 };
 
 WebFrameMain.prototype.postMessage = function (...args) {

--- a/lib/browser/print-to-pdf.ts
+++ b/lib/browser/print-to-pdf.ts
@@ -1,0 +1,113 @@
+// Option translation and job queueing for printToPDF, shared between
+// webContents.printToPDF and webFrameMain.printToPDF.
+
+let nextRequestId = 0;
+
+const paperFormats: Record<string, ElectronInternal.PageSize> = {
+  letter: { width: 8.5, height: 11 },
+  legal: { width: 8.5, height: 14 },
+  tabloid: { width: 11, height: 17 },
+  ledger: { width: 17, height: 11 },
+  a0: { width: 33.1, height: 46.8 },
+  a1: { width: 23.4, height: 33.1 },
+  a2: { width: 16.54, height: 23.4 },
+  a3: { width: 11.7, height: 16.54 },
+  a4: { width: 8.27, height: 11.7 },
+  a5: { width: 5.83, height: 8.27 },
+  a6: { width: 4.13, height: 5.83 }
+} as const;
+
+function checkType<T>(value: T, type: 'number' | 'boolean' | 'string' | 'object', name: string): T {
+  // eslint-disable-next-line valid-typeof
+  if (typeof value !== type) {
+    throw new TypeError(`${name} must be a ${type}`);
+  }
+
+  return value;
+}
+
+function parsePageSize(pageSize: string | ElectronInternal.PageSize) {
+  if (typeof pageSize === 'string') {
+    const format = paperFormats[pageSize.toLowerCase()];
+    if (!format) {
+      throw new Error(`Invalid pageSize ${pageSize}`);
+    }
+
+    return { paperWidth: format.width, paperHeight: format.height };
+  } else if (typeof pageSize === 'object') {
+    if (typeof pageSize.width !== 'number' || typeof pageSize.height !== 'number') {
+      throw new TypeError('width and height properties are required for pageSize');
+    }
+
+    return { paperWidth: pageSize.width, paperHeight: pageSize.height };
+  } else {
+    throw new TypeError('pageSize must be a string or an object');
+  }
+}
+
+type PrintToPDFOptions = Parameters<Electron.WebContents['printToPDF']>[0];
+
+interface PrintToPDFTarget {
+  _printToPDF?: (settings: any) => Promise<Buffer>;
+  // WebFrameMain#top; used to serialize jobs within a frame tree.
+  top?: Electron.WebFrameMain | null;
+  // WebContents#mainFrame.
+  mainFrame?: Electron.WebFrameMain;
+  // WebFrameMain#frameTreeNodeId.
+  frameTreeNodeId?: number;
+}
+
+// Concurrent PDF print jobs within the same frame tree conflict in the
+// renderer, so queue them per frame tree. Frames in other webContents can
+// print concurrently. Keyed by the top frame's frameTreeNodeId, which unlike
+// WebFrameMain object identity is stable across navigations; settled entries
+// are deleted, so the map only holds in-flight frame trees.
+const printToPDFQueues = new Map<number, Promise<unknown>>();
+
+export async function printToPDF(target: PrintToPDFTarget, options: PrintToPDFOptions): Promise<Buffer> {
+  const margins = checkType(options.margins ?? {}, 'object', 'margins');
+  const pageSize = parsePageSize(options.pageSize ?? 'letter');
+
+  const { top, bottom, left, right } = margins;
+  const validHeight = [top, bottom].every((u) => u === undefined || u <= pageSize.paperHeight);
+  const validWidth = [left, right].every((u) => u === undefined || u <= pageSize.paperWidth);
+
+  if (!validHeight || !validWidth) {
+    throw new Error('margins must be less than or equal to pageSize');
+  }
+
+  const printSettings = {
+    requestID: ++nextRequestId,
+    landscape: checkType(options.landscape ?? false, 'boolean', 'landscape'),
+    displayHeaderFooter: checkType(options.displayHeaderFooter ?? false, 'boolean', 'displayHeaderFooter'),
+    headerTemplate: checkType(options.headerTemplate ?? '', 'string', 'headerTemplate'),
+    footerTemplate: checkType(options.footerTemplate ?? '', 'string', 'footerTemplate'),
+    printBackground: checkType(options.printBackground ?? false, 'boolean', 'printBackground'),
+    scale: checkType(options.scale ?? 1.0, 'number', 'scale'),
+    marginTop: checkType(margins.top ?? 0.4, 'number', 'margins.top'),
+    marginBottom: checkType(margins.bottom ?? 0.4, 'number', 'margins.bottom'),
+    marginLeft: checkType(margins.left ?? 0.4, 'number', 'margins.left'),
+    marginRight: checkType(margins.right ?? 0.4, 'number', 'margins.right'),
+    pageRanges: checkType(options.pageRanges ?? '', 'string', 'pageRanges'),
+    preferCSSPageSize: checkType(options.preferCSSPageSize ?? false, 'boolean', 'preferCSSPageSize'),
+    generateTaggedPDF: checkType(options.generateTaggedPDF ?? false, 'boolean', 'generateTaggedPDF'),
+    generateDocumentOutline: checkType(options.generateDocumentOutline ?? false, 'boolean', 'generateDocumentOutline'),
+    ...pageSize
+  };
+
+  if (!target._printToPDF) {
+    throw new Error('Printing feature is disabled');
+  }
+
+  // mainFrame/top can be null mid-teardown; those jobs share one bucket.
+  const queueKey = (target.mainFrame ?? target.top ?? target).frameTreeNodeId ?? -1;
+  const prev = printToPDFQueues.get(queueKey) ?? Promise.resolve();
+  const next = prev.catch(() => {}).then(() => target._printToPDF!(printSettings));
+  printToPDFQueues.set(queueKey, next);
+  next
+    .finally(() => {
+      if (printToPDFQueues.get(queueKey) === next) printToPDFQueues.delete(queueKey);
+    })
+    .catch(() => {});
+  return next;
+}

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -147,7 +147,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
-#include "shell/common/gin_helper/locker.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/reply_channel.h"
@@ -200,10 +199,8 @@
 #include "chrome/browser/printing/print_view_manager_base.h"
 #include "components/printing/browser/print_composite_client.h"
 #include "components/printing/browser/print_manager_utils.h"
-#include "components/printing/browser/print_to_pdf/pdf_print_result.h"
-#include "components/printing/browser/print_to_pdf/pdf_print_utils.h"
 #include "printing/mojom/print.mojom.h"  // nogncheck
-#include "printing/page_range.h"
+#include "shell/browser/printing/print_to_pdf.h"
 #include "shell/browser/printing/print_view_manager_electron.h"
 #include "shell/browser/printing/printing_utils.h"
 
@@ -459,22 +456,6 @@ constexpr char kDpi[] = "dpi";
 constexpr char kMarginType[] = "marginType";
 constexpr char kMargins[] = "margins";
 
-// Constants we use for printToPDF options.
-constexpr char kLandscape[] = "landscape";
-constexpr char kDisplayHeaderFooter[] = "displayHeaderFooter";
-constexpr char kPrintBackground[] = "printBackground";
-constexpr char kScale[] = "scale";
-constexpr char kPaperWidth[] = "paperWidth";
-constexpr char kPaperHeight[] = "paperHeight";
-constexpr char kMarginTop[] = "marginTop";
-constexpr char kMarginBottom[] = "marginBottom";
-constexpr char kMarginLeft[] = "marginLeft";
-constexpr char kMarginRight[] = "marginRight";
-constexpr char kHeaderTemplate[] = "headerTemplate";
-constexpr char kFooterTemplate[] = "footerTemplate";
-constexpr char kPreferCSSPageSize[] = "preferCSSPageSize";
-constexpr char kGenerateTaggedPDF[] = "generateTaggedPDF";
-constexpr char kGenerateDocumentOutline[] = "generateDocumentOutline";
 constexpr char kDpiHorizontal[] = "horizontal";
 constexpr char kDpiVertical[] = "vertical";
 #endif  // BUILDFLAG(ENABLE_PRINTING)
@@ -3437,27 +3418,6 @@ void OnGetDeviceNameToUse(base::WeakPtr<content::WebContents> web_contents,
                                std::move(print_callback));
 }
 
-void OnPDFCreated(gin_helper::Promise<v8::Local<v8::Value>> promise,
-                  print_to_pdf::PdfPrintResult print_result,
-                  scoped_refptr<base::RefCountedMemory> data) {
-  if (print_result != print_to_pdf::PdfPrintResult::kPrintSuccess) {
-    promise.RejectWithErrorMessage(
-        "Failed to generate PDF: " +
-        print_to_pdf::PdfPrintResultToString(print_result));
-    return;
-  }
-
-  v8::Isolate* isolate = promise.isolate();
-  gin_helper::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-  v8::Context::Scope context_scope(
-      v8::Local<v8::Context>::New(isolate, promise.GetContext()));
-
-  v8::Local<v8::Value> buffer =
-      electron::Buffer::Copy(isolate, *data).ToLocalChecked();
-
-  promise.Resolve(buffer);
-}
 }  // namespace
 
 void WebContents::Print(gin::Arguments* const args) {
@@ -3632,64 +3592,8 @@ void WebContents::Print(gin::Arguments* const args) {
                      std::move(settings), std::move(callback)));
 }
 
-// Partially duplicated and modified from
-// headless/lib/browser/protocol/page_handler.cc;l=41
 v8::Local<v8::Promise> WebContents::PrintToPDF(const base::Value& settings) {
-  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
-  v8::Local<v8::Promise> handle = promise.GetHandle();
-
-  // This allows us to track headless printing calls.
-  auto unique_id = settings.GetDict().FindInt(printing::kPreviewRequestID);
-  auto landscape = settings.GetDict().FindBool(kLandscape);
-  auto display_header_footer =
-      settings.GetDict().FindBool(kDisplayHeaderFooter);
-  auto print_background = settings.GetDict().FindBool(kPrintBackground);
-  auto scale = settings.GetDict().FindDouble(kScale);
-  auto paper_width = settings.GetDict().FindDouble(kPaperWidth);
-  auto paper_height = settings.GetDict().FindDouble(kPaperHeight);
-  auto margin_top = settings.GetDict().FindDouble(kMarginTop);
-  auto margin_bottom = settings.GetDict().FindDouble(kMarginBottom);
-  auto margin_left = settings.GetDict().FindDouble(kMarginLeft);
-  auto margin_right = settings.GetDict().FindDouble(kMarginRight);
-  auto page_ranges = *settings.GetDict().FindString(kPageRanges);
-  auto header_template = *settings.GetDict().FindString(kHeaderTemplate);
-  auto footer_template = *settings.GetDict().FindString(kFooterTemplate);
-  auto prefer_css_page_size = settings.GetDict().FindBool(kPreferCSSPageSize);
-  auto generate_tagged_pdf = settings.GetDict().FindBool(kGenerateTaggedPDF);
-  auto generate_document_outline =
-      settings.GetDict().FindBool(kGenerateDocumentOutline);
-
-  content::RenderFrameHost* rfh = GetRenderFrameHostToUse(web_contents());
-  absl::variant<printing::mojom::PrintPagesParamsPtr, std::string>
-      print_pages_params = print_to_pdf::GetPrintPagesParams(
-          rfh->GetLastCommittedURL(), landscape, display_header_footer,
-          print_background, scale, paper_width, paper_height, margin_top,
-          margin_bottom, margin_left, margin_right,
-          std::make_optional(header_template),
-          std::make_optional(footer_template), prefer_css_page_size,
-          generate_tagged_pdf, generate_document_outline);
-
-  if (absl::holds_alternative<std::string>(print_pages_params)) {
-    auto error = absl::get<std::string>(print_pages_params);
-    promise.RejectWithErrorMessage("Invalid print parameters: " + error);
-    return handle;
-  }
-
-  auto* manager = PrintViewManagerElectron::FromWebContents(web_contents());
-  if (!manager) {
-    promise.RejectWithErrorMessage("Failed to find print manager");
-    return handle;
-  }
-
-  auto params = std::move(
-      absl::get<printing::mojom::PrintPagesParamsPtr>(print_pages_params));
-  params->params->document_cookie = unique_id.value_or(0);
-
-  manager->PrintToPdf(rfh, page_ranges, std::move(params),
-                      base::BindOnce(&OnPDFCreated, std::move(promise)));
-
-  return handle;
+  return PrintFrameToPDF(GetRenderFrameHostToUse(web_contents()), settings);
 }
 #endif
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -19,6 +19,7 @@
 #include "content/public/common/isolated_world_ids.h"
 #include "gin/object_template_builder.h"
 #include "gin/persistent.h"
+#include "printing/buildflags/buildflags.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/browser/api/message_port.h"
 #include "shell/browser/browser.h"
@@ -37,6 +38,10 @@
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_util.h"
+
+#if BUILDFLAG(ENABLE_PRINTING)
+#include "shell/browser/printing/print_to_pdf.h"
+#endif
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "third_party/blink/public/mojom/frame/media_player_action.mojom.h"
 #include "ui/gfx/geometry/point.h"
@@ -277,6 +282,20 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
 
   return handle;
 }
+
+#if BUILDFLAG(ENABLE_PRINTING)
+v8::Local<v8::Promise> WebFrameMain::PrintToPDF(const base::Value& settings) {
+  if (!HasRenderFrame()) {
+    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+    gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+    v8::Local<v8::Promise> handle = promise.GetHandle();
+    promise.RejectWithErrorMessage(
+        "Render frame was disposed before WebFrameMain could be accessed");
+    return handle;
+  }
+  return PrintFrameToPDF(render_frame_host(), settings);
+}
+#endif
 
 void WebFrameMain::CopyVideoFrameAt(int x, int y) {
   if (!CheckRenderFrame())
@@ -648,6 +667,9 @@ void WebFrameMain::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("executeJavaScript", &WebFrameMain::ExecuteJavaScript)
       .SetMethod("collectJavaScriptCallStack",
                  &WebFrameMain::CollectDocumentJSCallStack)
+#if BUILDFLAG(ENABLE_PRINTING)
+      .SetMethod("_printToPDF", &WebFrameMain::PrintToPDF)
+#endif
       .SetMethod("copyVideoFrameAt", &WebFrameMain::CopyVideoFrameAt)
       .SetMethod("saveVideoFrameAs", &WebFrameMain::SaveVideoFrameAs)
       .SetMethod("reload", &WebFrameMain::Reload)

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -17,6 +17,7 @@
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "printing/buildflags/buildflags.h"
 #include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gc_plugin.h"
@@ -110,6 +111,9 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* args,
                                            const std::u16string& code);
+#if BUILDFLAG(ENABLE_PRINTING)
+  v8::Local<v8::Promise> PrintToPDF(const base::Value& settings);
+#endif
   void CopyVideoFrameAt(int x, int y);
   void SaveVideoFrameAs(int x, int y);
   bool Reload();

--- a/shell/browser/printing/print_to_pdf.cc
+++ b/shell/browser/printing/print_to_pdf.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/printing/print_to_pdf.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/memory/ref_counted_memory.h"
+#include "base/values.h"
+#include "components/printing/browser/print_to_pdf/pdf_print_result.h"
+#include "components/printing/browser/print_to_pdf/pdf_print_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "printing/mojom/print.mojom.h"  // nogncheck
+#include "printing/print_job_constants.h"
+#include "shell/browser/javascript_environment.h"
+#include "shell/browser/printing/print_view_manager_electron.h"
+#include "shell/common/gin_helper/locker.h"
+#include "shell/common/gin_helper/promise.h"
+#include "shell/common/node_util.h"
+#include "third_party/abseil-cpp/absl/types/variant.h"
+
+namespace electron {
+
+namespace {
+
+// Constants we use for printToPDF options.
+constexpr char kLandscape[] = "landscape";
+constexpr char kDisplayHeaderFooter[] = "displayHeaderFooter";
+constexpr char kPrintBackground[] = "printBackground";
+constexpr char kScale[] = "scale";
+constexpr char kPaperWidth[] = "paperWidth";
+constexpr char kPaperHeight[] = "paperHeight";
+constexpr char kMarginTop[] = "marginTop";
+constexpr char kMarginBottom[] = "marginBottom";
+constexpr char kMarginLeft[] = "marginLeft";
+constexpr char kMarginRight[] = "marginRight";
+constexpr char kPageRanges[] = "pageRanges";
+constexpr char kHeaderTemplate[] = "headerTemplate";
+constexpr char kFooterTemplate[] = "footerTemplate";
+constexpr char kPreferCSSPageSize[] = "preferCSSPageSize";
+constexpr char kGenerateTaggedPDF[] = "generateTaggedPDF";
+constexpr char kGenerateDocumentOutline[] = "generateDocumentOutline";
+
+std::string FindStringOrEmpty(const base::DictValue& dict, const char* key) {
+  const std::string* value = dict.FindString(key);
+  return value ? *value : std::string();
+}
+
+void OnPDFCreated(gin_helper::Promise<v8::Local<v8::Value>> promise,
+                  print_to_pdf::PdfPrintResult print_result,
+                  scoped_refptr<base::RefCountedMemory> data) {
+  if (print_result != print_to_pdf::PdfPrintResult::kPrintSuccess) {
+    promise.RejectWithErrorMessage(
+        "Failed to generate PDF: " +
+        print_to_pdf::PdfPrintResultToString(print_result));
+    return;
+  }
+
+  v8::Isolate* isolate = promise.isolate();
+  gin_helper::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(
+      v8::Local<v8::Context>::New(isolate, promise.GetContext()));
+
+  v8::Local<v8::Value> buffer =
+      electron::Buffer::Copy(isolate, *data).ToLocalChecked();
+
+  promise.Resolve(buffer);
+}
+
+}  // namespace
+
+// Partially duplicated and modified from
+// headless/lib/browser/protocol/page_handler.cc;l=41
+v8::Local<v8::Promise> PrintFrameToPDF(content::RenderFrameHost* rfh,
+                                       const base::Value& settings) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  const base::DictValue& dict = settings.GetDict();
+
+  // This allows us to track headless printing calls.
+  auto unique_id = dict.FindInt(printing::kPreviewRequestID);
+  auto landscape = dict.FindBool(kLandscape);
+  auto display_header_footer = dict.FindBool(kDisplayHeaderFooter);
+  auto print_background = dict.FindBool(kPrintBackground);
+  auto scale = dict.FindDouble(kScale);
+  auto paper_width = dict.FindDouble(kPaperWidth);
+  auto paper_height = dict.FindDouble(kPaperHeight);
+  auto margin_top = dict.FindDouble(kMarginTop);
+  auto margin_bottom = dict.FindDouble(kMarginBottom);
+  auto margin_left = dict.FindDouble(kMarginLeft);
+  auto margin_right = dict.FindDouble(kMarginRight);
+  auto page_ranges = FindStringOrEmpty(dict, kPageRanges);
+  auto header_template = FindStringOrEmpty(dict, kHeaderTemplate);
+  auto footer_template = FindStringOrEmpty(dict, kFooterTemplate);
+  auto prefer_css_page_size = dict.FindBool(kPreferCSSPageSize);
+  auto generate_tagged_pdf = dict.FindBool(kGenerateTaggedPDF);
+  auto generate_document_outline = dict.FindBool(kGenerateDocumentOutline);
+
+  absl::variant<printing::mojom::PrintPagesParamsPtr, std::string>
+      print_pages_params = print_to_pdf::GetPrintPagesParams(
+          rfh->GetLastCommittedURL(), landscape, display_header_footer,
+          print_background, scale, paper_width, paper_height, margin_top,
+          margin_bottom, margin_left, margin_right,
+          std::make_optional(header_template),
+          std::make_optional(footer_template), prefer_css_page_size,
+          generate_tagged_pdf, generate_document_outline);
+
+  if (absl::holds_alternative<std::string>(print_pages_params)) {
+    auto error = absl::get<std::string>(print_pages_params);
+    promise.RejectWithErrorMessage("Invalid print parameters: " + error);
+    return handle;
+  }
+
+  auto* manager = PrintViewManagerElectron::FromWebContents(
+      content::WebContents::FromRenderFrameHost(rfh));
+  if (!manager) {
+    promise.RejectWithErrorMessage("Failed to find print manager");
+    return handle;
+  }
+
+  auto params = std::move(
+      absl::get<printing::mojom::PrintPagesParamsPtr>(print_pages_params));
+  params->params->document_cookie = unique_id.value_or(0);
+
+  manager->PrintToPdf(rfh, page_ranges, std::move(params),
+                      base::BindOnce(&OnPDFCreated, std::move(promise)));
+
+  return handle;
+}
+
+}  // namespace electron

--- a/shell/browser/printing/print_to_pdf.h
+++ b/shell/browser/printing/print_to_pdf.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_PRINTING_PRINT_TO_PDF_H_
+#define ELECTRON_SHELL_BROWSER_PRINTING_PRINT_TO_PDF_H_
+
+#include "v8/include/v8-forward.h"
+
+namespace base {
+class Value;
+}
+
+namespace content {
+class RenderFrameHost;
+}
+
+namespace electron {
+
+// Prints the current document of |rfh| to a PDF, per the printToPDF settings
+// dict built in lib/browser/print-to-pdf.ts. Returns a promise that resolves
+// with the PDF data as a Buffer.
+v8::Local<v8::Promise> PrintFrameToPDF(content::RenderFrameHost* rfh,
+                                       const base::Value& settings);
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_PRINTING_PRINT_TO_PDF_H_

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -12,7 +12,6 @@ import {
 
 import { assert, expect } from 'chai';
 
-import * as cp from 'node:child_process';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
@@ -23,6 +22,7 @@ import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 
 import { captureWithTabSourceId } from './lib/media-helpers';
+import { containsText, readPDF } from './lib/pdf-helpers';
 import { ifdescribe, defer, waitUntil, listen, ifit } from './lib/spec-helpers';
 import { cleanupWebContents, closeAllWindows } from './lib/window-helpers';
 
@@ -3832,45 +3832,8 @@ describe('webContents module', () => {
 
   ifdescribe(features.isPrintingEnabled())('printToPDF()', () => {
     let server: http.Server | null;
-    const readPDF = async (data: any) => {
-      const tmpDir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'e-spec-printtopdf-'));
-      const pdfPath = path.resolve(tmpDir, 'test.pdf');
-      await fs.promises.writeFile(pdfPath, data);
-      const pdfReaderPath = path.resolve(fixturesPath, 'api', 'pdf-reader.mjs');
-
-      const result = cp.spawn(process.execPath, [pdfReaderPath, pdfPath], {
-        stdio: 'pipe'
-      });
-
-      const stdout: Buffer[] = [];
-      const stderr: Buffer[] = [];
-      result.stdout.on('data', (chunk) => stdout.push(chunk));
-      result.stderr.on('data', (chunk) => stderr.push(chunk));
-
-      const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
-        result.on('close', (code, signal) => {
-          resolve([code, signal]);
-        });
-      });
-      await fs.promises.rm(tmpDir, { force: true, recursive: true });
-      if (code !== 0) {
-        const errMsg = Buffer.concat(stderr).toString().trim();
-        console.error(`Error parsing PDF file, exit code was ${code}; signal was ${signal}, error: ${errMsg}`);
-      }
-      try {
-        return JSON.parse(Buffer.concat(stdout).toString().trim());
-      } catch (err) {
-        console.error('Error parsing PDF file:', err);
-        console.error('Raw output:', Buffer.concat(stdout).toString().trim());
-        throw err;
-      }
-    };
 
     let w: BrowserWindow;
-
-    const containsText = (items: any[], text: RegExp) => {
-      return items.some(({ str }: { str: string }) => str.match(text));
-    };
 
     beforeEach(() => {
       w = new BrowserWindow({

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -9,8 +9,11 @@ import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 
 import { emittedNTimes } from './lib/events-helpers';
-import { defer, ifit, listen, waitUntil } from './lib/spec-helpers';
+import { containsText, readPDF } from './lib/pdf-helpers';
+import { defer, ifdescribe, ifit, listen, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
+
+const features = process._linkedBinding('electron_common_features');
 
 async function clipboardHasImageType(): Promise<boolean> {
   return clipboard.has('image/png');
@@ -525,6 +528,78 @@ describe('webFrameMain module', () => {
       w.webContents.mainFrame.executeJavaScript('"run a lil js"');
       const callStack = await callStackPromise;
       expect(callStack).to.be.a('string');
+    });
+  });
+
+  ifdescribe(features.isPrintingEnabled())('WebFrame.printToPDF', () => {
+    let server: http.Server;
+    let serverUrl: string;
+    let w: BrowserWindow;
+
+    before(async () => {
+      server = http.createServer((req, res) => {
+        res.setHeader('Content-Type', 'text/html');
+        if (req.url === '/frame') {
+          res.end('<p>This text lives in the iframe document</p>');
+        } else {
+          res.end('<p>This text lives in the parent document</p><iframe src="/frame"></iframe>');
+        }
+      });
+      serverUrl = (await listen(server)).url;
+    });
+
+    after(() => {
+      server.close();
+    });
+
+    beforeEach(() => {
+      w = new BrowserWindow({ show: false });
+    });
+
+    it('can print an iframe, excluding the parent document', async () => {
+      await w.loadURL(serverUrl);
+
+      const iframe = w.webContents.mainFrame.frames[0];
+      const data = await iframe.printToPDF({});
+      expect(data).to.be.an.instanceof(Buffer).that.is.not.empty();
+
+      const pdfInfo = await readPDF(data);
+      expect(containsText(pdfInfo.textContent, /This text lives in the iframe document/)).to.be.true();
+      expect(containsText(pdfInfo.textContent, /This text lives in the parent document/)).to.be.false();
+    });
+
+    it('can print the main frame', async () => {
+      await w.loadURL(serverUrl);
+
+      const data = await w.webContents.mainFrame.printToPDF({});
+      const pdfInfo = await readPDF(data);
+      expect(containsText(pdfInfo.textContent, /This text lives in the parent document/)).to.be.true();
+    });
+
+    it('does not crash when called on multiple frames in parallel', async () => {
+      await w.loadURL(serverUrl);
+
+      const frames = [w.webContents.mainFrame, ...w.webContents.mainFrame.frames];
+      const results = await Promise.all(frames.map((frame) => frame.printToPDF({})));
+      for (const data of results) {
+        expect(data).to.be.an.instanceof(Buffer).that.is.not.empty();
+      }
+    });
+
+    it('rejects on incorrectly typed parameters', async () => {
+      await w.loadURL(serverUrl);
+
+      const iframe = w.webContents.mainFrame.frames[0];
+      await expect(iframe.printToPDF({ landscape: [] as any })).to.eventually.be.rejected();
+    });
+
+    it('rejects when the render frame is disposed', async () => {
+      await w.loadURL(serverUrl);
+
+      const iframe = w.webContents.mainFrame.frames[0];
+      w.webContents.destroy();
+      await waitUntil(() => iframe.isDestroyed());
+      await expect(iframe.printToPDF({})).to.eventually.be.rejected();
     });
   });
 

--- a/spec/lib/pdf-helpers.ts
+++ b/spec/lib/pdf-helpers.ts
@@ -1,0 +1,45 @@
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const pdfReaderPath = path.resolve(__dirname, '..', 'fixtures', 'api', 'pdf-reader.mjs');
+
+// Parses a printToPDF result buffer with pdf.js in a subprocess and returns
+// info about the document and its first page.
+export const readPDF = async (data: any) => {
+  const tmpDir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'e-spec-printtopdf-'));
+  const pdfPath = path.resolve(tmpDir, 'test.pdf');
+  await fs.promises.writeFile(pdfPath, data);
+
+  const result = cp.spawn(process.execPath, [pdfReaderPath, pdfPath], {
+    stdio: 'pipe'
+  });
+
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  result.stdout.on('data', (chunk) => stdout.push(chunk));
+  result.stderr.on('data', (chunk) => stderr.push(chunk));
+
+  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
+    result.on('close', (code, signal) => {
+      resolve([code, signal]);
+    });
+  });
+  await fs.promises.rm(tmpDir, { force: true, recursive: true });
+  if (code !== 0) {
+    const errMsg = Buffer.concat(stderr).toString().trim();
+    console.error(`Error parsing PDF file, exit code was ${code}; signal was ${signal}, error: ${errMsg}`);
+  }
+  try {
+    return JSON.parse(Buffer.concat(stdout).toString().trim());
+  } catch (err) {
+    console.error('Error parsing PDF file:', err);
+    console.error('Raw output:', Buffer.concat(stdout).toString().trim());
+    throw err;
+  }
+};
+
+export const containsText = (items: any[], text: RegExp) => {
+  return items.some(({ str }: { str: string }) => str.match(text));
+};

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -148,6 +148,7 @@ declare namespace Electron {
     _send(internal: boolean, channel: string, args: any): void;
     _sendInternal(channel: string, ...args: any[]): void;
     _postMessage(channel: string, message: any, transfer?: any[]): void;
+    _printToPDF(options: any): Promise<Buffer>;
     _lifecycleStateForTesting: string;
   }
 


### PR DESCRIPTION
#### Description of Change

Adds `frame.printToPDF(options)` to `WebFrameMain`, allowing the main process to print individual frames (e.g. an `<iframe>`) to PDF. This reuses the existing `webContents.printToPDF` implementation, which already operates on a single frame internally — the C++ core and JS option handling are extracted into shared helpers used by both. Print jobs within a frame tree are serialized (the same guarantee `webContents.printToPDF` already had, as concurrent jobs in one tree conflict in the renderer), while frames in different webContents print concurrently.

resolves https://github.com/electron/electron/issues/33625
resolves https://github.com/electron/electron/issues/22796

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `webFrameMain.printToPDF()` to allow printing individual frames to PDF from the main process.