### PR TITLE
fix: remove shadow artifacts that appear when multiple windows are created on Linux

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -52,7 +52,6 @@
 #include "ui/views/window/client_view.h"
 #include "ui/views/window/frame_view.h"
 #include "ui/views/window/non_client_view.h"
-#include "ui/wm/core/shadow_types.h"
 #include "ui/wm/core/window_util.h"
 
 #if BUILDFLAG(IS_LINUX)
@@ -1339,31 +1338,30 @@ void NativeWindowViews::SetBackgroundColor(SkColor background_color) {
 }
 
 void NativeWindowViews::SetHasShadow(bool has_shadow) {
+  // Shadows are now drawn by CSD (Linux) or DWM (Windows) instead of Aura,
+  // so we no longer call wm::SetShadowElevation and similar to avoid
+  // artifacts. https://github.com/electron/electron/issues/51456.
+
 #if BUILDFLAG(IS_LINUX)
   auto* efvl = views::AsViewClass<ElectronFrameViewLinux>(
       widget()->non_client_view()->frame_view());
-  gfx::Rect visible_bounds;
   if (efvl) {
     // Shrink by the old frame border insets to isolate the visible area.
-    visible_bounds = widget()->GetWindowBoundsInScreen();
+    gfx::Rect visible_bounds = widget()->GetWindowBoundsInScreen();
     visible_bounds.Inset(GetRestoredFrameBorderInsets());
+
+    has_shadow_ = has_shadow;
+    efvl->SetWantsFrame(!IsTranslucent() &&
+                        (has_shadow || IsWindowControlsOverlayEnabled()));
+
+    // Grow by the new frame border insets to preserve the visible area.
+    visible_bounds.Inset(-GetRestoredFrameBorderInsets());
+    widget()->SetBounds(visible_bounds);
+    return;
   }
 #endif
 
   has_shadow_ = has_shadow;
-  wm::SetShadowElevation(GetNativeWindow(),
-                         has_shadow ? wm::kShadowElevationInactiveWindow
-                                    : wm::kShadowElevationNone);
-
-#if BUILDFLAG(IS_LINUX)
-  if (efvl) {
-    efvl->SetWantsFrame(!IsTranslucent() &&
-                        (has_shadow || IsWindowControlsOverlayEnabled()));
-    // Grow by the new frame border insets to preserve the visible area.
-    visible_bounds.Inset(-GetRestoredFrameBorderInsets());
-    widget()->SetBounds(visible_bounds);
-  }
-#endif
 }
 
 bool NativeWindowViews::HasShadow() const {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/51456.

Prevents Aura from applying its own drop shadows to windows, since modern versions of Electron and Chrome draw shadows directly on the frame or with DWM.

The Aura shadow manager was vestigial in Electron. All it was doing was producing subtle graphical glitches for additional windows created after first, due to a race where the controller only fully initialized after the first window was created.

This change applies to both Linux and Windows. At first I was confused about the impact on Windows, because there is no other code left in Electron to control shadows on the platform. On further investigation I discovered that `hasShadow` does not function on Windows already, and it seems it has not worked for a long time if ever  (I tested back to Electron 37). So I thought it would be best to remove the dead code and look into a solution for Windows separately: https://github.com/electron/electron/issues/52583.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Fixed a graphical glitch on Linux where thin borders appeared past the drop shadows on frameless windows when multiple windows were created.
