### PR TITLE
chore: remove redundant isolate params in the context bridge

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -462,6 +462,8 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
     BridgeErrorTarget error_target,
     context_bridge::ObjectCache* existing_object_cache) {
   TRACE_EVENT0("electron", "ContextBridge::PassValueToOtherContext");
+  CHECK_EQ(isolate, source_context->GetIsolate());
+  CHECK_EQ(isolate, destination_context->GetIsolate());
 
   context_bridge::ObjectCache local_object_cache;
   context_bridge::ObjectCache* object_cache =

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -462,8 +462,6 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
     BridgeErrorTarget error_target,
     context_bridge::ObjectCache* existing_object_cache) {
   TRACE_EVENT0("electron", "ContextBridge::PassValueToOtherContext");
-  CHECK_EQ(isolate, source_context->GetIsolate());
-  CHECK_EQ(isolate, destination_context->GetIsolate());
 
   context_bridge::ObjectCache local_object_cache;
   context_bridge::ObjectCache* object_cache =

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -140,10 +140,9 @@ v8::MaybeLocal<v8::Value> GetPrivate(v8::Isolate* const isolate,
 void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info);
 v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     const v8::Local<v8::Object>& api_object,
-    v8::Isolate* const source_isolate,
+    v8::Isolate* const isolate,
     const v8::Local<v8::Context>& source_context,
     const blink::ExecutionContext* source_execution_context,
-    v8::Isolate* const destination_isolate,
     const v8::Local<v8::Context>& destination_context,
     context_bridge::ObjectCache* object_cache,
     bool support_dynamic_properties,
@@ -151,10 +150,9 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     BridgeErrorTarget error_target);
 
 v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
-    v8::Isolate* const source_isolate,
+    v8::Isolate* const isolate,
     v8::Local<v8::Context> source_context,
     const blink::ExecutionContext* source_execution_context,
-    v8::Isolate* const destination_isolate,
     v8::Local<v8::Context> destination_context,
     v8::Local<v8::Value> value,
     v8::Local<v8::Value> parent_value,
@@ -167,8 +165,8 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     v8::Context::Scope error_scope(error_target == BridgeErrorTarget::kSource
                                        ? source_context
                                        : destination_context);
-    source_isolate->ThrowException(v8::Exception::TypeError(
-        gin::StringToV8(source_isolate,
+    isolate->ThrowException(v8::Exception::TypeError(
+        gin::StringToV8(isolate,
                         "Electron contextBridge recursion depth exceeded.  "
                         "Nested objects "
                         "deeper than 1000 are not supported.")));
@@ -195,8 +193,8 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
   // the global handle at the right time.
   if (value->IsFunction()) {
     auto func = value.As<v8::Function>();
-    v8::MaybeLocal<v8::Value> maybe_original_fn = GetPrivate(
-        source_isolate, source_context, func, kOriginalFunctionPrivateKey);
+    v8::MaybeLocal<v8::Value> maybe_original_fn =
+        GetPrivate(isolate, source_context, func, kOriginalFunctionPrivateKey);
 
     {
       v8::Context::Scope destination_scope(destination_context);
@@ -210,27 +208,25 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
       // creation context of the original method.  If it's not we proceed
       // with the proxy logic
       if (maybe_original_fn.ToLocal(&proxy_func) && proxy_func->IsFunction() &&
-          proxy_func.As<v8::Object>()->GetCreationContextChecked(
-              source_isolate) == destination_context) {
+          proxy_func.As<v8::Object>()->GetCreationContextChecked(isolate) ==
+              destination_context) {
         return v8::MaybeLocal<v8::Value>(proxy_func);
       }
 
-      v8::Local<v8::Object> state = v8::Object::New(destination_isolate);
-      SetPrivate(destination_isolate, destination_context, state,
-                 kProxyFunctionPrivateKey, func);
-      SetPrivate(destination_isolate, destination_context, state,
+      v8::Local<v8::Object> state = v8::Object::New(isolate);
+      SetPrivate(isolate, destination_context, state, kProxyFunctionPrivateKey,
+                 func);
+      SetPrivate(isolate, destination_context, state,
                  kProxyFunctionReceiverPrivateKey, parent_value);
-      SetPrivate(
-          destination_isolate, destination_context, state,
-          kSupportsDynamicPropertiesPrivateKey,
-          gin::ConvertToV8(destination_isolate, support_dynamic_properties));
+      SetPrivate(isolate, destination_context, state,
+                 kSupportsDynamicPropertiesPrivateKey,
+                 gin::ConvertToV8(isolate, support_dynamic_properties));
 
       if (!v8::Function::New(destination_context, ProxyFunctionWrapper, state)
                .ToLocal(&proxy_func))
         return {};
-      SetPrivate(destination_isolate, destination_context,
-                 proxy_func.As<v8::Object>(), kOriginalFunctionPrivateKey,
-                 func);
+      SetPrivate(isolate, destination_context, proxy_func.As<v8::Object>(),
+                 kOriginalFunctionPrivateKey, func);
       object_cache->CacheProxiedObject(value, proxy_func);
       return v8::MaybeLocal<v8::Value>(proxy_func);
     }
@@ -244,15 +240,13 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     // freed the proxy promise is correctly freed as well instead of being
     // left dangling
     auto proxied_promise =
-        std::make_shared<gin_helper::Promise<v8::Local<v8::Value>>>(
-            destination_isolate);
+        std::make_shared<gin_helper::Promise<v8::Local<v8::Value>>>(isolate);
     v8::Local<v8::Promise> proxied_promise_handle =
         proxied_promise->GetHandle();
 
-    v8::Global<v8::Context> global_then_source_context(source_isolate,
-                                                       source_context);
+    v8::Global<v8::Context> global_then_source_context(isolate, source_context);
     v8::Global<v8::Context> global_then_destination_context(
-        destination_isolate, destination_context);
+        isolate, destination_context);
     global_then_source_context.SetWeak();
     global_then_destination_context.SetWeak();
     auto then_cb = base::BindOnce(
@@ -270,7 +264,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
             v8::Local<v8::Context> source_context =
                 global_source_context.Get(isolate);
             val =
-                PassValueToOtherContext(isolate, source_context, isolate,
+                PassValueToOtherContext(isolate, source_context,
                                         global_destination_context.Get(isolate),
                                         result, source_context->Global(), false,
                                         BridgeErrorTarget::kDestination);
@@ -293,14 +287,13 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
           if (!val.IsEmpty())
             proxied_promise->Resolve(val.ToLocalChecked());
         },
-        proxied_promise, destination_isolate,
-        std::move(global_then_source_context),
+        proxied_promise, isolate, std::move(global_then_source_context),
         std::move(global_then_destination_context));
 
-    v8::Global<v8::Context> global_catch_source_context(source_isolate,
+    v8::Global<v8::Context> global_catch_source_context(isolate,
                                                         source_context);
     v8::Global<v8::Context> global_catch_destination_context(
-        destination_isolate, destination_context);
+        isolate, destination_context);
     global_catch_source_context.SetWeak();
     global_catch_destination_context.SetWeak();
     auto catch_cb = base::BindOnce(
@@ -318,7 +311,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
             v8::Local<v8::Context> source_context =
                 global_source_context.Get(isolate);
             val =
-                PassValueToOtherContext(isolate, source_context, isolate,
+                PassValueToOtherContext(isolate, source_context,
                                         global_destination_context.Get(isolate),
                                         result, source_context->Global(), false,
                                         BridgeErrorTarget::kDestination);
@@ -340,16 +333,13 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
           if (!val.IsEmpty())
             proxied_promise->Reject(val.ToLocalChecked());
         },
-        proxied_promise, destination_isolate,
-        std::move(global_catch_source_context),
+        proxied_promise, isolate, std::move(global_catch_source_context),
         std::move(global_catch_destination_context));
 
     std::ignore = source_promise->Then(
         source_context,
-        gin::ConvertToV8(destination_isolate, std::move(then_cb))
-            .As<v8::Function>(),
-        gin::ConvertToV8(destination_isolate, std::move(catch_cb))
-            .As<v8::Function>());
+        gin::ConvertToV8(isolate, std::move(then_cb)).As<v8::Function>(),
+        gin::ConvertToV8(isolate, std::move(catch_cb)).As<v8::Function>());
 
     object_cache->CacheProxiedObject(value, proxied_promise_handle);
     return v8::MaybeLocal<v8::Value>(proxied_promise_handle);
@@ -364,14 +354,14 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     // crosses the bridge we fallback to the v8::Message approach if we can't
     // pull "message" for some reason
     v8::MaybeLocal<v8::Value> maybe_message = value.As<v8::Object>()->Get(
-        source_context, gin::ConvertToV8(source_isolate, "message"));
+        source_context, gin::ConvertToV8(isolate, "message"));
     v8::Local<v8::Value> message;
     if (maybe_message.ToLocal(&message) && message->IsString()) {
       return v8::MaybeLocal<v8::Value>(
           v8::Exception::Error(message.As<v8::String>()));
     }
     return v8::MaybeLocal<v8::Value>(v8::Exception::Error(
-        v8::Exception::CreateMessage(destination_isolate, value)->Get()));
+        v8::Exception::CreateMessage(isolate, value)->Get()));
   }
 
   // Manually go through the array and pass each value individually into a new
@@ -381,14 +371,13 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     v8::Context::Scope destination_context_scope(destination_context);
     v8::Local<v8::Array> arr = value.As<v8::Array>();
     size_t length = arr->Length();
-    v8::Local<v8::Array> cloned_arr =
-        v8::Array::New(destination_isolate, length);
+    v8::Local<v8::Array> cloned_arr = v8::Array::New(isolate, length);
     for (size_t i = 0; i < length; i++) {
       auto value_for_array = PassValueToOtherContextInner(
-          source_isolate, source_context, source_execution_context,
-          destination_isolate, destination_context,
-          arr->Get(source_context, i).ToLocalChecked(), value, object_cache,
-          support_dynamic_properties, recursion_depth + 1, error_target);
+          isolate, source_context, source_execution_context,
+          destination_context, arr->Get(source_context, i).ToLocalChecked(),
+          value, object_cache, support_dynamic_properties, recursion_depth + 1,
+          error_target);
       if (value_for_array.IsEmpty())
         return {};
 
@@ -404,28 +393,26 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
   // Clone certain DOM APIs only within Window contexts.
   if (source_execution_context->IsWindow()) {
     // Custom logic to "clone" Element references
-    blink::WebElement elem =
-        blink::WebElement::FromV8Value(destination_isolate, value);
+    blink::WebElement elem = blink::WebElement::FromV8Value(isolate, value);
     if (!elem.IsNull()) {
       v8::Context::Scope destination_context_scope(destination_context);
-      return v8::MaybeLocal<v8::Value>(elem.ToV8Value(destination_isolate));
+      return v8::MaybeLocal<v8::Value>(elem.ToV8Value(isolate));
     }
 
     // Custom logic to "clone" Blob references
-    blink::WebBlob blob =
-        blink::WebBlob::FromV8Value(destination_isolate, value);
+    blink::WebBlob blob = blink::WebBlob::FromV8Value(isolate, value);
     if (!blob.IsNull()) {
       v8::Context::Scope destination_context_scope(destination_context);
-      return v8::MaybeLocal<v8::Value>(blob.ToV8Value(destination_isolate));
+      return v8::MaybeLocal<v8::Value>(blob.ToV8Value(isolate));
     }
 
     // Custom logic to "clone" VideoFrame references
     blink::VideoFrame* video_frame =
-        blink::V8VideoFrame::ToWrappable(source_isolate, value);
+        blink::V8VideoFrame::ToWrappable(isolate, value);
     if (video_frame != nullptr) {
       v8::Context::Scope destination_context_scope(destination_context);
       blink::ScriptState* script_state =
-          blink::ScriptState::From(destination_isolate, destination_context);
+          blink::ScriptState::From(isolate, destination_context);
       return v8::MaybeLocal<v8::Value>(
           blink::ToV8Traits<blink::VideoFrame>::ToV8(script_state,
                                                      video_frame));
@@ -436,9 +423,9 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
   if (IsPlainObject(value)) {
     auto object_value = value.As<v8::Object>();
     auto passed_value = CreateProxyForAPI(
-        object_value, source_isolate, source_context, source_execution_context,
-        destination_isolate, destination_context, object_cache,
-        support_dynamic_properties, recursion_depth + 1, error_target);
+        object_value, isolate, source_context, source_execution_context,
+        destination_context, object_cache, support_dynamic_properties,
+        recursion_depth + 1, error_target);
     if (passed_value.IsEmpty())
       return {};
     return v8::MaybeLocal<v8::Value>(passed_value.ToLocalChecked());
@@ -452,27 +439,22 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
                                                    : destination_context;
     v8::Context::Scope error_scope{error_context};
     // V8 serializer will throw an error if required
-    v8::Isolate* const error_isolate =
-        error_target == BridgeErrorTarget::kSource ? source_isolate
-                                                   : destination_isolate;
-    if (!gin::ConvertFromV8(error_isolate, value, &ret)) {
+    if (!gin::ConvertFromV8(isolate, value, &ret)) {
       return {};
     }
   }
 
   {
     v8::Context::Scope destination_context_scope(destination_context);
-    v8::Local<v8::Value> cloned_value =
-        gin::ConvertToV8(destination_isolate, ret);
+    v8::Local<v8::Value> cloned_value = gin::ConvertToV8(isolate, ret);
     object_cache->CacheProxiedObject(value, cloned_value);
     return v8::MaybeLocal<v8::Value>(cloned_value);
   }
 }
 
 v8::MaybeLocal<v8::Value> PassValueToOtherContext(
-    v8::Isolate* source_isolate,
+    v8::Isolate* isolate,
     v8::Local<v8::Context> source_context,
-    v8::Isolate* destination_isolate,
     v8::Local<v8::Context> destination_context,
     v8::Local<v8::Value> value,
     v8::Local<v8::Value> parent_value,
@@ -489,9 +471,9 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
       blink::ExecutionContext::From(source_context);
   DCHECK(source_execution_context);
   return PassValueToOtherContextInner(
-      source_isolate, source_context, source_execution_context,
-      destination_isolate, destination_context, value, parent_value,
-      object_cache, support_dynamic_properties, 0, error_target);
+      isolate, source_context, source_execution_context, destination_context,
+      value, parent_value, object_cache, support_dynamic_properties, 0,
+      error_target);
 }
 
 void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
@@ -534,7 +516,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
     for (auto value : original_args) {
       auto arg = PassValueToOtherContext(
-          isolate, calling_context, isolate, func_owning_context, value,
+          isolate, calling_context, func_owning_context, value,
           calling_context->Global(), support_dynamic_properties,
           BridgeErrorTarget::kSource, &object_cache);
       if (arg.IsEmpty())
@@ -602,7 +584,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
     {
       v8::TryCatch try_catch(isolate);
       ret = PassValueToOtherContext(
-          isolate, func_owning_context, isolate, calling_context,
+          isolate, func_owning_context, calling_context,
           maybe_return_value.ToLocalChecked(), func_owning_context->Global(),
           support_dynamic_properties, BridgeErrorTarget::kDestination);
       if (try_catch.HasCaught()) {
@@ -635,20 +617,19 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
 v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     const v8::Local<v8::Object>& api_object,
-    v8::Isolate* const source_isolate,
+    v8::Isolate* const isolate,
     const v8::Local<v8::Context>& source_context,
     const blink::ExecutionContext* source_execution_context,
-    v8::Isolate* const destination_isolate,
     const v8::Local<v8::Context>& destination_context,
     context_bridge::ObjectCache* object_cache,
     bool support_dynamic_properties,
     int recursion_depth,
     BridgeErrorTarget error_target) {
-  gin_helper::Dictionary api{source_isolate, api_object};
+  gin_helper::Dictionary api{isolate, api_object};
 
   {
     v8::Context::Scope destination_context_scope(destination_context);
-    auto proxy = gin_helper::Dictionary::CreateEmpty(destination_isolate);
+    auto proxy = gin_helper::Dictionary::CreateEmpty(isolate);
     object_cache->CacheProxiedObject(api.GetHandle(), proxy.GetHandle());
     auto maybe_keys = api.GetHandle()->GetOwnPropertyNames(
         source_context, static_cast<v8::PropertyFilter>(v8::ONLY_ENUMERABLE));
@@ -682,19 +663,19 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
             v8::Local<v8::Value> setter_proxy;
             if (!getter.IsEmpty()) {
               if (!PassValueToOtherContextInner(
-                       source_isolate, source_context, source_execution_context,
-                       destination_isolate, destination_context, getter,
-                       api.GetHandle(), object_cache,
-                       support_dynamic_properties, 1, error_target)
+                       isolate, source_context, source_execution_context,
+                       destination_context, getter, api.GetHandle(),
+                       object_cache, support_dynamic_properties, 1,
+                       error_target)
                        .ToLocal(&getter_proxy))
                 continue;
             }
             if (!setter.IsEmpty()) {
               if (!PassValueToOtherContextInner(
-                       source_isolate, source_context, source_execution_context,
-                       destination_isolate, destination_context, setter,
-                       api.GetHandle(), object_cache,
-                       support_dynamic_properties, 1, error_target)
+                       isolate, source_context, source_execution_context,
+                       destination_context, setter, api.GetHandle(),
+                       object_cache, support_dynamic_properties, 1,
+                       error_target)
                        .ToLocal(&setter_proxy))
                 continue;
             }
@@ -714,10 +695,9 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
           continue;
 
         auto passed_value = PassValueToOtherContextInner(
-            source_isolate, source_context, source_execution_context,
-            destination_isolate, destination_context, value, api.GetHandle(),
-            object_cache, support_dynamic_properties, recursion_depth + 1,
-            error_target);
+            isolate, source_context, source_execution_context,
+            destination_context, value, api.GetHandle(), object_cache,
+            support_dynamic_properties, recursion_depth + 1, error_target);
         if (passed_value.IsEmpty())
           return {};
 
@@ -748,13 +728,12 @@ namespace {
 
 void ExposeAPI(v8::Isolate* isolate,
                v8::Local<v8::Context> source_context,
-               v8::Isolate* target_isolate,
                v8::Local<v8::Context> target_context,
                const std::string& key,
                v8::Local<v8::Value> api) {
   DCHECK(!target_context.IsEmpty());
   v8::Context::Scope target_context_scope(target_context);
-  gin_helper::Dictionary global(target_isolate, target_context->Global());
+  gin_helper::Dictionary global(isolate, target_context->Global());
 
   if (global.Has(key)) {
     gin_helper::ErrorThrower{isolate}.ThrowError(
@@ -764,8 +743,8 @@ void ExposeAPI(v8::Isolate* isolate,
   }
 
   v8::MaybeLocal<v8::Value> maybe_proxy = PassValueToOtherContext(
-      isolate, source_context, target_isolate, target_context, api,
-      source_context->Global(), false, BridgeErrorTarget::kSource);
+      isolate, source_context, target_context, api, source_context->Global(),
+      false, BridgeErrorTarget::kSource);
   if (maybe_proxy.IsEmpty())
     return;
   auto proxy = maybe_proxy.ToLocalChecked();
@@ -788,8 +767,7 @@ void ExposeAPI(v8::Isolate* isolate,
 // world ID. For service workers, Electron only supports one isolated
 // context and the main worker context. Anything else is invalid.
 v8::MaybeLocal<v8::Context> GetTargetContext(v8::Isolate* isolate,
-                                             const int world_id,
-                                             v8::Isolate* target_isolate) {
+                                             const int world_id) {
   v8::Local<v8::Context> source_context = isolate->GetCurrentContext();
   v8::MaybeLocal<v8::Context> maybe_target_context;
 
@@ -811,8 +789,8 @@ v8::MaybeLocal<v8::Context> GetTargetContext(v8::Isolate* isolate,
           isolate, "Isolated worlds are not supported in preload realms.")));
       return maybe_target_context;
     }
-    maybe_target_context = electron::preload_realm::GetInitiatorContext(
-        source_context, target_isolate);
+    maybe_target_context =
+        electron::preload_realm::GetInitiatorContext(source_context);
   } else {
     NOTREACHED();
   }
@@ -829,13 +807,12 @@ void ExposeAPIInWorld(v8::Isolate* isolate,
                "worldId", world_id);
   v8::Local<v8::Context> source_context = isolate->GetCurrentContext();
   CHECK(!source_context.IsEmpty());
-  v8::Isolate* target_isolate = isolate;
   v8::MaybeLocal<v8::Context> maybe_target_context =
-      GetTargetContext(isolate, world_id, target_isolate);
-  if (maybe_target_context.IsEmpty() || !target_isolate)
+      GetTargetContext(isolate, world_id);
+  if (maybe_target_context.IsEmpty())
     return;
   v8::Local<v8::Context> target_context = maybe_target_context.ToLocalChecked();
-  ExposeAPI(isolate, source_context, target_isolate, target_context, key, api);
+  ExposeAPI(isolate, source_context, target_context, key, api);
 }
 
 std::optional<gin_helper::Dictionary> TraceKeyPath(
@@ -882,9 +859,8 @@ void OverrideGlobalValueFromIsolatedWorld(
     v8::Local<v8::Context> source_context =
         value->GetCreationContextChecked(isolate);
     v8::MaybeLocal<v8::Value> maybe_proxy = PassValueToOtherContext(
-        isolate, source_context, isolate, main_context, value,
-        source_context->Global(), support_dynamic_properties,
-        BridgeErrorTarget::kSource);
+        isolate, source_context, main_context, value, source_context->Global(),
+        support_dynamic_properties, BridgeErrorTarget::kSource);
     DCHECK(!maybe_proxy.IsEmpty());
     auto proxy = maybe_proxy.ToLocalChecked();
 
@@ -920,7 +896,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
       v8::Local<v8::Context> source_context =
           getter->GetCreationContextChecked(isolate);
       v8::MaybeLocal<v8::Value> maybe_getter_proxy = PassValueToOtherContext(
-          isolate, source_context, isolate, main_context, getter,
+          isolate, source_context, main_context, getter,
           source_context->Global(), false, BridgeErrorTarget::kSource);
       DCHECK(!maybe_getter_proxy.IsEmpty());
       getter_proxy = maybe_getter_proxy.ToLocalChecked();
@@ -929,7 +905,7 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
       v8::Local<v8::Context> source_context =
           setter.As<v8::Object>()->GetCreationContextChecked(isolate);
       v8::MaybeLocal<v8::Value> maybe_setter_proxy = PassValueToOtherContext(
-          isolate, source_context, isolate, main_context, setter,
+          isolate, source_context, main_context, setter,
           source_context->Global(), false, BridgeErrorTarget::kSource);
       DCHECK(!maybe_setter_proxy.IsEmpty());
       setter_proxy = maybe_setter_proxy.ToLocalChecked();
@@ -991,9 +967,8 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* const isolate,
   }
 
   // Get the target context
-  v8::Isolate* target_isolate = isolate;
   v8::MaybeLocal<v8::Context> maybe_target_context =
-      GetTargetContext(isolate, world_id, target_isolate);
+      GetTargetContext(isolate, world_id);
   v8::Local<v8::Context> target_context;
   if (!maybe_target_context.ToLocal(&target_context)) {
     isolate->ThrowException(v8::Exception::Error(gin::StringToV8(
@@ -1079,7 +1054,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* const isolate,
       }
 
       auto proxied_arg = PassValueToOtherContext(
-          isolate, source_context, target_isolate, target_context, arg,
+          isolate, source_context, target_context, arg,
           source_context->Global(), support_dynamic_properties,
           BridgeErrorTarget::kSource, &object_cache);
       if (proxied_arg.IsEmpty()) {
@@ -1126,7 +1101,7 @@ v8::Local<v8::Value> ExecuteInWorld(v8::Isolate* const isolate,
       v8::TryCatch try_catch(isolate);
       // Pass value from target context back to source context
       maybe_cloned_result = PassValueToOtherContext(
-          target_isolate, target_context, isolate, source_context, result,
+          isolate, target_context, source_context, result,
           target_context->Global(), false, BridgeErrorTarget::kSource);
       if (try_catch.HasCaught()) {
         v8::String::Utf8Value utf8(isolate, try_catch.Exception());

--- a/shell/renderer/api/electron_api_context_bridge.h
+++ b/shell/renderer/api/electron_api_context_bridge.h
@@ -31,9 +31,8 @@ enum class BridgeErrorTarget {
 };
 
 v8::MaybeLocal<v8::Value> PassValueToOtherContext(
-    v8::Isolate* source_isolate,
+    v8::Isolate* isolate,
     v8::Local<v8::Context> source_context,
-    v8::Isolate* destination_isolate,
     v8::Local<v8::Context> destination_context,
     v8::Local<v8::Value> value,
     /**

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -175,8 +175,8 @@ class ScriptExecutionCallback {
       v8::Local<v8::Context> source_context =
           result->GetCreationContextChecked(isolate);
       maybe_result = PassValueToOtherContext(
-          isolate, source_context, promise_.isolate(), promise_.GetContext(),
-          result, source_context->Global(), false, BridgeErrorTarget::kSource);
+          isolate, source_context, promise_.GetContext(), result,
+          source_context->Global(), false, BridgeErrorTarget::kSource);
       if (maybe_result.IsEmpty() || try_catch.HasCaught()) {
         success = false;
       }

--- a/shell/renderer/preload_realm_context.cc
+++ b/shell/renderer/preload_realm_context.cc
@@ -104,12 +104,6 @@ class PreloadRealmLifetimeController
                : v8::MaybeLocal<v8::Context>();
   }
 
-  v8::Isolate* GetInitiatorIsolate() {
-    return initiator_script_state_->ContextIsValid()
-               ? initiator_script_state_->GetIsolate()
-               : nullptr;
-  }
-
   electron::ServiceWorkerData* service_worker_data() {
     return service_worker_data_;
   }
@@ -244,17 +238,15 @@ class PreloadRealmLifetimeController
 
 }  // namespace
 
-v8::MaybeLocal<v8::Context> GetInitiatorContext(v8::Local<v8::Context> context,
-                                                v8::Isolate* target_isolate) {
+v8::MaybeLocal<v8::Context> GetInitiatorContext(
+    v8::Local<v8::Context> context) {
   DCHECK(!context.IsEmpty());
-  DCHECK(target_isolate);
   blink::ExecutionContext* execution_context =
       blink::ExecutionContext::From(context);
   if (!execution_context->IsShadowRealmGlobalScope())
     return v8::MaybeLocal<v8::Context>();
   auto* controller = PreloadRealmLifetimeController::From(context);
   if (controller) {
-    target_isolate = controller->GetInitiatorIsolate();
     return controller->GetInitiatorContext();
   }
   return v8::MaybeLocal<v8::Context>();

--- a/shell/renderer/preload_realm_context.h
+++ b/shell/renderer/preload_realm_context.h
@@ -14,8 +14,7 @@ class ServiceWorkerData;
 namespace electron::preload_realm {
 
 // Get initiator context given the preload context.
-v8::MaybeLocal<v8::Context> GetInitiatorContext(v8::Local<v8::Context> context,
-                                                v8::Isolate* target_isolate);
+v8::MaybeLocal<v8::Context> GetInitiatorContext(v8::Local<v8::Context> context);
 
 // Get the preload context given the initiator context.
 v8::MaybeLocal<v8::Context> GetPreloadRealmContext(

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -640,7 +640,7 @@ void RendererClientBase::SetupMainWorldOverrides(
   v8::Local<v8::Value> guest_view_internal;
   if (global.GetHidden("guestViewInternal", &guest_view_internal)) {
     auto result = api::PassValueToOtherContext(
-        isolate, source_context, isolate, context, guest_view_internal,
+        isolate, source_context, context, guest_view_internal,
         source_context->Global(), false, api::BridgeErrorTarget::kSource);
     if (!result.IsEmpty()) {
       isolated_api.Set("guestViewInternal", result.ToLocalChecked());


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

The `target_isolate` and `destination_isolate` parameters were plumbed in on #48212 but were left dangling in `GetInitiatorContext`, so they were dead code. Since contexts are within the same isolate, we shouldn't need to plumb down the target/destination isolate as its always the same as the source isolate - this was confirmed for all existing call sites.

This was initially flagged by the `clang-analyzer-deadcode.DeadStores` check in `clang-tidy`, since there's an assignment to `target_isolate` in `GetInitiatorContext` that's never read back.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
