### PR TITLE
chore: cleanup includes of Win32 headers

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -734,6 +734,7 @@ filenames = {
     "shell/common/skia_util.cc",
     "shell/common/skia_util.h",
     "shell/common/thread_restrictions.h",
+    "shell/common/uv_includes.h",
     "shell/common/v8_oom_diagnostics.cc",
     "shell/common/v8_oom_diagnostics.h",
     "shell/common/v8_util.cc",

--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -19,7 +19,7 @@
 #include "shell/app/node_main.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/mac/main_application_bundle.h"
-#include "uv.h"
+#include "shell/common/uv_includes.h"
 
 int ElectronMain(int argc, char* argv[]) {
   argv = uv_setup_args(argc, argv);

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -16,7 +16,7 @@
 #include "shell/app/uv_stdio_fix.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_constants.h"
-#include "uv.h"
+#include "shell/common/uv_includes.h"
 
 namespace {
 

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -4,7 +4,6 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include <atlbase.h>  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include <shellapi.h>
 #include <shellscalingapi.h>
 #include <tchar.h>
@@ -15,15 +14,11 @@
 #include <string>
 #include <utility>
 
-// workaround for base/strings/strcat.h(18,9): error: 'StrCat' macro redefined
-// [-Werror,-Wmacro-redefined]
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmacro-redefined"
-
 #include "base/at_exit.h"
 #include "base/debug/alias.h"
 #include "base/i18n/icu_util.h"
 #include "base/strings/cstring_view.h"
+#include "base/win/atl.h"  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include "base/win/dark_mode_support.h"
 #include "chrome/app/exit_code_watcher_win.h"
 #include "components/crash/core/app/crash_switches.h"
@@ -38,8 +33,6 @@
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_constants.h"
 #include "third_party/crashpad/crashpad/util/win/initial_client_data.h"
-
-#pragma clang diagnostic pop
 
 namespace {
 

--- a/shell/browser/api/electron_api_clipboard_win.cc
+++ b/shell/browser/api/electron_api_clipboard_win.cc
@@ -4,7 +4,7 @@
 
 #include "shell/browser/api/electron_api_clipboard.h"
 
-#include <windows.h>  // NOLINT(build/include_order)
+#include <windows.h>
 
 #include <cstdint>
 #include <string>

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -2,33 +2,30 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "base/functional/bind.h"
-#include "shell/browser/browser.h"
+#include <windows.h>
 
-// must come before other includes. fixes bad #defines from <shlwapi.h>.
-#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
-
-#include <windows.h>  // NOLINT(build/include_order)
-
-#include <atlbase.h>   // NOLINT(build/include_order)
-#include <shlobj.h>    // NOLINT(build/include_order)
-#include <shobjidl.h>  // NOLINT(build/include_order)
+#include <shlobj.h>
+#include <shobjidl.h>
 
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/file_version_info.h"
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
+#include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "base/strings/cstring_view.h"
 #include "base/strings/strcat_win.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/win/atl.h"
 #include "base/win/registry.h"
+#include "base/win/shlwapi.h"
 #include "base/win/windows_version.h"
 #include "chrome/browser/icon_manager.h"
 #include "electron/electron_version.h"
 #include "shell/browser/badging/badge_manager.h"
+#include "shell/browser/browser.h"
 #include "shell/browser/electron_browser_main_parts.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/ui/message_box.h"

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <optional>
 
-#include "uv.h"  // NOLINT(build/include_directory)
+#include "shell/common/uv_includes.h"
 #include "v8/include/v8-locker.h"
 
 namespace gin {

--- a/shell/browser/lib/power_observer_linux.cc
+++ b/shell/browser/lib/power_observer_linux.cc
@@ -4,7 +4,6 @@
 #include "shell/browser/lib/power_observer_linux.h"
 
 #include <unistd.h>
-#include <uv.h>
 #include <utility>
 
 #include "base/command_line.h"
@@ -14,6 +13,7 @@
 #include "components/dbus/thread_linux/dbus_thread_linux.h"
 #include "device/bluetooth/dbus/bluez_dbus_manager.h"
 #include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
+#include "shell/common/uv_includes.h"
 
 namespace {
 

--- a/shell/browser/notifications/win/windows_toast_activator.cc
+++ b/shell/browser/notifications/win/windows_toast_activator.cc
@@ -5,15 +5,9 @@
 #include "shell/browser/notifications/win/windows_toast_activator.h"
 
 #include <propkey.h>
-#include <propvarutil.h>
 #include <shlobj.h>
 #include <shobjidl.h>
 #include <wrl/module.h>
-#ifdef StrCat
-// Undefine Windows shlwapi.h StrCat macro to avoid conflict with
-// base/strings/strcat.h which deliberately defines a StrCat macro sentinel.
-#undef StrCat
-#endif
 
 #include <memory>
 #include <string>
@@ -30,6 +24,7 @@
 #include "base/strings/string_number_conversions_win.h"
 #include "base/strings/string_split.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/win/propvarutil.h"
 #include "base/win/registry.h"
 #include "base/win/scoped_propvariant.h"
 #include "content/public/browser/browser_thread.h"

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -6,17 +6,14 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
-
-// atlbase.h for CComPtr
-#include <atlbase.h>  // NOLINT(build/include_order)
-
-#include <shlobj.h>    // NOLINT(build/include_order)
-#include <shobjidl.h>  // NOLINT(build/include_order)
+#include <shlobj.h>
+#include <shobjidl.h>
 
 #include "base/files/file_util.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/win/atl.h"
+#include "base/win/shlwapi.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/win/dialog_thread.h"
 #include "shell/common/electron_paths.h"

--- a/shell/browser/ui/win/jump_list.cc
+++ b/shell/browser/ui/win/jump_list.cc
@@ -3,9 +3,7 @@
 // found in the LICENSE file.
 
 // FIXME(samuelmaddock): refactor this class to use modern
-// Microsoft::WRL::ComPtr must come before other includes. fixes bad #defines
-// from <shlwapi.h>.
-#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
+// Microsoft::WRL::ComPtr
 
 #include "shell/browser/ui/win/jump_list.h"
 
@@ -14,6 +12,7 @@
 #include "base/logging.h"
 #include "base/win/scoped_co_mem.h"
 #include "base/win/scoped_propvariant.h"
+#include "base/win/shlwapi.h"
 #include "base/win/win_util.h"
 
 namespace {

--- a/shell/browser/ui/win/jump_list.h
+++ b/shell/browser/ui/win/jump_list.h
@@ -5,11 +5,11 @@
 #ifndef ELECTRON_SHELL_BROWSER_UI_WIN_JUMP_LIST_H_
 #define ELECTRON_SHELL_BROWSER_UI_WIN_JUMP_LIST_H_
 
-#include <atlbase.h>
 #include <shobjidl.h>
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/win/atl.h"
 
 namespace electron {
 

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -11,7 +11,7 @@
 #include "base/process/process_metrics.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom-forward.h"
 #include "shell/common/node_bindings.h"
-#include "uv.h"  // NOLINT(build/include_directory)
+#include "shell/common/uv_includes.h"
 
 namespace base {
 class FilePath;

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -10,13 +10,12 @@
 #include <string>
 #include <vector>
 
-#include <uv.h>
-
 #include "base/containers/span.h"
 #include "base/files/file.h"
 #include "base/files/file_path.h"
 #include "base/synchronization/lock.h"
 #include "base/values.h"
+#include "shell/common/uv_includes.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace asar {

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -18,7 +18,7 @@
 #include "base/types/to_address.h"
 #include "gin/public/context_holder.h"
 #include "gin/public/gin_embedders.h"
-#include "uv.h"  // NOLINT(build/include_directory)
+#include "shell/common/uv_includes.h"
 #include "v8/include/v8-forward.h"
 
 namespace base {

--- a/shell/common/node_includes.h
+++ b/shell/common/node_includes.h
@@ -37,6 +37,10 @@
 
 #include "electron/pop_node_defines.h"
 
+// Undefine these defines from libuv which conflict with other headers
+#undef RB_BLACK
+#undef RB_RED
+
 // Alternative to NODE_BINDING_CONTEXT_AWARE_X.
 // Allows to explicitly register builtin bindings instead of using
 // __attribute__((constructor)).

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -6,9 +6,6 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include "base/win/shlwapi.h"  // NOLINT(build/include_order)
-
-#include <atlbase.h>
 #include <comdef.h>
 #include <commdlg.h>
 #include <dwmapi.h>
@@ -27,8 +24,10 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/scoped_blocking_call.h"
+#include "base/win/atl.h"
 #include "base/win/scoped_co_mem.h"
 #include "base/win/scoped_com_initializer.h"
+#include "base/win/shlwapi.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/common/electron_paths.h"
 #include "ui/base/win/shell.h"

--- a/shell/common/uv_includes.h
+++ b/shell/common/uv_includes.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_UV_INCLUDES_H_
+#define ELECTRON_SHELL_COMMON_UV_INCLUDES_H_
+
+#include <uv.h>
+
+// Undefine these defines from libuv which conflict with other headers
+#undef RB_BLACK
+#undef RB_RED
+
+#endif  // ELECTRON_SHELL_COMMON_UV_INCLUDES_H_


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Cleans up includes so we don't need `// NOLINT(build/include_order)` and the hacks around the `StrCat` macro. The main issue was we shouldn't be including `<atlbase.h>` directly, but rather `base/win/atl.h` (same with ` propvarutil.h`), as per the presubmit error in Chromium: "Do not #include shlwapi.h, atlbase.h, propvarutil.h or sphelper.h directly since they pollute code with StrCat macro. Instead, include matching header from base/win. See http://crbug.com/856536"

The introduction of `shell/common/uv_includes.h` is to counter the leaking of the `RB_BLACK` and `RB_RED` macros from libuv (not a part of the public API, just an internal implementation detail), which conflicts with a Windows header.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
