### PR TITLE
feat: support ELECTRON_DISABLE_GPU and ELECTRON_ENABLE_GPU env vars

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -125,6 +125,14 @@ Options:
 * `kioclient5`
 * `kioclient`
 
+### `ELECTRON_DISABLE_GPU`
+
+Disables GPU hardware acceleration across the application during early process startup (equivalent to passing `--disable-gpu`). Can be set to `1`, `true`, or `yes`.
+
+### `ELECTRON_ENABLE_GPU`
+
+Overrides `ELECTRON_DISABLE_GPU` to ensure GPU hardware acceleration remains enabled. Can be set to `1`, `true`, or `yes`.
+
 ## Development Variables
 
 The following environment variables are intended primarily for development and

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -21,6 +21,7 @@
 #include "base/path_service.h"
 #include "base/strings/cstring_view.h"
 #include "base/strings/string_number_conversions.cc"
+#include "base/strings/string_util.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"
 #include "chrome/common/profiler/process_type.h"
@@ -94,6 +95,10 @@ constexpr base::cstring_view kElectronDisableSandbox{
     "ELECTRON_DISABLE_SANDBOX"};
 constexpr base::cstring_view kElectronEnableStackDumping{
     "ELECTRON_ENABLE_STACK_DUMPING"};
+constexpr base::cstring_view kElectronDisableGPU{
+    "ELECTRON_DISABLE_GPU"};
+constexpr base::cstring_view kElectronEnableGPU{
+    "ELECTRON_ENABLE_GPU"};
 
 // Returns true if this subprocess type needs the ResourceBundle initialized
 // and resources loaded.
@@ -194,6 +199,24 @@ std::optional<int> ElectronMainDelegate::BasicStartupComplete() {
 
   if (env->HasVar(kElectronDisableSandbox))
     command_line->AppendSwitch(sandbox::policy::switches::kNoSandbox);
+
+  auto is_env_true = [](const std::string& val) {
+    return val == "1" || base::EqualsCaseInsensitiveASCII(val, "true") ||
+           base::EqualsCaseInsensitiveASCII(val, "yes");
+  };
+
+  std::string disable_gpu_val;
+  std::string enable_gpu_val;
+  if (env->GetVar(kElectronDisableGPU, &disable_gpu_val) &&
+      is_env_true(disable_gpu_val)) {
+    bool enable_gpu = command_line->HasSwitch("enable-gpu");
+    if (!enable_gpu && env->GetVar(kElectronEnableGPU, &enable_gpu_val)) {
+      enable_gpu = is_env_true(enable_gpu_val);
+    }
+    if (!enable_gpu && !command_line->HasSwitch(::switches::kDisableGpu)) {
+      command_line->AppendSwitch(::switches::kDisableGpu);
+    }
+  }
 
   tracing_sampler_profiler_ =
       tracing::TracingSamplerProfiler::CreateOnMainThread();

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -2260,6 +2260,30 @@ describe('app module', () => {
     });
   });
 
+  describe('ELECTRON_DISABLE_GPU / ELECTRON_ENABLE_GPU environment variables', () => {
+    it('disables GPU acceleration when ELECTRON_DISABLE_GPU=1', async () => {
+      const { hasDisableGpu } = await runTestApp('command-line', { env: { ELECTRON_DISABLE_GPU: '1' } });
+      expect(hasDisableGpu).to.equal(true);
+    });
+
+    it('disables GPU acceleration when ELECTRON_DISABLE_GPU=TrUe (case-insensitive)', async () => {
+      const { hasDisableGpu } = await runTestApp('command-line', { env: { ELECTRON_DISABLE_GPU: 'TrUe' } });
+      expect(hasDisableGpu).to.equal(true);
+    });
+
+    it('disables GPU acceleration when ELECTRON_DISABLE_GPU=yes', async () => {
+      const { hasDisableGpu } = await runTestApp('command-line', { env: { ELECTRON_DISABLE_GPU: 'yes' } });
+      expect(hasDisableGpu).to.equal(true);
+    });
+
+    it('does not disable GPU acceleration when ELECTRON_ENABLE_GPU=1 overrides ELECTRON_DISABLE_GPU=1', async () => {
+      const { hasDisableGpu } = await runTestApp('command-line', {
+        env: { ELECTRON_DISABLE_GPU: '1', ELECTRON_ENABLE_GPU: '1' }
+      });
+      expect(hasDisableGpu).to.equal(false);
+    });
+  });
+
   describe('commandLine.getSwitchValue', () => {
     afterEach(() => {
       app.commandLine.removeSwitch('foobar');
@@ -2653,10 +2677,24 @@ describe('default behavior', () => {
   });
 });
 
-async function runTestApp(name: string, ...args: any[]) {
+async function runTestApp(name: string, optionsOrArg?: any, ...extraArgs: any[]) {
   const appPath = path.join(fixturesPath, 'api', name);
   const electronPath = process.execPath;
-  const appProcess = cp.spawn(electronPath, [appPath, ...args]);
+  let args: string[] = [];
+  let spawnEnv = process.env;
+
+  if (typeof optionsOrArg === 'object' && optionsOrArg !== null && !Array.isArray(optionsOrArg)) {
+    if (optionsOrArg.env) {
+      spawnEnv = { ...process.env, ...optionsOrArg.env };
+    }
+    if (optionsOrArg.args) {
+      args = optionsOrArg.args;
+    }
+  } else if (optionsOrArg !== undefined) {
+    args = [optionsOrArg, ...extraArgs];
+  }
+
+  const appProcess = cp.spawn(electronPath, [appPath, ...args], { env: spawnEnv });
 
   let output = '';
   appProcess.stdout.on('data', (data) => {

--- a/spec/fixtures/api/command-line/main.js
+++ b/spec/fixtures/api/command-line/main.js
@@ -3,7 +3,8 @@ const { app } = require('electron');
 app.whenReady().then(() => {
   const payload = {
     hasSwitch: app.commandLine.hasSwitch('foobar'),
-    getSwitchValue: app.commandLine.getSwitchValue('foobar')
+    getSwitchValue: app.commandLine.getSwitchValue('foobar'),
+    hasDisableGpu: app.commandLine.hasSwitch('disable-gpu')
   };
 
   process.stdout.write(JSON.stringify(payload));


### PR DESCRIPTION
#### Description of Change
Fixes #52457
Adds support for `ELECTRON_DISABLE_GPU` and `ELECTRON_ENABLE_GPU` environment variables during early process delegate initialization (`BasicStartupComplete`).

This allows system administrators and end-users facing GPU hardware acceleration bugs (such as GPU process crashes, black screens, or display artifacts) to globally force hardware acceleration off across all Electron apps using `ELECTRON_DISABLE_GPU=1` without requiring individual app developers to expose a custom toggle or code changes.

- Case-insensitive boolean parsing (`1`, `true`, `yes`).
- Respects explicit `--enable-gpu` CLI flag overrides.
- Allows `ELECTRON_ENABLE_GPU=1` to override `ELECTRON_DISABLE_GPU=1` for individual processes or sessions.

#### Checklist
- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] Tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] Relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) Describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
#### Release Notes
Notes: Added support for `ELECTRON_DISABLE_GPU` and `ELECTRON_ENABLE_GPU` environment variables to toggle hardware acceleration globally.