### PR TITLE
feat: Use system-themed titlebar icons for frameless windows with WCO on Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -101,6 +101,7 @@ if (is_linux) {
     sigs = [
       "shell/browser/ui/electron_gdk.sigs",
       "shell/browser/ui/electron_gdk_pixbuf.sigs",
+      "shell/browser/ui/electron_gtk.sigs",
     ]
     extra_header = "shell/browser/ui/electron_gtk.fragment"
     output_name = "electron_gtk_stubs"

--- a/filenames.gni
+++ b/filenames.gni
@@ -46,6 +46,8 @@ filenames = {
     "shell/browser/ui/views/electron_frame_view_linux.h",
     "shell/browser/ui/views/caption_button_placeholder_container.cc",
     "shell/browser/ui/views/caption_button_placeholder_container.h",
+    "shell/browser/ui/views/freedesktop_nav_button_provider.cc",
+    "shell/browser/ui/views/freedesktop_nav_button_provider.h",
     "shell/browser/ui/views/native_frame_view_linux.cc",
     "shell/browser/ui/views/native_frame_view_linux.h",
     "shell/browser/ui/views/electron_frame_view_layout_linux.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -33,6 +33,8 @@ filenames = {
     "shell/browser/ui/electron_desktop_window_tree_host_linux.cc",
     "shell/browser/ui/file_dialog_linux.cc",
     "shell/browser/ui/file_dialog_linux_portal.cc",
+    "shell/browser/ui/gtk/gtk_symbolic_icon_provider.cc",
+    "shell/browser/ui/gtk/gtk_symbolic_icon_provider.h",
     "shell/browser/ui/gtk/menu_gtk.cc",
     "shell/browser/ui/gtk/menu_gtk.h",
     "shell/browser/ui/gtk/menu_util.cc",

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -63,7 +63,9 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/linux/x11_util.h"
 #include "shell/browser/ui/electron_desktop_window_tree_host_linux.h"
+#include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
 #include "shell/browser/ui/views/electron_frame_view_linux.h"
+#include "shell/browser/ui/views/freedesktop_nav_button_provider.h"
 #include "shell/browser/ui/views/native_frame_view.h"
 #include "shell/browser/ui/views/native_frame_view_linux.h"
 #include "shell/common/platform_util.h"
@@ -1980,8 +1982,24 @@ std::unique_ptr<views::FrameView> NativeWindowViews::CreateFrameView(
 #if BUILDFLAG(IS_WIN)
   return std::make_unique<WinFrameView>(this, widget);
 #else
-  if (!has_frame())
-    return std::make_unique<ElectronFrameViewLinux>(this, widget);
+  if (!has_frame()) {
+    // With WCO enabled, use native-looking self-drawn caption buttons when
+    // the desktop environment supports them; otherwise the frame view falls
+    // back to vector-icon buttons.
+    std::unique_ptr<FreedesktopNavButtonProvider> freedesktop;
+    if (IsWindowControlsOverlayEnabled())
+      freedesktop = FreedesktopNavButtonProvider::CreateIfAvailable();
+    FreedesktopNavButtonProvider* freedesktop_provider = freedesktop.get();
+    std::unique_ptr<ui::NavButtonProvider> nav_button_provider =
+        std::move(freedesktop);
+    // The layout needs the raw provider pointer while the frame view takes
+    // ownership, so construct it first.
+    auto* layout =
+        new ElectronFrameViewLayoutLinux(this, nav_button_provider.get());
+    return std::make_unique<ElectronFrameViewLinux>(
+        this, widget, std::move(nav_button_provider), layout,
+        freedesktop_provider);
+  }
 
   if (has_client_frame()) {
     auto* linux_ui_theme = ui::LinuxUiTheme::GetForProfile(nullptr);

--- a/shell/browser/ui/electron_gdk_pixbuf.sigs
+++ b/shell/browser/ui/electron_gdk_pixbuf.sigs
@@ -2,3 +2,4 @@ GdkPixbuf* gdk_pixbuf_new_from_bytes(GBytes* data, GdkColorspace colorspace, gbo
 GdkPixbuf* gdk_pixbuf_scale_simple(const GdkPixbuf* src, int dest_width, int dest_height, GdkInterpType interp_type)
 GdkPixbuf* gdk_pixbuf_new_from_file_at_size(const char* filename, int width, int height, GError** error);
 gint gdk_pixbuf_calculate_rowstride(GdkColorspace colorspace, gboolean has_alpha, int bits_per_sample, int width, int height)
+gboolean gdk_pixbuf_get_has_alpha(const GdkPixbuf* pixbuf)

--- a/shell/browser/ui/electron_gtk.sigs
+++ b/shell/browser/ui/electron_gtk.sigs
@@ -1,0 +1,1 @@
+GdkPixbuf* gtk_icon_info_load_symbolic(GtkIconInfo* icon_info, const GdkRGBA* fg, const GdkRGBA* success_color, const GdkRGBA* warning_color, const GdkRGBA* error_color, gboolean* was_symbolic, GError** error)

--- a/shell/browser/ui/gtk/gtk_symbolic_icon_provider.cc
+++ b/shell/browser/ui/gtk/gtk_symbolic_icon_provider.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/gtk/gtk_symbolic_icon_provider.h"
+
+#include <dlfcn.h>
+#include <gtk/gtk.h>
+
+#include <string>
+
+#include "electron/electron_gtk_stubs.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkPixmap.h"
+#include "ui/base/glib/scoped_gobject.h"
+
+namespace electron {
+
+// static
+SymbolicIconProvider* GtkSymbolicIconProvider::GetInstance() {
+  // Allow the app to fall back to another provider if GTK3 is not available.
+  static void* const gtk3 = dlopen("libgtk-3.so.0", RTLD_LAZY | RTLD_NOLOAD);
+  if (!gtk3 || !IsElectron_gdk_pixbufInitialized()) {
+    return nullptr;
+  }
+  if (!IsElectron_gtkInitialized()) {
+    InitializeElectron_gtk(gtk3);
+    if (!IsElectron_gtkInitialized()) {
+      return nullptr;
+    }
+  }
+  static GtkSymbolicIconProvider instance;
+  return &instance;
+}
+
+SkBitmap GtkSymbolicIconProvider::LoadIcon(const std::string& icon_name,
+                                           int icon_size,
+                                           int scale,
+                                           SkColor color) {
+  auto icon_info = TakeGObject(gtk_icon_theme_lookup_icon_for_scale(
+      gtk_icon_theme_get_default(), icon_name.c_str(), icon_size, scale,
+      static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_USE_BUILTIN |
+                                      GTK_ICON_LOOKUP_GENERIC_FALLBACK)));
+  if (!icon_info) {
+    return {};
+  }
+
+  const GdkRGBA fg = {SkColorGetR(color) / 255.0, SkColorGetG(color) / 255.0,
+                      SkColorGetB(color) / 255.0, SkColorGetA(color) / 255.0};
+  auto pixbuf = TakeGObject(gtk_icon_info_load_symbolic(
+      icon_info, &fg, nullptr, nullptr, nullptr, nullptr, nullptr));
+  if (!pixbuf) {
+    return {};
+  }
+
+  // Symbolic icons are decoded as unpremultiplied RGBA, so convert with Skia.
+  SkBitmap bitmap;
+  if (gdk_pixbuf_get_has_alpha(pixbuf)) {
+    const SkImageInfo pixbuf_info = SkImageInfo::Make(
+        gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf),
+        kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+    bitmap.allocN32Pixels(pixbuf_info.width(), pixbuf_info.height());
+    bitmap.writePixels(SkPixmap(pixbuf_info, gdk_pixbuf_get_pixels(pixbuf),
+                                gdk_pixbuf_get_rowstride(pixbuf)));
+  }
+  return bitmap;
+}
+
+std::string GtkSymbolicIconProvider::GetThemeName() {
+  GtkSettings* settings = gtk_settings_get_default();
+  if (!settings) {
+    return {};
+  }
+  gchar* value = nullptr;
+  g_object_get(settings, "gtk-theme-name", &value, nullptr);
+  std::string result = value ? value : "";
+  g_free(value);
+  return result;
+}
+
+}  // namespace electron

--- a/shell/browser/ui/gtk/gtk_symbolic_icon_provider.h
+++ b/shell/browser/ui/gtk/gtk_symbolic_icon_provider.h
@@ -21,6 +21,7 @@ class GtkSymbolicIconProvider : public SymbolicIconProvider {
 
   GtkSymbolicIconProvider(const GtkSymbolicIconProvider&) = delete;
   GtkSymbolicIconProvider& operator=(const GtkSymbolicIconProvider&) = delete;
+  ~GtkSymbolicIconProvider() = default;
 
   // SymbolicIconProvider:
   SkBitmap LoadIcon(const std::string& icon_name,
@@ -31,7 +32,6 @@ class GtkSymbolicIconProvider : public SymbolicIconProvider {
 
  private:
   GtkSymbolicIconProvider() = default;
-  ~GtkSymbolicIconProvider() = default;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/gtk/gtk_symbolic_icon_provider.h
+++ b/shell/browser/ui/gtk/gtk_symbolic_icon_provider.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_UI_GTK_GTK_SYMBOLIC_ICON_PROVIDER_H_
+#define ELECTRON_SHELL_BROWSER_UI_GTK_GTK_SYMBOLIC_ICON_PROVIDER_H_
+
+#include <string>
+
+#include "shell/browser/ui/views/freedesktop_nav_button_provider.h"
+
+namespace electron {
+
+// SymbolicIconProvider backed by the GTK 3 API already loaded into the
+// process by the LinuxUI toolkit backend.
+class GtkSymbolicIconProvider : public SymbolicIconProvider {
+ public:
+  // Returns the process-lifetime instance, or null when the process has not
+  // loaded GTK 3.
+  static SymbolicIconProvider* GetInstance();
+
+  GtkSymbolicIconProvider(const GtkSymbolicIconProvider&) = delete;
+  GtkSymbolicIconProvider& operator=(const GtkSymbolicIconProvider&) = delete;
+
+  // SymbolicIconProvider:
+  SkBitmap LoadIcon(const std::string& icon_name,
+                    int icon_size,
+                    int scale,
+                    SkColor color) override;
+  std::string GetThemeName() override;
+
+ private:
+  GtkSymbolicIconProvider() = default;
+  ~GtkSymbolicIconProvider() = default;
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_UI_GTK_GTK_SYMBOLIC_ICON_PROVIDER_H_

--- a/shell/browser/ui/views/electron_frame_view_layout_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_layout_linux.cc
@@ -4,7 +4,9 @@
 
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
 
+#include "base/functional/bind.h"
 #include "shell/browser/native_window_views.h"
+#include "ui/linux/nav_button_provider.h"
 #include "ui/views/layout/layout_provider.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/caption_button_layout_constants.h"
@@ -12,9 +14,22 @@
 
 namespace electron {
 
+namespace {
+
+ui::WindowFrameProvider* NullFrameProvider(bool tiled, bool maximized) {
+  return nullptr;
+}
+
+}  // namespace
+
 ElectronFrameViewLayoutLinux::ElectronFrameViewLayoutLinux(
-    NativeWindowViews* window)
-    : window_(window),
+    NativeWindowViews* window,
+    ui::NavButtonProvider* nav_buttons)
+    : views::NativeFrameViewLayoutLinux(
+          nav_buttons,
+          base::BindRepeating(&NullFrameProvider)),
+      window_(window),
+      nav_buttons_(nav_buttons),
       wants_frame_(
           !window->IsTranslucent() &&
           (window->HasShadow() || window->IsWindowControlsOverlayEnabled())) {}
@@ -25,13 +40,19 @@ gfx::Insets ElectronFrameViewLayoutLinux::GetRestoredFrameBorderInsets() const {
   if (window_->IsTranslucent())
     return gfx::Insets();
 
-  return FrameViewLayoutLinux::GetRestoredFrameBorderInsets();
+  return views::FrameViewLayoutLinux::GetRestoredFrameBorderInsets();
 }
 
 int ElectronFrameViewLayoutLinux::GetWCOContentHeight() const {
   int custom_height = window_->titlebar_overlay_height();
   if (custom_height)
     return custom_height;
+
+  if (nav_buttons_)
+    return nav_buttons_->GetNavButtonHeight(
+               view()->GetWidget()->IsMaximized()) +
+           nav_buttons_->GetTopAreaSpacing().top() +
+           nav_buttons_->GetTopAreaSpacing().bottom();
 
   return views::GetCaptionButtonLayoutSize(
              views::CaptionButtonLayoutSize::kNonBrowserCaption)
@@ -82,13 +103,33 @@ gfx::RoundedCornersF ElectronFrameViewLayoutLinux::GetCornerRadii() const {
 
   // Chrome rounds only the top corners, so mirror its default value to all 4.
   return gfx::RoundedCornersF(
-      FrameViewLayoutLinux::GetCornerRadii().upper_left());
+      views::FrameViewLayoutLinux::GetCornerRadii().upper_left());
 }
 
 bool ElectronFrameViewLayoutLinux::ShouldShowTitlebarAndBorder() const {
   if (window_->IsTranslucent())
     return false;
   return !view()->GetWidget()->IsFullscreen();
+}
+
+gfx::Insets ElectronFrameViewLayoutLinux::GetTopAreaBorderInsets() const {
+  return gfx::Insets();
+}
+
+views::FrameViewLayoutLinux::ButtonLayoutParams
+ElectronFrameViewLayoutLinux::GetButtonLayoutParams(
+    views::FrameButton button_id,
+    views::Button* button) const {
+  return nav_buttons_
+             ? views::NativeFrameViewLayoutLinux::GetButtonLayoutParams(
+                   button_id, button)
+             : views::FrameViewLayoutLinux::GetButtonLayoutParams(button_id,
+                                                                  button);
+}
+
+gfx::Insets ElectronFrameViewLayoutLinux::GetTopAreaSpacing() const {
+  return nav_buttons_ ? views::NativeFrameViewLayoutLinux::GetTopAreaSpacing()
+                      : gfx::Insets();
 }
 
 gfx::Rect ElectronFrameViewLayoutLinux::GetWindowControlsOverlayRect() const {

--- a/shell/browser/ui/views/electron_frame_view_layout_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_layout_linux.h
@@ -7,18 +7,30 @@
 
 #include "base/memory/raw_ptr.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
-#include "ui/views/window/frame_view_layout_linux.h"
+#include "ui/views/window/native_frame_view_layout_linux.h"
+
+namespace ui {
+class NavButtonProvider;
+}  // namespace ui
 
 namespace electron {
 
 class NativeWindowViews;
 
-// Adapts FrameViewLayoutLinux for ElectronFrameViewLinux's shadow-only, WCO,
-// and transparent modes.
-class ElectronFrameViewLayoutLinux : public views::FrameViewLayoutLinux {
+// Adapts NativeFrameViewLayoutLinux for ElectronFrameViewLinux's
+// shadow-only, WCO, and transparent modes.
+class ElectronFrameViewLayoutLinux : public views::NativeFrameViewLayoutLinux {
  public:
-  explicit ElectronFrameViewLayoutLinux(NativeWindowViews* window);
+  ElectronFrameViewLayoutLinux(NativeWindowViews* window,
+                               ui::NavButtonProvider* nav_buttons);
   ~ElectronFrameViewLayoutLinux() override;
+
+  void set_nav_buttons(ui::NavButtonProvider* nav_buttons) {
+    nav_buttons_ = nav_buttons;
+    set_nav_button_provider(nav_buttons);
+  }
+
+  ui::NavButtonProvider* nav_buttons() const { return nav_buttons_; }
 
   bool wants_frame() const { return wants_frame_; }
   void set_wants_frame(bool wants_frame) { wants_frame_ = wants_frame; }
@@ -30,22 +42,28 @@ class ElectronFrameViewLayoutLinux : public views::FrameViewLayoutLinux {
   gfx::Rect GetLeadingButtonRect() const;
   gfx::Rect GetTrailingButtonRect() const;
 
-  // FrameViewLayoutLinux:
+  // NativeFrameViewLayoutLinux:
   gfx::Insets GetRestoredFrameBorderInsets() const override;
   int GetTopAreaHeight() const override;
   int GetClientTopOffset() const override;
   bool ShouldShowTitlebarAndBorder() const override;
   gfx::ShadowValues GetShadowValues(bool active) const override;
   gfx::RoundedCornersF GetCornerRadii() const override;
+  gfx::Insets GetTopAreaBorderInsets() const override;
+  ButtonLayoutParams GetButtonLayoutParams(
+      views::FrameButton button_id,
+      views::Button* button) const override;
+  gfx::Insets GetTopAreaSpacing() const override;
 
  protected:
-  // FrameViewLayoutLinux:
+  // NativeFrameViewLayoutLinux:
   void LayoutWindowControls() override;
 
  private:
   int GetWCOContentHeight() const;
 
   raw_ptr<NativeWindowViews> window_;
+  raw_ptr<ui::NavButtonProvider> nav_buttons_;
   bool wants_frame_;
 };
 

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -5,11 +5,16 @@
 
 #include "shell/browser/ui/views/electron_frame_view_linux.h"
 
+#include <utility>
+
+#include "base/functional/callback_helpers.h"
 #include "base/i18n/rtl.h"
+#include "base/time/time.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/ui/views/caption_button_placeholder_container.h"
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
+#include "shell/browser/ui/views/freedesktop_nav_button_provider.h"
 #include "ui/base/hit_test.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
@@ -20,14 +25,28 @@
 
 namespace electron {
 
-ElectronFrameViewLinux::ElectronFrameViewLinux(NativeWindowViews* window,
-                                               views::Widget* widget)
-    : FrameViewLinux(widget, new ElectronFrameViewLayoutLinux(window)),
-      window_(window) {
+ElectronFrameViewLinux::ElectronFrameViewLinux(
+    NativeWindowViews* window,
+    views::Widget* widget,
+    std::unique_ptr<ui::NavButtonProvider> nav_button_provider,
+    ElectronFrameViewLayoutLinux* layout,
+    FreedesktopNavButtonProvider* freedesktop_provider)
+    // The frame provider getter is unused when a layout is supplied; the
+    // layout carries its own null-resolving getter.
+    : NativeFrameViewLinux(widget,
+                           std::move(nav_button_provider),
+                           base::NullCallback(),
+                           layout),
+      window_(window),
+      freedesktop_provider_(freedesktop_provider) {
   InitViews();
 }
 
-ElectronFrameViewLinux::~ElectronFrameViewLinux() = default;
+ElectronFrameViewLinux::~ElectronFrameViewLinux() {
+  // The layout manager is owned by View and outlives this destructor; clear
+  // its reference to the provider we own before the provider is destroyed.
+  efv_layout()->set_nav_buttons(nullptr);
+}
 
 ElectronFrameViewLayoutLinux* ElectronFrameViewLinux::efv_layout() const {
   return static_cast<ElectronFrameViewLayoutLinux*>(layout());
@@ -59,7 +78,12 @@ void ElectronFrameViewLinux::CreateCaptionButtons() {
     container->layer()->SetIsFastRoundedCorner(true);
   }
 
-  FrameViewLinux::CreateCaptionButtons();
+  // ImageButtons with provider-rendered images, or vector caption buttons
+  // when no provider is available.
+  if (efv_layout()->nav_buttons())
+    NativeFrameViewLinux::CreateCaptionButtons();
+  else
+    FrameViewLinux::CreateCaptionButtons();
 
   // Promote to layers so buttons render above the overlapping client view.
   for (auto* btn : {minimize_button(), maximize_button(), restore_button(),
@@ -67,6 +91,11 @@ void ElectronFrameViewLinux::CreateCaptionButtons() {
     if (btn) {
       btn->SetPaintToLayer();
       btn->layer()->SetFillsBoundsOpaquely(false);
+      // Disable the hover cross-fade: ImageButton blends the state images
+      // through an ImageSkia that rasterizes at the nearest integer scale,
+      // which momentarily shifts/blurs the glyph on fractional-scale
+      // displays. Native titlebuttons switch state instantly anyway.
+      btn->SetAnimationDuration(base::TimeDelta());
     }
   }
 }
@@ -122,7 +151,13 @@ int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
 }
 
 void ElectronFrameViewLinux::Layout(PassKey) {
-  LayoutSuperclass<FrameViewLinux>(this);
+  // Route through NativeFrameViewLinux::Layout only when provider-rendered
+  // buttons exist: it refreshes the cached button images, which requires
+  // both a provider and buttons to apply them to.
+  if (efv_layout()->nav_buttons() && close_button())
+    LayoutSuperclass<NativeFrameViewLinux>(this);
+  else
+    LayoutSuperclass<FrameViewLinux>(this);
 
   if (auto* iwcv = window_->primary_web_contents_view())
     iwcv->SetCornerRadii(GetCornerRadii());
@@ -183,6 +218,34 @@ gfx::Size ElectronFrameViewLinux::GetMaximumSize() const {
 }
 
 void ElectronFrameViewLinux::UpdateButtonColors() {
+  if (freedesktop_provider_) {
+    // Feed the effective titlebar background — and the app's symbolColor,
+    // if set — to the provider. The glyph takes the symbol color and each
+    // style's hover treatment derives from it; without one, colors derive
+    // from the backdrop for legibility.
+    const auto* color_provider = GetColorProvider();
+    if (!color_provider)
+      return;
+    const bool active = ShouldPaintAsActive();
+    const SkColor background = SkColorSetA(
+        window_->overlay_button_color().value_or(color_provider->GetColor(
+            active ? ui::kColorFrameActive : ui::kColorFrameInactive)),
+        SK_AlphaOPAQUE);
+    const std::optional<SkColor> symbol = window_->overlay_symbol_color();
+    if (last_titlebar_background_ != background ||
+        last_symbol_color_ != symbol) {
+      last_titlebar_background_ = background;
+      last_symbol_color_ = symbol;
+      freedesktop_provider_->SetTitlebarColors(background, symbol);
+      // Drop the cached button images so they re-render with the new colors
+      // on the next layout.
+      OnThemeOrButtonOrderChanged();
+    }
+    return;
+  }
+  // Other provider-rendered buttons (GTK-rasterized) carry their own colors.
+  if (efv_layout()->nav_buttons())
+    return;
   if (!window_->IsWindowControlsOverlayEnabled())
     return;
 

--- a/shell/browser/ui/views/electron_frame_view_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_linux.h
@@ -6,22 +6,37 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_ELECTRON_FRAME_VIEW_LINUX_H_
 #define ELECTRON_SHELL_BROWSER_UI_VIEWS_ELECTRON_FRAME_VIEW_LINUX_H_
 
+#include <memory>
+#include <optional>
+
 #include "base/memory/raw_ptr.h"
+#include "third_party/skia/include/core/SkColor.h"
 #include "ui/base/metadata/metadata_header_macros.h"
-#include "ui/views/window/frame_view_linux.h"
+#include "ui/views/window/native_frame_view_linux.h"
 
 class CaptionButtonPlaceholderContainer;
 
 namespace electron {
 
+class FreedesktopNavButtonProvider;
 class NativeWindowViews;
 class ElectronFrameViewLayoutLinux;
 
-class ElectronFrameViewLinux : public views::FrameViewLinux {
-  METADATA_HEADER(ElectronFrameViewLinux, views::FrameViewLinux)
+// View used for frame: false with optional WCO.
+//
+// TODO(mitchchn): Rebase on FrameViewLinux after it is refactored upstream
+// to accept a nav button provider, since NativeFrameViewLinux
+// is supposed to be used with a frame provider, which we do not need here.
+class ElectronFrameViewLinux : public views::NativeFrameViewLinux {
+  METADATA_HEADER(ElectronFrameViewLinux, views::NativeFrameViewLinux)
 
  public:
-  ElectronFrameViewLinux(NativeWindowViews* window, views::Widget* widget);
+  ElectronFrameViewLinux(
+      NativeWindowViews* window,
+      views::Widget* widget,
+      std::unique_ptr<ui::NavButtonProvider> nav_button_provider,
+      ElectronFrameViewLayoutLinux* layout,
+      FreedesktopNavButtonProvider* freedesktop_provider = nullptr);
   ~ElectronFrameViewLinux() override;
 
   NativeWindowViews* window() const { return window_; }
@@ -49,6 +64,11 @@ class ElectronFrameViewLinux : public views::FrameViewLinux {
   void LayoutWindowControlsOverlay();
 
   raw_ptr<NativeWindowViews> window_;
+
+  raw_ptr<FreedesktopNavButtonProvider> freedesktop_provider_ = nullptr;
+
+  std::optional<SkColor> last_titlebar_background_;
+  std::optional<SkColor> last_symbol_color_;
 
   // Background views behind the leading and trailing caption buttons.
   raw_ptr<CaptionButtonPlaceholderContainer> leading_button_container_ =

--- a/shell/browser/ui/views/freedesktop_nav_button_provider.cc
+++ b/shell/browser/ui/views/freedesktop_nav_button_provider.cc
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/views/freedesktop_nav_button_provider.h"
+
+#include <dlfcn.h>
+#include <gtk/gtk.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+
+#include "base/check.h"
+#include "base/memory/ptr_util.h"
+#include "base/strings/string_util.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkPixmap.h"
+#include "third_party/skia/include/core/SkSamplingOptions.h"
+#include "ui/gfx/color_utils.h"
+#include "ui/gfx/image/image_skia_rep.h"
+#include "ui/gfx/image/image_skia_source.h"
+#include "ui/views/window/frame_caption_button.h"
+
+namespace electron {
+
+namespace {
+
+using ButtonState = ui::NavButtonProvider::ButtonState;
+using DisplayType = ui::NavButtonProvider::FrameButtonDisplayType;
+
+constexpr size_t Idx(ButtonState state) {
+  return static_cast<size_t>(state);
+}
+
+static_assert(Idx(ButtonState::kDisabled) + 1 ==
+                  std::tuple_size_v<decltype(ButtonStyle::states)>,
+              "StateStyle arrays are indexed by ButtonState");
+
+// Matches default height for Chromium vector icons in WCO.
+constexpr int kDefaultBandHeight = 32;
+
+constexpr int kNominalIconSize = 16;
+
+// Freedesktop symbolic icon names.
+constexpr std::array<const char*, 4> kIconNames = {
+    "window-minimize-symbolic", "window-maximize-symbolic",
+    "window-restore-symbolic", "window-close-symbolic"};
+static_assert(static_cast<size_t>(DisplayType::kClose) + 1 ==
+              kIconNames.size());
+
+// -------------------------------------------------------------------------
+// GTK API
+//
+// GTK is used only to load glyphs, styles, and user settings.
+// The buttons are rendered entirely with Skia, and the GTK API can be
+// replaced by an abstract provider (e.g. on LinuxUiTheme) in the future.
+// -------------------------------------------------------------------------
+
+// Dynamically-resolved GTK 3 entry points.
+#define RESOLVE(handle, fn) \
+  ((fn = reinterpret_cast<decltype(fn)>(dlsym(handle, #fn))) != nullptr)
+
+struct GtkApi {
+  decltype(&::gtk_settings_get_default) gtk_settings_get_default = nullptr;
+  decltype(&::gtk_icon_theme_get_default) gtk_icon_theme_get_default = nullptr;
+  decltype(&::gtk_icon_theme_lookup_icon_for_scale)
+      gtk_icon_theme_lookup_icon_for_scale = nullptr;
+  decltype(&::gtk_icon_info_load_symbolic) gtk_icon_info_load_symbolic =
+      nullptr;
+  decltype(&::gdk_pixbuf_get_width) gdk_pixbuf_get_width = nullptr;
+  decltype(&::gdk_pixbuf_get_height) gdk_pixbuf_get_height = nullptr;
+  decltype(&::gdk_pixbuf_get_rowstride) gdk_pixbuf_get_rowstride = nullptr;
+  decltype(&::gdk_pixbuf_get_pixels) gdk_pixbuf_get_pixels = nullptr;
+  decltype(&::gdk_pixbuf_get_has_alpha) gdk_pixbuf_get_has_alpha = nullptr;
+  bool valid = false;
+
+  static const GtkApi* Get() {
+    static const GtkApi api;
+    return api.valid ? &api : nullptr;
+  }
+
+  GtkApi() {
+    void* gtk = dlopen("libgtk-3.so.0", RTLD_LAZY | RTLD_NOLOAD);
+    void* pixbuf = dlopen("libgdk_pixbuf-2.0.so.0", RTLD_LAZY | RTLD_NOLOAD);
+    valid = gtk && pixbuf && RESOLVE(gtk, gtk_settings_get_default) &&
+            RESOLVE(gtk, gtk_icon_theme_get_default) &&
+            RESOLVE(gtk, gtk_icon_theme_lookup_icon_for_scale) &&
+            RESOLVE(gtk, gtk_icon_info_load_symbolic) &&
+            RESOLVE(pixbuf, gdk_pixbuf_get_width) &&
+            RESOLVE(pixbuf, gdk_pixbuf_get_height) &&
+            RESOLVE(pixbuf, gdk_pixbuf_get_rowstride) &&
+            RESOLVE(pixbuf, gdk_pixbuf_get_pixels) &&
+            RESOLVE(pixbuf, gdk_pixbuf_get_has_alpha);
+  }
+};
+
+#undef RESOLVE
+
+std::string GetGtkSettingString(const char* property) {
+  const GtkApi* api = GtkApi::Get();
+  GtkSettings* settings = api ? api->gtk_settings_get_default() : nullptr;
+  if (!settings) {
+    return {};
+  }
+  gchar* value = nullptr;
+  g_object_get(settings, property, &value, nullptr);
+  std::string result = value ? value : "";
+  g_free(value);
+  return result;
+}
+
+SkBitmap LoadSymbolicIcon(DisplayType type,
+                          int icon_size,
+                          int scale,
+                          SkColor color) {
+  const GtkApi* api = GtkApi::Get();
+  if (!api) {
+    return {};
+  }
+  GtkIconInfo* icon_info = api->gtk_icon_theme_lookup_icon_for_scale(
+      api->gtk_icon_theme_get_default(), kIconNames[static_cast<size_t>(type)],
+      icon_size, scale,
+      static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_USE_BUILTIN |
+                                      GTK_ICON_LOOKUP_GENERIC_FALLBACK));
+  if (!icon_info) {
+    return {};
+  }
+  GdkRGBA fg = {SkColorGetR(color) / 255.0, SkColorGetG(color) / 255.0,
+                SkColorGetB(color) / 255.0, SkColorGetA(color) / 255.0};
+  GdkPixbuf* pixbuf = api->gtk_icon_info_load_symbolic(
+      icon_info, &fg, nullptr, nullptr, nullptr, nullptr, nullptr);
+  g_object_unref(icon_info);
+  if (!pixbuf) {
+    return {};
+  }
+
+  // Symbolic icons are decoded as unpremultiplied RGBA, so convert with Skia.
+  SkBitmap bitmap;
+  if (api->gdk_pixbuf_get_has_alpha(pixbuf)) {
+    const SkImageInfo pixbuf_info = SkImageInfo::Make(
+        api->gdk_pixbuf_get_width(pixbuf), api->gdk_pixbuf_get_height(pixbuf),
+        kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+    bitmap.allocN32Pixels(pixbuf_info.width(), pixbuf_info.height());
+    bitmap.writePixels(SkPixmap(pixbuf_info, api->gdk_pixbuf_get_pixels(pixbuf),
+                                api->gdk_pixbuf_get_rowstride(pixbuf)));
+  }
+  g_object_unref(pixbuf);
+  return bitmap;
+}
+
+// ---------------------------------------------------------------------------
+// Styles.
+//
+// Icon glyphs are monochrome and come directly from the Freedesktop
+// symbolic icon theme installed on the system. (Different Linux distributions
+// and desktop environments install glyphs for their default themes,
+// e.g. Adwaita/Yaru/Breeze.)
+//
+// Styles allow further customization of the colors, sizing and spacing to
+// match the look and feel of specific Linux desktop themes.
+//
+// ---------------------------------------------------------------------------
+
+// Adwaita style (GNOME, also the fallback). Follows libadwaita's
+// headerbar window buttons: a 24px circle of the foreground color
+// at 10%/15%/30% opacity at rest/hover/pressed.
+ButtonStyle AdwaitaButtonStyle() {
+  ButtonStyle style;
+  style.pill_diameter = 24;
+  // libadwaita spaces window buttons by 3px of gap plus 5px of padding on
+  // each button side (13px between circles), with ~10px from the window
+  // edge to the outermost circle.
+  style.button_margin = 5;
+  style.inter_spacing = 3;
+  style.end_spacing = 5;
+  style.states = {{
+      {PillColor::kBase, 0.10},  // normal
+      {PillColor::kBase, 0.15},  // hovered
+      {PillColor::kBase, 0.30},  // pressed
+      {},                        // disabled
+  }};
+  style.close_states = style.states;
+  return style;
+}
+
+// Breeze style (KDE Plasma). An 18px circle (Plasma's default grid unit),
+// glyph only at rest, inverted colors on hover, and the palette's negative
+// color for the close button (darker when pressed).
+ButtonStyle BreezeButtonStyle() {
+  constexpr SkColor kNegative = SkColorSetRGB(0xDA, 0x44, 0x53);
+  // KDE's small spacing: max(2px, grid unit / 4).
+  constexpr int kSmallSpacing = 4;
+
+  ButtonStyle style;
+  style.pill_diameter = 18;
+  // Plasma lays decoration buttons out with smallSpacing between them and
+  // ~2x smallSpacing at the edge; split half of it into per-button margins
+  // so the group also gets breathing room at its inner edge.
+  style.button_margin = kSmallSpacing / 2;
+  style.inter_spacing = kSmallSpacing - 2 * (kSmallSpacing / 2);
+  style.end_spacing = 2 * kSmallSpacing - kSmallSpacing / 2;
+  style.states = {{
+      {},                                             // normal: glyph only
+      {PillColor::kBase, 1.0, GlyphColor::kInverse},  // hovered
+      {PillColor::kBase, 0.5, GlyphColor::kInverse},  // pressed
+      {},                                             // disabled
+  }};
+  style.close_states = style.states;
+  style.close_states[Idx(ButtonState::kHovered)] = {
+      PillColor::kAccent, 1.0, GlyphColor::kContrastWithPill, kNegative};
+  style.close_states[Idx(ButtonState::kPressed)] = {
+      PillColor::kAccent, 1.0, GlyphColor::kContrastWithPill,
+      color_utils::AlphaBlend(SK_ColorBLACK, kNegative, 0.4f)};
+  return style;
+}
+
+// Selects the style from the GTK theme name: Breeze themes get the Breeze
+// treatment; everything else — including an unset or unknown theme — falls
+// back to Adwaita, which is a common convention.
+ButtonStyle DetectButtonStyle() {
+  const bool breeze =
+      base::StartsWith(GetGtkSettingString("gtk-theme-name"), "Breeze",
+                       base::CompareCase::INSENSITIVE_ASCII);
+  return breeze ? BreezeButtonStyle() : AdwaitaButtonStyle();
+}
+
+// ---------------------------------------------------------------------------
+// Rendering.
+// ---------------------------------------------------------------------------
+
+class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
+ public:
+  FreedesktopButtonImageSource(DisplayType type,
+                               const StateStyle& spec,
+                               bool active,
+                               int width,
+                               int height,
+                               int icon_size,
+                               int pill_diameter,
+                               std::optional<SkColor> background,
+                               std::optional<SkColor> symbol)
+      : type_(type),
+        spec_(spec),
+        active_(active),
+        width_(width),
+        height_(height),
+        icon_size_(icon_size),
+        pill_diameter_(pill_diameter),
+        background_(background),
+        symbol_(symbol) {}
+
+  ~FreedesktopButtonImageSource() override = default;
+
+  gfx::ImageSkiaRep GetImageForScale(float scale) override {
+    if (width_ <= 0 || height_ <= 0) {
+      return gfx::ImageSkiaRep();
+    }
+
+    // Icon themes rasterize at integer scales. Render large and downscale
+    // to the exact requested scale below so the result stays crisp on
+    // fractional-scale displays.
+    const int render_scale = std::ceil(scale);
+
+    // Resolve the color roles. The base (glyph) color is the app's symbol
+    // color when requested. Otherwise it is derived from the effective titlebar
+    // background with the same contrast logic used by Chromium's vector icons
+    const SkColor base =
+        symbol_ ? *symbol_
+        : background_
+            ? views::FrameCaptionButton::GetAccessibleButtonColor(*background_)
+            : SkColorSetRGB(0x2E, 0x34, 0x36);
+    const SkColor inverse =
+        background_ ? *background_ : color_utils::GetColorWithMaxContrast(base);
+    const SkColor pill = spec_.pill == PillColor::kAccent ? spec_.accent : base;
+    SkColor glyph = spec_.glyph == GlyphColor::kBase ? base
+                    : spec_.glyph == GlyphColor::kInverse
+                        ? inverse
+                        : color_utils::GetColorWithMaxContrast(pill);
+    if (!active_) {
+      glyph = SkColorSetA(
+          glyph,
+          std::lround(
+              SkColorGetA(glyph) *
+              views::FrameCaptionButton::GetInactiveButtonColorAlphaRatio()));
+    }
+
+    const SkBitmap icon =
+        LoadSymbolicIcon(type_, icon_size_, render_scale, glyph);
+
+    const int physical_width = render_scale * width_;
+    const int physical_height = render_scale * height_;
+    SkBitmap bitmap;
+    bitmap.allocN32Pixels(physical_width, physical_height);
+    bitmap.eraseColor(SK_ColorTRANSPARENT);
+    SkCanvas canvas(bitmap);
+
+    if (spec_.pill_alpha > 0) {
+      SkPaint paint;
+      paint.setAntiAlias(true);
+      paint.setColor(
+          SkColorSetA(pill, static_cast<U8CPU>(spec_.pill_alpha * 0xFF)));
+      const int max_diameter = std::min(width_, height_);
+      const int diameter = pill_diameter_ > 0
+                               ? std::min(pill_diameter_, max_diameter)
+                               : max_diameter;
+      canvas.drawCircle(physical_width / 2.0f, physical_height / 2.0f,
+                        render_scale * diameter / 2.0f, paint);
+    }
+
+    if (!icon.isNull()) {
+      canvas.drawImage(icon.asImage(), (physical_width - icon.width()) / 2.0f,
+                       (physical_height - icon.height()) / 2.0f);
+    }
+
+    if (scale != render_scale) {
+      SkBitmap scaled;
+      scaled.allocN32Pixels(std::lround(scale * width_),
+                            std::lround(scale * height_));
+      scaled.eraseColor(SK_ColorTRANSPARENT);
+      bitmap.pixmap().scalePixels(
+          scaled.pixmap(), SkSamplingOptions(SkCubicResampler::Mitchell()));
+      bitmap = scaled;
+    }
+
+    return gfx::ImageSkiaRep(bitmap, scale);
+  }
+
+  bool HasRepresentationAtAllScales() const override { return true; }
+
+ private:
+  DisplayType type_;
+  StateStyle spec_;
+  bool active_;
+  int width_;
+  int height_;
+  int icon_size_;
+  int pill_diameter_;
+  std::optional<SkColor> background_;
+  std::optional<SkColor> symbol_;
+};
+
+}  // namespace
+
+// static
+std::unique_ptr<FreedesktopNavButtonProvider>
+FreedesktopNavButtonProvider::CreateIfAvailable() {
+  if (!GtkApi::Get()) {
+    return nullptr;
+  }
+  return base::WrapUnique(new FreedesktopNavButtonProvider());
+}
+
+FreedesktopNavButtonProvider::FreedesktopNavButtonProvider() {
+  style_ = DetectButtonStyle();
+}
+
+FreedesktopNavButtonProvider::~FreedesktopNavButtonProvider() = default;
+
+void FreedesktopNavButtonProvider::RedrawImages(int top_area_height,
+                                                bool maximized,
+                                                bool active) {
+  style_ = DetectButtonStyle();
+
+  // Button bounds are full-height for hit targets when maximized/tiled
+  // (Fitts' law) but they are only as wide as the icon pill.
+  const int height = std::max(kNominalIconSize, top_area_height);
+  const int width = style_.pill_diameter > 0
+                        ? std::min(style_.pill_diameter, height)
+                        : height;
+  const int icon_size = std::min(kNominalIconSize, std::min(width, height) - 2);
+
+  const gfx::Size button_size(width, height);
+  for (auto type : {DisplayType::kMinimize,
+                    maximized ? DisplayType::kRestore : DisplayType::kMaximize,
+                    DisplayType::kClose}) {
+    const auto& states =
+        type == DisplayType::kClose ? style_.close_states : style_.states;
+    for (auto state : {ButtonState::kNormal, ButtonState::kHovered,
+                       ButtonState::kPressed, ButtonState::kDisabled}) {
+      button_images_[type][state] = gfx::ImageSkia(
+          std::make_unique<FreedesktopButtonImageSource>(
+              type, states[Idx(state)], active, width, height, icon_size,
+              style_.pill_diameter, titlebar_background_, symbol_color_),
+          button_size);
+    }
+  }
+}
+
+gfx::ImageSkia FreedesktopNavButtonProvider::GetImage(
+    FrameButtonDisplayType type,
+    ButtonState state) const {
+  auto it = button_images_.find(type);
+  CHECK(it != button_images_.end());
+  auto it2 = it->second.find(state);
+  CHECK(it2 != it->second.end());
+  return it2->second;
+}
+
+gfx::Insets FreedesktopNavButtonProvider::GetNavButtonMargin(
+    FrameButtonDisplayType type) const {
+  return gfx::Insets::TLBR(0, style_.button_margin, 0, style_.button_margin);
+}
+
+gfx::Insets FreedesktopNavButtonProvider::GetTopAreaSpacing() const {
+  // Horizontal spacing only: while native themes normally apply vertical
+  // spacing, it would conflict with the app's WCO titlebar configuration.
+  return gfx::Insets::TLBR(0, style_.end_spacing, 0, style_.end_spacing);
+}
+
+int FreedesktopNavButtonProvider::GetNavButtonHeight(bool maximized) const {
+  return kDefaultBandHeight;
+}
+
+int FreedesktopNavButtonProvider::GetInterNavButtonSpacing() const {
+  return style_.inter_spacing;
+}
+
+void FreedesktopNavButtonProvider::SetTitlebarColors(
+    std::optional<SkColor> background,
+    std::optional<SkColor> symbol) {
+  titlebar_background_ = background;
+  symbol_color_ = symbol;
+}
+
+}  // namespace electron

--- a/shell/browser/ui/views/freedesktop_nav_button_provider.cc
+++ b/shell/browser/ui/views/freedesktop_nav_button_provider.cc
@@ -4,9 +4,6 @@
 
 #include "shell/browser/ui/views/freedesktop_nav_button_provider.h"
 
-#include <dlfcn.h>
-#include <gtk/gtk.h>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -15,10 +12,10 @@
 #include "base/check.h"
 #include "base/memory/ptr_util.h"
 #include "base/strings/string_util.h"
+#include "shell/browser/ui/gtk/gtk_symbolic_icon_provider.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkPixmap.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/image/image_skia_rep.h"
@@ -51,106 +48,6 @@ constexpr std::array<const char*, 4> kIconNames = {
     "window-restore-symbolic", "window-close-symbolic"};
 static_assert(static_cast<size_t>(DisplayType::kClose) + 1 ==
               kIconNames.size());
-
-// -------------------------------------------------------------------------
-// GTK API
-//
-// GTK is used only to load glyphs, styles, and user settings.
-// The buttons are rendered entirely with Skia, and the GTK API can be
-// replaced by an abstract provider (e.g. on LinuxUiTheme) in the future.
-// -------------------------------------------------------------------------
-
-// Dynamically-resolved GTK 3 entry points.
-#define RESOLVE(handle, fn) \
-  ((fn = reinterpret_cast<decltype(fn)>(dlsym(handle, #fn))) != nullptr)
-
-struct GtkApi {
-  decltype(&::gtk_settings_get_default) gtk_settings_get_default = nullptr;
-  decltype(&::gtk_icon_theme_get_default) gtk_icon_theme_get_default = nullptr;
-  decltype(&::gtk_icon_theme_lookup_icon_for_scale)
-      gtk_icon_theme_lookup_icon_for_scale = nullptr;
-  decltype(&::gtk_icon_info_load_symbolic) gtk_icon_info_load_symbolic =
-      nullptr;
-  decltype(&::gdk_pixbuf_get_width) gdk_pixbuf_get_width = nullptr;
-  decltype(&::gdk_pixbuf_get_height) gdk_pixbuf_get_height = nullptr;
-  decltype(&::gdk_pixbuf_get_rowstride) gdk_pixbuf_get_rowstride = nullptr;
-  decltype(&::gdk_pixbuf_get_pixels) gdk_pixbuf_get_pixels = nullptr;
-  decltype(&::gdk_pixbuf_get_has_alpha) gdk_pixbuf_get_has_alpha = nullptr;
-  bool valid = false;
-
-  static const GtkApi* Get() {
-    static const GtkApi api;
-    return api.valid ? &api : nullptr;
-  }
-
-  GtkApi() {
-    void* gtk = dlopen("libgtk-3.so.0", RTLD_LAZY | RTLD_NOLOAD);
-    void* pixbuf = dlopen("libgdk_pixbuf-2.0.so.0", RTLD_LAZY | RTLD_NOLOAD);
-    valid = gtk && pixbuf && RESOLVE(gtk, gtk_settings_get_default) &&
-            RESOLVE(gtk, gtk_icon_theme_get_default) &&
-            RESOLVE(gtk, gtk_icon_theme_lookup_icon_for_scale) &&
-            RESOLVE(gtk, gtk_icon_info_load_symbolic) &&
-            RESOLVE(pixbuf, gdk_pixbuf_get_width) &&
-            RESOLVE(pixbuf, gdk_pixbuf_get_height) &&
-            RESOLVE(pixbuf, gdk_pixbuf_get_rowstride) &&
-            RESOLVE(pixbuf, gdk_pixbuf_get_pixels) &&
-            RESOLVE(pixbuf, gdk_pixbuf_get_has_alpha);
-  }
-};
-
-#undef RESOLVE
-
-std::string GetGtkSettingString(const char* property) {
-  const GtkApi* api = GtkApi::Get();
-  GtkSettings* settings = api ? api->gtk_settings_get_default() : nullptr;
-  if (!settings) {
-    return {};
-  }
-  gchar* value = nullptr;
-  g_object_get(settings, property, &value, nullptr);
-  std::string result = value ? value : "";
-  g_free(value);
-  return result;
-}
-
-SkBitmap LoadSymbolicIcon(DisplayType type,
-                          int icon_size,
-                          int scale,
-                          SkColor color) {
-  const GtkApi* api = GtkApi::Get();
-  if (!api) {
-    return {};
-  }
-  GtkIconInfo* icon_info = api->gtk_icon_theme_lookup_icon_for_scale(
-      api->gtk_icon_theme_get_default(), kIconNames[static_cast<size_t>(type)],
-      icon_size, scale,
-      static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_USE_BUILTIN |
-                                      GTK_ICON_LOOKUP_GENERIC_FALLBACK));
-  if (!icon_info) {
-    return {};
-  }
-  GdkRGBA fg = {SkColorGetR(color) / 255.0, SkColorGetG(color) / 255.0,
-                SkColorGetB(color) / 255.0, SkColorGetA(color) / 255.0};
-  GdkPixbuf* pixbuf = api->gtk_icon_info_load_symbolic(
-      icon_info, &fg, nullptr, nullptr, nullptr, nullptr, nullptr);
-  g_object_unref(icon_info);
-  if (!pixbuf) {
-    return {};
-  }
-
-  // Symbolic icons are decoded as unpremultiplied RGBA, so convert with Skia.
-  SkBitmap bitmap;
-  if (api->gdk_pixbuf_get_has_alpha(pixbuf)) {
-    const SkImageInfo pixbuf_info = SkImageInfo::Make(
-        api->gdk_pixbuf_get_width(pixbuf), api->gdk_pixbuf_get_height(pixbuf),
-        kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
-    bitmap.allocN32Pixels(pixbuf_info.width(), pixbuf_info.height());
-    bitmap.writePixels(SkPixmap(pixbuf_info, api->gdk_pixbuf_get_pixels(pixbuf),
-                                api->gdk_pixbuf_get_rowstride(pixbuf)));
-  }
-  g_object_unref(pixbuf);
-  return bitmap;
-}
 
 // ---------------------------------------------------------------------------
 // Styles.
@@ -221,10 +118,9 @@ ButtonStyle BreezeButtonStyle() {
 // Selects the style from the GTK theme name: Breeze themes get the Breeze
 // treatment; everything else — including an unset or unknown theme — falls
 // back to Adwaita, which is a common convention.
-ButtonStyle DetectButtonStyle() {
-  const bool breeze =
-      base::StartsWith(GetGtkSettingString("gtk-theme-name"), "Breeze",
-                       base::CompareCase::INSENSITIVE_ASCII);
+ButtonStyle DetectButtonStyle(const std::string& theme_name) {
+  const bool breeze = base::StartsWith(theme_name, "Breeze",
+                                       base::CompareCase::INSENSITIVE_ASCII);
   return breeze ? BreezeButtonStyle() : AdwaitaButtonStyle();
 }
 
@@ -234,7 +130,8 @@ ButtonStyle DetectButtonStyle() {
 
 class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
  public:
-  FreedesktopButtonImageSource(DisplayType type,
+  FreedesktopButtonImageSource(SymbolicIconProvider* icon_provider,
+                               DisplayType type,
                                const StateStyle& spec,
                                bool active,
                                int width,
@@ -243,7 +140,8 @@ class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
                                int pill_diameter,
                                std::optional<SkColor> background,
                                std::optional<SkColor> symbol)
-      : type_(type),
+      : icon_provider_(icon_provider),
+        type_(type),
         spec_(spec),
         active_(active),
         width_(width),
@@ -289,7 +187,8 @@ class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
     }
 
     const SkBitmap icon =
-        LoadSymbolicIcon(type_, icon_size_, render_scale, glyph);
+        icon_provider_->LoadIcon(kIconNames[static_cast<size_t>(type_)],
+                                 icon_size_, render_scale, glyph);
 
     const int physical_width = render_scale * width_;
     const int physical_height = render_scale * height_;
@@ -332,6 +231,7 @@ class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
   bool HasRepresentationAtAllScales() const override { return true; }
 
  private:
+  raw_ptr<SymbolicIconProvider> icon_provider_;
   DisplayType type_;
   StateStyle spec_;
   bool active_;
@@ -348,14 +248,18 @@ class FreedesktopButtonImageSource : public gfx::ImageSkiaSource {
 // static
 std::unique_ptr<FreedesktopNavButtonProvider>
 FreedesktopNavButtonProvider::CreateIfAvailable() {
-  if (!GtkApi::Get()) {
+  // TODO(mitchchn): replace with LinuxUi call if/when available upstream.
+  SymbolicIconProvider* icon_provider = GtkSymbolicIconProvider::GetInstance();
+  if (!icon_provider) {
     return nullptr;
   }
-  return base::WrapUnique(new FreedesktopNavButtonProvider());
+  return base::WrapUnique(new FreedesktopNavButtonProvider(icon_provider));
 }
 
-FreedesktopNavButtonProvider::FreedesktopNavButtonProvider() {
-  style_ = DetectButtonStyle();
+FreedesktopNavButtonProvider::FreedesktopNavButtonProvider(
+    SymbolicIconProvider* icon_provider)
+    : icon_provider_(icon_provider) {
+  style_ = DetectButtonStyle(icon_provider_->GetThemeName());
 }
 
 FreedesktopNavButtonProvider::~FreedesktopNavButtonProvider() = default;
@@ -363,7 +267,7 @@ FreedesktopNavButtonProvider::~FreedesktopNavButtonProvider() = default;
 void FreedesktopNavButtonProvider::RedrawImages(int top_area_height,
                                                 bool maximized,
                                                 bool active) {
-  style_ = DetectButtonStyle();
+  style_ = DetectButtonStyle(icon_provider_->GetThemeName());
 
   // Button bounds are full-height for hit targets when maximized/tiled
   // (Fitts' law) but they are only as wide as the icon pill.
@@ -381,11 +285,12 @@ void FreedesktopNavButtonProvider::RedrawImages(int top_area_height,
         type == DisplayType::kClose ? style_.close_states : style_.states;
     for (auto state : {ButtonState::kNormal, ButtonState::kHovered,
                        ButtonState::kPressed, ButtonState::kDisabled}) {
-      button_images_[type][state] = gfx::ImageSkia(
-          std::make_unique<FreedesktopButtonImageSource>(
-              type, states[Idx(state)], active, width, height, icon_size,
-              style_.pill_diameter, titlebar_background_, symbol_color_),
-          button_size);
+      button_images_[type][state] =
+          gfx::ImageSkia(std::make_unique<FreedesktopButtonImageSource>(
+                             icon_provider_, type, states[Idx(state)], active,
+                             width, height, icon_size, style_.pill_diameter,
+                             titlebar_background_, symbol_color_),
+                         button_size);
     }
   }
 }

--- a/shell/browser/ui/views/freedesktop_nav_button_provider.cc
+++ b/shell/browser/ui/views/freedesktop_nav_button_provider.cc
@@ -86,9 +86,10 @@ ButtonStyle AdwaitaButtonStyle() {
 
 // Breeze style (KDE Plasma). An 18px circle (Plasma's default grid unit),
 // glyph only at rest, inverted colors on hover, and the palette's negative
-// color for the close button (darker when pressed).
+// color for the close button (lightened on hover, darkened when pressed).
 ButtonStyle BreezeButtonStyle() {
-  constexpr SkColor kNegative = SkColorSetRGB(0xDA, 0x44, 0x53);
+  constexpr SkColor kNegativeHover = SkColorSetRGB(0xFF, 0x98, 0xA2);
+  constexpr SkColor kNegativePressed = SkColorSetRGB(0x6D, 0x22, 0x29);
   // KDE's small spacing: max(2px, grid unit / 4).
   constexpr int kSmallSpacing = 4;
 
@@ -108,10 +109,9 @@ ButtonStyle BreezeButtonStyle() {
   }};
   style.close_states = style.states;
   style.close_states[Idx(ButtonState::kHovered)] = {
-      PillColor::kAccent, 1.0, GlyphColor::kContrastWithPill, kNegative};
+      PillColor::kAccent, 1.0, GlyphColor::kInverse, kNegativeHover};
   style.close_states[Idx(ButtonState::kPressed)] = {
-      PillColor::kAccent, 1.0, GlyphColor::kContrastWithPill,
-      color_utils::AlphaBlend(SK_ColorBLACK, kNegative, 0.4f)};
+      PillColor::kAccent, 1.0, GlyphColor::kInverse, kNegativePressed};
   return style;
 }
 

--- a/shell/browser/ui/views/freedesktop_nav_button_provider.h
+++ b/shell/browser/ui/views/freedesktop_nav_button_provider.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_UI_VIEWS_FREEDESKTOP_NAV_BUTTON_PROVIDER_H_
+#define ELECTRON_SHELL_BROWSER_UI_VIEWS_FREEDESKTOP_NAV_BUTTON_PROVIDER_H_
+
+#include <array>
+#include <map>
+#include <memory>
+#include <optional>
+
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/linux/nav_button_provider.h"
+
+namespace electron {
+
+enum class PillColor { kBase, kAccent };
+enum class GlyphColor { kBase, kInverse, kContrastWithPill };
+
+struct StateStyle {
+  PillColor pill = PillColor::kBase;
+  double pill_alpha = 0.0;
+  GlyphColor glyph = GlyphColor::kBase;
+  SkColor accent = SK_ColorTRANSPARENT;
+};
+
+// Button styles customize the appearance and metrics of caption buttons
+// to support different themes.
+struct ButtonStyle {
+  // Diameter of the circular highlight; 0 means the full button size.
+  int pill_diameter = 0;
+  // Horizontal spacing is composed the way desktop headerbars compose it:
+  int button_margin = 0;
+  int inter_spacing = 0;
+  int end_spacing = 0;
+  std::array<StateStyle, 4> states;
+  std::array<StateStyle, 4> close_states;
+};
+
+// A NavButtonProvider that draws caption buttons using freedesktop -symbolic
+// icons.
+class FreedesktopNavButtonProvider : public ui::NavButtonProvider {
+ public:
+  static std::unique_ptr<FreedesktopNavButtonProvider> CreateIfAvailable();
+
+  FreedesktopNavButtonProvider(const FreedesktopNavButtonProvider&) = delete;
+  FreedesktopNavButtonProvider& operator=(const FreedesktopNavButtonProvider&) =
+      delete;
+  ~FreedesktopNavButtonProvider() override;
+
+  // ui::NavButtonProvider:
+  void RedrawImages(int top_area_height, bool maximized, bool active) override;
+  gfx::ImageSkia GetImage(FrameButtonDisplayType type,
+                          ButtonState state) const override;
+  gfx::Insets GetNavButtonMargin(FrameButtonDisplayType type) const override;
+  gfx::Insets GetTopAreaSpacing() const override;
+  int GetNavButtonHeight(bool maximized) const override;
+  int GetInterNavButtonSpacing() const override;
+
+  void SetTitlebarColors(std::optional<SkColor> background,
+                         std::optional<SkColor> symbol);
+
+ private:
+  FreedesktopNavButtonProvider();
+
+  std::map<FrameButtonDisplayType, std::map<ButtonState, gfx::ImageSkia>>
+      button_images_;
+
+  ButtonStyle style_;
+  std::optional<SkColor> titlebar_background_;
+  std::optional<SkColor> symbol_color_;
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_UI_VIEWS_FREEDESKTOP_NAV_BUTTON_PROVIDER_H_

--- a/shell/browser/ui/views/freedesktop_nav_button_provider.h
+++ b/shell/browser/ui/views/freedesktop_nav_button_provider.h
@@ -9,13 +9,31 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/linux/nav_button_provider.h"
 
+class SkBitmap;
+
 namespace electron {
+
+// Allows toolkit-specific impls to load Freedesktop icons and
+// provide system theme information.
+class SymbolicIconProvider {
+ public:
+  virtual SkBitmap LoadIcon(const std::string& icon_name,
+                            int icon_size,
+                            int scale,
+                            SkColor color) = 0;
+  virtual std::string GetThemeName() = 0;
+
+ protected:
+  ~SymbolicIconProvider() = default;
+};
 
 enum class PillColor { kBase, kAccent };
 enum class GlyphColor { kBase, kInverse, kContrastWithPill };
@@ -64,7 +82,12 @@ class FreedesktopNavButtonProvider : public ui::NavButtonProvider {
                          std::optional<SkColor> symbol);
 
  private:
-  FreedesktopNavButtonProvider();
+  explicit FreedesktopNavButtonProvider(SymbolicIconProvider* icon_provider);
+
+  // Should be process lifetime (ideally provided by the LinuxUi singleton)
+  // since the ImageSkia passed to the caption buttons can call the icon
+  // provider lazily and can outlive the nav button provider.
+  raw_ptr<SymbolicIconProvider> icon_provider_;
 
   std::map<FrameButtonDisplayType, std::map<ButtonState, gfx::ImageSkia>>
       button_images_;


### PR DESCRIPTION
#### Description of Change

Brings system-themed titlebar buttons to Linux when Window Controls Overlay (WCO) is enabled:

1. The implementation uses named [Freedesktop symbolic icons](https://specifications.freedesktop.org/icon-naming/latest/#names) and is compatible with any Linux distribution and desktop environment that implements the standard.
2. The new icons fully support Electron's existing `titlebarOverlay` API (including `height`, `color`, `symbolColor`) and automatic contrast, like the current vector icons.
3. Minor styling accommodations for color and spacing are applied to the glyphs if the user's theme is Breeze (default for KDE Plasma). Otherwise, the buttons adopt styling based on Adwaita.
   * Beyond being the default theme for GNOME, Adwaita is a safe, conventional default which Linux users are accustomed to seeing everywhere, as modern GTK4 apps already prefer it over the user's GTK theme.
   * This approach was inspired by Firefox, which also makes small adjustments for Breeze but otherwise bases its system titlebar styling on Adwaita and does not attempt to integrate arbitrary GTK themes.
4. If a Freedesktop icon theme is not installed, Electron will fall back to the built-in Chromium vector icons.

The new look has been tested with a range of web content backgrounds and system configurations. (Examples below.) App developers should not need to make any changes to their app design or code to accommodate the different icons.

Resolves https://github.com/electron/electron/issues/44540.

#### Alternatives considered

Earlier in the year I looked into using GTK titlebar buttons directly for WCO. But there is too much variety in third-party GTK themes for them to be embedded automatically into web content. GTK buttons are designed to be placed inside controlled headerbar components, not arbitrary backgrounds, and the icons often use bitmap assets and cannot be tinted or switched between light/dark without changing the app's entire theme.

I also did not want to add new, hard dependencies on GTK to Electron, as it might not always link to GTK and we should build against XDG/Freedesktop standards rather than framework-specific libraries. The vector buttons in this PR are drawn entirely with Skia and do not depend on GTK. (The PR does introduce a GTK impl. for an abstract provider to load the icon glyph and theme name, but this can be upstreamed to `LinuxUi`.)

#### Upstreaming

While this feature did not require a Chromium patch, I intend to submit the new button provider and frame view changes in this PR upstream. If it is accepted, this entire implementation will be replaced with about 30 lines of code in Electron.

#### Examples

**Breeze style on KDE (with mouse hovered over close button)**

Light | Dark 
----|----
<img width="575" height="605" alt="breeze light" src="https://github.com/user-attachments/assets/447bb676-a23d-4bf5-a142-62dc08fa158b" /> | <img width="583" height="584" alt="breeze dark" src="https://github.com/user-attachments/assets/26752d8e-5e80-46e1-92a3-4a8b1583a6bd" /> 

**Adwaita style on GNOME (with Yaru glyphs supplied by Ubuntu)**


Light | Dark 
----|----
<img width="590" height="598" alt="adwaita light" src="https://github.com/user-attachments/assets/84765ebb-51a9-46c5-adc6-e8b993ef75a6" /> | <img width="567" height="557" alt="adwaita dark" src="https://github.com/user-attachments/assets/5b103b2b-9816-4ef3-ad3f-5eb0ece26f04" />


**A bunch of VS Code themes showing the effects of color and symbolColor**

<img width="1519" height="1048" alt="Screenshot_20260727_000649" src="https://github.com/user-attachments/assets/10b9cd36-4588-46bf-bbf6-cca0afa5c073" />
<img width="1519" height="1048" alt="Screenshot_20260727_000630" src="https://github.com/user-attachments/assets/e97c6137-292a-43a6-bd16-b2e72c5e7916" />
<img width="1572" height="1061" alt="Screenshot_20260727_000608" src="https://github.com/user-attachments/assets/35203804-1c64-4afb-a144-d4239ad46d1e" />

Assisted-By: Claude Fable 5

(Claude implemented the `FreedesktopNavButtonProvider` based on my architectural requirements. I reviewed the file and  revised several times for maintainability and separation of concerns)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Frameless windows on Linux now use system-themed titlebar icons for Window Controls Overlay (WCO).
