### PR TITLE
fix: filter discarded devices from WebHID chooser

### DIFF
--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -9,6 +9,7 @@
 
 #include "base/command_line.h"
 #include "base/functional/bind.h"
+#include "content/browser/hid/hid_service.h"  // nogncheck
 #include "content/public/browser/web_contents.h"
 #include "gin/data_object_builder.h"
 #include "services/device/public/cpp/hid/hid_blocklist.h"
@@ -288,6 +289,29 @@ bool HidChooserController::DisplayDevice(
                         "productId=%d, name='%s', serial='%s'",
                         device.vendor_id, device.product_id,
                         device.product_name, device.serial_number));
+    return false;
+  }
+
+  // Mirror the report filtering that HidService::FinishRequestDevice applies
+  // after a device is selected. With Chromium's recursive nested-collection
+  // filtering (features::kWebHidRecursiveFiltering), a device whose reports all
+  // live in protected collections is stripped down to having no collections and
+  // is then dropped from the granted result, making requestDevice() resolve
+  // empty. Exclude such devices from the chooser so the `select-hid-device`
+  // device list stays consistent with the devices that can actually be granted.
+  auto filtered_device = device.Clone();
+  content::HidService::RemoveProtectedReports(
+      *filtered_device, /*is_known_security_key=*/false,
+      chooser_context_ && chooser_context_->IsFidoAllowedForOrigin(origin_));
+  if (filtered_device->collections.empty()) {
+    AddMessageToConsole(
+        blink::mojom::ConsoleMessageLevel::kInfo,
+        absl::StrFormat(
+            "Chooser dialog is not displaying a device whose reports "
+            "are all protected: vendorId=%d, "
+            "productId=%d, name='%s', serial='%s'",
+            device.vendor_id, device.product_id, device.product_name,
+            device.serial_number));
     return false;
   }
 


### PR DESCRIPTION
- Follow up to https://github.com/electron/electron/pull/52448 which included CL [7987617: hid: Recursively filter nested collections](https://chromium-review.googlesource.com/c/chromium/src/+/7987617) (hid: Recursively filter nested collections), HidService::FinishRequestDevice recursively strips protected reports from a selected device and drops it entirely when all of its collections are removed. The `select-hid-device` event only filtered devices by the HID blocklist, FIDO usage, and request filters, so it could present a device that FinishRequestDevice then discarded, causing `navigator.hid.requestDevice()` to resolve with an empty array.
- This PR fixes the issues by using `content::HidService::RemoveProtectedReports`  to filter out unusable device, so that what gets returned by the `select-hid-device` event consists of devices that can actually be granted.

Fixes: https://github.com/electron/electron/issues/52459

Assisted-by: Claude Opus 4.8

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Fixed `select-hid-device` presenting HID devices that could not be granted, which caused `navigator.hid.requestDevice()` to resolve with no device.
