### PR TITLE
docs: fix OS name typo in menus.md

### DIFF
--- a/docs/tutorial/menus.md
+++ b/docs/tutorial/menus.md
@@ -135,7 +135,7 @@ default to appropriate values for each platform.
 
 #### Window roles
 
-* `about` - Trigger a native about panel (custom message box on Window, which does not provide its own).
+* `about` - Trigger a native about panel (custom message box on Windows, which does not provide its own).
 * `minimize` - Minimize current window.
 * `close` - Close current window.
 * `quit` - Quit the application.


### PR DESCRIPTION
## Description

Fixes a grammar issue in `docs/tutorial/menus.md` (line 138).

### Problem
'Window' should be 'Windows' — referring to the operating system.

### Before
```
custom message box on Window, which does not provide its own
```

### After
```
custom message box on Windows, which does not provide its own
```

Notes: none