### PR TITLE
chore: add triage-prs skill and script

### DIFF
--- a/.claude/skills/triage-prs/SKILL.md
+++ b/.claude/skills/triage-prs/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: triage-prs
+description: Find open electron/electron pull requests by their CI status — PRs with green (passing) checks, failing checks, still-pending checks, or no checks running at all, optionally annotated with their Status on the "PR Triage" project board. Also scopes to a single named check (e.g. find PRs whose "faraday/cage" check is pending or failing). Use when asked to list PRs with passing/green CI, find mergeable PRs, find PRs with failing CI, find PRs with no checks running, find PRs with a pending/failing faraday/cage (or other named) check, classify open PRs by their check status, or show each PR's triage/board status. When the request is simply "faraday", run the faraday shortcut described below; when it is simply "failing", run the failing shortcut described below.
+---
+
+# Find PRs By CI Status
+
+Lists open (non-draft) pull requests filtered by their GitHub checks. Backed by
+the bundled script [`script/triage-prs.sh`](../../../script/triage-prs.sh).
+
+## Shortcuts
+
+- **`faraday`** — when the user says just "faraday" (or "faraday prs",
+  "pending faraday", etc.), run:
+
+  ```bash
+  ./script/triage-prs.sh --check "faraday/cage" --status pending
+  ```
+
+  This lists open PRs whose `faraday/cage` check is still pending.
+
+- **`failing`** — when the user says just "failing" (or "failing prs",
+  "failing ci", etc.), run:
+
+  ```bash
+  ./script/triage-prs.sh --status failing
+  ```
+
+  This lists open PRs whose checks are failing.
+
+By default, evaluation is scoped to the **"GitHub Actions Completed"** check —
+Electron's umbrella check that reflects the overall GitHub Actions run. Pass
+`--check ""` to evaluate every check on the PR instead, or `--check "<name>"`
+for a different single check.
+
+Each PR is classified as one of:
+
+| Status    | Icon | Meaning |
+|-----------|------|---------|
+| `green`   | ✅   | All checks succeeded (`SUCCESS`/`NEUTRAL`/`SKIPPED`). |
+| `failing` | ❌   | At least one check failed (`FAILURE`/`ERROR`/`CANCELLED`/`TIMED_OUT`/…). |
+| `pending` | 🟡   | Checks exist but some are still running (`PENDING`/`IN_PROGRESS`/…). |
+| `none`    | ⚪   | No checks are running at all. |
+
+Each listed PR can also be annotated with its **Status** on the **"PR Triage"**
+GitHub project board (e.g. `[PR Triage: Needs Review]`). This is shown by
+default and requires the `gh` token to have the `read:project` scope; if the
+scope is missing the script prints a one-time note and omits the column.
+
+## Prerequisites
+
+- The [`gh`](https://cli.github.com/) CLI, authenticated (`gh auth login`).
+- `jq` on `PATH`.
+- To show the triage board Status column, the token needs the `read:project`
+  scope. Grant it with:
+
+  ```bash
+  gh auth refresh -s read:project
+  ```
+
+## Usage
+
+Run the script from the repo root:
+
+```bash
+# Green PRs (default), 200 most recent open PRs in electron/electron
+./script/triage-prs.sh
+
+# Filter by a different status
+./script/triage-prs.sh --status failing
+./script/triage-prs.sh --status none
+./script/triage-prs.sh --status pending
+
+# Classify every scanned PR and show its status
+./script/triage-prs.sh --status all
+
+# Scan more PRs
+./script/triage-prs.sh --status failing --limit 100
+
+# Target another repo, or change the check scope
+./script/triage-prs.sh --repo electron/electron --limit 100
+./script/triage-prs.sh --check ""          # evaluate all checks
+./script/triage-prs.sh --check "macos-x64 / build / build"
+
+# Scope to a single named check, e.g. find PRs whose faraday/cage is pending
+./script/triage-prs.sh --check "faraday/cage" --status pending
+./script/triage-prs.sh --check "faraday/cage" --status failing
+
+# Triage board Status column
+./script/triage-prs.sh --no-triage                  # hide the Status column
+./script/triage-prs.sh --triage-project "PR Triage" # read a different board
+```
+
+Environment variables `REPO`, `LIMIT`, `CHECK_NAME`, `STATUS`, `TRIAGE`, and
+`TRIAGE_PROJECT` are honored as defaults and can be overridden by the
+corresponding flags.
+
+## How it works
+
+1. `gh pr list --state open` enumerates open PR numbers (capped by `--limit`).
+   Draft PRs are skipped.
+2. For each PR, `gh pr view --json statusCheckRollup,title,url` returns the
+   checks on the PR head commit plus its title and URL (one API call per PR).
+3. The rollup mixes two shapes, both handled:
+   - **GitHub Actions** `CheckRun` entries expose `.name`, `.status`, and
+     `.conclusion`.
+   - **Legacy** `StatusContext` entries expose `.context` + `.state`.
+   By default only the **"GitHub Actions Completed"** check is considered;
+   `--check ""` widens evaluation to every check, and `--check <name>` scopes to
+   a different single check. The collected states are reduced to one
+   classification (`none` → `failing` → `pending` → `green`, in priority order).
+4. PRs matching the requested `--status` (or all of them, for `--status all`)
+   are printed as a clickable link followed by the title, with the raw PR URL on
+   the next line:
+
+   ```text
+   ✅ #52533  feat: support `restrictOwnAudio` constraint  [PR Triage: Needs Review]
+        https://github.com/electron/electron/pull/52533
+   ```
+
+   The `#<number>` is emitted as an [OSC 8 hyperlink](https://gist.github.com/egmontkob/eb114294efdcfddb1b38f3714a0de4d6)
+   pointing at the PR URL, so terminals that support it render it clickable; the
+   raw URL is always printed too for plain terminals and for easy copying. The
+   icon reflects the PR's classification (useful with `--status all`).
+5. Unless `--no-triage` is passed, a second call
+   (`gh api graphql … projectItems … fieldValueByName(name:"Status")`) fetches
+   the PR's Status on the **"PR Triage"** board and appends it as
+   `[PR Triage: <status>]`. PRs not on the board show no suffix. If the token
+   lacks the `read:project` scope, the column is skipped with a one-time note.
+
+## Reporting results
+
+When summarizing to the user, render each PR as a Markdown link so it is
+clickable in chat, e.g. `[#52533](https://github.com/electron/electron/pull/52533) — feat: support restrictOwnAudio constraint`.
+The script's output includes the PR URL on the second line for each entry, so
+use that URL directly.
+
+When a PR carries the `new-pr` label (the script appends a `[new-pr]` marker),
+indicate it in the summary with the plain text `[new-pr]` rather than an emoji.
+
+## Interpreting results
+
+- With a status filter (the default is `green`), only PRs whose classification
+  matches are listed; all others are omitted.
+- `none` means the PR genuinely has no checks at all (nothing has been
+  triggered yet), which is different from `pending` (checks exist but haven't
+  finished).
+- Because evaluation defaults to the **"GitHub Actions Completed"** check, a PR
+  reads as `pending` while its other checks run but that umbrella check has not
+  been posted yet, then flips to `green`/`failing` once the umbrella check
+  reports. A PR is only `none` when it has zero checks whatsoever. Use
+  `--check ""` to judge by all checks instead.
+
+## Adjusting the criteria
+
+- Use `--status green|failing|pending|none|all` to choose which PRs to show.
+- Use `--check "<check name>"` to evaluate a different single check, or
+  `--check ""` to evaluate every check on the PR instead of the default
+  `"GitHub Actions Completed"`.
+- Use `--no-triage` to omit the board Status column, or `--triage-project`
+  `"<name>"` to read Status from a project other than `"PR Triage"`.
+- The classification buckets are defined by the `jq` expression in the script;
+  edit the `any($s[]; …)` clauses to change which conclusions count as failing
+  or pending.

--- a/.claude/skills/triage-prs/SKILL.md
+++ b/.claude/skills/triage-prs/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: triage-prs
-description: Find open electron/electron pull requests by their CI status — PRs with green (passing) checks, failing checks, still-pending checks, or no checks running at all, optionally annotated with their Status on the "PR Triage" project board. Also scopes to a single named check (e.g. find PRs whose "faraday/cage" check is pending or failing). Use when asked to list PRs with passing/green CI, find mergeable PRs, find PRs with failing CI, find PRs with no checks running, find PRs with a pending/failing faraday/cage (or other named) check, classify open PRs by their check status, or show each PR's triage/board status. When the request is simply "faraday", run the faraday shortcut described below; when it is simply "failing", run the failing shortcut described below.
+description: Triage open electron/electron pull requests by CI check status — lists PRs that are green/passing, failing, still pending, or have no checks at all, annotated with their Status on the "PR Triage" project board and with the new-pr label. Can scope to a single named check, e.g. PRs whose "faraday/cage" check is pending. Use when asked to triage PRs or do PR triage, list green/passing or mergeable PRs, find PRs with failing or pending CI, find PRs with no checks running, check faraday/cage status, or show each PR's triage board status. Also triggers on the bare words "faraday" or "failing prs".
 ---
 
-# Find PRs By CI Status
+# Triage PRs By CI Status
 
-Lists open (non-draft) pull requests filtered by their GitHub checks. Backed by
-the bundled script [`script/triage-prs.sh`](../../../script/triage-prs.sh).
+Lists open pull requests filtered by their GitHub checks. Backed by the bundled
+script [`triage-prs.sh`](./triage-prs.sh), which lives alongside this file.
 
 ## Shortcuts
 
@@ -14,16 +14,16 @@ the bundled script [`script/triage-prs.sh`](../../../script/triage-prs.sh).
   "pending faraday", etc.), run:
 
   ```bash
-  ./script/triage-prs.sh --check "faraday/cage" --status pending
+  .claude/skills/triage-prs/triage-prs.sh --check "faraday/cage" --status pending
   ```
 
   This lists open PRs whose `faraday/cage` check is still pending.
 
-- **`failing`** — when the user says just "failing" (or "failing prs",
-  "failing ci", etc.), run:
+- **`failing`** — when the user says just "failing prs" (or "failing ci" in the
+  context of PR triage), run:
 
   ```bash
-  ./script/triage-prs.sh --status failing
+  .claude/skills/triage-prs/triage-prs.sh --status failing
   ```
 
   This lists open PRs whose checks are failing.
@@ -42,7 +42,7 @@ Each PR is classified as one of:
 | `pending` | 🟡   | Checks exist but some are still running (`PENDING`/`IN_PROGRESS`/…). |
 | `none`    | ⚪   | No checks are running at all. |
 
-Each listed PR can also be annotated with its **Status** on the **"PR Triage"**
+Each listed PR is also annotated with its **Status** on the **"PR Triage"**
 GitHub project board (e.g. `[PR Triage: Needs Review]`). This is shown by
 default and requires the `gh` token to have the `read:project` scope; if the
 scope is missing the script prints a one-time note and omits the column.
@@ -58,75 +58,59 @@ scope is missing the script prints a one-time note and omits the column.
   gh auth refresh -s read:project
   ```
 
+## Runtime
+
+The script makes up to two `gh` calls per PR, sequentially, so a full scan at
+the default `--limit 200` takes **several minutes** and consumes a few hundred
+API requests. Run it with an explicit long timeout (10 minutes is safe), or
+lower `--limit` for a quicker partial scan. Do not assume it has hung.
+
 ## Usage
 
 Run the script from the repo root:
 
 ```bash
 # Green PRs (default), 200 most recent open PRs in electron/electron
-./script/triage-prs.sh
+.claude/skills/triage-prs/triage-prs.sh
 
 # Filter by a different status
-./script/triage-prs.sh --status failing
-./script/triage-prs.sh --status none
-./script/triage-prs.sh --status pending
+.claude/skills/triage-prs/triage-prs.sh --status failing
+.claude/skills/triage-prs/triage-prs.sh --status none
+.claude/skills/triage-prs/triage-prs.sh --status pending
 
 # Classify every scanned PR and show its status
-./script/triage-prs.sh --status all
+.claude/skills/triage-prs/triage-prs.sh --status all
 
-# Scan more PRs
-./script/triage-prs.sh --status failing --limit 100
+# Scan fewer PRs for a faster result
+.claude/skills/triage-prs/triage-prs.sh --status failing --limit 50
 
 # Target another repo, or change the check scope
-./script/triage-prs.sh --repo electron/electron --limit 100
-./script/triage-prs.sh --check ""          # evaluate all checks
-./script/triage-prs.sh --check "macos-x64 / build / build"
+.claude/skills/triage-prs/triage-prs.sh --repo electron/forge --limit 50
+.claude/skills/triage-prs/triage-prs.sh --check ""          # evaluate all checks
+.claude/skills/triage-prs/triage-prs.sh --check "macos-x64 / build / build"
 
 # Scope to a single named check, e.g. find PRs whose faraday/cage is pending
-./script/triage-prs.sh --check "faraday/cage" --status pending
-./script/triage-prs.sh --check "faraday/cage" --status failing
+.claude/skills/triage-prs/triage-prs.sh --check "faraday/cage" --status pending
+.claude/skills/triage-prs/triage-prs.sh --check "faraday/cage" --status failing
 
 # Triage board Status column
-./script/triage-prs.sh --no-triage                  # hide the Status column
-./script/triage-prs.sh --triage-project "PR Triage" # read a different board
+.claude/skills/triage-prs/triage-prs.sh --no-triage                  # hide the Status column
+.claude/skills/triage-prs/triage-prs.sh --triage-project "PR Triage" # read a different board
 ```
 
 Environment variables `REPO`, `LIMIT`, `CHECK_NAME`, `STATUS`, `TRIAGE`, and
 `TRIAGE_PROJECT` are honored as defaults and can be overridden by the
 corresponding flags.
 
-## How it works
+Output is one entry per PR — an icon, a clickable
+[OSC 8 hyperlink](https://gist.github.com/egmontkob/eb114294efdcfddb1b38f3714a0de4d6)
+on the PR number, the title, and any markers — with the raw URL on the next
+line:
 
-1. `gh pr list --state open` enumerates open PR numbers (capped by `--limit`).
-   Draft PRs are skipped.
-2. For each PR, `gh pr view --json statusCheckRollup,title,url` returns the
-   checks on the PR head commit plus its title and URL (one API call per PR).
-3. The rollup mixes two shapes, both handled:
-   - **GitHub Actions** `CheckRun` entries expose `.name`, `.status`, and
-     `.conclusion`.
-   - **Legacy** `StatusContext` entries expose `.context` + `.state`.
-   By default only the **"GitHub Actions Completed"** check is considered;
-   `--check ""` widens evaluation to every check, and `--check <name>` scopes to
-   a different single check. The collected states are reduced to one
-   classification (`none` → `failing` → `pending` → `green`, in priority order).
-4. PRs matching the requested `--status` (or all of them, for `--status all`)
-   are printed as a clickable link followed by the title, with the raw PR URL on
-   the next line:
-
-   ```text
-   ✅ #52533  feat: support `restrictOwnAudio` constraint  [PR Triage: Needs Review]
-        https://github.com/electron/electron/pull/52533
-   ```
-
-   The `#<number>` is emitted as an [OSC 8 hyperlink](https://gist.github.com/egmontkob/eb114294efdcfddb1b38f3714a0de4d6)
-   pointing at the PR URL, so terminals that support it render it clickable; the
-   raw URL is always printed too for plain terminals and for easy copying. The
-   icon reflects the PR's classification (useful with `--status all`).
-5. Unless `--no-triage` is passed, a second call
-   (`gh api graphql … projectItems … fieldValueByName(name:"Status")`) fetches
-   the PR's Status on the **"PR Triage"** board and appends it as
-   `[PR Triage: <status>]`. PRs not on the board show no suffix. If the token
-   lacks the `read:project` scope, the column is skipped with a one-time note.
+```text
+✅ #52533  feat: support `restrictOwnAudio` constraint  [PR Triage: Needs Review]
+     https://github.com/electron/electron/pull/52533
+```
 
 ## Reporting results
 
@@ -140,6 +124,13 @@ indicate it in the summary with the plain text `[new-pr]` rather than an emoji.
 
 ## Interpreting results
 
+- Two categories of PR are **silently excluded** from every run, and neither is
+  reported in the totals. Say so when summarizing, so the output is not read as
+  the complete set of open PRs:
+  - **Draft** PRs.
+  - PRs whose **"PR Triage" board Status contains `WIP`** — these are treated as
+    not ready for review. Note that `--no-triage` skips the board lookup
+    entirely, so WIP PRs _are_ included when it is passed.
 - With a status filter (the default is `green`), only PRs whose classification
   matches are listed; all others are omitted.
 - `none` means the PR genuinely has no checks at all (nothing has been
@@ -150,15 +141,6 @@ indicate it in the summary with the plain text `[new-pr]` rather than an emoji.
   been posted yet, then flips to `green`/`failing` once the umbrella check
   reports. A PR is only `none` when it has zero checks whatsoever. Use
   `--check ""` to judge by all checks instead.
-
-## Adjusting the criteria
-
-- Use `--status green|failing|pending|none|all` to choose which PRs to show.
-- Use `--check "<check name>"` to evaluate a different single check, or
-  `--check ""` to evaluate every check on the PR instead of the default
-  `"GitHub Actions Completed"`.
-- Use `--no-triage` to omit the board Status column, or `--triage-project`
-  `"<name>"` to read Status from a project other than `"PR Triage"`.
-- The classification buckets are defined by the `jq` expression in the script;
-  edit the `any($s[]; …)` clauses to change which conclusions count as failing
-  or pending.
+- A `SKIPPED` umbrella check is not treated as a pass: Electron skips
+  "GitHub Actions Completed" when a required upstream job fails, so the script
+  falls back to the full check set to find the real status.

--- a/.claude/skills/triage-prs/triage-prs.sh
+++ b/.claude/skills/triage-prs/triage-prs.sh
@@ -13,15 +13,18 @@
 # a pass: Electron skips the umbrella check when a required upstream job fails,
 # so classification falls back to the full check set to find the real status.
 #
+# Draft PRs are skipped, as are PRs whose "PR Triage" board Status contains WIP
+# (--no-triage skips the board lookup, so WIP PRs are included when it is set).
+#
 # Requires the `gh` CLI, authenticated via `gh auth login`, and `jq`.
 #
 # Usage:
-#   ./script/triage-prs.sh                      # green PRs (default)
-#   ./script/triage-prs.sh --status failing
-#   ./script/triage-prs.sh --status none
-#   ./script/triage-prs.sh --status all --limit 100
-#   ./script/triage-prs.sh --check "GitHub Actions Completed"
-#   ./script/triage-prs.sh --check "faraday/cage" --status pending
+#   .claude/skills/triage-prs/triage-prs.sh                      # green PRs (default)
+#   .claude/skills/triage-prs/triage-prs.sh --status failing
+#   .claude/skills/triage-prs/triage-prs.sh --status none
+#   .claude/skills/triage-prs/triage-prs.sh --status all --limit 100
+#   .claude/skills/triage-prs/triage-prs.sh --check "GitHub Actions Completed"
+#   .claude/skills/triage-prs/triage-prs.sh --check "faraday/cage" --status pending
 #
 # Options:
 #   --status <s>          Which PRs to show: green | failing | pending | none | all
@@ -49,8 +52,11 @@ STATUS="${STATUS:-green}"
 TRIAGE="${TRIAGE:-1}"
 TRIAGE_PROJECT="${TRIAGE_PROJECT:-PR Triage}"
 
+# Print the header comment block (everything between the shebang and the first
+# non-comment line) as help text. Deriving the range this way keeps --help in
+# sync when the header grows, unlike a hard-coded line range.
 usage() {
-  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/script/triage-prs.sh
+++ b/script/triage-prs.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# triage-prs.sh — list open PRs filtered by their CI status.
+#
+# Classifies each open (non-draft) PR by its GitHub checks:
+#   green    all checks succeeded (SUCCESS/NEUTRAL/SKIPPED)
+#   failing  at least one check failed (FAILURE/ERROR/CANCELLED/TIMED_OUT/...)
+#   pending  checks exist but some are still running (PENDING/IN_PROGRESS/...)
+#   none     no checks are running at all
+#
+# When scoped to a single named check (the default is the "GitHub Actions
+# Completed" umbrella check), a SKIPPED result on that check is not treated as
+# a pass: Electron skips the umbrella check when a required upstream job fails,
+# so classification falls back to the full check set to find the real status.
+#
+# Requires the `gh` CLI, authenticated via `gh auth login`, and `jq`.
+#
+# Usage:
+#   ./script/triage-prs.sh                      # green PRs (default)
+#   ./script/triage-prs.sh --status failing
+#   ./script/triage-prs.sh --status none
+#   ./script/triage-prs.sh --status all --limit 100
+#   ./script/triage-prs.sh --check "GitHub Actions Completed"
+#   ./script/triage-prs.sh --check "faraday/cage" --status pending
+#
+# Options:
+#   --status <s>          Which PRs to show: green | failing | pending | none | all
+#                         (default: green)
+#   --check <name>        Only consider the named check instead of all checks.
+#                         (default: "GitHub Actions Completed"). Pass an empty
+#                         string to evaluate every check on the PR.
+#   --triage / --no-triage
+#                         Show (default) or hide the Status field from the
+#                         "PR Triage" project next to each PR. Requires the
+#                         gh token to have the 'read:project' scope
+#                         (run: gh auth refresh -s read:project).
+#   --triage-project <n>  Name of the project board to read Status from
+#                         (default: "PR Triage").
+#   --repo <owner/name>   Target repository (default: electron/electron)
+#   --limit <n>           Max number of open PRs to scan (default: 200)
+#   -h, --help            Show this help and exit
+
+set -euo pipefail
+
+REPO="${REPO:-electron/electron}"
+LIMIT="${LIMIT:-200}"
+CHECK_NAME="${CHECK_NAME:-GitHub Actions Completed}"
+STATUS="${STATUS:-green}"
+TRIAGE="${TRIAGE:-1}"
+TRIAGE_PROJECT="${TRIAGE_PROJECT:-PR Triage}"
+
+usage() {
+  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --status)         STATUS="$2";         shift 2 ;;
+    --check)          CHECK_NAME="$2";     shift 2 ;;
+    --triage)         TRIAGE=1;            shift   ;;
+    --no-triage)      TRIAGE=0;            shift   ;;
+    --triage-project) TRIAGE_PROJECT="$2"; shift 2 ;;
+    --repo)           REPO="$2";           shift 2 ;;
+    --limit)          LIMIT="$2";          shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+case "$STATUS" in
+  green|failing|pending|none|all) ;;
+  *) echo "error: --status must be one of: green, failing, pending, none, all" >&2; exit 1 ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: the GitHub CLI (gh) is required but was not found on PATH." >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but was not found on PATH." >&2
+  exit 1
+fi
+
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+# Reading a ProjectV2 board's fields needs the 'read:project' token scope. If it
+# is missing, disable the triage column rather than failing every PR.
+if [[ "$TRIAGE" == "1" ]]; then
+  # Reading a project's `title` is what requires read:project, so probe that.
+  probe=$(gh api graphql -f owner="$OWNER" -f name="$NAME" -f query='
+    query($owner:String!,$name:String!){
+      repository(owner:$owner,name:$name){ projectsV2(first:1){ nodes{ title } } }
+    }' 2>&1 || true)
+  if grep -q 'INSUFFICIENT_SCOPES' <<<"$probe"; then
+    echo "note: gh token lacks the 'read:project' scope, so the \"${TRIAGE_PROJECT}\" Status" >&2
+    echo "      column is disabled. Enable it with: gh auth refresh -s read:project" >&2
+    echo >&2
+    TRIAGE=0
+  fi
+fi
+
+# Fetch the Status field value from the triage project for one PR (may be empty).
+triage_status() {
+  gh api graphql \
+    -f owner="$OWNER" -f name="$NAME" -F number="$1" \
+    -f query='
+      query($owner:String!,$name:String!,$number:Int!){
+        repository(owner:$owner,name:$name){
+          pullRequest(number:$number){
+            projectItems(first:20){
+              nodes{
+                project{ title }
+                fieldValueByName(name:"Status"){
+                  ... on ProjectV2ItemFieldSingleSelectValue { name }
+                }
+              }
+            }
+          }
+        }
+      }' 2>/dev/null |
+    jq -r --arg p "$TRIAGE_PROJECT" '
+      [ .data.repository.pullRequest.projectItems.nodes[]?
+        | select(.project.title == $p)
+        | (.fieldValueByName.name // empty) ] | first // ""
+    ' 2>/dev/null || printf ''
+}
+
+# Icon for each classification.
+icon_for() {
+  case "$1" in
+    green)   printf '✅' ;;
+    failing) printf '❌' ;;
+    pending) printf '🟡' ;;
+    none)    printf '⚪' ;;
+  esac
+}
+
+scope_desc="all checks"
+[[ -n "$CHECK_NAME" ]] && scope_desc="the \"${CHECK_NAME}\" check"
+
+if [[ "$STATUS" == "all" ]]; then
+  echo "Scanning up to ${LIMIT} open PRs in ${REPO}, classifying by ${scope_desc}..."
+else
+  echo "Scanning up to ${LIMIT} open PRs in ${REPO} for ${STATUS} PRs (by ${scope_desc})..."
+fi
+echo
+
+found=0
+
+# List open, non-draft PR numbers, then inspect each PR's status check rollup.
+while read -r number; do
+  [[ -z "$number" ]] && continue
+
+  json=$(gh pr view "$number" --repo "$REPO" \
+    --json statusCheckRollup,title,url,labels 2>/dev/null) || continue
+
+  # Classify the PR. statusCheckRollup mixes GitHub Actions CheckRun entries
+  # (status/conclusion) and legacy StatusContext entries (state). When --check
+  # is set, only that named check is considered; otherwise every check is.
+  # gh's --jq does not accept jq's --arg, so pipe raw JSON to jq for $name.
+  class=$(echo "$json" | jq -r --arg name "$CHECK_NAME" '
+    def state_of:
+      # CheckRun entries expose .status (QUEUED/IN_PROGRESS/COMPLETED) and,
+      # only once COMPLETED, a .conclusion. An in-progress CheckRun reports
+      # .conclusion as "" (empty string, not null), so key off .status
+      # first. StatusContext entries only expose .state.
+      if (.status != null and .status != "COMPLETED") then .status
+      elif ((.conclusion // "") != "") then .conclusion
+      elif ((.state // "") != "") then .state
+      else "PENDING"
+      end;
+    # Reduce a list of resolved states to a single classification, or null for
+    # an empty list.
+    def classify($s):
+      if ($s | length) == 0 then null
+      elif any($s[]; . == "FAILURE" or . == "ERROR" or . == "CANCELLED"
+                     or . == "TIMED_OUT" or . == "ACTION_REQUIRED"
+                     or . == "STARTUP_FAILURE" or . == "STALE") then "failing"
+      elif any($s[]; . == "PENDING" or . == "EXPECTED" or . == "IN_PROGRESS"
+                     or . == "QUEUED" or . == "REQUESTED"
+                     or . == "WAITING") then "pending"
+      else "green"
+      end;
+    (.statusCheckRollup // []) as $all
+    | ($all | map(state_of)) as $allStates
+    | ( if $name == "" then $all
+        else [ $all[] | select((.name // .context) == $name) ]
+        end ) as $matched
+    | ($matched | map(state_of)) as $s
+    | if $name == "" then
+        # Evaluating every check on the PR.
+        ( classify($s) // "none" )
+      elif ($s | length) == 0 then
+        # No matching check. Only "none" when the PR has zero checks at all;
+        # if other checks exist, the named (umbrella) check simply has not
+        # been posted yet, so CI is still pending.
+        ( if ($all | length) == 0 then "none" else "pending" end )
+      elif any($s[]; . == "SKIPPED") then
+        # The named (umbrella) check was SKIPPED. In Electron the "GitHub
+        # Actions Completed" umbrella check is skipped when a required upstream
+        # job failed, so it never ran to a real conclusion. A SKIPPED umbrella
+        # is therefore NOT a pass; fall back to the full check set to determine
+        # the true status.
+        ( classify($allStates) // "green" )
+      else
+        ( classify($s) // "green" )
+      end
+  ')
+
+  if [[ "$STATUS" != "all" && "$class" != "$STATUS" ]]; then
+    continue
+  fi
+
+  IFS=$'\t' read -r title url < <(echo "$json" | jq -r '[.title, .url] | @tsv')
+
+  # Flag PRs that carry the "new-pr" label so they stand out as needing a first
+  # look. The label name includes a trailing emoji ("new-pr 🌱"), so match by
+  # prefix. jq exits non-zero-safely; default to empty if the label is absent.
+  new_pr_suffix=""
+  if echo "$json" | jq -e '.labels[]? | select(.name | startswith("new-pr"))' >/dev/null 2>&1; then
+    new_pr_suffix="  [new-pr]"
+  fi
+
+  # Optionally look up the PR's Status on the triage project board.
+  triage=""
+  if [[ "$TRIAGE" == "1" ]]; then
+    triage=$(triage_status "$number")
+  fi
+
+  # Exclude PRs marked WIP on the triage board; these are not ready for review.
+  if [[ "$triage" == *WIP* ]]; then
+    continue
+  fi
+
+  triage_suffix=""
+  [[ -n "$triage" ]] && triage_suffix="  [${TRIAGE_PROJECT}: ${triage}]"
+
+  # Emit an OSC 8 hyperlink so terminals that support it render a clickable
+  # link on the PR reference; the raw URL is printed too for plain terminals.
+  printf '%s \e]8;;%s\e\\#%s\e]8;;\e\\  %s%s%s\n     %s\n' \
+    "$(icon_for "$class")" "$url" "$number" "$title" "$new_pr_suffix" "$triage_suffix" "$url"
+  found=$((found + 1))
+done < <(gh pr list --repo "$REPO" --state open --limit "$LIMIT" \
+  --json number,isDraft --jq '.[] | select(.isDraft | not) | .number')
+
+echo
+if [[ "$STATUS" == "all" ]]; then
+  echo "Done. ${found} non-draft PR(s) scanned and classified."
+else
+  echo "Done. ${found} ${STATUS} PR(s) (by ${scope_desc})."
+fi


### PR DESCRIPTION
#### Description of Change
Adds a PR triage helper script that classifies open PRs by CI status (green/failing/pending/none), annotates them with their PR Triage board Status, excludes WIP, and flags PRs labeled as `new-pr`. Includes a Claude skill wrapping the script with faraday and failing shortcuts.

By default the script and skill will return all open PRs that are green.  The skill will sort them by PR Triage status.
Running the skill with `faraday` will show all green PRS needing faraday approvals
Running the skill with `failing` will show all PRs with failing CI

Assisted-by: Claude Opus 4.8

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
