### PR TITLE
fix: create window.open() children in their own process when their sandbox state differs from the opener

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -6,11 +6,22 @@ untrusted content within a renderer. Windows can be created from the renderer in
 * clicking on links or submitting forms adorned with `target=_blank`
 * JavaScript calling `window.open()`
 
-For same-origin content, the new window is created within the same process,
+For same-site content, the new window is created within the same process,
 enabling the parent to access the child window directly. This can be very
 useful for app sub-windows that act as preference panels, or similar, as the
 parent can render to the sub-window directly, as if it were a `div` in the
 parent. This is the same behavior as in the browser.
+
+Process-level `webPreferences` such as `sandbox` and `nodeIntegration` are
+baked into a renderer process when it launches, so a child window whose sandbox
+state differs from the opener's process cannot share it. In that case the child
+is created in a process of its own with no opener relationship: `window.open()`
+returns `null` in the opener and `window.opener` is `null` in the child. Child
+windows default to sandboxed, so a `window.open()` from an unsandboxed opener
+(for example one with `nodeIntegration: true`) is isolated like this by
+default. To keep such a child in the opener's process, explicitly set
+`sandbox: false` in the `webPreferences` returned from
+[`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandlerhandler).
 
 Electron pairs this native DOM `Window` with a BrowserWindow under the hood.
 You can take advantage of all the customization available when creating a

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,40 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (44.0)
 
+### Behavior Changed: `window.open()` children of unsandboxed windows get their own sandboxed process
+
+A `window.open()` child normally shares its opener's renderer process, and the OS sandbox
+of a renderer process is fixed when it launches. Previously a child opened from an
+unsandboxed (e.g. `nodeIntegration: true`) window silently ran in that unsandboxed process
+even though `webContents.getLastWebPreferences()` reported `sandbox: true` for it.
+
+Now the child's own web preferences decide the sandbox state, and when that state differs
+from the opener's process the child is created in a new process with no opener
+relationship: `window.open()` returns `null` in the opener and `window.opener` is `null`
+in the child, matching the behavior of `window.open(url, '_blank', 'noopener')`. A
+warning is logged to the opener's console when this happens.
+
+Child windows default to sandboxed, so a child opened from an unsandboxed window is now
+isolated in its own sandboxed process by default. To restore the previous behavior of
+sharing the opener's unsandboxed process (and the scriptable `window.opener` / returned
+`WindowProxy` that comes with it), opt in explicitly from
+[`webContents.setWindowOpenHandler`](api/web-contents.md#contentssetwindowopenhandlerhandler):
+
+```js
+win.webContents.setWindowOpenHandler(() => ({
+  action: 'allow',
+  overrideBrowserWindowOptions: {
+    webPreferences: {
+      // Match the (unsandboxed) opener so the child shares its process.
+      sandbox: false
+    }
+  }
+}))
+```
+
+Setting `nodeIntegration: true` in the override also makes the child unsandboxed and has
+the same effect.
+
 ### Behavior Changed: `webContents` may be `null` in `select-client-certificate`
 
 The `app` `'select-client-certificate'` event is now also emitted for requests made

--- a/patches/chromium/can_create_window.patch
+++ b/patches/chromium/can_create_window.patch
@@ -6,6 +6,9 @@ Subject: can_create_window.patch
 This adds a hook to the window creation flow so that Electron can intercede and
 potentially prevent a window from being created.
 
+It also makes |no_javascript_access| from the embedder suppress the opener, so
+that the new window is created in its own BrowsingInstance (and process).
+
 TODO(loc): this patch is currently broken.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
@@ -20,6 +23,18 @@ index 452b885cd88cc8c4542e7025bf0e42e6c58a38d6..129158312fbd6f1055982403cab4073e
            effective_transient_activation_state, params->opener_suppressed,
            &no_javascript_access);
  
+@@ -10472,6 +10473,11 @@ void RenderFrameHostImpl::CreateNewWindow(
+     return;
+   }
+ 
++  // A window the opener has no script access to must live in its own
++  // BrowsingInstance, which is exactly what suppressing the opener does.
++  if (no_javascript_access)
++    params->opener_suppressed = true;
++
+   // Otherwise, consume user activation before we proceed. In particular, it is
+   // important to do this before we return from the |opener_suppressed| case
+   // below.
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
 index 46715b0f8733c58473c6530654ff0915adb9ef7c..d55feba617cadc22108b0c495aa0be7858f95d11 100644
 --- a/content/browser/web_contents/web_contents_impl.cc

--- a/patches/chromium/can_create_window.patch
+++ b/patches/chromium/can_create_window.patch
@@ -12,7 +12,7 @@ that the new window is created in its own BrowsingInstance (and process).
 TODO(loc): this patch is currently broken.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
-index 452b885cd88cc8c4542e7025bf0e42e6c58a38d6..129158312fbd6f1055982403cab4073e3d32261a 100644
+index 452b885cd88cc8c4542e7025bf0e42e6c58a38d6..e0b4f417c37f012b14476e62acb0fa66c991de91 100644
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
 @@ -10514,6 +10514,7 @@ void RenderFrameHostImpl::CreateNewWindow(
@@ -23,7 +23,7 @@ index 452b885cd88cc8c4542e7025bf0e42e6c58a38d6..129158312fbd6f1055982403cab4073e
            effective_transient_activation_state, params->opener_suppressed,
            &no_javascript_access);
  
-@@ -10472,6 +10473,11 @@ void RenderFrameHostImpl::CreateNewWindow(
+@@ -10524,6 +10525,11 @@ void RenderFrameHostImpl::CreateNewWindow(
      return;
    }
  

--- a/patches/chromium/feat_carry_embedder_startup_data_in_createnewwindowreply.patch
+++ b/patches/chromium/feat_carry_embedder_startup_data_in_createnewwindowreply.patch
@@ -26,10 +26,10 @@ hook called before the new RenderFrame is created so it can be picked up
 by RenderFrameCreated() on the same call stack.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
-index f6bf7af98e4d09334a926b0de0915f3b352b3fae..edcadd068bfd008d649b6ae89732ff9fbabd7a6b 100644
+index 3938359abdd379cc7a8f485841850898516499b5..c53d658976f98f4f8535a96be742a56c6ef434ba 100644
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
-@@ -10711,7 +10711,12 @@ void RenderFrameHostImpl::CreateNewWindow(
+@@ -10716,7 +10716,12 @@ void RenderFrameHostImpl::CreateNewWindow(
        new_main_rfh->GetSiteInstance()->browsing_instance_token(),
        delegate_->GetColorProviderColorMaps(),
        /*widget_screen_rect=*/std::nullopt,

--- a/patches/chromium/webview_fullscreen.patch
+++ b/patches/chromium/webview_fullscreen.patch
@@ -15,7 +15,7 @@ Note that we also need to manually update embedder's
 `api::WebContents::IsFullscreenForTabOrPending` value.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
-index 129158312fbd6f1055982403cab4073e3d32261a..f6bf7af98e4d09334a926b0de0915f3b352b3fae 100644
+index e0b4f417c37f012b14476e62acb0fa66c991de91..3938359abdd379cc7a8f485841850898516499b5 100644
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
 @@ -9481,6 +9481,17 @@ void RenderFrameHostImpl::EnterFullscreen(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -103,6 +103,7 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/child_web_contents_tracker.h"
 #include "shell/browser/electron_autofill_driver_factory.h"
+#include "shell/browser/electron_browser_client.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/electron_browser_main_parts.h"
 #include "shell/browser/electron_navigation_throttle.h"
@@ -1342,19 +1343,64 @@ void WebContents::WebContentsCreatedWithFullParams(
   new WebContentsPreferences(new_contents, dict);
 }
 
-bool WebContents::IsWebContentsCreationOverridden(
+bool WebContents::OnWillCreateWindow(
     content::RenderFrameHost* opener,
-    content::SiteInstance* source_site_instance,
-    content::mojom::WindowContainerType window_container_type,
-    const GURL& opener_url,
-    const content::mojom::CreateNewWindowParams& params) {
-  bool default_prevented = Emit(
-      "-will-add-new-contents", params.target_url, params.frame_name,
-      params.raw_features, params.disposition, *params.referrer, params.body);
-  // If the app prevented the default, redirect to CreateCustomWebContents,
-  // which always returns nullptr, which will result in the window open being
-  // prevented (window.open() will return null in the renderer).
-  return default_prevented;
+    const GURL& target_url,
+    const std::string& frame_name,
+    const std::string& raw_features,
+    WindowOpenDisposition disposition,
+    const content::Referrer& referrer,
+    const scoped_refptr<network::ResourceRequestBody>& body,
+    bool opener_suppressed,
+    bool* no_javascript_access) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  pending_child_web_preferences_.Reset();
+
+  // If the app prevents the default the window open is denied and
+  // window.open() will return null in the renderer.
+  if (Emit("-will-add-new-contents", target_url, frame_name, raw_features,
+           disposition, referrer, body)) {
+    pending_child_web_preferences_.Reset();
+    return false;
+  }
+
+  // A suppressed opener (e.g. noopener) already puts the child in its own
+  // BrowsingInstance and process, so its sandbox state is honoured either way.
+  if (opener_suppressed)
+    return true;
+
+  // The OS sandbox is fixed when a renderer process launches, so a child whose
+  // sandbox state differs from the opener's process must not share it.
+  std::optional<bool> opener_sandboxed =
+      ElectronBrowserClient::Get()->IsRendererProcessSandboxed(
+          opener->GetProcess()->GetID());
+  if (!opener_sandboxed) {
+    opener_sandboxed = WebContentsPreferences::ShouldUseSandbox(
+        content::WebContents::FromRenderFrameHost(opener));
+  }
+
+  gin_helper::Dictionary child_web_preferences =
+      gin::Dictionary::CreateEmpty(isolate);
+  if (!pending_child_web_preferences_.IsEmpty()) {
+    gin::ConvertFromV8(isolate, pending_child_web_preferences_.Get(isolate),
+                       &child_web_preferences);
+  }
+
+  if (WebContentsPreferences::IsSandboxed(child_web_preferences) !=
+      *opener_sandboxed) {
+    opener->AddMessageToConsole(
+        blink::mojom::ConsoleMessageLevel::kWarning,
+        "window.open(): the new window's sandbox setting differs from the "
+        "sandbox state of the opener's renderer process, so it was created in "
+        "a separate process without an opener relationship and window.open() "
+        "returned null. Set `sandbox` (or `nodeIntegration`) explicitly in "
+        "webContents.setWindowOpenHandler() to match the opener if the "
+        "windows need to share a process.");
+    *no_javascript_access = true;
+  }
+  return true;
 }
 
 void WebContents::SetNextChildWebPreferences(
@@ -1364,20 +1410,6 @@ void WebContents::SetNextChildWebPreferences(
   // Store these prefs for when Chrome calls WebContentsCreatedWithFullParams
   // with the new child contents.
   pending_child_web_preferences_.Reset(isolate, preferences.GetHandle());
-}
-
-content::WebContents* WebContents::CreateCustomWebContents(
-    content::RenderFrameHost* opener,
-    content::SiteInstance* source_site_instance,
-    bool is_new_browsing_instance,
-    const GURL& opener_url,
-    const std::string& frame_name,
-    const GURL& target_url,
-    WindowOpenDisposition disposition,
-    const blink::mojom::WindowFeatures& window_features,
-    const content::StoragePartitionConfig& partition_config,
-    content::SessionStorageNamespace* session_storage_namespace) {
-  return nullptr;
 }
 
 void WebContents::MaybeOverrideCreateParamsForNewWindow(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -273,6 +273,20 @@ class WebContents final : public ExclusiveAccessContext,
 
   void SetNextChildWebPreferences(const gin_helper::Dictionary);
 
+  // Called for renderer-initiated window creation before the child
+  // WebContents exists. Runs the window open handler and decides whether the
+  // child must be isolated from the opener's process.
+  bool OnWillCreateWindow(
+      content::RenderFrameHost* opener,
+      const GURL& target_url,
+      const std::string& frame_name,
+      const std::string& raw_features,
+      WindowOpenDisposition disposition,
+      const content::Referrer& referrer,
+      const scoped_refptr<network::ResourceRequestBody>& body,
+      bool opener_suppressed,
+      bool* no_javascript_access);
+
   // DevTools workspace api.
   void AddWorkSpace(v8::Isolate* isolate, const base::FilePath& path);
   void RemoveWorkSpace(v8::Isolate* isolate, const base::FilePath& path);
@@ -505,23 +519,6 @@ class WebContents final : public ExclusiveAccessContext,
 #endif
 
   // content::WebContentsDelegate:
-  bool IsWebContentsCreationOverridden(
-      content::RenderFrameHost* opener,
-      content::SiteInstance* source_site_instance,
-      content::mojom::WindowContainerType window_container_type,
-      const GURL& opener_url,
-      const content::mojom::CreateNewWindowParams& params) override;
-  content::WebContents* CreateCustomWebContents(
-      content::RenderFrameHost* opener,
-      content::SiteInstance* source_site_instance,
-      bool is_new_browsing_instance,
-      const GURL& opener_url,
-      const std::string& frame_name,
-      const GURL& target_url,
-      WindowOpenDisposition disposition,
-      const blink::mojom::WindowFeatures& window_features,
-      const content::StoragePartitionConfig& partition_config,
-      content::SessionStorageNamespace* session_storage_namespace) override;
   void WebContentsCreatedWithFullParams(
       content::WebContents* source_contents,
       int opener_render_process_id,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -65,6 +65,7 @@
 #include "net/ssl/ssl_cert_request_info.h"
 #include "net/ssl/ssl_private_key.h"
 #include "printing/buildflags/buildflags.h"
+#include "sandbox/policy/switches.h"
 #include "services/device/public/cpp/geolocation/geolocation_system_permission_manager.h"
 #include "services/device/public/cpp/geolocation/location_provider.h"
 #include "services/network/public/cpp/features.h"
@@ -418,6 +419,14 @@ bool ElectronBrowserClient::IsRendererSubFrame(
   return renderer_is_subframe_.contains(process_id);
 }
 
+std::optional<bool> ElectronBrowserClient::IsRendererProcessSandboxed(
+    content::ChildProcessId process_id) const {
+  const auto iter = renderer_process_sandboxed_.find(process_id);
+  if (iter == std::end(renderer_process_sandboxed_))
+    return std::nullopt;
+  return iter->second;
+}
+
 void ElectronBrowserClient::RenderProcessWillLaunch(
     content::RenderProcessHost* host) {
   // Remove in case the host is reused after a crash, otherwise noop.
@@ -639,6 +648,9 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
             command_line, IsRendererSubFrame(unsafe_process_id));
     }
 
+    renderer_process_sandboxed_[unsafe_process_id] =
+        !command_line->HasSwitch(sandbox::policy::switches::kNoSandbox);
+
     // Service worker processes should only run preloads if one has been
     // registered prior to startup.
     auto* render_process_host = content::RenderProcessHost::FromID(process_id);
@@ -730,10 +742,14 @@ bool ElectronBrowserClient::CanCreateWindow(
       // <webview> without allowpopups attribute should return
       // null from window.open calls
       return false;
-    } else {
-      *no_javascript_access = false;
-      return true;
     }
+    *no_javascript_access = false;
+    if (auto* api_web_contents = api::WebContents::From(web_contents)) {
+      return api_web_contents->OnWillCreateWindow(
+          opener, target_url, frame_name, raw_features, disposition, referrer,
+          body, opener_suppressed, no_javascript_access);
+    }
+    return true;
   }
 
   if (delegate_) {
@@ -1003,6 +1019,7 @@ void ElectronBrowserClient::RenderProcessHostDestroyed(
   content::ChildProcessId process_id = host->GetID();
   pending_processes_.erase(process_id);
   renderer_is_subframe_.erase(process_id);
+  renderer_process_sandboxed_.erase(process_id);
   host->RemoveObserver(this);
 }
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -69,6 +69,11 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   content::WebContents* GetWebContentsFromProcessID(
       content::ChildProcessId process_id);
 
+  // Whether the given renderer process was launched with the OS sandbox
+  // enabled. Returns nullopt if the launch state of the process is unknown.
+  std::optional<bool> IsRendererProcessSandboxed(
+      content::ChildProcessId process_id) const;
+
   NotificationPresenter* GetNotificationPresenter();
 
   void WebNotificationAllowed(content::RenderFrameHost* rfh,
@@ -380,6 +385,9 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       pending_processes_;
 
   base::flat_set<content::ChildProcessId> renderer_is_subframe_;
+
+  // Sandbox state each renderer process was launched with.
+  base::flat_map<content::ChildProcessId, bool> renderer_process_sandboxed_;
 
   std::unique_ptr<PlatformNotificationService> notification_service_;
   std::unique_ptr<NotificationPresenter> notification_presenter_;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -307,6 +307,24 @@ WebContentsPreferences* WebContentsPreferences::From(
 }
 
 // static
+bool WebContentsPreferences::IsSandboxed(
+    const gin_helper::Dictionary& web_preferences) {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kEnableSandbox)) {
+    return true;
+  }
+  bool sandbox;
+  if (web_preferences.Get(options::kSandbox, &sandbox))
+    return sandbox;
+  bool node_integration = false;
+  bool node_integration_in_worker = false;
+  web_preferences.Get(options::kNodeIntegration, &node_integration);
+  web_preferences.Get(options::kNodeIntegrationInWorker,
+                      &node_integration_in_worker);
+  return !(node_integration || node_integration_in_worker);
+}
+
+// static
 bool WebContentsPreferences::ShouldUseSandbox(
     content::WebContents* web_contents) {
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -42,6 +42,10 @@ class WebContentsPreferences
   // renderer sandboxed regardless of per-WC webPreferences.
   static bool ShouldUseSandbox(content::WebContents* web_contents);
 
+  // The sandbox state a WebContents constructed from |web_preferences| would
+  // have, following the same defaulting rules as IsSandboxed().
+  static bool IsSandboxed(const gin_helper::Dictionary& web_preferences);
+
   WebContentsPreferences(content::WebContents* web_contents,
                          const gin_helper::Dictionary& web_preferences);
   ~WebContentsPreferences() override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4746,6 +4746,12 @@ describe('BrowserWindow module', () => {
             contextIsolation: false
           }
         });
+        // Cross-scripting the popup requires it to share the (unsandboxed)
+        // opener's process, so opt the child out of the default sandbox.
+        w.webContents.setWindowOpenHandler(() => ({
+          action: 'allow',
+          overrideBrowserWindowOptions: { webPreferences: { sandbox: false } }
+        }));
       });
 
       it('opens window of about:blank with cross-scripting enabled', async () => {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2409,6 +2409,12 @@ describe('chromium features', () => {
           contextIsolation: false
         }
       });
+      // The opener is unsandboxed, so keep the child unsandboxed too or it is
+      // isolated in its own process with no opener.
+      w.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: { webPreferences: { sandbox: false } }
+      }));
       w.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
 
       const windowUrl = `file://${fixturesPath}/pages/window-opener.html`;
@@ -2897,7 +2903,11 @@ describe('chromium features', () => {
     describe('when opened from main window', () => {
       for (const { parent, child, nodeIntegration, openerAccessible } of table) {
         for (const sandboxPopup of [false, true]) {
-          const description = `when parent=${s(parent)} opens child=${s(child)} with nodeIntegration=${nodeIntegration} sandboxPopup=${sandboxPopup}, child should ${openerAccessible ? '' : 'not '}be able to access opener`;
+          // The opener runs unsandboxed (nodeIntegration), so a sandboxed
+          // popup can't share its process and is isolated with no opener.
+          const description = sandboxPopup
+            ? `when parent=${s(parent)} opens child=${s(child)} with nodeIntegration=${nodeIntegration} sandboxPopup=true, child is isolated from the opener`
+            : `when parent=${s(parent)} opens child=${s(child)} with nodeIntegration=${nodeIntegration} sandboxPopup=false, child should ${openerAccessible ? '' : 'not '}be able to access opener`;
           it(description, async () => {
             const w = new BrowserWindow({
               show: true,
@@ -2912,6 +2922,13 @@ describe('chromium features', () => {
               }
             }));
             await w.loadURL(parent);
+            if (sandboxPopup) {
+              const openedNull = await w.webContents.executeJavaScript(
+                `window.open(${JSON.stringify(child)}, "", "show=no,nodeIntegration=${nodeIntegration ? 'yes' : 'no'}") === null`
+              );
+              expect(openedNull).to.be.true();
+              return;
+            }
             const childOpenerLocation = await w.webContents.executeJavaScript(`new Promise(resolve => {
               window.addEventListener('message', function f(e) {
                 resolve(e.data)

--- a/spec/fixtures/crash-cases/setimmediate-window-open-crash/index.js
+++ b/spec/fixtures/crash-cases/setimmediate-window-open-crash/index.js
@@ -8,6 +8,13 @@ function createWindow() {
     }
   });
 
+  // The child posts back via window.opener, so it has to share the
+  // opener's unsandboxed process.
+  mainWindow.webContents.setWindowOpenHandler(() => ({
+    action: 'allow',
+    overrideBrowserWindowOptions: { webPreferences: { sandbox: false } }
+  }));
+
   mainWindow.on('close', () => {
     app.quit();
   });

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -269,6 +269,51 @@ describe('webContents.setWindowOpenHandler', () => {
       expect(size).to.equal('30px');
     });
 
+    it('creates a sandboxed child in its own process from an unsandboxed opener by default', async () => {
+      const parent = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true, contextIsolation: false }
+      });
+      await parent.loadURL('about:blank');
+      parent.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: { show: false }
+      }));
+
+      const didCreateWindow = once(parent.webContents, 'did-create-window') as Promise<
+        [BrowserWindow, Electron.DidCreateWindowDetails]
+      >;
+      const openedNull = await parent.webContents.executeJavaScript("window.open('about:blank') === null");
+      const [child] = await didCreateWindow;
+      if (child.webContents.isLoading()) await once(child.webContents, 'did-finish-load');
+
+      expect(openedNull).to.equal(true);
+      expect(child.webContents.getLastWebPreferences()?.sandbox).to.equal(true);
+      expect(child.webContents.getOSProcessId()).to.not.equal(parent.webContents.getOSProcessId());
+      expect(await child.webContents.executeJavaScript('window.opener === null')).to.equal(true);
+    });
+
+    it('keeps the child in the opener process when the override sandbox state matches the opener', async () => {
+      const parent = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true, contextIsolation: false }
+      });
+      await parent.loadURL('about:blank');
+      parent.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: { show: false, webPreferences: { sandbox: false } }
+      }));
+
+      const didCreateWindow = once(parent.webContents, 'did-create-window') as Promise<
+        [BrowserWindow, Electron.DidCreateWindowDetails]
+      >;
+      const openedNull = await parent.webContents.executeJavaScript("window.open('about:blank') === null");
+      const [child] = await didCreateWindow;
+
+      expect(openedNull).to.equal(false);
+      expect(child.webContents.getOSProcessId()).to.equal(parent.webContents.getOSProcessId());
+    });
+
     it('does not hang parent window when denying window.open', async () => {
       browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
       browserWindow.webContents.executeJavaScript("window.open('https://127.0.0.1')");

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -667,6 +667,14 @@ describe('<webview> tag', function () {
         show: false,
         webPreferences: { nodeIntegration: true, webviewTag: true, contextIsolation: false }
       });
+      // Cross-scripting the popup requires it to share the webview's
+      // unsandboxed process, so opt the child out of the default sandbox.
+      w.webContents.on('did-attach-webview', (_event, webviewContents) => {
+        webviewContents.setWindowOpenHandler(() => ({
+          action: 'allow',
+          overrideBrowserWindowOptions: { webPreferences: { sandbox: false } }
+        }));
+      });
       await w.loadURL('about:blank');
     });
     afterEach(closeAllWindows);


### PR DESCRIPTION
#### Description of Change

Fixes a case where `webPreferences` supplied for a `window.open()` child were silently not applied.

Process-level web preferences like `sandbox` and `nodeIntegration` are baked into a renderer process when it launches, but a `window.open()` child normally shares its opener's process. When the child's sandbox state differed from the state the opener's process was actually launched with, the child just ran with the opener's process configuration while `getLastWebPreferences()` reported the child's requested values.

Now the child's effective sandbox state is compared against the opener process's real launch state, and on mismatch the child is created in its own BrowsingInstance/process (same path as `noopener`): `window.open()` returns `null`, `window.opener` is `null`, and a console warning explains why. Since child prefs default to sandboxed, popups from unsandboxed openers are isolated by default; passing `sandbox: false` (or `nodeIntegration: true`) in `setWindowOpenHandler`'s override restores process sharing.

- `can_create_window.patch`: `no_javascript_access` from the embedder now also suppresses the opener
- `ElectronBrowserClient`: track each renderer's launch sandbox state; run the window open handler at decision time via `api::WebContents::OnWillCreateWindow`
- docs: `window-open.md` (same-site, not same-origin, shares the process; new isolation note) + breaking-changes entry
- specs: new coverage in `guest-window-manager-spec.ts`; opener-access matrix and cross-scripting suites updated for the new default

Follow-up: `chore_provide_iswebcontentscreationoverridden_with_full_params.patch` no longer has a consumer after this and can be dropped in a separate PR.

Notes: A `window.open()` child whose `sandbox` state differs from its opener's renderer process is now created in its own process with no opener relationship instead of silently sharing the opener's process; set `sandbox: false` in `setWindowOpenHandler` to keep sharing an unsandboxed opener's process.
