### PR TITLE
test: wait on conditions instead of fixed timeouts

### DIFF
--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -668,23 +668,27 @@ describe('cpp heap', () => {
           const { protocol, net, app } = require('electron');
           const { recordState } = require(heap);
           const { containsRetainingPath } = require(snapshotHelper);
-          const { setTimeout: delay } = require('node:timers/promises');
           const v8Util = (process as any)._linkedBinding('electron_common_v8_util');
-          const withTimeout = <T>(p: Promise<T>, ms: number, label: string) => {
-            const ac = new AbortController();
-            return Promise.race([
-              p.finally(() => ac.abort()),
-              delay(ms, undefined, { signal: ac.signal }).then(() => {
-                throw new Error(`timeout waiting for ${label}`);
-              })
-            ]);
-          };
 
           const gc = async () => {
             for (let i = 0; i < 10; i++) {
               await new Promise((resolve) => setTimeout(resolve, 0));
               v8Util.requestGarbageCollectionForTesting();
             }
+          };
+
+          // Yield to the event loop and run GC until `predicate` becomes true.
+          // This waits on the actual condition instead of a fixed delay,
+          // returning false only if it never settles within a generous attempt
+          // budget. Yielding before collecting lets any pending teardown tasks
+          // run so the collection sees no lingering references.
+          const gcUntil = async (predicate: () => boolean, attempts = 50) => {
+            for (let i = 0; i < attempts; i++) {
+              await new Promise((resolve) => setTimeout(resolve, 0));
+              v8Util.requestGarbageCollectionForTesting();
+              if (predicate()) return true;
+            }
+            return false;
           };
 
           let streamWeakRef: WeakRef<any> | undefined;
@@ -740,7 +744,9 @@ describe('cpp heap', () => {
           request.write(Buffer.from('hello'));
 
           try {
-            await withTimeout(reached, 5000, 'stream upload handler');
+            // Wait until the handler has parked a pending read and dropped its
+            // only JS reference to the stream.
+            await reached;
 
             await gc();
             const state = recordState();
@@ -749,19 +755,21 @@ describe('cpp heap', () => {
               'Electron / ChunkedDataPipeReadableStream'
             ]);
             const refAliveWhilePending = streamWeakRef!.deref() !== undefined;
-            // Settle the pending read by ending the request body.
+            // Settle the pending read by ending the request body, then wait for
+            // the read itself to complete.
             request.end();
-            await withTimeout(
-              pendingRead!.catch(() => {}),
-              5000,
-              'pending read to settle'
-            );
+            await pendingRead!.catch(() => {});
 
-            await gc();
-            const released = streamWeakRef!.deref() === undefined;
-
-            // The handler never produced a response; abort to clean up.
+            // Tear down the request so the network stack drops its reference to
+            // the upload stream; otherwise the live request keeps it reachable
+            // and it can never be collected. The handler never produced a
+            // response, so aborting is also the cleanup path.
             request.abort();
+
+            // Wait until the stream is actually released now that no read is
+            // pending and the request has been torn down.
+            const released = await gcUntil(() => streamWeakRef!.deref() === undefined);
+
             return { ok: true, aliveWhilePending, refAliveWhilePending, released };
           } catch (err) {
             request.abort();


### PR DESCRIPTION
- This change was originally included in #52417, but the issue is appearing in 44-x-y (eg https://github.com/electron/electron/actions/runs/30044599484/job/89335624171?pr=52434#step:26:1358) so we should address it in 44-x-y as well (test is not present on older branches).

The "keeps a ChunkedDataPipeReadableStream alive while a read is pending" test failed under Linux ASAN because hard-coded 5s timeout caps expired before the slower instrumented build made progress.

Replace the fixed timeouts with condition-based waits: await the real promises for handler setup and the pending read, poll GC via gcUntil() until the stream is actually released, and abort the request before the release check so the live request no longer roots the stream. Test intent and assertions are unchanged.

(cherry picked from commit 9c78554d5a651088d039a104a8ce391e8bee9642)

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
