### PR TITLE
refactor: use forward declarations

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -27,6 +27,7 @@
 #include "chrome/browser/icon_manager.h"
 #include "chrome/common/chrome_features.h"
 #include "chrome/common/chrome_paths.h"
+#include "components/prefs/value_map_pref_store.h"
 #include "components/proxy_config/proxy_config_dictionary.h"
 #include "components/proxy_config/proxy_config_pref_names.h"
 #include "components/proxy_config/proxy_prefs.h"

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -27,6 +27,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/pref_service_factory.h"
+#include "components/prefs/value_map_pref_store.h"
 #include "components/proxy_config/pref_proxy_config_tracker_impl.h"
 #include "components/proxy_config/proxy_config_dictionary.h"
 #include "components/proxy_config/proxy_config_pref_names.h"

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -15,7 +15,6 @@
 
 #include "chrome/browser/browser_process.h"
 #include "components/embedder_support/origin_trials/origin_trials_settings_storage.h"
-#include "components/prefs/value_map_pref_store.h"
 #include "printing/buildflags/buildflags.h"
 #include "services/network/public/cpp/network_quality_tracker.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -27,6 +26,7 @@
 #endif
 
 class PrefService;
+class ValueMapPrefStore;
 
 namespace printing {
 class PrintJobManager;

--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -11,6 +11,7 @@
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/notimplemented.h"
 #include "base/strings/string_number_conversions.h"

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <utility>
 
-#include "base/functional/callback.h"
+#include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "extensions/browser/extension_registrar.h"

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -10,6 +10,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "gin/arguments.h"
 #include "gin/dictionary.h"
+#include "net/http/http_response_headers.h"
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/api/electron_api_utility_process.h"
 #include "shell/browser/api/electron_api_web_contents.h"

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -7,7 +7,6 @@
 
 #include "base/process/process_handle.h"
 #include "content/public/browser/login_delegate.h"
-#include "net/http/http_response_headers.h"
 
 namespace content {
 class WebContents;
@@ -15,6 +14,10 @@ class WebContents;
 
 namespace gin {
 class Arguments;
+}
+
+namespace net {
+class HttpResponseHeaders;
 }
 
 namespace electron {

--- a/shell/browser/mac/in_app_purchase.h
+++ b/shell/browser/mac/in_app_purchase.h
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "base/functional/callback.h"
+#include "base/functional/callback_forward.h"
 
 namespace in_app_purchase {
 

--- a/shell/browser/mac/in_app_purchase.mm
+++ b/shell/browser/mac/in_app_purchase.mm
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
 

--- a/shell/browser/mac/in_app_purchase_product.h
+++ b/shell/browser/mac/in_app_purchase_product.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "base/functional/callback.h"
+#include "base/functional/callback_forward.h"
 
 namespace in_app_purchase {
 

--- a/shell/browser/mac/in_app_purchase_product.mm
+++ b/shell/browser/mac/in_app_purchase_product.mm
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_thread.h"
 

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 
+#include "base/functional/callback.h"
 #include "shell/browser/notifications/notification.h"
 
 namespace electron {

--- a/shell/browser/notifications/notification_presenter.h
+++ b/shell/browser/notifications/notification_presenter.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "base/functional/callback.h"
+#include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
 #include "shell/browser/notifications/notification.h"
 

--- a/shell/browser/osr/osr_host_display_client.cc
+++ b/shell/browser/osr/osr_host_display_client.cc
@@ -10,6 +10,8 @@
 #include "components/viz/common/resources/shared_image_format_utils.h"
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "skia/ext/platform_canvas.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/src/core/SkDevice.h"

--- a/shell/browser/osr/osr_host_display_client.h
+++ b/shell/browser/osr/osr_host_display_client.h
@@ -11,11 +11,8 @@
 #include "components/viz/host/host_display_client.h"
 #include "services/viz/privileged/mojom/compositing/layered_window_updater.mojom.h"
 #include "shell/browser/osr/osr_paint_event.h"
-#include "third_party/skia/include/core/SkBitmap.h"
-#include "third_party/skia/include/core/SkCanvas.h"
 #include "ui/gfx/native_ui_types.h"
 
-class SkBitmap;
 class SkCanvas;
 
 namespace electron {

--- a/shell/browser/osr/osr_view_proxy.cc
+++ b/shell/browser/osr/osr_view_proxy.cc
@@ -6,6 +6,8 @@
 
 #include <memory>
 
+#include "third_party/skia/include/core/SkBitmap.h"
+
 namespace electron {
 
 OffscreenViewProxy::OffscreenViewProxy(views::View* view) : view_(view) {

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -8,10 +8,11 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
-#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/events/event.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/views/view.h"
+
+class SkBitmap;
 
 namespace electron {
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -19,6 +19,7 @@
 #include "shell/renderer/electron_ipc_native.h"
 
 #include "base/no_destructor.h"
+#include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_thread.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/renderer_client_base.h"

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -14,6 +14,7 @@
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
+#include "services/service_manager/public/cpp/binder_registry.h"
 #include "shell/common/api/api.mojom.h"
 
 namespace content {

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/memory/weak_ptr.h"
-#include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "content/public/renderer/render_frame_observer_tracker.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
@@ -16,6 +15,10 @@
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "shell/common/api/api.mojom.h"
+
+namespace content {
+class RenderFrame;
+}
 
 namespace electron {
 

--- a/shell/renderer/preload_utils.cc
+++ b/shell/renderer/preload_utils.cc
@@ -20,6 +20,7 @@
 #include "crypto/hash.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/electron_version.h"
+#include "electron/shell/common/api/api.mojom.h"
 #include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "shell/common/gin_helper/dictionary.h"

--- a/shell/renderer/preload_utils.h
+++ b/shell/renderer/preload_utils.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "shell/common/api/api.mojom.h"
+#include "electron/shell/common/api/api.mojom-forward.h"
 #include "v8/include/v8-forward.h"
 
 namespace content {


### PR DESCRIPTION
#### Description of Change

Fifth in a [series](https://github.com/electron/electron/pull/52468) to remove unnecessary `#include` calls from the codebase. This PR tries to use forward declarations where possible so that heavier `#include` calls can be skipped. 

Smaller payoff in this one, most of the opportunities for this change were in headers that didn't touch as many files. :man_shrugging: 

CC @nikwen, @dsanders11, @jkleinsc as prior reviewers / stakeholders

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none.