### PR TITLE
fix: WCO captions not appearing on Linux

### DIFF
--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -95,17 +95,6 @@ InspectableWebContentsView::InspectableWebContentsView(
   if (!inspectable_web_contents_->is_guest() &&
       inspectable_web_contents_->GetWebContents()->GetNativeView()) {
     auto* contents_web_view = new views::WebView(nullptr);
-#if defined(USE_AURA)
-    // Chromium's NativeViewHostAura defaults to managing the hosted native
-    // view's layer via views crrev.com/c/8013273. Under that
-    // path the web contents' aura window layer is reparented out of its aura
-    // parent window's layer, which breaks occlusion-based visibility tracking
-    // (document.visibilityState) for WebContentsViews nested inside another
-    // View. Opt back into the legacy parent-managed layer path so occlusion is
-    // computed correctly. This must run before the WebView is attached to a
-    // Widget.
-    contents_web_view->holder()->SetLayerManagedByViews(false);
-#endif
     contents_web_view->SetWebContents(
         inspectable_web_contents_->GetWebContents());
     contents_web_view_ = contents_web_view;

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -428,32 +428,6 @@ describe('WebContentsView', () => {
       // would indicate the occlusion checker is causing spurious transitions.
       expect(changes).to.deep.equal(['visible', 'hidden']);
     });
-
-    it('becomes hidden when occluded by another WebContentsView', async () => {
-      const w = new BaseWindow({ width: 400, height: 600 });
-      const cv = new View();
-      w.setContentView(cv);
-
-      const bottom = new WebContentsView();
-      const top = new WebContentsView();
-      cv.addChildView(bottom);
-      cv.addChildView(top);
-
-      bottom.setBounds({ x: 0, y: 0, width: 400, height: 600 });
-      top.setBounds({ x: 0, y: 0, width: 0, height: 0 });
-      await bottom.webContents.loadURL('about:blank');
-      await top.webContents.loadURL('about:blank');
-
-      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'visible'))).to.eventually.be.fulfilled();
-
-      // Fully cover `bottom` with an opaque sibling.
-      top.setBounds({ x: 0, y: 0, width: 400, height: 600 });
-      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'hidden'))).to.eventually.be.fulfilled();
-
-      // Uncovering it restores visibility.
-      top.setBounds({ x: 0, y: 0, width: 0, height: 0 });
-      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'visible'))).to.eventually.be.fulfilled();
-    });
   });
 
   describe('setBorderRadius', () => {

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -428,6 +428,32 @@ describe('WebContentsView', () => {
       // would indicate the occlusion checker is causing spurious transitions.
       expect(changes).to.deep.equal(['visible', 'hidden']);
     });
+
+    it('becomes hidden when occluded by another WebContentsView', async () => {
+      const w = new BaseWindow({ width: 400, height: 600 });
+      const cv = new View();
+      w.setContentView(cv);
+
+      const bottom = new WebContentsView();
+      const top = new WebContentsView();
+      cv.addChildView(bottom);
+      cv.addChildView(top);
+
+      bottom.setBounds({ x: 0, y: 0, width: 400, height: 600 });
+      top.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+      await bottom.webContents.loadURL('about:blank');
+      await top.webContents.loadURL('about:blank');
+
+      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'visible'))).to.eventually.be.fulfilled();
+
+      // Fully cover `bottom` with an opaque sibling.
+      top.setBounds({ x: 0, y: 0, width: 400, height: 600 });
+      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'hidden'))).to.eventually.be.fulfilled();
+
+      // Uncovering it restores visibility.
+      top.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+      await expect(waitUntil(async () => await haveVisibilityState(bottom, 'visible'))).to.eventually.be.fulfilled();
+    });
   });
 
   describe('setBorderRadius', () => {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/52576.

Restores WCO on Linux in Electron 44 alpha/45 nightly.

This removes the opt-out added with the Chromium roll in https://github.com/electron/electron/pull/52288. Opting out of Views layer management for occlusion tracking is no longer necessary following https://chromium-review.googlesource.com/c/chromium/src/+/8060981, and it no longer works correctly as of https://chromium-review.googlesource.com/c/chromium/src/+/8117151 and https://chromium-review.googlesource.com/c/chromium/src/+/8111037.

Passes the existing tests in `api-web-contents-view-spec` that guard against this regression:

- `tracks visibility for multiple child WebContentsViews`
- `tracks visibility independently when a child WebContentsView is hidden via setVisible`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed Window Controls Overlay caption buttons not rendering on Linux.
