### PR TITLE
docs: add faynoSync to the list of update servers

### DIFF
--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -173,6 +173,9 @@ Depending on your needs, you can choose from one of these:
 - [Nucleus][nucleus] – A complete update server for Electron apps maintained by
   Atlassian. Supports multiple applications and channels; uses a static file store
   to minify server cost.
+- [faynoSync][faynosync] – Self-hosted update server that stores artifacts in any
+  S3-compatible bucket. Supports multiple applications, release channels and staged
+  rollouts, and collects update statistics and crash reports.
 
 Once you've deployed your update server, you can instrument your app code to receive and
 apply the updates with Electron's [autoUpdater](../api/auto-updater.md) module.
@@ -321,5 +324,6 @@ HTTP response.
 [gh-releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release
 [electron-release-server]: https://github.com/ArekSredzki/electron-release-server
 [nucleus]: https://github.com/atlassian/nucleus
+[faynosync]: https://github.com/ku9nov/faynoSync
 [update.electronjs.org]: https://github.com/electron/update.electronjs.org
 [update-electron-app]: https://github.com/electron/update-electron-app


### PR DESCRIPTION
#### Description of Change

Adds [faynoSync](https://github.com/ku9nov/faynoSync) to the list of update servers in "Step 1: Deploying an update server".

The tutorial's Step 2 builds on Electron's built-in `autoUpdater`, so anything listed here has to speak the Squirrel protocols. faynoSync does: `squirrel_darwin` returns the JSON payload with the `url` field and a `204 No Content` when no update is available, and `squirrel_windows` serves a rewritten `RELEASES` feed with absolute URLs so Squirrel pulls each `.nupkg` straight from storage. There is a runnable [Squirrel example app](https://github.com/ku9nov/faynoSync-squirrel-example) for this flow.

What it offers next to the existing entries:

- Artifacts live in any S3-compatible bucket (AWS S3, Garage/MinIO, DigitalOcean Spaces, GCS) rather than GitHub Releases or local disk.
- Staged rollouts - the update check returns a percentage plus a seed fixed at upload time, so buckets are deterministic and a device already in the cohort stays in it as you ramp up.
- Update statistics per app, showing how many clients run the latest version versus an outdated one.
- Crash and event reports grouped by signature hash, with a triage lifecycle and automatic reopen on regression.
- Release channels, critical releases and mandatory intermediate versions for upgrades across a breaking migration.

Apps can consume updates in more than one way. Beyond the built-in `autoUpdater`, faynoSync also hosts electron-builder feeds: the latest*.yml / latest-mac.yml produced by your build is uploaded together with the artifacts and served back from the feed directory, so electron-updater can be pointed straight at it. The recommended setup for that path is the [JS/TS SDK](https://github.com/ku9nov/faynosync-sdk-js) alongside `electron-updater`: the `*.yml` feed only describes the artifact and does not carry faynoSync's `changelog`, `critical` or `isIntermediateRequired` flags. So the app takes the yml package URL from the SDK's `checkForUpdates` response, derives its parent directory as the feed URL for `electron-updater`, and keeps reading the display fields from the same SDK response. One server response then serves both a manual "pick a package" UI and the automatic update flow, without losing the critical-update styling or the intermediate-update signal. This is written up in the [Electron example docs](https://faynosync.com/docs/examples/electron), with the app itself at [faynoSync-electron-example](https://github.com/ku9nov/faynoSync-electron-example).

faynoSync is Apache-2.0, written in Go, public since January 2023 and actively maintained, with Go unit tests and a Docker Compose integration suite in CI. There is a Docker Compose quickstart, a web dashboard, a CLI, JS and Go SDKs, and documentation at [faynosync.com](https://faynosync.com/).

Disclosure: I maintain faynoSync. Happy to trim the entry down if it reads long next to the others.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
