### PR TITLE
fix: don't crash when the helper executable no longer resolves on disk

### DIFF
--- a/shell/app/electron_main_delegate_mac.mm
+++ b/shell/app/electron_main_delegate_mac.mm
@@ -62,8 +62,10 @@ void ElectronMainDelegate::OverrideChildProcessPath() {
       GetHelperAppPath(frameworks_path, ELECTRON_PRODUCT_NAME);
   if (!base::PathExists(helper_path))
     helper_path = GetHelperAppPath(frameworks_path, GetApplicationName());
+  // The helper can be missing when the bundle is replaced or deleted while
+  // running; child launches will fail cleanly, so don't crash this process.
   if (!base::PathExists(helper_path))
-    LOG(FATAL) << "Unable to find helper app";
+    LOG(ERROR) << "Unable to find helper app at " << helper_path;
   base::PathService::OverrideAndCreateIfNeeded(
       content::CHILD_PROCESS_EXE, helper_path, /*is_absolute=*/true,
       /*create=*/false);

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -525,6 +525,11 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
     base::FilePath child_path;
     base::FilePath program =
         base::MakeAbsoluteFilePath(command_line->GetProgram());
+    // realpath() fails if the helper is no longer on disk (e.g. the app bundle
+    // was replaced or removed while running). Such a path cannot be exec'd, so
+    // compare it literally and let the launch fail instead of crashing here.
+    if (program.empty())
+      program = command_line->GetProgram();
 #if BUILDFLAG(IS_MAC)
     auto renderer_child_path = content::ChildProcessHost::GetChildPath(
         content::ChildProcessHost::CHILD_RENDERER);


### PR DESCRIPTION
#### Description of Change

When the app bundle is replaced or removed on disk while the app is running, `AppendExtraCommandLineSwitches` runs the child program path through `base::MakeAbsoluteFilePath`, which returns an empty path once the helper no longer resolves, and the allow-list `CHECK_EQ` kills the browser on the next child launch. On mac, `OverrideChildProcessPath` `LOG(FATAL)`s in every helper when the helper `.app` can't be found.

Compare the literal path when `realpath()` fails (a path that no longer resolves can't be exec'd, so the launch fails through content's normal path) and make helper-not-found a `LOG(ERROR)` so child launches fail instead of the current process aborting.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or are not needed

#### Release Notes

Notes: Fixed crashes when the app bundle was replaced or removed on disk while the app was running.
