### PR TITLE
docs: remove self-closing syntax

### DIFF
--- a/docs/fiddles/native-ui/dialogs/error-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/error-dialog/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Error Dialog</title>
   </head>
 

--- a/docs/fiddles/native-ui/dialogs/information-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/information-dialog/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Information Dialog</title>
   </head>
 

--- a/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
+++ b/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Open File or Directory</title>
   </head>
 

--- a/docs/fiddles/native-ui/dialogs/save-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/save-dialog/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Save Dialog</title>
   </head>
 

--- a/docs/fiddles/native-ui/drag-and-drop/index.html
+++ b/docs/fiddles/native-ui/drag-and-drop/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Drag and drop files</title>
   </head>
 

--- a/docs/fiddles/native-ui/external-links-file-manager/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Open external links and the file manager</title>
   </head>
   <body>

--- a/docs/fiddles/native-ui/notifications/index.html
+++ b/docs/fiddles/native-ui/notifications/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Desktop notifications</title>
   </head>
   <body>

--- a/docs/fiddles/tutorial-first-app/index.html
+++ b/docs/fiddles/tutorial-first-app/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <meta
       http-equiv="X-Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <title>Hello from Electron renderer!</title>
   </head>
   <body>

--- a/docs/fiddles/tutorial-preload/index.html
+++ b/docs/fiddles/tutorial-preload/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <meta
       http-equiv="X-Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <title>Hello from Electron renderer!</title>
   </head>
   <body>

--- a/docs/fiddles/windows/manage-windows/frameless-window/index.html
+++ b/docs/fiddles/windows/manage-windows/frameless-window/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Frameless window</title>
   </head>
 

--- a/docs/fiddles/windows/manage-windows/manage-window-state/index.html
+++ b/docs/fiddles/windows/manage-windows/manage-window-state/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Manage window state</title>
   </head>
 

--- a/docs/fiddles/windows/manage-windows/window-events/index.html
+++ b/docs/fiddles/windows/manage-windows/window-events/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Window events</title>
   </head>
 

--- a/docs/tutorial/tutorial-2-first-app.md
+++ b/docs/tutorial/tutorial-2-first-app.md
@@ -183,16 +183,16 @@ by creating a barebones web page in an `index.html` file in the root folder of y
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <meta
       http-equiv="X-Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <title>Hello from Electron renderer!</title>
   </head>
   <body>

--- a/docs/tutorial/tutorial-3-preload.md
+++ b/docs/tutorial/tutorial-3-preload.md
@@ -131,15 +131,15 @@ and attach your `renderer.js` script:
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <meta
       http-equiv="X-Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"
-    />
+    >
     <title>Hello from Electron renderer!</title>
   </head>
   <body>


### PR DESCRIPTION
Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.

Ref:

- https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing
- https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none