### PR TITLE
fix: validate protocol scheme names in RegisterSchemesAsPrivileged

### DIFF
--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -120,6 +120,16 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
   }
 
   for (const auto& custom_scheme : custom_schemes) {
+    // Schemes are comma-separated for --*-schemes. Sanitize names so
+    // extra commas don't trick child processes into splitting one
+    // scheme into many.
+    if (!Browser::IsValidProtocolScheme(custom_scheme.scheme)) {
+      thrower.ThrowError(
+          "Invalid scheme name '" + custom_scheme.scheme +
+          "'. Scheme names must start with an ASCII letter and contain only "
+          "ASCII letters, digits, '+', '-', or '.'.");
+      return;
+    }
     if (custom_scheme.options.codeCache && !custom_scheme.options.standard) {
       thrower.ThrowError(
           "Code cache can only be enabled when the custom scheme is registered "

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -62,8 +62,11 @@ struct Converter<CustomScheme> {
       return false;
     if (!dict.Get("scheme", &(out->scheme)))
       return false;
-    if (!electron::Browser::IsValidProtocolScheme(out->scheme))
+    if (!electron::Browser::IsValidProtocolScheme(out->scheme)) {
+      isolate->ThrowException(v8::Exception::Error(gin::StringToV8(
+          isolate, "Invalid scheme name '" + out->scheme + "'")));
       return false;
+    }
 
     gin::Dictionary opt(isolate);
     // options are optional. Default values specified in SchemeOptions are used
@@ -116,9 +119,14 @@ void AddServiceWorkerScheme(const std::string& scheme) {
 
 void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val) {
+  v8::TryCatch try_catch(thrower.isolate());
   std::vector<CustomScheme> custom_schemes;
   if (!gin::ConvertFromV8(thrower.isolate(), val, &custom_schemes)) {
-    thrower.ThrowError("Argument must be an array of custom schemes.");
+    if (try_catch.HasCaught()) {
+      try_catch.ReThrow();
+    } else {
+      thrower.ThrowError("Argument must be an array of custom schemes.");
+    }
     return;
   }
 

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -62,6 +62,9 @@ struct Converter<CustomScheme> {
       return false;
     if (!dict.Get("scheme", &(out->scheme)))
       return false;
+    if (!electron::Browser::IsValidProtocolScheme(out->scheme))
+      return false;
+
     gin::Dictionary opt(isolate);
     // options are optional. Default values specified in SchemeOptions are used
     if (dict.Get("privileges", &opt)) {
@@ -120,13 +123,6 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
   }
 
   for (const auto& custom_scheme : custom_schemes) {
-    if (!electron::Browser::IsValidProtocolScheme(custom_scheme.scheme)) {
-      thrower.ThrowError(
-          "Invalid protocol scheme \"" + custom_scheme.scheme +
-          "\". Schemes cannot contain commas, spaces, or special characters.");
-      return;
-    }
-
     if (custom_scheme.options.codeCache && !custom_scheme.options.standard) {
       thrower.ThrowError(
           "Code cache can only be enabled when the custom scheme is registered "

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -120,6 +120,13 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
   }
 
   for (const auto& custom_scheme : custom_schemes) {
+    if (!electron::Browser::IsValidProtocolScheme(custom_scheme.scheme)) {
+      thrower.ThrowError(
+          "Invalid protocol scheme \"" + custom_scheme.scheme +
+          "\". Schemes cannot contain commas, spaces, or special characters.");
+      return;
+    }
+
     if (custom_scheme.options.codeCache && !custom_scheme.options.standard) {
       thrower.ThrowError(
           "Code cache can only be enabled when the custom scheme is registered "

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -916,6 +916,19 @@ describe('protocol module', () => {
       expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
+
+    it('throws an error for invalid protocol scheme', () => {
+      const appPath = path.join(fixturesPath, 'apps', 'remote-control');
+      const result = ChildProcess.spawnSync(process.execPath, [
+        appPath,
+        '--boot-eval=try { require("electron").protocol.registerSchemesAsPrivileged([{ scheme: "foo,bar", privileges: { standard: true } }]); } catch (e) { console.log(e.message); } process.exit(0);'
+      ]);
+
+      const stdout = result.stdout.toString();
+
+      expect(result.status).to.equal(0);
+      expect(stdout).to.include("Invalid scheme name 'foo,bar'");
+    });
   });
 
   describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {
@@ -946,17 +959,6 @@ describe('protocol module', () => {
     it('should be able to register service worker for custom scheme', async () => {
       await contents.loadURL(`${serviceWorkerScheme}://${v4()}.com`);
       await contents.executeJavaScript(`navigator.serviceWorker.register('${v4()}.js', {scope: './'})`);
-    });
-
-    it('throws an error for invalid protocol scheme', () => {
-      const appPath = path.join(fixturesPath, 'apps', 'remote-control');
-      const result = ChildProcess.spawnSync(process.execPath, [
-        appPath,
-        '--boot-eval=try { require("electron").protocol.registerSchemesAsPrivileged([{ scheme: "foo,bar", privileges: { standard: true } }]); } catch (e) { console.error(e.message); } process.exit(0);'
-      ]);
-      const stderr = result.stderr.toString();
-      expect(stderr).to.match(/invalid character/i);
-      expect(result.status).to.equal(0);
     });
   });
 

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -954,7 +954,9 @@ describe('protocol module', () => {
         appPath,
         '--boot-eval=try { require("electron").protocol.registerSchemesAsPrivileged([{ scheme: "foo,bar", privileges: { standard: true } }]); } catch (e) { console.error(e.message); } process.exit(0);'
       ]);
-      expect(result.stderr.toString()).to.include('Invalid protocol scheme');
+      const stderr = result.stderr.toString();
+      expect(stderr).to.match(/invalid character/i);
+      expect(result.status).to.equal(0);
     });
   });
 

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -947,6 +947,15 @@ describe('protocol module', () => {
       await contents.loadURL(`${serviceWorkerScheme}://${v4()}.com`);
       await contents.executeJavaScript(`navigator.serviceWorker.register('${v4()}.js', {scope: './'})`);
     });
+
+    it('throws an error for invalid protocol scheme', () => {
+      const appPath = path.join(fixturesPath, 'apps', 'remote-control');
+      const result = ChildProcess.spawnSync(process.execPath, [
+        appPath,
+        '--boot-eval=try { require("electron").protocol.registerSchemesAsPrivileged([{ scheme: "foo,bar", privileges: { standard: true } }]); } catch (e) { console.error(e.message); } process.exit(0);'
+      ]);
+      expect(result.stderr.toString()).to.include('Invalid protocol scheme');
+    });
   });
 
   describe('protocol.registerSchemesAsPrivileged standard', () => {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -960,6 +960,43 @@ describe('protocol module', () => {
       expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
+
+    it('throws for invalid scheme names', () => {
+      const appPath = path.join(fixturesPath, 'apps', 'remote-control');
+      const bootEval = `
+        const { protocol } = require('electron');
+        const results = {};
+        for (const scheme of ['foo,bar', '1foo', 'foo_bar', '', 'foo-bar.baz+qux']) {
+          try {
+            protocol.registerSchemesAsPrivileged([{ scheme, privileges: { standard: true } }]);
+            results[scheme] = null;
+          } catch (e) {
+            results[scheme] = e.message;
+          }
+        }
+        console.log(JSON.stringify(results));
+        process.exit(0);
+      `;
+      const result = ChildProcess.spawnSync(process.execPath, [appPath, `--boot-eval=${bootEval}`]);
+
+      const stdout = result.stdout.toString();
+      expect(result.status, `stdout: ${stdout}\nstderr: ${result.stderr.toString()}`).to.equal(0);
+
+      const line = stdout.split('\n').find((l) => l.startsWith('{'));
+      expect(line, `unexpected stdout: ${stdout}`).to.be.a('string');
+
+      const invalid = (scheme: string) => `Invalid scheme name '${scheme}'. Scheme names must ` +
+        "start with an ASCII letter and contain only ASCII letters, digits, '+', '-', or '.'.";
+
+      expect(JSON.parse(line!)).to.deep.equal({
+        'foo,bar': invalid('foo,bar'),
+        '1foo': invalid('1foo'),
+        'foo_bar': invalid('foo_bar'),
+        '': invalid(''),
+        // A valid RFC 3986 scheme still registers.
+        'foo-bar.baz+qux': null
+      });
+    });
   });
 
   describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -985,13 +985,14 @@ describe('protocol module', () => {
       const line = stdout.split('\n').find((l) => l.startsWith('{'));
       expect(line, `unexpected stdout: ${stdout}`).to.be.a('string');
 
-      const invalid = (scheme: string) => `Invalid scheme name '${scheme}'. Scheme names must ` +
+      const invalid = (scheme: string) =>
+        `Invalid scheme name '${scheme}'. Scheme names must ` +
         "start with an ASCII letter and contain only ASCII letters, digits, '+', '-', or '.'.";
 
       expect(JSON.parse(line!)).to.deep.equal({
         'foo,bar': invalid('foo,bar'),
         '1foo': invalid('1foo'),
-        'foo_bar': invalid('foo_bar'),
+        foo_bar: invalid('foo_bar'),
         '': invalid(''),
         // A valid RFC 3986 scheme still registers.
         'foo-bar.baz+qux': null


### PR DESCRIPTION
#### Description of Change

Fixes #52484

This PR adds validation of `protocol.registerSchemesAsPrivileged()` for customScheme. scheme is now validated before registering it and forwarding it to child processes.


#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: Added validation to `protocol.registerSchemesAsPrivileged()` to reject protocol names that do not conform to RFC 3986 URI scheme grammar.