### PR TITLE
fix: use WeakPtr for MenuDelegate cancellation

### DIFF
--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -133,12 +133,17 @@ views::MenuItemView* MenuDelegate::GetSiblingMenu(
     // Switching menu asynchronously to avoid crash.
     if (!switch_in_progress) {
       content::GetUIThreadTaskRunner({})->PostTask(
-          FROM_HERE, base::BindOnce(&views::MenuRunner::Cancel,
-                                    base::Unretained(menu_runner_.get())));
+          FROM_HERE, base::BindOnce(&MenuDelegate::CancelSelf,
+                                    weak_factory_.GetWeakPtr()));
     }
   }
 
   return nullptr;
+}
+
+void MenuDelegate::CancelSelf() {
+  if (menu_runner_)
+    menu_runner_->Cancel();
 }
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_delegate.h
+++ b/shell/browser/ui/views/menu_delegate.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "ui/views/controls/menu/menu_delegate.h"
 
@@ -71,6 +72,7 @@ class MenuDelegate : public views::MenuDelegate {
                                       views::MenuButton** button) override;
 
  private:
+  void CancelSelf();
   raw_ptr<MenuBar> menu_bar_;
   int id_ = -1;
   std::unique_ptr<views::MenuDelegate> adapter_;
@@ -81,6 +83,7 @@ class MenuDelegate : public views::MenuDelegate {
   bool hold_first_switch_ = false;
 
   base::ObserverList<Observer>::Unchecked observers_;
+  base::WeakPtrFactory<MenuDelegate> weak_factory_{this};
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Resolves #52579 

`MenuDelegate` cancellation used `base::Unretained` and didn't guarantee the callee lifecycle. This change adds `WeakPtrFactory` to `MenuDelegate` so [cancel-on-destroy](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/callback.md#Binding-A-Class-Method-With-Weak-Pointers) semantics protect the cancellation callback if the `MenuDelegate` is destroyed before the event loop runs the callback.

This issue was actually originally reported by Microsoft **8 years ago** in #14213

#### Checklist

- [X] I have built and tested this change
- [X] I have filled out the PR description
- [X] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [X] `npm test` passes
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when quickly switching menus while the app is under heavy load.
