### PR TITLE
chore: cherry-pick d73358403b31 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -205,3 +205,4 @@ cherry-pick-094448afb6ab.patch
 cherry-pick-e3cd72e404a5.patch
 cherry-pick-64f023ac1648.patch
 fix_ignore_non-occluding_windows_in_the_mac_occlusion_checker.patch
+cherry-pick-d73358403b31.patch

--- a/patches/chromium/cherry-pick-d73358403b31.patch
+++ b/patches/chromium/cherry-pick-d73358403b31.patch
@@ -21,7 +21,7 @@ Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1618677}
 
 diff --git a/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc b/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
-index f771c0c..46e3b46 100644
+index f771c0c1fb6ff726d9ca42df9ddbb4ccb93b8d0e..46e3b466cab6074fc09daa9351ef47cca7df88f3 100644
 --- a/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
 +++ b/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
 @@ -393,11 +393,12 @@ void DevToolsEmulator::DisableDeviceEmulation() {

--- a/patches/chromium/cherry-pick-d73358403b31.patch
+++ b/patches/chromium/cherry-pick-d73358403b31.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rakina Zata Amni <rakina@chromium.org>
+Date: Wed, 22 Apr 2026 06:29:20 +0000
+Subject: Fix null dereference in DevToolsEmulator::DisableDeviceEmulation
+
+DevToolsEmulator::DisableDeviceEmulation() calls
+WebViewImpl::SetPageScaleFactor(1.f) without checking if
+MainFrameImpl() is null. WebViewImpl::SetPageScaleFactor assumes
+MainFrameImpl() is non-null and attempts to access it, leading to a
+crash when it is null (which can happen during cleanup or remote <->
+local frame swaps).
+
+This CL adds a null check for MainFrameImpl() before calling
+SetPageScaleFactor, consistent with other checks in the same method.
+
+Fixed: 411541676
+Change-Id: Ie3e5bddff1d738d64456046c4d9f10d644589f7d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7784850
+Reviewed-by: Alex Rudenko <alexrudenko@chromium.org>
+Commit-Queue: Rakina Zata Amni <rakina@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1618677}
+
+diff --git a/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc b/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
+index f771c0c..46e3b46 100644
+--- a/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
++++ b/third_party/blink/renderer/core/inspector/dev_tools_emulator.cc
+@@ -393,11 +393,12 @@ void DevToolsEmulator::DisableDeviceEmulation() {
+   DisableMobileEmulation();
+   SetForceAndroidOverlayScrollbar(false);
+   web_view_->SetCompositorDeviceScaleFactorOverride(0.f);
+-  web_view_->SetPageScaleFactor(1.f);
+ 
+-  // TODO(wjmaclean): Tell all local frames in the WebView's frame tree, not
+-  // just a local main frame.
+   if (web_view_->MainFrameImpl()) {
++    web_view_->SetPageScaleFactor(1.f);
++
++    // TODO(wjmaclean): Tell all local frames in the WebView's frame tree,
++    // not just a local main frame.
+     if (Document* document =
+             web_view_->MainFrameImpl()->GetFrame()->GetDocument())
+       document->MediaQueryAffectingValueChanged(MediaValueChange::kOther);


### PR DESCRIPTION
#### Description of Change

Cherry-picks the upstream fix for a null dereference in `DevToolsEmulator::DisableDeviceEmulation` when the page's main frame is not local (crbug.com/411541676). The fix landed on Chromium main for M149; 42-x-y is on M148, so it needs the patch here.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or are not needed

#### Release Notes

Notes: Fixed a renderer crash when disabling device emulation while the main frame was not local.
