### PR TITLE
test: warm up HID subsystem before navigator.hid requestDevice

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -4682,6 +4682,14 @@ describe('navigator.hid', () => {
         callback();
       }
     });
+    // Warm up the HID subsystem before requesting a device. The WebHID
+    // blocklist is populated lazily on first access and, as of Chromium's
+    // recursive nested-collection filtering, a composite device can be
+    // enumerated into the `select-hid-device` list before the blocklist is
+    // fully applied and then excluded during the post-selection permission
+    // recheck, causing `requestDevice()` to resolve empty. Enumerating first
+    // ensures the device list is stable before the request is made.
+    await w.webContents.executeJavaScript('navigator.hid.getDevices();', true);
     const device = await requestDevices();
     expect(selectFired).to.be.true();
     if (haveDevices) {


### PR DESCRIPTION
- https://github.com/electron/electron/pull/52417 included the Chromium CL 'hid: Recursively filter nested collections':
https://chromium-review.googlesource.com/c/chromium/src/+/7987617.  This change caused the `navigator.hid` test to be flaky on macOS, eg
```
2026-07-24T18:24:14.1824340Z not ok 1928 navigator.hid returns a device when select-hid-device event is defined
2026-07-24T18:24:14.1825010Z   expected '' to include '[object HIDDevice]'
2026-07-24T18:24:14.1825660Z   AssertionError: expected '' to include '[object HIDDevice]'
2026-07-24T18:24:14.1826310Z       at Context.<anonymous> (electron/spec/chromium-spec.ts:4688:25)
```

The WebHID blocklist is populated lazily on first access and, with Chromium's recursive nested-collection filtering, a composite device could be enumerated into the select-hid-device list before the blocklist was fully applied, then excluded during the post-selection permission recheck, making requestDevice() resolve empty and the test flaky. This PR fixes that issue by enumerating devices first to stabilize the device list.

Assisted-by: Claude Opus 4.8

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
