### PR TITLE
ci: try to detect bug issues from issue body

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   add-to-issue-triage:
-    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') }}
+    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') || contains(github.event.issue.body, '# Expected Behavior') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -27,7 +27,7 @@ jobs:
           project-number: 90
           token: ${{ steps.generate-token.outputs.token }}
   set-labels:
-    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') }}
+    if: ${{ contains(github.event.issue.labels.*.name, 'bug :beetle:') || contains(github.event.issue.body, '# Expected Behavior') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We're seeing more issues opened via the API (e.g. from AI agents) which unfortunately bypasses issue templates all together and as such these issues do not get added to the issue triage board or labeled automatically, even if they otherwise have correct issue bodies that match our expected template.

Lets try to work around this problem by detecting `# Expected Behavior` in the issue body and assuming it's a bug report, if the bug label is not present.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
