### PR TITLE
fix: honor tabs permission for url and title in tabs.query results

### DIFF
--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -88,6 +88,17 @@ api::tabs::MutedInfo CreateMutedInfo(content::WebContents* contents) {
   return info;
 }
 
+// "title" and "url" properties are considered privileged data and can only
+// be exposed if the extension has the "tabs" permission or it has access to
+// the WebContents's origin.
+bool CanAccessPrivilegedTabFields(const Extension* extension,
+                                  int tab_id,
+                                  const GURL& url) {
+  return extension->permissions_data()->HasAPIPermissionForTab(
+             tab_id, mojom::APIPermissionID::kTab) ||
+         extension->permissions_data()->HasHostPermission(url);
+}
+
 }  // namespace
 
 ExecuteCodeInTabFunction::ExecuteCodeInTabFunction() : execute_tab_id_(-1) {}
@@ -294,16 +305,14 @@ ExtensionFunction::ResponseAction TabsQueryFunction::Run() {
     if (!MatchesBool(params->query_info.active, contents->IsFocused()))
       continue;
 
+    const GURL& committed_url = wc->GetLastCommittedURL();
+    const bool has_privileged_access = CanAccessPrivilegedTabFields(
+        extension(), contents->ID(), committed_url);
+
     if (!title.empty() || !url_patterns.is_empty()) {
-      // "title" and "url" properties are considered privileged data and can
-      // only be checked if the extension has the "tabs" permission or it has
-      // access to the WebContents's origin. Otherwise, this tab is considered
-      // not matched.
-      if (!extension()->permissions_data()->HasAPIPermissionForTab(
-              contents->ID(), mojom::APIPermissionID::kTab) &&
-          !extension()->permissions_data()->HasHostPermission(wc->GetURL())) {
+      // Without privileged access, this tab is considered not matched.
+      if (!has_privileged_access)
         continue;
-      }
 
       // Match webContents title.
       if (!title.empty() &&
@@ -311,14 +320,16 @@ ExtensionFunction::ResponseAction TabsQueryFunction::Run() {
         continue;
 
       // Match webContents url.
-      if (!url_patterns.is_empty() && !url_patterns.MatchesURL(wc->GetURL()))
+      if (!url_patterns.is_empty() && !url_patterns.MatchesURL(committed_url))
         continue;
     }
 
     tabs::Tab tab;
     tab.id = contents->ID();
-    tab.title = base::UTF16ToUTF8(wc->GetTitle());
-    tab.url = wc->GetLastCommittedURL().spec();
+    if (has_privileged_access) {
+      tab.title = base::UTF16ToUTF8(wc->GetTitle());
+      tab.url = committed_url.spec();
+    }
     tab.active = contents->IsFocused();
     tab.audible = contents->IsCurrentlyAudible();
     tab.muted_info = CreateMutedInfo(wc);
@@ -343,13 +354,9 @@ ExtensionFunction::ResponseAction TabsGetFunction::Run() {
   tabs::Tab tab;
   tab.id = tab_id;
 
-  // "title" and "url" properties are considered privileged data and can
-  // only be checked if the extension has the "tabs" permission or it has
-  // access to the WebContents's origin.
   auto* wc = contents->web_contents();
-  if (extension()->permissions_data()->HasAPIPermissionForTab(
-          contents->ID(), mojom::APIPermissionID::kTab) ||
-      extension()->permissions_data()->HasHostPermission(wc->GetURL())) {
+  if (CanAccessPrivilegedTabFields(extension(), contents->ID(),
+                                   wc->GetLastCommittedURL())) {
     tab.url = wc->GetLastCommittedURL().spec();
     tab.title = base::UTF16ToUTF8(wc->GetTitle());
   }
@@ -684,13 +691,9 @@ ExtensionFunction::ResponseValue TabsUpdateFunction::GetResult() {
   auto* api_web_contents = electron::api::WebContents::From(web_contents_);
   tab.id = (api_web_contents ? api_web_contents->ID() : -1);
 
-  // "title" and "url" properties are considered privileged data and can
-  // only be checked if the extension has the "tabs" permission or it has
-  // access to the WebContents's origin.
-  if (extension()->permissions_data()->HasAPIPermissionForTab(
-          api_web_contents->ID(), mojom::APIPermissionID::kTab) ||
-      extension()->permissions_data()->HasHostPermission(
-          web_contents_->GetURL())) {
+  if (CanAccessPrivilegedTabFields(
+          extension(), api_web_contents ? api_web_contents->ID() : -1,
+          web_contents_->GetLastCommittedURL())) {
     tab.url = web_contents_->GetLastCommittedURL().spec();
     tab.title = base::UTF16ToUTF8(web_contents_->GetTitle());
   }

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -1332,6 +1332,27 @@ describe('chrome extensions', () => {
           expect(response).to.have.property('selected').that.is.a('boolean');
           expect(response).to.have.property('windowId').that.is.a('number');
         });
+
+        it('does not return privileged properties from query without tabs permission', async () => {
+          const noPrivilegeSes = session.fromPartition(`persist:${uuid.v4()}`);
+          await noPrivilegeSes.extensions.loadExtension(
+            path.join(fixtures, 'extensions', 'chrome-tabs', 'no-privileges')
+          );
+
+          w = new BrowserWindow({ show: false, webPreferences: { session: noPrivilegeSes } });
+          await w.loadURL(url);
+
+          const message = { method: 'query' };
+          w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`);
+          const [{ message: responseString }] = await once(w.webContents, 'console-message');
+          const response = JSON.parse(responseString);
+          expect(response).to.be.an('array').that.is.not.empty();
+          for (const tab of response) {
+            expect(tab).not.to.have.property('url');
+            expect(tab).not.to.have.property('title');
+            expect(tab).to.have.property('id').that.is.a('number');
+          }
+        });
       });
 
       it('reload', async () => {

--- a/spec/fixtures/extensions/chrome-tabs/no-privileges/background.js
+++ b/spec/fixtures/extensions/chrome-tabs/no-privileges/background.js
@@ -1,6 +1,11 @@
 /* global chrome */
 
-chrome.runtime.onMessage.addListener((_request, sender, sendResponse) => {
-  chrome.tabs.get(sender.tab.id).then(sendResponse);
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  const { method } = request || {};
+  if (method === 'query') {
+    chrome.tabs.query({}).then(sendResponse);
+  } else {
+    chrome.tabs.get(sender.tab.id).then(sendResponse);
+  }
   return true;
 });

--- a/spec/fixtures/extensions/chrome-tabs/no-privileges/main.js
+++ b/spec/fixtures/extensions/chrome-tabs/no-privileges/main.js
@@ -6,8 +6,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 window.addEventListener(
   'message',
-  () => {
-    chrome.runtime.sendMessage({}, (response) => {
+  (event) => {
+    let message = {};
+    try {
+      message = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+    } catch {
+      // Fall through with an empty message.
+    }
+    chrome.runtime.sendMessage(message, (response) => {
       console.log(JSON.stringify(response));
     });
   },


### PR DESCRIPTION
#### Description of Change

- `chrome.tabs.query()` returned `url`/`title` even when the extension had neither the `tabs` permission nor host access to the tab; `tabs.get`/`tabs.update` already gated these, matching Chrome and our own [tabs schema docs](https://github.com/electron/electron/blob/main/shell/common/extensions/api/tabs.json). Now all three go through one `CanAccessPrivilegedTabFields` check.
- The check (and the query URL filter) is evaluated against the last committed URL rather than the visible URL, so a pending navigation can't change which page's fields are exposed.
- Extends the `no-privileges` MV3 fixture and adds a spec for the `query` case.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `chrome.tabs.query()` returning tab `url` and `title` to extensions without the `tabs` permission or host access, aligning with `tabs.get`.
