### PR TITLE
Resolve: macOS: dialog.showOpenDialog fails to show custom macOS packages (LSTy

### DIFF
--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -271,7 +271,7 @@ deprecated:
 ```
 -->
 
-* `position` [Point](structures/point.md)
+* `position` [Point](docs/api/structures/point.md)
 
 Set a custom position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`.
 `````


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/48191

Opened by TRAVIS. The change was applied and reviewed; see the commit for exactly what was modified.