### PR TITLE
docs: clarify initiator field can be parent or child frame in navigation events

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -255,10 +255,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation. This can be a parent frame (e.g. via `window.open` with a
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -289,10 +290,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation. This can be a parent frame (e.g. via `window.open` with a
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 
 Emitted when a user or the page wants to start navigation in any frame. It can happen when
 the `window.location` object is changed or a user clicks a link in the page.
@@ -321,10 +323,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation. This can be a parent frame (e.g. via `window.open` with a
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -346,10 +349,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation. This can be a parent frame (e.g. via `window.open` with a
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_
@@ -378,10 +382,11 @@ Returns:
   * `frame` WebFrameMain | null - The frame to be navigated.
     May be `null` if accessed after the frame has either navigated or been destroyed.
   * `initiator` WebFrameMain | null (optional) - The frame which initiated the
-    navigation, which can be a parent frame (e.g. via `window.open` with a
-    frame's name), or null if the navigation was not initiated by a frame. This
-    can also be null if the initiating frame was deleted before the event was
-    emitted.
+    navigation. This can be a parent frame (e.g. via `window.open` with a
+    frame's name), a child frame (e.g. an unsandboxed iframe navigating its
+    parent via `<a target="_top">`), or null if the navigation was not initiated
+    by a frame. This can also be null if the initiating frame was deleted before
+    the event was emitted.
 * `url` string _Deprecated_
 * `isInPlace` boolean _Deprecated_
 * `isMainFrame` boolean _Deprecated_


### PR DESCRIPTION
#### Description of Change

Closes #48793

Recreates #48915 (approved, but stalled on unsigned commits and an inactive PR) on top of latest `main`, preserving the original author's commit attribution.

- Documents that the `initiator` field on `will-frame-navigate` / `will-navigate` / `did-start-navigation` (and related navigation events) can also be a **child** frame — e.g. an unsandboxed iframe navigating its parent via `<a target="_top">` — not just a parent frame. Refs #48793.

#### Release Notes

Notes: none