### PR TITLE
ci: enable LSan on existing Linux ASan build job

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -155,7 +155,7 @@ jobs:
         if [ "${{ inputs.target-arch }}" = "arm64" ]; then
           GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
         elif [ "${{ inputs.is-asan }}" = true ]; then
-          GN_EXTRA_ARGS='is_asan=true'
+          GN_EXTRA_ARGS='is_asan=true is_lsan=true v8_enable_verify_heap=true'
         fi
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
     - name: Set Chromium Git Cookie

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -163,7 +163,7 @@ jobs:
           if [ "${{ inputs.target-arch }}" = "arm64" ]; then
             GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
           elif [ "${{ inputs.is-asan }}" = true ]; then
-            GN_EXTRA_ARGS='is_asan=true'
+            GN_EXTRA_ARGS='is_asan=true is_lsan=true v8_enable_verify_heap=true'
           fi
 
           echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -326,7 +326,12 @@ jobs:
           if [ "${{ inputs.is-asan }}" == "true" ]; then
             cd ..
             ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
-            export ASAN_OPTIONS="symbolize=0 handle_abort=1"
+            # symbolize=1 is required for leak suppressions to work: LSan can
+            # only match "leak:" entries against function and file names, and
+            # with symbolization off it has neither, which silently disables
+            # both Chromium's built-in list and lsan_suppressions.txt.
+            export ASAN_OPTIONS="detect_leaks=1 handle_abort=1 symbolize=1 strip_path_prefix=/../../ external_symbolizer_path=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer"
+            export LSAN_OPTIONS="suppressions=$PWD/electron/build/lsan_suppressions.txt"
             export G_SLICE=always-malloc
             export NSS_DISABLE_ARENA_FREE_LIST=1
             export NSS_DISABLE_UNLOAD=1

--- a/build/lsan_suppressions.txt
+++ b/build/lsan_suppressions.txt
@@ -1,0 +1,14 @@
+# LeakSanitizer suppressions for the Linux ASan/LSan CI job.
+#
+# Chromium's built-in list (build/sanitizers/lsan_suppressions.cc) is parsed in
+# addition to this file, so only add entries it doesn't already cover.
+
+# Upstream test bots never reach this code at all because they point
+# FONTCONFIG_SYSROOT at a hermetic config with no <include> and no
+# <selectfont>, whereas Electron's tests parse the build container's
+# /etc/fonts.
+leak:third_party/fontconfig
+
+# GLib/GTK process-lifetime state (type system, quarks, theme and settings
+# caches) that is never freed by design.
+leak:libglib-2.0.so

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2387,7 +2387,7 @@ describe('chromium features', () => {
       const w = new BrowserWindow({ show: false });
       w.loadURL('about:blank');
       await expect(
-        w.webContents.executeJavaScript("window.open('', '', 'show=no,webPreferences='); null")
+        w.webContents.executeJavaScript("const b = window.open('', '', 'show=no,webPreferences='); b.close(); null")
       ).to.eventually.be.fulfilled();
     });
   });


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Testing this out, [according to the Chromium docs](https://www.chromium.org/developers/testing/leaksanitizer/) there's no performance hit for running LSan on top of ASan, so might as well run it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
