### PR TITLE
fix: add kFromPlatform flag to Windows WM_GETOBJECT accessibility activation

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -319,7 +319,8 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       if (axState && axState->GetAccessibilityMode() != ui::kAXModeComplete) {
         scoped_accessibility_mode_ =
             content::BrowserAccessibilityState::GetInstance()
-                ->CreateScopedModeForProcess(ui::kAXModeComplete);
+                ->CreateScopedModeForProcess(ui::kAXModeComplete |
+                                             ui::AXMode::kFromPlatform);
         Browser::Get()->OnAccessibilitySupportChanged();
       }
 


### PR DESCRIPTION
#### Description of Change

The `WM_GETOBJECT` handler in `native_window_views_win.cc` activates full accessibility mode (`kAXModeComplete`) when a screen reader queries the window, but was missing the `ui::AXMode::kFromPlatform` meta-flag.

This is inconsistent with:
- **macOS**: `electron_application.mm` correctly uses `kFromPlatform` when activating accessibility in response to platform assistive technology queries.
- **Chromium Windows**: The upstream `WM_GETOBJECT` path goes through `EnableAXModeFromPlatform()`, which automatically attaches `kFromPlatform`.

Without this flag, `SetActivationFromPlatformEnabled(false)` cannot suppress the activation in test environments, potentially causing unintended accessibility side effects during CI.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `kFromPlatform` flag to Windows accessibility activation via `WM_GETOBJECT`, aligning behavior with macOS and Chromium upstream.