### PR TITLE
test: fix flaky navigator.hid test on macOS

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -4640,6 +4640,15 @@ describe('navigator.hid', () => {
     );
   };
 
+  // A device is only reliably grantable if it exposes both a name and a serial
+  // number. Devices lacking them (e.g. system devices whose reports are all
+  // protected) are dropped by Chromium's WebHID report filtering after
+  // selection, so requestDevice() would resolve empty for them and make the
+  // test flaky. Select such a valid device rather than blindly picking the
+  // first entry in the list.
+  const findValidDevice = (deviceList: Electron.HIDDevice[]) =>
+    deviceList.find((device) => device.name && device.name !== '' && device.serialNumber && device.serialNumber !== '');
+
   after(() => {
     server.close();
     closeAllWindows();
@@ -4675,21 +4684,14 @@ describe('navigator.hid', () => {
     w.webContents.session.on('select-hid-device', (event, details, callback) => {
       expect(details.frame).to.have.property('frameTreeNodeId').that.is.a('number');
       selectFired = true;
-      if (details.deviceList.length > 0) {
+      const foundDevice = findValidDevice(details.deviceList);
+      if (foundDevice) {
         haveDevices = true;
-        callback(details.deviceList[0].deviceId);
+        callback(foundDevice.deviceId);
       } else {
         callback();
       }
     });
-    // Warm up the HID subsystem before requesting a device. The WebHID
-    // blocklist is populated lazily on first access and, as of Chromium's
-    // recursive nested-collection filtering, a composite device can be
-    // enumerated into the `select-hid-device` list before the blocklist is
-    // fully applied and then excluded during the post-selection permission
-    // recheck, causing `requestDevice()` to resolve empty. Enumerating first
-    // ensures the device list is stable before the request is made.
-    await w.webContents.executeJavaScript('navigator.hid.getDevices();', true);
     const device = await requestDevices();
     expect(selectFired).to.be.true();
     if (haveDevices) {
@@ -4718,18 +4720,11 @@ describe('navigator.hid', () => {
     let gotDevicePerms = false;
     w.webContents.session.on('select-hid-device', (event, details, callback) => {
       selectFired = true;
-      if (details.deviceList.length > 0) {
-        const foundDevice = details.deviceList.find((device) => {
-          if (device.name && device.name !== '' && device.serialNumber && device.serialNumber !== '') {
-            haveDevices = true;
-            return true;
-          }
-          return false;
-        });
-        if (foundDevice) {
-          callback(foundDevice.deviceId);
-          return;
-        }
+      const foundDevice = findValidDevice(details.deviceList);
+      if (foundDevice) {
+        haveDevices = true;
+        callback(foundDevice.deviceId);
+        return;
       }
       callback();
     });


### PR DESCRIPTION
- Followup to #52448.  That PR unfortunately did not fix the underlying flake because when `select-hid-device` fires it was grabbing the first device returned, even if it was a system device that couldn't be used for the test. There is another test `returns a device when DevicePermissionHandler is defined` that already had logic to only return a valid device instead of the first device, so that check was extracted out to a helper function so that the flaky test can also use that function to get a valid device for testing (if such a device exists).

Assisted-by: Claude Opus 4.8

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
