### PR TITLE
fix: prevent crash when repeatedly opening and closing file selection…

### DIFF
--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -393,8 +393,10 @@ void FileSelectHelper::RunFileChooserOnUIThread(
   DCHECK(params);
 
   select_file_dialog_ = ui::SelectFileDialog::Create(this, nullptr);
-  if (!select_file_dialog_.get())
+  if (!select_file_dialog_.get()) {
+    RunFileChooserEnd();
     return;
+  }
 
   dialog_mode_ = params->mode;
   switch (params->mode) {
@@ -418,8 +420,10 @@ void FileSelectHelper::RunFileChooserOnUIThread(
 
   auto* web_contents = electron::api::WebContents::From(
       content::WebContents::FromRenderFrameHost(render_frame_host_));
-  if (!web_contents || !web_contents->owner_window())
+  if (!web_contents || !web_contents->owner_window()) {
+    RunFileChooserEnd();
     return;
+  }
 
   // Never consider the current scope as hung. The hang watching deadline (if
   // any) is not valid since the user can take unbounded time to choose the
@@ -451,6 +455,7 @@ void FileSelectHelper::RunFileChooserEnd() {
     listener_->FileSelectionCanceled();
   render_frame_host_ = nullptr;
   web_contents_ = nullptr;
+  content::WebContentsObserver::Observe(nullptr);
   // If the dialog was actually opened, dispose of our reference.
   if (select_file_dialog_) {
     select_file_dialog_->ListenerDestroyed();

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -52,6 +52,21 @@ describe('dialog module', () => {
     });
   });
 
+  describe('<input type="file">', () => {
+    afterEach(closeAllWindows);
+
+    it('does not crash when triggering file chooser repeatedly across window lifecycle', async () => {
+      for (let i = 0; i < 3; i++) {
+        const w = new BrowserWindow({ show: false });
+        await w.loadURL('data:text/html,<input type="file" id="file">');
+        w.webContents.executeJavaScript('document.getElementById("file").click()', true);
+        await setTimeout(50);
+        w.destroy();
+        await setTimeout(50);
+      }
+    });
+  });
+
   describe('showSaveDialog', () => {
     afterEach(closeAllWindows);
     ifit(process.platform !== 'win32')('should not throw for valid cases', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #52496 

Fixes a Use-After-Free (UAF) crash when opening and closing file selection dialogs repeatedly. When FileSelectHelper ends, it now detaches as a WebContentsObserver via Observe(nullptr). Also ensures early-return error paths invoke RunFileChooserEnd() to prevent memory and observer leaks.

FileSelectHelper class in [file_select_helper.cc](https://github.com/electron/electron/blob/main/shell/browser/file_select_helper.cc) is inherited from the content::WebContentsObserver::Observe(web_contents_). After the file selection dialog finishes it is setting the web_contents_ = nullptr and then calling the Release() to delete the instance. As a result, WebContents retain the dangling pointers to deleted FileSelectHelper instances triggering the UAF crashes when subsequent WebContents observer events were dispatched like the repeated open/close operations on the file dialog.

Replacing it to content::WebContentsObserver::Observe(nullptr) ensures that the observer is detached before releasing or destroying the object. Also to avoid the memory and listener leaks if the dialog creation fails or when the owner_window is missing, we called the early RunFileChooserEnd() in FileSelectHelper::RunFileChooserOnUIThread.
Also added a unit test in the spec/api-dialog-spec.ts to verify the fix (Repeated file input triggers does not crash Electron).
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the Electron Application Crash occurring due to the repeated open/close operations on the file dialog.