### PR TITLE
fix: return null from BrowserWindow.webContents after destroy

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -509,8 +509,8 @@ win.loadURL('https://github.com')
 
 #### `win.webContents` _Readonly_
 
-A `WebContents` object this window owns. All web page related events and
-operations will be done via it.
+A `WebContents` object this window owns, or `null` once the window has been
+destroyed. All web page related events and operations will be done via it.
 
 See the [`webContents` documentation](web-contents.md) for its methods and
 events.

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -267,9 +267,26 @@ void BrowserWindow::BlurWebView() {
 }
 
 v8::Local<v8::Value> BrowserWindow::GetWebContents(v8::Isolate* isolate) {
-  if (web_contents_.IsEmpty())
+  // WebContentsDestroyed() clears |api_web_contents_| but leaves the wrapper in
+  // |web_contents_| alive, so both have to be checked here.
+  if (web_contents_.IsEmpty() || !api_web_contents_)
     return v8::Null(isolate);
   return v8::Local<v8::Value>::New(isolate, web_contents_);
+}
+
+// static
+void BrowserWindow::GetWebContentsCallback(
+    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Isolate* const isolate = info.GetIsolate();
+  BrowserWindow* self = nullptr;
+  // Conversion fails once the window has been destroyed, because the wrapper's
+  // internal field has been cleared. That is exactly when this property should
+  // read as null instead of throwing.
+  if (!gin::ConvertFromV8(isolate, info.This(), &self)) {
+    info.GetReturnValue().SetNull();
+    return;
+  }
+  info.GetReturnValue().Set(self->GetWebContents(isolate));
 }
 
 void BrowserWindow::OnWindowShow() {
@@ -335,8 +352,18 @@ void BrowserWindow::BuildPrototype(v8::Isolate* isolate,
   prototype->SetClassName(gin::StringToV8(isolate, "BrowserWindow"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("focusOnWebView", &BrowserWindow::FocusOnWebView)
-      .SetMethod("blurWebView", &BrowserWindow::BlurWebView)
-      .SetProperty("webContents", &BrowserWindow::GetWebContents);
+      .SetMethod("blurWebView", &BrowserWindow::BlurWebView);
+
+  // |webContents| is bound by hand rather than with SetProperty() because
+  // SetProperty() routes member functions through CallbackTraits, which sets
+  // InvokerOptions::holder_is_first_argument. ArgumentHolder then rejects a
+  // destroyed holder with "Object has been destroyed" before the getter runs,
+  // and this property is documented to return null for a destroyed window.
+  auto getter = v8::FunctionTemplate::New(
+      isolate, &BrowserWindow::GetWebContentsCallback);
+  getter->RemovePrototype();
+  prototype->PrototypeTemplate()->SetAccessorProperty(
+      gin::StringToSymbol(isolate, "webContents"), getter);
 }
 
 // static

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -76,6 +76,10 @@ class BrowserWindow : public BaseWindow,
  private:
   // Helpers.
 
+  // Getter for the |webContents| accessor installed by BuildPrototype().
+  static void GetWebContentsCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& info);
+
   v8::Global<v8::Value> web_contents_;
   bool web_contents_shown_ = false;
   v8::Global<v8::Value> web_contents_view_;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -381,6 +381,15 @@ describe('BrowserWindow module', () => {
         contents.getProcessId();
       }).to.throw('Object has been destroyed');
     });
+
+    it('makes the webContents property read as null instead of throwing', async () => {
+      expect(w.webContents).to.not.be.null();
+      w.destroy();
+      await new Promise(setImmediate);
+      expect(() => w.webContents).to.not.throw();
+      expect(w.webContents).to.be.null();
+    });
+
     it('should not crash when destroying windows with pending events', () => {
       const focusListener = () => {};
       app.on('browser-window-focus', focusListener);


### PR DESCRIPTION
#### Description of Change

Fixes #44605.

Reading `win.webContents` after the window has been destroyed throws
`Error: Object has been destroyed` instead of returning `null`. The issue reports
it from a `DownloadItem` `updated` handler, but any callback that runs after the
window is gone hits it.

`BuildPrototype()` binds the property with
`SetProperty("webContents", &BrowserWindow::GetWebContents)`. `SetProperty()` runs
the getter through `CallbackTraits`, and the member-function-pointer specialization
(`shell/common/gin_helper/function_template.h:407-417`) always sets
`InvokerOptions::holder_is_first_argument`, because for a member function the first
argument is normally the JS `this`. `ArgumentHolder` (`function_template.h:201-208`)
sees that flag and throws `"Object has been destroyed"` for a destroyed holder
before the getter body runs — so the `v8::Null()` return already in
`GetWebContents()` is unreachable in exactly the case it was written for.

So this binds the property to a plain V8 accessor instead. The getter converts
`info.This()` itself and returns `null` when that fails. Conversion failing *is* the
destroyed case: `gin_helper::internal::FromV8Impl()`
(`shell/common/gin_helper/wrappable.cc:207-215`) reads the same internal field that
`Destroyable::IsDestroyed()` reads, and returns `nullptr` once it has been cleared.
I did not add a separate `IsDestroyed()` guard because it would test the same bit
twice.

`GetWebContents()` also needed the `api_web_contents_` check: `WebContentsDestroyed()`
sets `api_web_contents_ = nullptr` but leaves the `web_contents_` wrapper alive, so
`web_contents_.IsEmpty()` alone does not cover that window.

`RemovePrototype()` on the getter template matches how `destroyable.cc` builds its
callback templates; an accessor getter has no reason to be constructible.

#### Testing

Built on Windows 11 x64 with `e build --no-remote` (testing config), then ran the
`BrowserWindow.destroy()` specs:

```
ok 1 BrowserWindow module BrowserWindow.destroy() prevents users to access methods of webContents
ok 2 BrowserWindow module BrowserWindow.destroy() makes the webContents property read as null instead of throwing
ok 3 BrowserWindow module BrowserWindow.destroy() should not crash when destroying windows with pending events
# tests 3
# pass 3
# fail 0
```

To confirm the new spec actually guards the regression, I reverted the two C++ files,
kept the spec, rebuilt, and re-ran:

```
ok 1 BrowserWindow module BrowserWindow.destroy() prevents users to access methods of webContents
not ok 2 BrowserWindow module BrowserWindow.destroy() makes the webContents property read as null instead of throwing
  expected [Function] to not throw an error but 'TypeError: Object has been destroyed' was thrown
ok 3 BrowserWindow module BrowserWindow.destroy() should not crash when destroying windows with pending events
# tests 3
# pass 2
# fail 1
```

I also checked the user-visible behavior with a small app that reads the property
from a deferred callback, which is the shape the issue reports:

```js
const win = new BrowserWindow({ show: false })
await win.loadURL('about:blank')
win.destroy()
setImmediate(() => { console.log(win.webContents) })
```

```
before this PR:   FAIL  after destroy -> threw: Object has been destroyed
with this PR:     PASS  after destroy -> null
```

Two notes on scope:

* One test in the wider `api-browser-window-spec.ts` run fails on my machine —
  `sizing BrowserWindow.setBounds(bounds[, animate]) does not emits the resize event
  for move-only changes`. It fails identically on an unmodified build, so it is
  pre-existing here and not caused by this change.
* My local build tree is a few weeks behind `main`, while this branch is rebased on
  current `main`. The two files this fix reasons about — `function_template.h` and
  `wrappable.cc` — are byte-identical between the two, and `electron_api_browser_window.cc`
  differs only outside the functions touched here, so the results above apply.

#### Notes on AI assistance

I used Claude Code while working on this, and the commit carries `Assisted-By:` and
`Co-Authored-By:` trailers per the [AI Tool Policy](https://github.com/electron/governance/blob/main/policy/ai.md).

This supersedes #51335, which was labelled `ai-pr` and closed. That PR was fair to
close: it shipped a null check that could never fire, put the V8 callback in the
header's `protected:` section, said in its description that it followed the
`destroyable.cc` pattern while skipping `RemovePrototype()`, and included a commit
that only fixed indentation — which meant `lint:clang-format` had never been run
locally. I have gone back through the change, removed the dead code, and this branch
is a single commit rebased on current `main`. `lint:clang-format`, `lint:fmt`,
`lint:js` and `lint:markdown` all pass locally. Happy to answer questions on any of
it during review.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `win.webContents` throwing `Object has been destroyed` instead of returning `null` after the window was destroyed.
