### PR TITLE
fix: exit and lower child shutdown priority when the windows session ends

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -211,6 +211,12 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     return crashpad_status;
   }
 
+  if (!process_type.empty()) {
+    // Have Windows shut child processes down after the browser at logoff and
+    // shutdown, as Chrome does, so the browser never watches them die.
+    ::SetProcessShutdownParameters(0x280 - 1, SHUTDOWN_NORETRY);
+  }
+
   // access ui native theme here to prevent blocking calls later
   base::win::AllowDarkModeForApp(true);
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -7,6 +7,7 @@
 #include <wrl/client.h>
 
 #include "base/logging.h"
+#include "base/process/process.h"
 #include "base/win/atl.h"  // Must be before UIAutomationCore.h
 #include "base/win/registry.h"
 #include "base/win/scoped_handle.h"
@@ -17,6 +18,7 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/views/root_view.h"
 #include "shell/browser/ui/views/win_frame_view.h"
+#include "shell/browser/window_list.h"
 #include "shell/common/color_util.h"
 #include "shell/common/electron_constants.h"
 #include "skia/ext/skia_utils_win.h"
@@ -428,10 +430,25 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       return prevent_default;
     }
     case WM_ENDSESSION: {
+      static bool session_ended = false;
+      if (!w_param || session_ended)
+        return false;
+      session_ended = true;
       std::vector<std::string> reasons = EndSessionToStringVec(l_param);
-      if (w_param) {
-        NotifyWindowEndSession(reasons);
+      // The OS kills us and our child processes right after this returns, so
+      // every window hears about the end of the session now.
+      std::vector<base::WeakPtr<NativeWindow>> windows;
+      for (NativeWindow* window : WindowList::GetWindows())
+        windows.push_back(window->GetWeakPtr());
+      for (const auto& window : windows) {
+        if (window)
+          window->NotifyWindowEndSession(reasons);
       }
+      // Then leave immediately (as Chrome's SessionEnding() does) instead of
+      // lingering while Windows tears our children down, unless the app
+      // already began its own quit from a session-end handler.
+      if (!Browser::Get()->is_quitting())
+        base::Process::TerminateCurrentProcessImmediately(0);
       return false;
     }
     case WM_PARENTNOTIFY: {


### PR DESCRIPTION
#### Description of Change

At Windows logoff and shutdown the OS kills an app's child processes at the same shutdown level as the browser and refuses to spawn new ones. Content counts each of those GPU child exits as a GPU crash, walks the fallback ladder in about a second, and the still-running browser dies in `IntentionallyCrashBrowserForUnusableGpuProcess()` - a crash report on every logoff for apps that outlive the message.

This copies the two things Chrome does: child processes get `SetProcessShutdownParameters` one level below the browser's so csrss ends the browser first, and `WM_ENDSESSION` notifies every window then terminates immediately, unless the app already began its own quit from a `session-end` handler.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation, tutorials, templates and examples are changed or are not needed

#### Release Notes

Notes: Fixed a browser process crash that could occur during Windows logoff, shutdown, or restart.
