### PR TITLE
build: build siso per host so a cache miss only reruns that platform

### DIFF
--- a/.github/workflows/apply-patches.yml
+++ b/.github/workflows/apply-patches.yml
@@ -88,9 +88,31 @@ jobs:
         if-no-files-found: ignore
         archive: false
 
-  build-siso:
+  # Validate that the siso patches still apply and build for each CI build host.
+  # Each host is a separate job so a re-run for one host only re-runs that host.
+  build-siso-macos:
     needs: setup
     if: ${{ needs.setup.outputs.has-siso-patches == 'true' }}
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: darwin-arm64
+
+  build-siso-linux:
+    needs: setup
+    if: ${{ needs.setup.outputs.has-siso-patches == 'true' }}
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: linux-amd64
+
+  build-siso-windows:
+    needs: setup
+    if: ${{ needs.setup.outputs.has-siso-patches == 'true' }}
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: windows-amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,15 +221,37 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
-  # Build patched siso binaries for every CI build host (windows-amd64,
-  # linux-amd64, darwin-arm64) in parallel with the checkout jobs. The build
-  # jobs download the host-matching artifact and use it via SISO_PATH.
-  build-siso:
+  # Build the patched siso binary for each CI build host (windows-amd64,
+  # linux-amd64, darwin-arm64) in parallel with the checkout jobs. Each host is
+  # a separate job so a cache miss or re-run for one host only blocks that
+  # host's build jobs. The build jobs download the host-matching artifact and
+  # use it via SISO_PATH.
+  build-siso-macos:
     needs: setup
     if: ${{ needs.setup.outputs.src == 'true' }}
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: darwin-arm64
+
+  build-siso-linux:
+    needs: setup
+    if: ${{ needs.setup.outputs.src == 'true' }}
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: linux-amd64
+
+  build-siso-windows:
+    needs: setup
+    if: ${{ needs.setup.outputs.src == 'true' }}
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: windows-amd64
 
   # GN Check Jobs
   macos-gn-check:
@@ -275,7 +297,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: [checkout-macos, build-siso]
+    needs: [checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
       test-runs-on: macos-15-large
@@ -294,7 +316,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
-    needs: [checkout-macos, build-siso]
+    needs: [checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
       clang-tidy-runs-on: macos-15-xlarge
@@ -314,7 +336,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
-    needs: [checkout-linux, build-siso]
+    needs: [checkout-linux, build-siso-linux]
     if: ${{ needs.setup.outputs.src == 'true' }}
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
@@ -337,7 +359,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: [checkout-linux, build-siso]
+    needs: [checkout-linux, build-siso-linux]
     if: ${{ needs.setup.outputs.src == 'true' }}
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
@@ -359,7 +381,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: [checkout-linux, build-siso]
+    needs: [checkout-linux, build-siso-linux]
     if: ${{ needs.setup.outputs.src == 'true' }}
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
@@ -392,7 +414,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
-    needs: [checkout-windows, build-siso]
+    needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -413,7 +435,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: [checkout-windows, build-siso]
+    needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
@@ -431,7 +453,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [docs-only, checkout-macos, checkout-linux, checkout-windows, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm64, build-siso, windows-x64, windows-arm64]
+    needs: [docs-only, checkout-macos, checkout-linux, checkout-windows, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-arm64, build-siso-macos, build-siso-linux, build-siso-windows, windows-x64, windows-arm64]
     if: always() && github.repository == 'electron/electron'
     steps:
     - name: Fail if any needed job failed or was cancelled

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -59,13 +59,15 @@ jobs:
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
 
-  # Build the patched siso binaries in parallel with checkout-linux; the
+  # Build the patched siso binary in parallel with checkout-linux; the
   # publish jobs consume the linux-amd64 artifact via SISO_PATH.
   build-siso:
     needs: setup
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: linux-amd64
 
   publish-x64:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -62,7 +62,7 @@ jobs:
         generate-sas-token: 'true'
         target-platform: macos
 
-  # Build the patched siso binaries in parallel with checkout-macos; the
+  # Build the patched siso binary in parallel with checkout-macos; the
   # publish jobs consume the darwin-arm64 artifact via SISO_PATH (macOS builds,
   # x64 and arm64, run on arm64 hosts).
   build-siso:
@@ -70,6 +70,8 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: darwin-arm64
 
   publish-x64-darwin:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -142,13 +142,33 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
-  # All builds need the patched siso binary (same as build.yml); the matrix
-  # produces windows-amd64, linux-amd64 and darwin-arm64 artifacts.
-  build-siso:
+  # All builds need the patched siso binary (same as build.yml). Each host is a
+  # separate job so a cache miss or re-run for one host only blocks that host's
+  # builds; they produce the windows-amd64, linux-amd64 and darwin-arm64
+  # artifacts.
+  build-siso-macos:
     needs: setup
     permissions:
       contents: read
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    with:
+      host: darwin-arm64
+
+  build-siso-linux:
+    needs: setup
+    permissions:
+      contents: read
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    with:
+      host: linux-amd64
+
+  build-siso-windows:
+    needs: setup
+    permissions:
+      contents: read
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    with:
+      host: windows-amd64
 
   # ---------------------------------------------------------------------------
   # Instrumented builds (gn-build-type: pgo-instrument -> build/args/pgo-instrument.gn)
@@ -160,7 +180,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-linux, build-siso]
+    needs: [checkout-linux, build-siso-linux]
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
@@ -180,7 +200,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-linux, build-siso]
+    needs: [checkout-linux, build-siso-linux]
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
@@ -200,7 +220,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-macos, build-siso]
+    needs: [checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
       target-platform: macos
@@ -220,7 +240,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-macos, build-siso]
+    needs: [checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
       target-platform: macos
@@ -240,7 +260,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-windows, build-siso]
+    needs: [checkout-windows, build-siso-windows]
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
       target-platform: win
@@ -259,7 +279,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-windows, build-siso]
+    needs: [checkout-windows, build-siso-windows]
     with:
       build-runs-on: electron-arc-centralus-windows-amd64-16core
       target-platform: win

--- a/.github/workflows/pipeline-segment-build-siso.yml
+++ b/.github/workflows/pipeline-segment-build-siso.yml
@@ -1,20 +1,28 @@
 name: Pipeline Segment - Build Siso
 
-# Builds a patched siso binary for every CI build host. Reads the siso revision
-# from the Chromium DEPS file at the pinned chromium_version, shallow-clones
-# chromium.googlesource.com/build at that revision, applies the patches under
-# .github/siso-patches/, and cross-compiles siso for each build host:
-# windows/amd64, linux/amd64 and darwin/arm64. siso runs on the build host (not
-# the target), so these three host arches cover every build job: Windows targets
-# use siso-windows-amd64, Linux targets (any arch) use siso-linux-amd64, and
-# macOS targets (x64 or arm64) use siso-darwin-arm64 because the macOS build
-# hosts are arm64. Each binary is published as a distinct artifact that the build
-# and publish jobs download and use via SISO_PATH. The built binary is cached
-# keyed on the siso revision + sha256 of the patch contents, so subsequent runs
-# just restore it.
+# Builds a patched siso binary for a single CI build host. Reads the siso
+# revision from the Chromium DEPS file at the pinned chromium_version,
+# shallow-clones chromium.googlesource.com/build at that revision, applies the
+# patches under .github/siso-patches/, and cross-compiles siso for the requested
+# build host. siso runs on the build host (not the target), so three host arches
+# cover every build job: Windows targets use windows-amd64, Linux targets (any
+# arch) use linux-amd64, and macOS targets (x64 or arm64) use darwin-arm64
+# because the macOS build hosts are arm64. Each caller invokes this segment once
+# per host it needs, so a cache miss (or manual re-run) for one host only affects
+# that host's builds rather than every platform. The binary is published as the
+# artifact siso-<host> that the build and publish jobs download and use via
+# SISO_PATH, and is cached keyed on the siso revision + sha256 of the patch
+# contents, so subsequent runs just restore it.
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      host:
+        description: >-
+          Build host to compile siso for: windows-amd64, linux-amd64 or
+          darwin-arm64.
+        required: true
+        type: string
 
 permissions: {}
 
@@ -23,23 +31,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - goos: windows
-            goarch: amd64
-            artifact: siso-windows-amd64
-            binary: siso.exe
-          - goos: linux
-            goarch: amd64
-            artifact: siso-linux-amd64
-            binary: siso
-          - goos: darwin
-            goarch: arm64
-            artifact: siso-darwin-arm64
-            binary: siso
     steps:
+    - name: Resolve host build parameters
+      id: host
+      env:
+        HOST: ${{ inputs.host }}
+      run: |
+        set -euo pipefail
+        case "$HOST" in
+          windows-amd64) goos=windows; goarch=amd64; binary=siso.exe ;;
+          linux-amd64)   goos=linux;   goarch=amd64; binary=siso ;;
+          darwin-arm64)  goos=darwin;  goarch=arm64; binary=siso ;;
+          *) echo "error: unsupported host: $HOST" >&2; exit 1 ;;
+        esac
+        {
+          echo "goos=${goos}"
+          echo "goarch=${goarch}"
+          echo "binary=${binary}"
+        } >> "$GITHUB_OUTPUT"
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -72,8 +81,8 @@ jobs:
       id: cache-siso
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: siso-out/${{ matrix.binary }}
-        key: siso-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
+        path: siso-out/${{ steps.host.outputs.binary }}
+        key: siso-${{ inputs.host }}-${{ steps.resolve.outputs.siso-sha }}-${{ steps.resolve.outputs.patches-hash }}
     - name: Shallow clone chromium build repo at pinned revision
       if: steps.cache-siso.outputs.cache-hit != 'true'
       env:
@@ -114,20 +123,20 @@ jobs:
       # because it drives the spawn helper end-to-end.
       run: |
         go test ./execute/spawnhelper/ ./execute/localexec/
-    - name: Build siso (${{ matrix.goos }}/${{ matrix.goarch }})
+    - name: Build siso (${{ inputs.host }})
       if: steps.cache-siso.outputs.cache-hit != 'true'
       working-directory: chromium-build/siso
       env:
         CGO_ENABLED: '0'
-        GOOS: ${{ matrix.goos }}
-        GOARCH: ${{ matrix.goarch }}
+        GOOS: ${{ steps.host.outputs.goos }}
+        GOARCH: ${{ steps.host.outputs.goarch }}
       run: |
         mkdir -p "${GITHUB_WORKSPACE}/siso-out"
-        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/${{ matrix.binary }}" .
+        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/${{ steps.host.outputs.binary }}" .
     - name: Upload siso artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ matrix.artifact }}
-        path: siso-out/${{ matrix.binary }}
+        name: siso-${{ inputs.host }}
+        path: siso-out/${{ steps.host.outputs.binary }}
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -122,18 +122,38 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
-  # Build patched siso binaries for every CI build host (windows-amd64,
-  # linux-amd64, darwin-arm64) in parallel with the checkout jobs; the build
-  # jobs consume the host-matching artifact via SISO_PATH.
-  build-siso:
+  # Build the patched siso binary for each CI build host (windows-amd64,
+  # linux-amd64, darwin-arm64) in parallel with the checkout jobs; each host is
+  # a separate job so a cache miss or re-run for one host only blocks that
+  # host's build. The build jobs consume the host-matching artifact via
+  # SISO_PATH.
+  build-siso-macos:
     needs: setup
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: darwin-arm64
+
+  build-siso-linux:
+    needs: setup
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: linux-amd64
+
+  build-siso-windows:
+    needs: setup
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: windows-amd64
 
   macos:
     name: macos-${{ matrix.target-arch }}-${{ matrix.target-variant }}
-    needs: [checkout-macos, build-siso]
+    needs: [checkout-macos, build-siso-macos]
     permissions:
       contents: read
     strategy:
@@ -162,7 +182,7 @@ jobs:
 
   linux:
     name: linux-${{ matrix.target-arch }}
-    needs: [setup, checkout-linux, build-siso]
+    needs: [setup, checkout-linux, build-siso-linux]
     permissions:
       contents: read
     strategy:
@@ -185,7 +205,7 @@ jobs:
 
   windows:
     name: windows-${{ matrix.target-arch }}
-    needs: [checkout-windows, build-siso]
+    needs: [checkout-windows, build-siso-windows]
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -64,13 +64,15 @@ jobs:
         generate-sas-token: 'true'
         target-platform: win
 
-  # Build the patched siso binaries in parallel with checkout-windows; the
+  # Build the patched siso binary in parallel with checkout-windows; the
   # publish-*-win jobs consume the windows-amd64 artifact via SISO_PATH.
   build-siso:
     needs: setup
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
+    with:
+      host: windows-amd64
 
   publish-x64-win:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml


### PR DESCRIPTION
#### Description of Change
Currently `pipeline-segment-build-siso.yml` builds all three host binaries (windows-amd64, linux-amd64, darwin-arm64) in a single matrix job, and every downstream build/publish job depends on that one job. Because GitHub Actions dependencies are job-level, a cache miss or manual re-run for a single host forced the whole siso job — and therefore every platform's builds — to re-run.

Additionally, the release jobs were running the jobs to build all three binaries, eg linux builds (or at least checks the cache for) mac: https://github.com/electron/electron/actions/runs/30454044312/job/90583265600

This PR changes `pipeline-segment-build-siso.yml` to include a parameter to specify which host to build for so it builds exactly one binary per invocation. Callers now instantiate one siso job per host they actually need, and each build job depends only on its own host's siso job. A cache miss or re-run for one host is now isolated to that host's builds.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
