### PR TITLE
fix: don't hang WebAuthn requests on platform passkey failures

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1283,7 +1283,9 @@ added:
   * `platformPasskeys` boolean (optional) - Enables passkeys via Apple's
     `ASAuthorizationController`. When enabled, passkey operations present the
     system credential provider sheet (iCloud Keychain, 1Password, Bitwarden,
-    etc.) and credentials sync across the user's devices.
+    etc.) and credentials sync across the user's devices. Defaults to `false`.
+    Passing `null`/`undefined` (or omitting the key) leaves the previous
+    setting unchanged.
 
 Configures platform authenticators for the Web Authentication API
 (`navigator.credentials.create()` / `navigator.credentials.get()`). Until this
@@ -1299,7 +1301,15 @@ When `platformPasskeys` is `true`, passkey operations use Apple's
 `ASAuthorizationController` which delegates to the system's configured
 Credential Provider Extensions. This enables the same passkey experience as
 Safari — credentials are available across all devices signed into the same
-account.
+account. Unlike Touch ID credentials, platform passkeys are stored by the
+credential provider and scoped to the relying party, not to Electron: they are
+shared across all [`session`](session.md) partitions and with any other app or
+browser associated with the same domain. Platform passkeys cannot serve
+cross-origin (iframe) requests; those requests are left to the other available
+authenticators (Touch ID supports iframes) and a warning is logged to the
+DevTools console. The `prf` and `largeBlob` WebAuthn extensions are not
+currently supported by this authenticator — `prf` inputs are ignored, and a
+`create()` call with `largeBlob: { support: 'required' }` fails.
 
 ```js
 const { app } = require('electron')
@@ -1387,7 +1397,9 @@ the embedded development provisioning profile described above:
 > browser), the `clientDataJSON` returned to the page reports
 > `origin: "https://<rpId>"` — the associated domain — rather than the page's
 > own origin. Relying-party servers that enforce a strict `expectedOrigin`
-> allowlist must include `https://<rpId>` for verification to succeed.
+> allowlist must include `https://<rpId>` for verification to succeed. This
+> also means the relying party cannot distinguish which subdomain of the
+> associated domain initiated the ceremony.
 
 > [!NOTE]
 > Touch ID WebAuthn credentials are device-bound and are not synced via iCloud

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -654,9 +654,13 @@ Emitted when both `touchID` and `platformPasskeys` are configured via
 WebAuthn request needs to choose which platform authenticator to use. `callback`
 should be called with one of the names from `event.authenticators`; passing no
 arguments or a name that does not match will cancel the request and the page
-will receive a `NotAllowedError`. If no listener is registered, `platformPasskeys`
-is used by default. If only one authenticator is available for the request, this
-event is not emitted and that authenticator is used automatically.
+will receive a `NotAllowedError`. The request remains pending until the
+listener invokes the callback, so always invoke it exactly once — typically
+from a `try { … } finally { callback(…) }` block. If no listener is registered,
+`platformPasskeys` is used by default; a listener that throws before invoking
+the callback is treated as unhandled and the default applies. If only one
+authenticator is available for the request, this event is not emitted and that
+authenticator is used automatically.
 
 ```js
 const { app, BrowserWindow } = require('electron')
@@ -707,9 +711,11 @@ invokes the callback, so always invoke it exactly once — typically from a
 
 > [!NOTE]
 > If no listener is registered for this event, `navigator.credentials.get()`
-> calls that resolve multiple discoverable credentials are cancelled with a
-> `NotAllowedError`. Register a listener if your app supports
-> discoverable-credential (passkey) sign-in.
+> calls that resolve discoverable Touch ID credentials are cancelled with a
+> `NotAllowedError` — even when only a single credential matches. Register a
+> listener if your app supports discoverable-credential (passkey) sign-in.
+> Assertions fulfilled by `platformPasskeys` select the account in the system
+> sheet and do not use this event.
 
 On macOS, the Touch ID platform authenticator surfaces accounts via this event
 once it has been configured with

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1695,6 +1695,20 @@ void App::ConfigureWebAuthn(gin_helper::ErrorThrower thrower,
     return;
   }
 
+  // Validate before applying so a TypeError leaves existing configuration
+  // untouched; null/undefined mean "not set".
+  std::optional<bool> platform_passkeys;
+  v8::Local<v8::Value> platform_passkeys_value;
+  if (options.Get("platformPasskeys", &platform_passkeys_value) &&
+      !platform_passkeys_value->IsNullOrUndefined()) {
+    if (!platform_passkeys_value->IsBoolean()) {
+      thrower.ThrowTypeError(
+          "configureWebAuthn: 'platformPasskeys' must be a boolean");
+      return;
+    }
+    platform_passkeys = platform_passkeys_value.As<v8::Boolean>()->Value();
+  }
+
   gin_helper::Dictionary touch_id;
   if (options.Get("touchID", &touch_id)) {
     std::string keychain_access_group;
@@ -1732,10 +1746,9 @@ void App::ConfigureWebAuthn(gin_helper::ErrorThrower thrower,
     }
   }
 
-  bool platform_passkeys = false;
-  if (options.Get("platformPasskeys", &platform_passkeys)) {
+  if (platform_passkeys.has_value()) {
     ElectronWebAuthenticationDelegate::SetPlatformPasskeysEnabled(
-        platform_passkeys);
+        *platform_passkeys);
   }
 }
 

--- a/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
+++ b/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
@@ -32,6 +32,8 @@
 #if BUILDFLAG(IS_MAC)
 #include "shell/browser/webauthn/electron_authenticator_request_delegate.h"
 #include "shell/browser/webauthn/electron_platform_passkeys_discovery.h"
+#include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
+#include "url/origin.h"
 #endif
 
 namespace electron {
@@ -54,6 +56,20 @@ std::string CredentialIdFor(
   }
   return {};
 }
+
+#if BUILDFLAG(IS_MAC)
+// Mirrors Chromium's cross-origin (iframe) ceremony check.
+bool IsSameOriginWithAncestors(content::RenderFrameHost* frame) {
+  const url::Origin& origin = frame->GetLastCommittedOrigin();
+  for (content::RenderFrameHost* parent = frame->GetParent(); parent;
+       parent = parent->GetParent()) {
+    if (!parent->GetLastCommittedOrigin().IsSameOriginWith(origin)) {
+      return false;
+    }
+  }
+  return true;
+}
+#endif
 
 }  // namespace
 
@@ -271,8 +287,11 @@ void ElectronAuthenticatorRequestClientDelegate::
 void ElectronAuthenticatorRequestClientDelegate::
     MaybeEmitSelectAuthenticatorEvent() {
   if (pending_authenticators_.size() == 1) {
-    request_callback_.Run(pending_authenticators_[0].id);
+    // Run may destroy |this|; consume member state first.
+    std::string id = std::move(pending_authenticators_[0].id);
     pending_authenticators_.clear();
+    auto callback = request_callback_;
+    callback.Run(id);
     return;
   }
 
@@ -330,46 +349,49 @@ void ElectronAuthenticatorRequestClientDelegate::
 
 void ElectronAuthenticatorRequestClientDelegate::
     DispatchDefaultAuthenticator() {
+  // A listener may have consumed the selection synchronously and then thrown.
+  if (pending_authenticators_.empty()) {
+    return;
+  }
   auto auth = std::ranges::find(pending_authenticators_, "platformPasskeys",
                                 &PendingAuthenticator::display_name);
-  request_callback_.Run(auth != pending_authenticators_.end()
-                            ? auth->id
-                            : pending_authenticators_.front().id);
+  // Run may destroy |this|; consume member state first.
+  std::string id = std::move(auth != pending_authenticators_.end()
+                                 ? auth->id
+                                 : pending_authenticators_.front().id);
   pending_authenticators_.clear();
+  auto callback = request_callback_;
+  callback.Run(id);
 }
 
 void ElectronAuthenticatorRequestClientDelegate::OnAuthenticatorSelected(
     gin::Arguments* args) {
-  // The emit callback is a repeating callback, so guard against an app invoking
-  // it more than once: after the first call clears pending_authenticators_, a
-  // second call would otherwise fall through to the unknown-name branch and
-  // cancel a request we already dispatched.
+  // Repeating callback: ignore any call after the first.
   if (pending_authenticators_.empty()) {
     return;
   }
 
   std::string selected_name;
-  if (!args->GetNext(&selected_name) || selected_name.empty()) {
-    if (cancel_callback_) {
-      std::move(cancel_callback_).Run();
-    }
+  const bool has_name = args->GetNext(&selected_name) && !selected_name.empty();
+  const auto selected =
+      has_name ? std::ranges::find(pending_authenticators_, selected_name,
+                                   &PendingAuthenticator::display_name)
+               : pending_authenticators_.end();
+
+  // Run may destroy |this|; consume member state first.
+  if (selected != pending_authenticators_.end()) {
+    std::string id = std::move(selected->id);
     pending_authenticators_.clear();
+    auto callback = request_callback_;
+    callback.Run(id);
     return;
   }
 
-  for (const auto& auth : pending_authenticators_) {
-    if (auth.display_name == selected_name) {
-      request_callback_.Run(auth.id);
-      pending_authenticators_.clear();
-      return;
-    }
-  }
-
-  // Unknown name — cancel.
+  // No argument, empty, or unknown name: cancel.
+  pending_authenticators_.clear();
   if (cancel_callback_) {
     std::move(cancel_callback_).Run();
   }
-  pending_authenticators_.clear();
 }
 
 #if BUILDFLAG(IS_MAC)
@@ -378,9 +400,18 @@ ElectronAuthenticatorRequestClientDelegate::CreatePlatformDiscoveries() {
   std::vector<std::unique_ptr<device::FidoDiscoveryBase>> discoveries;
   if (ElectronWebAuthenticationDelegate::IsPlatformPasskeysEnabled()) {
     auto* rfh = content::RenderFrameHost::FromID(render_frame_host_id_);
-    if (rfh) {
+    if (rfh && IsSameOriginWithAncestors(rfh)) {
       discoveries.push_back(
           std::make_unique<ElectronPlatformPasskeysDiscovery>(rfh));
+    } else if (rfh) {
+      // Apple's API can't serve cross-origin ceremonies; other authenticators
+      // still can.
+      rfh->AddMessageToConsole(
+          blink::mojom::ConsoleMessageLevel::kWarning,
+          "WebAuthn platform passkeys are unavailable to cross-origin "
+          "(iframe) requests: Apple's ASAuthorizationController cannot "
+          "fulfill them. Other authenticators can still serve the request; "
+          "the Touch ID authenticator supports iframes.");
     }
   }
   return discoveries;

--- a/shell/browser/webauthn/electron_platform_passkeys_authenticator.h
+++ b/shell/browser/webauthn/electron_platform_passkeys_authenticator.h
@@ -5,10 +5,12 @@
 #ifndef ELECTRON_SHELL_BROWSER_WEBAUTHN_ELECTRON_PLATFORM_PASSKEYS_AUTHENTICATOR_H_
 #define ELECTRON_SHELL_BROWSER_WEBAUTHN_ELECTRON_PLATFORM_PASSKEYS_AUTHENTICATOR_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 
+#include "base/containers/span.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/global_routing_id.h"
 #include "device/fido/fido_authenticator.h"
@@ -49,6 +51,8 @@ class ElectronPlatformPasskeysAuthenticator : public device::FidoAuthenticator {
   device::AuthenticatorType GetType() const override;
   std::string GetId() const override;
   const device::AuthenticatorSupportedOptions& Options() const override;
+  // ES256 only: the public ASAuthorization API cannot honor other algorithms.
+  std::optional<base::span<const int32_t>> GetAlgorithms() override;
   std::optional<device::FidoTransportProtocol> AuthenticatorTransport()
       const override;
   base::WeakPtr<FidoAuthenticator> GetWeakPtr() override;
@@ -63,6 +67,9 @@ class ElectronPlatformPasskeysAuthenticator : public device::FidoAuthenticator {
   // error 1004 (no application-identifier / association), which surfaces to the
   // page as a bare NotAllowedError. Called from the completion handlers.
   void MaybeLogUnconfiguredError();
+
+  // Console error when Apple's response fails parsing or validation.
+  void LogInvalidResponse();
 
   const content::GlobalRenderFrameHostToken render_frame_host_token_;
   std::unique_ptr<ObjCStorage> objc_storage_;

--- a/shell/browser/webauthn/electron_platform_passkeys_authenticator_mac.mm
+++ b/shell/browser/webauthn/electron_platform_passkeys_authenticator_mac.mm
@@ -19,6 +19,7 @@
 
 #include "base/base64url.h"
 #include "base/compiler_specific.h"
+#include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
@@ -39,7 +40,6 @@
 #include "device/fido/public/fido_constants.h"
 #include "device/fido/public/fido_types.h"
 #include "device/fido/public/public_key_credential_descriptor.h"
-#include "device/fido/public/public_key_credential_params.h"
 #include "device/fido/public/public_key_credential_user_entity.h"
 #include "shell/browser/native_window.h"
 #include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
@@ -64,6 +64,23 @@ bool IsExcludedCredentialError(const std::string& error_domain,
   // 1006 == ASAuthorizationErrorMatchedExcludedCredential (macOS 15+).
   return error_domain == base::SysNSStringToUTF8(ASAuthorizationErrorDomain) &&
          error_code == 1006;
+}
+
+// kAuthenticatorResponseInvalid is ignored for this authenticator type (the
+// page would hang until timeout), so fail with a terminal status instead.
+constexpr auto kMakeCredentialTerminalFailure =
+    device::MakeCredentialStatus::kUserConsentDenied;
+constexpr auto kGetAssertionTerminalFailure =
+    device::GetAssertionStatus::kUserConsentDenied;
+
+// Cross-origin rejects are deterministic; the page only sees NotAllowedError.
+void LogCrossOriginUnsupported(content::RenderFrameHost* rfh) {
+  rfh->AddMessageToConsole(
+      blink::mojom::ConsoleMessageLevel::kError,
+      "WebAuthn platform passkey request rejected: Apple's "
+      "ASAuthorizationController cannot fulfill cross-origin (iframe) "
+      "ceremonies. Serve the request from a top-level (or same-origin) frame, "
+      "or configure the Touch ID authenticator, which supports iframes.");
 }
 
 NSData* VectorToNSData(const std::vector<uint8_t>& vec) {
@@ -347,21 +364,6 @@ void ElectronPlatformPasskeysAuthenticator::MakeCredential(
       return;
     }
 
-    // The public ASAuthorization API ignores pubKeyCredParams and always mints
-    // an ES256 (-7) credential. If the RP doesn't accept ES256, creating a
-    // credential here would produce one it immediately rejects, so fail early.
-    const auto& params =
-        request.public_key_credential_params.public_key_credential_params();
-    const bool supports_es256 = std::ranges::any_of(params, [](const auto& p) {
-      return p.algorithm == base::strict_cast<int32_t>(
-                                device::CoseAlgorithmIdentifier::kEs256);
-    });
-    if (!supports_es256) {
-      std::move(callback).Run(device::MakeCredentialStatus::kNoCommonAlgorithms,
-                              std::nullopt);
-      return;
-    }
-
     // Hand Apple the real challenge (not client_data_hash) so it builds a
     // clientDataJSON — with our challenge and the associated-domain origin —
     // and signs over its hash, letting the RP verify against the
@@ -373,18 +375,15 @@ void ElectronPlatformPasskeysAuthenticator::MakeCredential(
     if (!client_data.valid) {
       // Falling back to client_data_hash here would let Apple hash it again,
       // producing a signature no RP can verify. Reject instead.
-      std::move(callback).Run(
-          device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-          std::nullopt);
+      std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
       return;
     }
     if (client_data.cross_origin) {
       // Apple's public API always builds a top-level `origin: https://<rpId>`
       // clientDataJSON, so we can't represent a cross-origin (iframe) ceremony.
       // Reject rather than silently present it to the RP as same-origin.
-      std::move(callback).Run(
-          device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-          std::nullopt);
+      LogCrossOriginUnsupported(rfh);
+      std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
       return;
     }
 
@@ -501,16 +500,15 @@ void ElectronPlatformPasskeysAuthenticator::GetAssertion(
     if (!client_data.valid) {
       // Falling back to client_data_hash here would let Apple hash it again,
       // producing a signature no RP can verify. Reject instead.
-      std::move(callback).Run(
-          device::GetAssertionStatus::kAuthenticatorResponseInvalid, {});
+      std::move(callback).Run(kGetAssertionTerminalFailure, {});
       return;
     }
     if (client_data.cross_origin) {
       // Apple's public API always builds a top-level `origin: https://<rpId>`
       // clientDataJSON, so we can't represent a cross-origin (iframe) ceremony.
       // Reject rather than silently present it to the RP as same-origin.
-      std::move(callback).Run(
-          device::GetAssertionStatus::kAuthenticatorResponseInvalid, {});
+      LogCrossOriginUnsupported(rfh);
+      std::move(callback).Run(kGetAssertionTerminalFailure, {});
       return;
     }
 
@@ -617,6 +615,15 @@ ElectronPlatformPasskeysAuthenticator::Options() const {
   return *options;
 }
 
+std::optional<base::span<const int32_t>>
+ElectronPlatformPasskeysAuthenticator::GetAlgorithms() {
+  // Pre-filters non-ES256 RPs before dispatch. Returning kNoCommonAlgorithms
+  // from MakeCredential would hit the base GetTouch() no-op and hang.
+  static constexpr int32_t kAlgorithms[] = {
+      base::strict_cast<int32_t>(device::CoseAlgorithmIdentifier::kEs256)};
+  return base::span<const int32_t>(kAlgorithms);
+}
+
 std::optional<device::FidoTransportProtocol>
 ElectronPlatformPasskeysAuthenticator::AuthenticatorTransport() const {
   return device::FidoTransportProtocol::kInternal;
@@ -655,6 +662,20 @@ void ElectronPlatformPasskeysAuthenticator::MaybeLogUnconfiguredError() {
       "via the entitlement's ?mode=developer modifier.");
 }
 
+void ElectronPlatformPasskeysAuthenticator::LogInvalidResponse() {
+  content::RenderFrameHost* rfh =
+      content::RenderFrameHost::FromFrameToken(render_frame_host_token_);
+  if (!rfh) {
+    return;
+  }
+  rfh->AddMessageToConsole(
+      blink::mojom::ConsoleMessageLevel::kError,
+      "WebAuthn platform passkey request failed: the response from the system "
+      "credential provider failed parsing or validation, and the request was "
+      "cancelled. This may indicate an incompatible credential provider or "
+      "macOS version.");
+}
+
 void ElectronPlatformPasskeysAuthenticator::OnMakeCredentialComplete(
     MakeCredentialCallback callback) {
   if (!objc_storage_->succeeded) {
@@ -674,18 +695,16 @@ void ElectronPlatformPasskeysAuthenticator::OnMakeCredentialComplete(
   std::optional<cbor::Value> cbor_value =
       cbor::Reader::Read(objc_storage_->raw_attestation_object);
   if (!cbor_value) {
-    std::move(callback).Run(
-        device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-        std::nullopt);
+    LogInvalidResponse();
+    std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
     return;
   }
 
   std::optional<device::AttestationObject> attestation_object =
       device::AttestationObject::Parse(*cbor_value);
   if (!attestation_object) {
-    std::move(callback).Run(
-        device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-        std::nullopt);
+    LogInvalidResponse();
+    std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
     return;
   }
 
@@ -699,9 +718,8 @@ void ElectronPlatformPasskeysAuthenticator::OnMakeCredentialComplete(
   if (!std::ranges::equal(
           response.attestation_object.authenticator_data().GetCredentialId(),
           objc_storage_->credential_id)) {
-    std::move(callback).Run(
-        device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-        std::nullopt);
+    LogInvalidResponse();
+    std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
     return;
   }
 
@@ -722,9 +740,8 @@ void ElectronPlatformPasskeysAuthenticator::OnMakeCredentialComplete(
                                    objc_storage_->expected_challenge,
                                    objc_storage_->expected_origin,
                                    objc_storage_->expected_type)) {
-    std::move(callback).Run(
-        device::MakeCredentialStatus::kAuthenticatorResponseInvalid,
-        std::nullopt);
+    LogInvalidResponse();
+    std::move(callback).Run(kMakeCredentialTerminalFailure, std::nullopt);
     return;
   }
   response.raw_client_data_json =
@@ -746,8 +763,8 @@ void ElectronPlatformPasskeysAuthenticator::OnGetAssertionComplete(
       device::AuthenticatorData::DecodeAuthenticatorData(
           base::span<const uint8_t>(objc_storage_->raw_authenticator_data));
   if (!auth_data) {
-    std::move(callback).Run(
-        device::GetAssertionStatus::kAuthenticatorResponseInvalid, {});
+    LogInvalidResponse();
+    std::move(callback).Run(kGetAssertionTerminalFailure, {});
     return;
   }
 
@@ -774,8 +791,8 @@ void ElectronPlatformPasskeysAuthenticator::OnGetAssertionComplete(
                                    objc_storage_->expected_challenge,
                                    objc_storage_->expected_origin,
                                    objc_storage_->expected_type)) {
-    std::move(callback).Run(
-        device::GetAssertionStatus::kAuthenticatorResponseInvalid, {});
+    LogInvalidResponse();
+    std::move(callback).Run(kGetAssertionTerminalFailure, {});
     return;
   }
   response.raw_client_data_json =

--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -65,12 +65,26 @@ ifdescribe(process.platform === 'darwin')('app.configureWebAuthn', () => {
   });
 
   describe('platformPasskeys', () => {
+    afterEach(() => {
+      // Reset the process-global flag so it doesn't leak into later suites.
+      configureWebAuthn({ platformPasskeys: false });
+    });
+
     it('accepts platformPasskeys: true', () => {
       expect(() => configureWebAuthn({ platformPasskeys: true })).to.not.throw();
     });
 
     it('accepts platformPasskeys: false', () => {
       expect(() => configureWebAuthn({ platformPasskeys: false })).to.not.throw();
+    });
+
+    it('throws when platformPasskeys is not a boolean', () => {
+      expect(() => configureWebAuthn({ platformPasskeys: 'no' })).to.throw(/platformPasskeys/);
+    });
+
+    it('treats platformPasskeys: null and undefined as not set', () => {
+      expect(() => configureWebAuthn({ platformPasskeys: undefined })).to.not.throw();
+      expect(() => configureWebAuthn({ platformPasskeys: null })).to.not.throw();
     });
 
     it('accepts both touchID and platformPasskeys together', () => {
@@ -180,6 +194,8 @@ ifdescribe(process.platform === 'darwin')("session 'select-webauthn-authenticato
 
   afterEach(async () => {
     session.defaultSession.removeAllListeners('select-webauthn-authenticator');
+    // Reset the process-global flag so it doesn't leak into later suites.
+    configureWebAuthn({ platformPasskeys: false });
     try {
       w.webContents.debugger.detach();
     } catch {}


### PR DESCRIPTION
#### Description of Change

Follow-up to #51563.

The platform passkey authenticator reported its failures with statuses the FIDO request handlers ignore for its authenticator type, so an unparseable clientDataJSON, a cross-origin frame, an RP that doesn't accept ES256, or a malformed Apple response left `navigator.credentials.create()`/`get()` pending until the WebAuthn timeout, in the worst case after a passkey had already been minted. Dispatching a selected authenticator could also complete the request synchronously and destroy the delegate while the selection code still touched its members, and `configureWebAuthn` silently coerced non-boolean `platformPasskeys` values.

This reports terminal statuses instead (the page gets a prompt `NotAllowedError`), advertises ES256 via `GetAlgorithms()` so unsupported registrations are filtered before dispatch, consumes selection state before running dispatch callbacks, skips the passkeys discovery for cross-origin frames so other authenticators can still serve them, validates `platformPasskeys` strictly, and logs DevTools errors on the failure paths that previously gave no signal. Docs and specs are updated to match.

#### Checklist

- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed WebAuthn platform passkey requests on macOS hanging until the request timeout when an operation failed, and a potential crash when selecting between Touch ID and platform passkeys.
