### PR TITLE
chore: include the asar entry in integrity-check failure messages

### DIFF
--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -245,7 +245,8 @@ bool Archive::Init() {
     // more below ensure we read them in preference order from most secure to
     // least
     if (integrity->algorithm != HashAlgorithm::kNone) {
-      ValidateIntegrityOrDie(base::as_byte_span(header), *integrity);
+      ValidateIntegrityOrDie(base::as_byte_span(header), *integrity,
+                             "<header>");
     } else {
       LOG(FATAL) << "No eligible hash for validatable asar archive: "
                  << RelativePath().value();

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -142,9 +142,9 @@ void ValidateIntegrityOrDie(base::span<const uint8_t> input,
     const std::string hex_hash =
         base::ToLowerASCII(base::HexEncode(crypto::hash::Sha256(input)));
     if (integrity.hash != hex_hash) {
-      LOG(FATAL) << "Integrity check failed for asar entry '" << what
-                 << "' (" << integrity.hash << " vs " << hex_hash
-                 << ", " << input.size() << " bytes)";
+      LOG(FATAL) << "Integrity check failed for asar archive entry '" << what
+                 << "' (" << integrity.hash << " vs " << hex_hash << ", "
+                 << input.size() << " bytes)";
     }
   } else {
     LOG(FATAL) << "Unsupported hashing algorithm in ValidateIntegrityOrDie";

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -129,19 +129,22 @@ bool ReadFileToString(const base::FilePath& path, std::string* contents) {
     return false;
 
   if (info.integrity)
-    ValidateIntegrityOrDie(base::as_byte_span(*contents), *info.integrity);
+    ValidateIntegrityOrDie(base::as_byte_span(*contents), *info.integrity,
+                           relative_path.AsUTF8Unsafe());
 
   return true;
 }
 
 void ValidateIntegrityOrDie(base::span<const uint8_t> input,
-                            const IntegrityPayload& integrity) {
+                            const IntegrityPayload& integrity,
+                            std::string_view what) {
   if (integrity.algorithm == HashAlgorithm::kSHA256) {
     const std::string hex_hash =
         base::ToLowerASCII(base::HexEncode(crypto::hash::Sha256(input)));
     if (integrity.hash != hex_hash) {
-      LOG(FATAL) << "Integrity check failed for asar archive ("
-                 << integrity.hash << " vs " << hex_hash << ")";
+      LOG(FATAL) << "Integrity check failed for asar entry '" << what
+                 << "' (" << integrity.hash << " vs " << hex_hash
+                 << ", " << input.size() << " bytes)";
     }
   } else {
     LOG(FATAL) << "Unsupported hashing algorithm in ValidateIntegrityOrDie";

--- a/shell/common/asar/asar_util.h
+++ b/shell/common/asar/asar_util.h
@@ -32,7 +32,8 @@ bool GetAsarArchivePath(const base::FilePath& full_path,
 bool ReadFileToString(const base::FilePath& path, std::string* contents);
 
 void ValidateIntegrityOrDie(base::span<const uint8_t> input,
-                            const IntegrityPayload& integrity);
+                            const IntegrityPayload& integrity,
+                            std::string_view what = {});
 
 }  // namespace asar
 

--- a/shell/common/asar/scoped_temporary_file.cc
+++ b/shell/common/asar/scoped_temporary_file.cc
@@ -67,7 +67,7 @@ bool ScopedTemporaryFile::InitFromFile(
     return false;
 
   if (integrity)
-    ValidateIntegrityOrDie(buf, *integrity);
+    ValidateIntegrityOrDie(buf, *integrity, "<copied-out entry>");
 
   base::File dest(path_, base::File::FLAG_OPEN | base::File::FLAG_WRITE);
   return dest.IsValid() && dest.WriteAtCurrentPosAndCheck(buf);


### PR DESCRIPTION
#### Description of Change

`asar::ValidateIntegrityOrDie()` logs only the two hashes when a check
fails, so a crash report from a damaged install ("Integrity check failed
for asar archive (<expected> vs <actual>)") can't say which entry - or the
header - failed the check.

Thread a short `what` label through the three call sites (header
validation, packed-file read, unpacked copy-out) and include it, with the
input size, in the fatal message. Message text only; no behavior change.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or are not needed

#### Release Notes

Notes: Improved the error message when an asar integrity check fails to name the entry that failed.