### PR TITLE
fix: don't kill the primary instance on large second-instance messages

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1072,6 +1072,12 @@ events will be emitted for that. However when users start your app in command
 line, the system's single instance mechanism will be bypassed, and you have to
 use this method to ensure single instance.
 
+> [!NOTE]
+> On macOS and Linux, the second instance's command line arguments and
+> `additionalData` are sent to the primary instance in a single message that is
+> limited to 32 MB. Larger messages are dropped: this method still returns
+> `false`, but the primary instance does not emit `second-instance`.
+
 An example of activating the window of primary instance when a second instance
 starts:
 

--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -12,6 +12,13 @@ On the Electron side, we then expose an extra parameter to the
 app.requestSingleInstanceLock API so that users can pass in a JSON
 object for the second instance to send to the first instance.
 
+Since the payload can be large, the POSIX implementation reads the
+message into a growable buffer until the client shuts down its end of
+the socket instead of a fixed 32 KiB array, and the client waits for
+the socket to become writable rather than giving up, so an oversized
+message no longer gets truncated or causes the second instance to kill
+the primary as unresponsive.
+
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
 index 7da4c199de1d2721a2e6ba9cb10ba0bc146917b7..b100f5feb95aabf63558aebc4d0054c95b90c4a9 100644
 --- a/chrome/browser/process_singleton.h
@@ -65,10 +72,100 @@ index 7da4c199de1d2721a2e6ba9cb10ba0bc146917b7..b100f5feb95aabf63558aebc4d0054c9
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f966fae6a 100644
+index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..e8162aa9286288e65285c165f23806a6adaa0704 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -621,6 +621,7 @@ class ProcessSingleton::LinuxWatcher
+@@ -144,7 +144,9 @@ constexpr std::string_view kStartToken = "START";
+ constexpr std::string_view kACKToken = "ACK";
+ constexpr std::string_view kShutdownToken = "SHUTDOWN";
+ const char kTokenDelimiter = '\0';
+-const int kMaxMessageLength = 32 * 1024;
++// The maximum length of a message the browser will buffer. Longer messages
++// are drained from the socket and dropped.
++const size_t kMaxMessageLength = 32 * 1024 * 1024;
+ 
+ bool g_disable_prompt = false;
+ bool g_skip_is_chrome_process_check = false;
+@@ -167,15 +169,23 @@ void CloseSocket(int fd) {
+   DPCHECK(rv == 0) << "Error closing socket";
+ }
+ 
+-// Write a message to a socket fd.
+-bool WriteToSocket(int fd, std::string_view message) {
++// Wait a socket for write for a certain timeout.
++// Returns -1 if error occurred, 0 if timeout reached, > 0 if the socket is
++// ready for write.
++int WaitSocketForWrite(int fd, const base::TimeDelta& timeout);
++
++// Write a message to a socket fd. If the socket would block, wait for it to be
++// writable for up to |timeout|.
++bool WriteToSocket(int fd,
++                   std::string_view message,
++                   const base::TimeDelta& timeout = base::TimeDelta()) {
+   DCHECK(!message.empty());
+   while (!message.empty()) {
+     ssize_t rv = HANDLE_EINTR(write(fd, message.data(), message.size()));
+     if (rv < 0) {
+       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+-        // The socket shouldn't block, we're sending so little data.  Just give
+-        // up here, since NotifyOtherProcess() doesn't have an asynchronous api.
++        if (timeout.is_positive() && WaitSocketForWrite(fd, timeout) > 0)
++          continue;
+         LOG(ERROR) << "ProcessSingleton would block on write(), so it gave up.";
+         return false;
+       }
+@@ -215,6 +225,23 @@ int WaitSocketForRead(int fd, const base::TimeDelta& timeout) {
+   return HANDLE_EINTR(select(fd + 1, &read_fds, nullptr, nullptr, &tv));
+ }
+ 
++int WaitSocketForWrite(int fd, const base::TimeDelta& timeout) {
++  fd_set write_fds;
++  struct timeval tv = TimeDeltaToTimeVal(timeout);
++
++  // SAFETY: FD_ZERO is a macro provided by linux that ensures the fd_set
++  // is empty. Because we are providing a stack variable this memory address
++  // will always be valid.
++  // See https://linux.die.net/man/3/fd_zero
++  UNSAFE_BUFFERS(FD_ZERO(&write_fds));
++
++  // SAFETY: FD_SET adds fd to the set write_fds, which was just cleared
++  // before. See https://linux.die.net/man/3/fd_set
++  UNSAFE_BUFFERS(FD_SET(fd, &write_fds));
++
++  return HANDLE_EINTR(select(fd + 1, nullptr, &write_fds, nullptr, &tv));
++}
++
+ // Read a message from a socket fd, with an optional timeout.
+ // If |timeout| <= 0 then read immediately.
+ // Return number of bytes actually read, or -1 on error.
+@@ -548,10 +575,7 @@ class ProcessSingleton::LinuxWatcher
+     SocketReader(ProcessSingleton::LinuxWatcher* parent,
+                  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner,
+                  int fd)
+-        : parent_(parent),
+-          ui_task_runner_(ui_task_runner),
+-          fd_(fd),
+-          bytes_read_(0) {
++        : parent_(parent), ui_task_runner_(ui_task_runner), fd_(fd) {
+       DCHECK_CURRENTLY_ON(BrowserThread::IO);
+       // Wait for reads.
+       fd_watch_controller_ = base::FileDescriptorWatcher::WatchReadable(
+@@ -595,11 +619,10 @@ class ProcessSingleton::LinuxWatcher
+     const int fd_;
+ 
+     // Store the message in this buffer.
+-    std::array<char, kMaxMessageLength> buf_;
++    std::string buf_;
+ 
+-    // Tracks the number of bytes we've read in case we're getting partial
+-    // reads.
+-    size_t bytes_read_;
++    // Whether the message exceeded kMaxMessageLength and is being dropped.
++    bool message_too_long_ = false;
+ 
+     base::OneShotTimer timer_;
+   };
+@@ -621,6 +644,7 @@ class ProcessSingleton::LinuxWatcher
    // |reader| is for sending back ACK message.
    void HandleMessage(const std::string& current_dir,
                       const std::vector<std::string>& argv,
@@ -76,7 +173,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
                       SocketReader* reader);
  
    // Called when the ProcessSingleton that owns this class is about to be
-@@ -680,13 +681,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
+@@ -680,13 +704,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
  }
  
  void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -96,18 +193,65 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
      // Send back "ACK" message to prevent the client process from starting up.
      reader->FinishWithACK(kACKToken);
    } else {
-@@ -716,7 +721,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-   bytes_read_ += ReadFromSocketWithTimeout(
-       fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
+@@ -713,23 +741,56 @@ void ProcessSingleton::LinuxWatcher::RemoveSocketReader(SocketReader* reader) {
+ void ProcessSingleton::LinuxWatcher::SocketReader::
+     OnSocketCanReadWithoutBlocking() {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  bytes_read_ += ReadFromSocketWithTimeout(
+-      fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
  
 -  // Validate the message.  The shortest message is kStartToken\0x\0x
++  // The client shuts down its writing end after sending the message, so read
++  // until EOF to get the whole message.
++  std::array<char, 4096> chunk;
++  while (true) {
++    ssize_t rv = HANDLE_EINTR(read(fd_, chunk.data(), chunk.size()));
++    if (rv > 0) {
++      const size_t bytes_read = base::checked_cast<size_t>(rv);
++      if (message_too_long_) {
++        continue;
++      }
++      if (buf_.size() + bytes_read > kMaxMessageLength) {
++        LOG(ERROR) << "Socket message too long, dropping it";
++        message_too_long_ = true;
++        buf_.clear();
++        continue;
++      }
++      buf_.append(base::as_string_view(base::span(chunk).first(bytes_read)));
++      continue;
++    }
++    if (rv == 0)  // The client has finished sending.
++      break;
++    if (errno == EAGAIN || errno == EWOULDBLOCK)
++      return;  // Wait for the rest of the message.
++    PLOG(ERROR) << "read() failed";
++    CleanupAndDeleteSelf();
++    return;
++  }
++
++  if (message_too_long_) {
++    // Reply so the client exits instead of treating this process as hung.
++    fd_watch_controller_.reset();
++    timer_.Stop();
++    FinishWithACK(kACKToken);
++    return;
++  }
++
 +  // Validate the message.  The shortest message kStartToken\0\00
 +  // The shortest message with additional data is kStartToken\0\00\00\0.
    const size_t kMinMessageLength = kStartToken.length() + 4;
-   if (bytes_read_ < kMinMessageLength) {
-     buf_[bytes_read_] = 0;
-@@ -729,7 +735,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-       base::as_string_view(base::span(buf_).first(bytes_read_));
+-  if (bytes_read_ < kMinMessageLength) {
+-    buf_[bytes_read_] = 0;
+-    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_.data();
++  if (buf_.size() < kMinMessageLength) {
++    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_;
+     CleanupAndDeleteSelf();
+     return;
+   }
+ 
+-  std::string_view str =
+-      base::as_string_view(base::span(buf_).first(bytes_read_));
++  std::string_view str = buf_;
    std::vector<std::string> tokens =
        base::SplitString(str, std::string(1, kTokenDelimiter),
 -                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
@@ -115,7 +259,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
  
    if (tokens.size() < 3 || tokens[0] != kStartToken) {
      LOG(ERROR) << "Wrong message format: " << str;
-@@ -747,10 +753,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -747,10 +808,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());
  
@@ -162,7 +306,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
    fd_watch_controller_.reset();
  
    // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
-@@ -779,8 +820,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
+@@ -779,8 +875,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
  //
  ProcessSingleton::ProcessSingleton(
      const base::FilePath& user_data_dir,
@@ -173,7 +317,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
        current_pid_(base::GetCurrentProcId()) {
    socket_path_ = user_data_dir.Append(chrome::kSingletonSocketFilename);
    lock_path_ = user_data_dir.Append(chrome::kSingletonLockFilename);
-@@ -901,7 +944,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -901,7 +999,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
               sizeof(socket_timeout));
  
    // Found another process, prepare our command line
@@ -183,7 +327,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
    std::string to_send(kStartToken);
    to_send.push_back(kTokenDelimiter);
  
-@@ -911,11 +955,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -911,13 +1010,23 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
    to_send.append(current_dir.value());
  
    const std::vector<std::string>& argv = cmd_line.argv();
@@ -203,8 +347,11 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
 +  }
 +
    // Send the message
-   if (!WriteToSocket(socket.fd(), to_send)) {
+-  if (!WriteToSocket(socket.fd(), to_send)) {
++  if (!WriteToSocket(socket.fd(), to_send, timeout)) {
      // Try to kill the other process, because it might have been dead.
+     if (!kill_unresponsive || !KillProcessByLockPath(true))
+       return PROFILE_IN_USE;
 diff --git a/chrome/browser/process_singleton_win.cc b/chrome/browser/process_singleton_win.cc
 index b60a546b39b0fe2747e5bbe5716b693b7ffe09bd..edc9b6b7942420dd83b3362bd41b30f1b3d04830 100644
 --- a/chrome/browser/process_singleton_win.cc

--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -12,6 +12,13 @@ On the Electron side, we then expose an extra parameter to the
 app.requestSingleInstanceLock API so that users can pass in a JSON
 object for the second instance to send to the first instance.
 
+Since the payload can be large, the POSIX implementation reads the
+message into a growable buffer until the client shuts down its end of
+the socket instead of a fixed 32 KiB array, and the client waits for
+the socket to become writable rather than giving up, so an oversized
+message no longer gets truncated or causes the second instance to kill
+the primary as unresponsive.
+
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
 index 7da4c199de1d2721a2e6ba9cb10ba0bc146917b7..b100f5feb95aabf63558aebc4d0054c95b90c4a9 100644
 --- a/chrome/browser/process_singleton.h
@@ -65,10 +72,93 @@ index 7da4c199de1d2721a2e6ba9cb10ba0bc146917b7..b100f5feb95aabf63558aebc4d0054c9
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f966fae6a 100644
+index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..f1ac6b53fdabbcb5df53589be32c5a7ffbb62f0c 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -621,6 +621,7 @@ class ProcessSingleton::LinuxWatcher
+@@ -41,6 +41,7 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
++#include <poll.h>
+ #include <signal.h>
+ #include <stddef.h>
+ #include <string.h>
+@@ -144,7 +145,9 @@ constexpr std::string_view kStartToken = "START";
+ constexpr std::string_view kACKToken = "ACK";
+ constexpr std::string_view kShutdownToken = "SHUTDOWN";
+ const char kTokenDelimiter = '\0';
+-const int kMaxMessageLength = 32 * 1024;
++// The maximum length of a message the browser will buffer. Longer messages
++// are drained from the socket and dropped.
++const size_t kMaxMessageLength = 32 * 1024 * 1024;
+ 
+ bool g_disable_prompt = false;
+ bool g_skip_is_chrome_process_check = false;
+@@ -167,15 +170,32 @@ void CloseSocket(int fd) {
+   DPCHECK(rv == 0) << "Error closing socket";
+ }
+ 
+-// Write a message to a socket fd.
+-bool WriteToSocket(int fd, std::string_view message) {
++// Wait for a socket to become writable, for up to |timeout|.
++// Returns -1 if error occurred, 0 if timeout reached, > 0 if the socket is
++// ready for write.
++int WaitSocketForWrite(int fd, const base::TimeDelta& timeout) {
++  struct pollfd pfd = {};
++  pfd.fd = fd;
++  pfd.events = POLLOUT;
++  return HANDLE_EINTR(poll(
++      &pfd, 1, base::saturated_cast<int>(timeout.InMillisecondsRoundedUp())));
++}
++
++// Write a message to a socket fd. Whenever the socket would block, wait for it
++// to become writable again; |timeout| bounds the total time spent waiting.
++bool WriteToSocket(int fd,
++                   std::string_view message,
++                   const base::TimeDelta& timeout = base::TimeDelta()) {
+   DCHECK(!message.empty());
++  const base::TimeTicks deadline = base::TimeTicks::Now() + timeout;
+   while (!message.empty()) {
+     ssize_t rv = HANDLE_EINTR(write(fd, message.data(), message.size()));
+     if (rv < 0) {
+       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+-        // The socket shouldn't block, we're sending so little data.  Just give
+-        // up here, since NotifyOtherProcess() doesn't have an asynchronous api.
++        const base::TimeDelta remaining = deadline - base::TimeTicks::Now();
++        if (remaining.is_positive() && WaitSocketForWrite(fd, remaining) > 0) {
++          continue;
++        }
+         LOG(ERROR) << "ProcessSingleton would block on write(), so it gave up.";
+         return false;
+       }
+@@ -548,10 +568,7 @@ class ProcessSingleton::LinuxWatcher
+     SocketReader(ProcessSingleton::LinuxWatcher* parent,
+                  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner,
+                  int fd)
+-        : parent_(parent),
+-          ui_task_runner_(ui_task_runner),
+-          fd_(fd),
+-          bytes_read_(0) {
++        : parent_(parent), ui_task_runner_(ui_task_runner), fd_(fd) {
+       DCHECK_CURRENTLY_ON(BrowserThread::IO);
+       // Wait for reads.
+       fd_watch_controller_ = base::FileDescriptorWatcher::WatchReadable(
+@@ -595,11 +612,10 @@ class ProcessSingleton::LinuxWatcher
+     const int fd_;
+ 
+     // Store the message in this buffer.
+-    std::array<char, kMaxMessageLength> buf_;
++    std::string buf_;
+ 
+-    // Tracks the number of bytes we've read in case we're getting partial
+-    // reads.
+-    size_t bytes_read_;
++    // Whether the message exceeded kMaxMessageLength and is being dropped.
++    bool message_too_long_ = false;
+ 
+     base::OneShotTimer timer_;
+   };
+@@ -621,6 +637,7 @@ class ProcessSingleton::LinuxWatcher
    // |reader| is for sending back ACK message.
    void HandleMessage(const std::string& current_dir,
                       const std::vector<std::string>& argv,
@@ -76,7 +166,19 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
                       SocketReader* reader);
  
    // Called when the ProcessSingleton that owns this class is about to be
-@@ -680,13 +681,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
+@@ -665,8 +682,9 @@ void ProcessSingleton::LinuxWatcher::OnSocketCanReadWithoutBlocking(
+     PLOG(ERROR) << "accept() failed";
+     return;
+   }
+-  DCHECK(base::SetNonBlocking(connection_socket))
+-      << "Failed to make non-blocking socket.";
++  if (!base::SetNonBlocking(connection_socket)) {
++    PLOG(ERROR) << "Failed to make non-blocking socket.";
++  }
+   readers_.insert(
+       std::make_unique<SocketReader>(this, ui_task_runner_, connection_socket));
+ }
+@@ -680,13 +698,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
  }
  
  void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -96,18 +198,67 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
      // Send back "ACK" message to prevent the client process from starting up.
      reader->FinishWithACK(kACKToken);
    } else {
-@@ -716,7 +721,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-   bytes_read_ += ReadFromSocketWithTimeout(
-       fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
+@@ -713,23 +735,58 @@ void ProcessSingleton::LinuxWatcher::RemoveSocketReader(SocketReader* reader) {
+ void ProcessSingleton::LinuxWatcher::SocketReader::
+     OnSocketCanReadWithoutBlocking() {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  bytes_read_ += ReadFromSocketWithTimeout(
+-      fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
  
 -  // Validate the message.  The shortest message is kStartToken\0x\0x
++  // The client shuts down its writing end after sending the message, so read
++  // until EOF to get the whole message.
++  std::array<char, 64 * 1024> chunk;
++  while (true) {
++    ssize_t rv = HANDLE_EINTR(read(fd_, chunk.data(), chunk.size()));
++    if (rv > 0) {
++      const size_t bytes_read = base::checked_cast<size_t>(rv);
++      if (message_too_long_) {
++        continue;
++      }
++      if (buf_.size() + bytes_read > kMaxMessageLength) {
++        LOG(ERROR) << "Socket message too long, dropping it";
++        message_too_long_ = true;
++        buf_.clear();
++        continue;
++      }
++      buf_.append(base::as_string_view(base::span(chunk).first(bytes_read)));
++      continue;
++    }
++    if (rv == 0) {  // The client has finished sending.
++      break;
++    }
++    if (errno == EAGAIN || errno == EWOULDBLOCK) {
++      return;  // Wait for the rest of the message.
++    }
++    PLOG(ERROR) << "read() failed";
++    CleanupAndDeleteSelf();
++    return;
++  }
++
++  if (message_too_long_) {
++    // Reply so the client exits instead of treating this process as hung.
++    fd_watch_controller_.reset();
++    timer_.Stop();
++    FinishWithACK(kACKToken);
++    return;
++  }
++
 +  // Validate the message.  The shortest message kStartToken\0\00
 +  // The shortest message with additional data is kStartToken\0\00\00\0.
    const size_t kMinMessageLength = kStartToken.length() + 4;
-   if (bytes_read_ < kMinMessageLength) {
-     buf_[bytes_read_] = 0;
-@@ -729,7 +735,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-       base::as_string_view(base::span(buf_).first(bytes_read_));
+-  if (bytes_read_ < kMinMessageLength) {
+-    buf_[bytes_read_] = 0;
+-    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_.data();
++  if (buf_.size() < kMinMessageLength) {
++    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_;
+     CleanupAndDeleteSelf();
+     return;
+   }
+ 
+-  std::string_view str =
+-      base::as_string_view(base::span(buf_).first(bytes_read_));
++  std::string_view str = buf_;
    std::vector<std::string> tokens =
        base::SplitString(str, std::string(1, kTokenDelimiter),
 -                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
@@ -115,7 +266,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
  
    if (tokens.size() < 3 || tokens[0] != kStartToken) {
      LOG(ERROR) << "Wrong message format: " << str;
-@@ -747,10 +753,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -747,10 +804,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());
  
@@ -162,7 +313,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
    fd_watch_controller_.reset();
  
    // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
-@@ -779,8 +820,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
+@@ -779,8 +871,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
  //
  ProcessSingleton::ProcessSingleton(
      const base::FilePath& user_data_dir,
@@ -173,7 +324,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
        current_pid_(base::GetCurrentProcId()) {
    socket_path_ = user_data_dir.Append(chrome::kSingletonSocketFilename);
    lock_path_ = user_data_dir.Append(chrome::kSingletonLockFilename);
-@@ -901,7 +944,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -901,7 +995,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
               sizeof(socket_timeout));
  
    // Found another process, prepare our command line
@@ -183,7 +334,7 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
    std::string to_send(kStartToken);
    to_send.push_back(kTokenDelimiter);
  
-@@ -911,11 +955,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -911,13 +1006,23 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
    to_send.append(current_dir.value());
  
    const std::vector<std::string>& argv = cmd_line.argv();
@@ -203,8 +354,11 @@ index 5e7a66aafbbe6c388ac0ec780ef1eb0994bb3976..7d1cba20bc810f841519802339e91f5f
 +  }
 +
    // Send the message
-   if (!WriteToSocket(socket.fd(), to_send)) {
+-  if (!WriteToSocket(socket.fd(), to_send)) {
++  if (!WriteToSocket(socket.fd(), to_send, timeout)) {
      // Try to kill the other process, because it might have been dead.
+     if (!kill_unresponsive || !KillProcessByLockPath(true))
+       return PROFILE_IN_USE;
 diff --git a/chrome/browser/process_singleton_win.cc b/chrome/browser/process_singleton_win.cc
 index b60a546b39b0fe2747e5bbe5716b693b7ffe09bd..edc9b6b7942420dd83b3362bd41b30f1b3d04830 100644
 --- a/chrome/browser/process_singleton_win.cc

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -365,6 +365,20 @@ describe('app module', () => {
       });
     });
 
+    it('sends and receives data larger than the singleton message buffer', async () => {
+      await testArgumentPassing({
+        args: ['--send-data', '--data-size=300000'],
+        expectedAdditionalData: 'x'.repeat(300000)
+      });
+    });
+
+    ifit(process.platform !== 'win32')('passes long arguments to the second-instance event', async () => {
+      await testArgumentPassing({
+        args: [`--long-arg=${'a'.repeat(50000)}`],
+        expectedAdditionalData: null
+      });
+    });
+
     it('sends and receives numerical data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=2'],

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -345,6 +345,20 @@ describe('app module', () => {
       });
     });
 
+    it('sends and receives data larger than the singleton message buffer', async () => {
+      await testArgumentPassing({
+        args: ['--send-data', '--data-size=300000'],
+        expectedAdditionalData: 'x'.repeat(300000)
+      });
+    });
+
+    ifit(process.platform !== 'win32')('passes long arguments to the second-instance event', async () => {
+      await testArgumentPassing({
+        args: [`--long-arg=${'a'.repeat(50000)}`],
+        expectedAdditionalData: null
+      });
+    });
+
     it('sends and receives numerical data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=2'],

--- a/spec/fixtures/api/singleton-data/main.js
+++ b/spec/fixtures/api/singleton-data/main.js
@@ -21,13 +21,16 @@ if (app.commandLine.hasSwitch('data-content')) {
     obj = undefined;
   }
 }
+if (app.commandLine.hasSwitch('data-size')) {
+  obj = 'x'.repeat(parseInt(app.commandLine.getSwitchValue('data-size')));
+}
 
 const gotTheLock = sendAdditionalData ? app.requestSingleInstanceLock(obj) : app.requestSingleInstanceLock();
 
 app.on('second-instance', (event, args, workingDirectory, data) => {
   setImmediate(() => {
-    console.log([JSON.stringify(args), JSON.stringify(data)].join('||'));
-    app.exit(0);
+    const line = [JSON.stringify(args), JSON.stringify(data)].join('||');
+    process.stdout.write(line + '\n', () => app.exit(0));
   });
 });
 


### PR DESCRIPTION
#### Description of Change

The POSIX process singleton read a second instance's notification message into a fixed 32 KiB buffer, and the sending side gave up as soon as `write()` would block on its non-blocking socket. A command line or `additionalData` payload beyond those limits was therefore either silently truncated or, when the write couldn't complete, made the second instance SIGKILL the primary process as "unresponsive."

This extends the existing `additionalData` patch so the primary reads the message into a growable buffer until the client shuts down its end of the socket, and the client waits for the socket to become writable instead of bailing out. Adds specs covering a large `additionalData` payload and a long command-line argument.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples)

#### Release Notes

Notes: Fixed the primary instance being killed or receiving truncated arguments when a second instance passed a very long command line or large `additionalData` to `app.requestSingleInstanceLock()`.