### PR TITLE
fix: prevent crash when redirecting CORS preflight requests

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -512,6 +512,11 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToStartRequest(
   }
 
   if (current_request_uses_header_client_ && !redirect_url_.is_empty()) {
+    if (for_cors_preflight_) {
+      // CORS preflight doesn't support redirect.
+      OnRequestError(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+      return;
+    }
     HandleBeforeRequestRedirect();
     return;
   }

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -367,6 +367,33 @@ describe('webRequest module', () => {
       await ajax(defaultURL + 'serverRedirect');
     });
 
+    it('does not crash when redirecting a CORS preflight OPTIONS request', async () => {
+      const target = http.createServer((req, res) => {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Headers', 'x-trigger');
+        res.setHeader('Access-Control-Allow-Methods', 'POST');
+        res.end('ok');
+      });
+      const targetPort = (await listen(target)).port;
+      defer(() => target.close());
+
+      ses.webRequest.onBeforeRequest(
+        { urls: ['http://127.0.0.1/*'] },
+        (details, callback) => {
+          if (details.method === 'OPTIONS' && details.url.endsWith('/data')) {
+            callback({ redirectURL: `http://127.0.0.1:${targetPort}/noop` });
+            return;
+          }
+          callback({});
+        }
+      );
+
+      await ajax(`http://127.0.0.1:${targetPort}/data`, {
+        method: 'POST',
+        headers: { 'X-Trigger': '1' }
+      }).catch(() => {});
+    });
+
     it('works with file:// protocol', async () => {
       ses.webRequest.onBeforeRequest((details, callback) => {
         callback({ cancel: true });


### PR DESCRIPTION
#### Description of Change

Fixes a main process crash (segmentation fault / access violation) when returning a `redirectURL` from `session.webRequest.onBeforeRequest` for a CORS preflight `OPTIONS` request.

When `current_request_uses_header_client_` is `true` (such as when header listeners or extraHeaders options are active), `OnBeforeRequest` sets its continuation to `ContinueToStartRequest`. When `redirect_url_` is non-empty, `ContinueToStartRequest` previously called `HandleBeforeRequestRedirect()` without verifying whether the request was a CORS preflight.

Because CORS preflight requests managed by `ProxyingURLLoaderFactory` do not have an associated downstream `target_client_` (`network::mojom::URLLoaderClient`), calling `target_client_->OnReceiveRedirect()` in `ContinueToBeforeRedirect` dereferenced a null pointer and crashed the main process.

This change adds a `for_cors_preflight_` guard check inside `ContinueToStartRequest` to fail preflight redirects safely with `net::ERR_FAILED`. This mirrors the preflight guard handling in `ContinueToBeforeSendHeaders` and `ContinueToHandleOverrideHeaders`.

A regression test has been added to `spec/api-web-request-spec.ts`.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a main process crash when `webRequest.onBeforeRequest` returns a `redirectURL` for CORS preflight requests.
