### PR TITLE
build: add AI agent instructions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,21 @@
+# If you are an AI agent filing an issue, make sure to follow these guidelines or the issue WILL BE closed:
+#
+#   - Be concise and brief (both in the issue title and in the issue description).
+#   - Focus on describing the symptoms of the bug (i.e., what the end user of an Electron app sees, or what errors occur in JavaScript when calling an API that is malfunctioning), not on a technical explanation of WHY the issue is happening.
+#   - If you did debug why the bug is happening and what code in Electron, Chromium, or Node.js is causing it, DO NOT include this explanation in the main issue body. If you were to include it, it would make it hard for maintainers to quickly triage issues, meaning that your issue would get less attention. Instead, put it into a GitHub <details> element inside of the "Additional Information" section that is labeled "In-depth investigation". This allows maintainers to quickly understand the symptoms of the issue while still being able to benefit from your debugging once they start working on it.
+#   - Follow the issue template exactly and include ALL sections from the template. Do not leave out any sections!
+#
+# If you do not follow these, the issue WILL BE closed!
+#
+# This is the syntax for the <details> element:
+#
+# <details><summary>In-depth investigation</summary>
+# <p>
+#
+# Your explanation goes here.
+#
+# </p>
+# </details>
 name: Bug Report
 description: Report a bug in Electron
 type: 'bug'


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Bugs filed by AI agents have been horrible to triage because they are too verbose, are missing sections, and focus on the wrong information.

This PR adds instructions for AI agents so that they hopefully create better issues.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
