### PR TITLE
fix: Emit warnings for invalid headers in webRequest API

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -490,9 +490,8 @@ void WebRequest::OnBeforeSendHeadersListenerResult(
       if (dict.Get("requestHeaders", &value) && value->IsObject()) {
         if (!gin::Converter<net::HttpRequestHeaders>::FromV8(isolate, value,
                                                              &new_headers)) {
-          util::EmitWarning(isolate,
-                            "Invalid header provided in requestHeaders",
-                            "Warning");
+          util::EmitWarning(
+              isolate, "Invalid header provided in requestHeaders", "Warning");
         } else {
           user_modified_headers = true;
         }
@@ -593,9 +592,8 @@ void WebRequest::OnHeadersReceivedListenerResult(
         override_headers->ReplaceStatusLine(status_line);
         if (!gin::Converter<net::HttpResponseHeaders*>::FromV8(
                 isolate, value, override_headers.get())) {
-          util::EmitWarning(isolate,
-                            "Invalid header provided in responseHeaders",
-                            "Warning");
+          util::EmitWarning(
+              isolate, "Invalid header provided in responseHeaders", "Warning");
         } else {
           user_modified_headers = true;
         }

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -488,9 +488,14 @@ void WebRequest::OnBeforeSendHeadersListenerResult(
     } else {
       v8::Local<v8::Value> value;
       if (dict.Get("requestHeaders", &value) && value->IsObject()) {
-        user_modified_headers = true;
-        gin::Converter<net::HttpRequestHeaders>::FromV8(isolate, value,
-                                                        &new_headers);
+        if (!gin::Converter<net::HttpRequestHeaders>::FromV8(isolate, value,
+                                                             &new_headers)) {
+          util::EmitWarning(isolate,
+                            "Invalid header provided in requestHeaders",
+                            "Warning");
+        } else {
+          user_modified_headers = true;
+        }
       }
     }
   }
@@ -498,7 +503,9 @@ void WebRequest::OnBeforeSendHeadersListenerResult(
   // If the user passes |cancel|, |new_headers| should be nullptr.
   const auto updated_headers = CalculateOnBeforeSendHeadersDelta(
       old_headers,
-      result == net::ERR_BLOCKED_BY_CLIENT ? nullptr : &new_headers);
+      (result == net::ERR_BLOCKED_BY_CLIENT || !user_modified_headers)
+          ? nullptr
+          : &new_headers);
 
   // Leave |request.request_headers| unchanged if the user didn't modify it.
   if (user_modified_headers)
@@ -583,10 +590,15 @@ void WebRequest::OnHeadersReceivedListenerResult(
         status_line = request.status_line;
       v8::Local<v8::Value> value;
       if (dict.Get("responseHeaders", &value) && value->IsObject()) {
-        user_modified_headers = true;
         override_headers->ReplaceStatusLine(status_line);
-        gin::Converter<net::HttpResponseHeaders*>::FromV8(
-            isolate, value, override_headers.get());
+        if (!gin::Converter<net::HttpResponseHeaders*>::FromV8(
+                isolate, value, override_headers.get())) {
+          util::EmitWarning(isolate,
+                            "Invalid header provided in responseHeaders",
+                            "Warning");
+        } else {
+          user_modified_headers = true;
+        }
       }
     }
   }

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -289,9 +289,11 @@ bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
     if (!gin::ConvertFromV8(isolate, v8key, &key) ||
         !gin::ConvertFromV8(isolate, v8value, &value))
       return false;
-    if (net::HttpUtil::IsValidHeaderName(key) &&
-        net::HttpUtil::IsValidHeaderValue(value))
-      out->SetHeader(key, std::move(value));
+    if (!net::HttpUtil::IsValidHeaderName(key) ||
+        !net::HttpUtil::IsValidHeaderValue(value)) {
+      return false;
+    }
+    out->SetHeader(key, std::move(value));
   }
   return true;
 }

--- a/spec/api-net-session-spec.ts
+++ b/spec/api-net-session-spec.ts
@@ -631,6 +631,61 @@ describe('net module (session)', () => {
         expect(body).to.equal('hi');
         expect(webRequestDetails).to.have.property('url', serverUrl);
       });
+
+      it('emits a warning when invalid headers are provided in onBeforeSendHeaders', async () => {
+        const serverUrl = await respondOnce.toSingleURL((req, res) => res.end('hi'));
+        let warningEmitted = false;
+        const warningListener = (warning: Error) => {
+          console.log('WARNING EMITTED:', warning.message);
+          if (warning.message.includes('Invalid header provided in requestHeaders')) {
+            warningEmitted = true;
+          }
+        };
+        process.on('warning', warningListener);
+
+        session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+          callback({
+            requestHeaders: {
+              'X-Bad': 'bad\r\nvalue',
+              ...details.requestHeaders
+            }
+          });
+        });
+        try {
+          await net.fetch(serverUrl);
+        } finally {
+          process.off('warning', warningListener);
+          session.defaultSession.webRequest.onBeforeSendHeaders(null);
+        }
+        expect(warningEmitted).to.be.true('Warning should have been emitted');
+      });
+
+      it('emits a warning when invalid headers are provided in onHeadersReceived', async () => {
+        const serverUrl = await respondOnce.toSingleURL((req, res) => res.end('hi'));
+        let warningEmitted = false;
+        const warningListener = (warning: Error) => {
+          if (warning.message.includes('Invalid header provided in responseHeaders')) {
+            warningEmitted = true;
+          }
+        };
+        process.on('warning', warningListener);
+
+        session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+          callback({
+            responseHeaders: {
+              'X-Bad': ['bad\r\nvalue'],
+              ...details.responseHeaders
+            }
+          });
+        });
+        try {
+          await net.fetch(serverUrl);
+        } finally {
+          process.off('warning', warningListener);
+          session.defaultSession.webRequest.onHeadersReceived(null);
+        }
+        expect(warningEmitted).to.be.true('Warning should have been emitted');
+      });
     });
 
     it('should throw if given an invalid session option', () => {


### PR DESCRIPTION
#### Description of Change
Fixes: #52483

Previously a `session.webRequest.onHeadersReceived` (or `onBeforeSendHeaders`) listener calls callback() with a `responseHeaders` / `requestHeaders` object containing an invalid name or value (e.g. a value with `\r\n` in it), the `JS-to-HttpResponseHeaders` conversion fails partway, but we ignore the converter's return value and apply the empty or partially-built set and `gin::Converter<net::HttpRequestHeaders>::FromV8` was explicitly written to silently ignore invalid headers and return `true `

Now it give warning and leaves the original headers untouched and `gin::Converter<net::HttpRequestHeaders>::FromV8 ` returns `false` if invalid name or value provide. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue where invalid header values provided in `session.webRequest` callbacks would silently truncate subsequent headers.
