### PR TITLE
build: add extensions_renderer_generated_resources.pak

### DIFF
--- a/build/electron_paks.gni
+++ b/build/electron_paks.gni
@@ -112,6 +112,7 @@ template("electron_extra_paks") {
     if (enable_electron_extensions) {
       sources += [
         "$root_gen_dir/chrome/component_extension_resources.pak",
+        "$root_gen_dir/extensions/extensions_renderer_generated_resources.pak",
         "$root_gen_dir/extensions/extensions_renderer_resources.pak",
         "$root_gen_dir/extensions/extensions_resources.pak",
       ]


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/52265

As stated in the thread of the issue, the extensions renderer bindings moved into `extensions_renderer_generated_resources.pak` in Chromium 150, but `build/electron_paks.gni` was never updated to repack it, resulting in the error. This change was included in `main` and `44-x-y` via https://github.com/electron/electron/pull/51804. Given that PR has a number of other changes it in that might make it harder to backport, just the necessary change was extracted from it here.

Fiddles used for testing:
- https://gist.github.com/mlaurencin/46915c5cb32a8ccf7ada1fce207982b9
- https://gist.github.com/mlaurencin/f13a908d52ed8dc9bc5d4c04da224ef0

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed bindings for MV3 service workers
