### PR TITLE
fix: refactor to avoid UAF in NodeStreamLoader

### DIFF
--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -79,11 +79,21 @@ void NodeStreamLoader::NotifyError() {
 }
 
 void NodeStreamLoader::NotifyReadable() {
-  if (!readable_)
-    ReadMore();
-  else if (is_reading_)
-    has_read_waiting_ = true;
+  if (readable_) {
+    // 'readable' was emitted from within stream.read(), so remember to read
+    // again once the in-progress read completes.
+    if (is_reading_)
+      has_read_waiting_ = true;
+    return;
+  }
+
+  // `readable_` must be set before ReadMore(): it clears the flag itself when
+  // read() comes up empty, and a re-entrant 'readable' emitted from within
+  // read() needs to see `true` so that it records `has_read_waiting_`.
   readable_ = true;
+
+  // ReadMore() may delete `this`, so it must be the last thing we do.
+  ReadMore();
 }
 
 void NodeStreamLoader::NotifyComplete(int result) {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -549,6 +549,56 @@ describe('protocol module', () => {
         await hasEndedPromise;
       });
 
+      it('keeps reading after a read yields no data', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const body = new stream.Readable({
+            objectMode: true,
+            read() {}
+          });
+          // Not a Buffer, so the loader treats this read as yielding nothing
+          // and goes back to waiting for the next 'readable' event. The real
+          // data only shows up later, so the request stalls forever unless the
+          // loader re-arms itself for that second event.
+          body.push('not a buffer');
+          setImmediate(() => {
+            body.push(Buffer.from(text));
+            body.push(null);
+          });
+          callback({
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain' },
+            data: body
+          });
+        });
+
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal(text);
+      });
+
+      it('keeps reading when readable is emitted during the first read', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const chunks: (string | Buffer)[] = ['not a buffer', Buffer.from(text)];
+          const body = new stream.Readable({
+            objectMode: true,
+            read() {
+              // Queues the next chunk while the loader is still inside read(),
+              // so 'readable' re-emits before that read completes. The first
+              // read yields a non-Buffer, so the loader has to remember that
+              // re-entrant event or the request stalls forever.
+              process.nextTick(() => this.push(chunks.shift() ?? null));
+            }
+          });
+          callback({
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain' },
+            data: body
+          });
+        });
+
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal(text);
+      });
+
       it('completes cleanly when the stream errors from within read()', async () => {
         // A stream can emit 'error' synchronously from _read(). That reaches
         // the loader while it is inside read(), so it defers completion. The

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -549,6 +549,39 @@ describe('protocol module', () => {
         await hasEndedPromise;
       });
 
+      it('completes cleanly when the stream errors from within read()', async () => {
+        // A stream can emit 'error' synchronously from _read(). That reaches
+        // the loader while it is inside read(), so it defers completion. The
+        // chunk that comes back then isn't a Buffer, so the loader treats the
+        // read as empty and completes - destroying itself - while it is still
+        // unwinding out of its 'readable' handler, leaving it touching freed
+        // memory on the way out. Only a sanitized build reports the bad
+        // access; unsanitized builds just pass.
+        let pushed = false;
+        const body = new stream.Readable({
+          objectMode: true,
+          read() {
+            if (pushed) {
+              this.emit('error', new Error('read failed'));
+              return;
+            }
+            pushed = true;
+            // Not a Buffer, so the loader treats this read as yielding nothing
+            this.push('not a buffer');
+          }
+        });
+
+        registerStreamProtocol(protocolName, (request, callback) => {
+          callback({
+            statusCode: 200,
+            headers: { 'Content-Type': 'text/plain' },
+            data: body
+          });
+        });
+
+        await expect(ajax(protocolName + '://fake-host')).to.eventually.be.rejected();
+      });
+
       it('destroys response streams when aborted before completion', async () => {
         const events = new EventEmitter();
         registerStreamProtocol(protocolName, (request, callback) => {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Under specific circumstances `NodeStreamLoader` can hit a UAF when it deletes itself before completing `NodeStreamLoader::NotifyReadable`, so refactor to avoid that possibility.

Test added as a separate commit first to show the ASan failure flagging the UAF: https://github.com/electron/electron/actions/runs/30314440929/job/90138979629

Also added tests for two other edge cases which get fixed by the refactor, which would cause the streaming response to stall out: https://github.com/electron/electron/actions/runs/30321732441/job/90160483107

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a UAF with `protocol.registerStreamProtocol` when an error is emitted during a read<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
