### PR TITLE
chore: update patch description for fix_guard_webstoreprivateapi_factory_against_null_delegate.patch

### DIFF
--- a/patches/chromium/fix_guard_webstoreprivateapi_factory_against_null_delegate.patch
+++ b/patches/chromium/fix_guard_webstoreprivateapi_factory_against_null_delegate.patch
@@ -13,6 +13,16 @@ dereferenced a null delegate and crashed at startup.
 
 Skip building the factory when no delegate is available.
 
+This was proposed upstream at
+https://chromium-review.googlesource.com/c/chromium/src/+/8153762 but was
+rejected: Chromium generally does not accept patches that only support a
+specific embedder configuration, since guarding against embedder-specific
+state (such as a possibly-null delegate) is not tenable for the project to
+maintain and could mask genuine Chromium bugs. The upstream guidance is for
+Electron to keep patching this code or to provide a "stub" delegate
+implementation instead.  Since Electron does not support the webstorePrivate
+API, it is more concise to carry this patch.
+
 diff --git a/extensions/browser/api/webstore_private/webstore_private_api.cc b/extensions/browser/api/webstore_private/webstore_private_api.cc
 index 7702598c7136bb482abaca5d58a84788e2d0469b..fe048d37126c5465a8d8aa8bb2539a86a013bde4 100644
 --- a/extensions/browser/api/webstore_private/webstore_private_api.cc


### PR DESCRIPTION
#### Description of Change
An attempt was made to upstream patches/chromium/fix_guard_webstoreprivateapi_factory_against_null_delegate.patch to chromium but it was rejected (https://chromium-review.googlesource.com/c/chromium/src/+/8153762).  This PR updates the patch description to explain that rejection/why this patch can't be upstreamed.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
