### PR TITLE
fix: avoid closing uninitialized uv handles

### DIFF
--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -26,7 +26,8 @@ bool UvTaskRunner::PostDelayedTask(const base::Location& from_here,
 
   auto timer = UvHandle<uv_timer_t>{};
   timer->data = this;
-  uv_timer_init(loop_, timer.get());
+  timer.Init(
+      [this](uv_timer_t* handle) { return uv_timer_init(loop_, handle); });
   uv_timer_start(timer.get(), on_timeout, delay.InMilliseconds(), 0);
   tasks_.insert_or_assign(std::move(timer), std::move(task));
   return true;

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -32,7 +32,9 @@
 namespace electron {
 
 ElectronBindings::ElectronBindings(uv_loop_t* loop) {
-  uv_async_init(loop, call_next_tick_async_.get(), OnCallNextTick);
+  call_next_tick_async_.Init([loop](uv_async_t* handle) {
+    return uv_async_init(loop, handle, OnCallNextTick);
+  });
   call_next_tick_async_.get()->data = this;
   metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
 }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -1065,7 +1065,9 @@ void NodeBindings::PrepareEmbedThread() {
   if (!embed_thread_prepared_) {
     // Add dummy handle for libuv, otherwise libuv would quit when there is
     // nothing to do.
-    uv_async_init(uv_loop_, dummy_uv_handle_.get(), nullptr);
+    dummy_uv_handle_.Init([this](uv_async_t* handle) {
+      return uv_async_init(uv_loop_, handle, nullptr);
+    });
 
     // Start worker that will interrupt main loop when having uv events.
     uv_sem_init(&embed_sem_, 0);

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -64,13 +64,17 @@ class UvHandle {
 
   explicit UvHandle(UvHandle&& that) {
     t_ = that.t_;
+    initialized_ = that.initialized_;
     that.t_ = nullptr;
+    that.initialized_ = false;
   }
 
   UvHandle& operator=(UvHandle&& that) {
     reset();
     t_ = that.t_;
+    initialized_ = that.initialized_;
     that.t_ = nullptr;
+    that.initialized_ = false;
     return *this;
   }
 
@@ -87,12 +91,27 @@ class UvHandle {
   // compare by handle pointer address
   auto operator<=>(const UvHandle& that) const = default;
 
+  // Record whether libuv successfully initialized the handle so reset() can
+  // choose the matching cleanup path.
+  template <typename InitCallback>
+  int Init(InitCallback init_callback) {
+    const int result = init_callback(t_);
+    initialized_ = result == 0;
+    return result;
+  }
+
   void reset() {
     auto* h = handle();
     if (h != nullptr) {
+      if (!initialized_) {
+        delete t_;
+        t_ = nullptr;
+        return;
+      }
       DCHECK_EQ(0, uv_is_closing(h));
       uv_close(h, OnClosed);
       t_ = nullptr;
+      initialized_ = false;
     }
   }
 
@@ -102,6 +121,9 @@ class UvHandle {
   }
 
   RAW_PTR_EXCLUSION T* t_ = {};
+  // Uninitialized handle memory is not owned by libuv and must not be passed
+  // to uv_close().
+  bool initialized_ = false;
 };
 
 // Helper for comparing UvHandles and raw uv pointers, e.g. as map keys


### PR DESCRIPTION
#### Description of Change

`UvHandle` allocates handle storage in its constructor, while libuv
initialization happens later in owner-specific setup. If an owner is destroyed
before that setup runs, `reset()` calls `uv_close()` on uninitialized memory and
libuv can abort while reading the handle type.

This change makes `UvHandle` track successful initialization. Uninitialized
storage is deleted directly, while initialized handles continue through
`uv_close()`. The state follows handle ownership during moves, and all existing
async and timer initialization sites use the tracking helper.

Validation performed:

- `clang-format` passed for all four changed C++ files.
- `git diff --check` passed.
- A full build and test run has not been performed because this lightweight
  clone does not contain the Chromium dependencies or build output.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when a libuv handle was destroyed before initialization.