### PR TITLE
fix: support partial BaseWindow bounds

### DIFF
--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -11,6 +11,21 @@ BaseWindow.prototype._init = function (this: TLWT) {
   // Avoid recursive require.
   const { app } = require('electron');
 
+  const nativeSetBounds = this.setBounds;
+  this.setBounds = (bounds, ...opts) => {
+    bounds = bounds ?? {};
+    if (bounds.x == null || bounds.y == null || bounds.width == null || bounds.height == null) {
+      const currentBounds = this.getBounds();
+      bounds = {
+        x: bounds.x ?? currentBounds.x,
+        y: bounds.y ?? currentBounds.y,
+        width: bounds.width ?? currentBounds.width,
+        height: bounds.height ?? currentBounds.height
+      };
+    }
+    nativeSetBounds.call(this, bounds, ...opts);
+  };
+
   // Simulate the application menu on platforms other than macOS.
   if (process.platform !== 'darwin') {
     const menu = app.applicationMenu;

--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -20,15 +20,6 @@ BrowserWindow.prototype._init = function (this: BWT) {
     writable: false
   });
 
-  const nativeSetBounds = this.setBounds;
-  this.setBounds = (bounds, ...opts) => {
-    bounds = {
-      ...this.getBounds(),
-      ...bounds
-    };
-    nativeSetBounds.call(this, bounds, ...opts);
-  };
-
   // Redirect focus/blur event to app instance too.
   this.on('blur', (event: Electron.Event) => {
     app.emit('browser-window-blur', event, this);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -90,6 +90,63 @@ describe('BrowserWindow module', () => {
     expect(BrowserWindow.prototype.constructor.name).to.equal('BrowserWindow');
   });
 
+  describe('BaseWindow.setBounds(bounds[, animate])', () => {
+    it('sets the window bounds with partial bounds', () => {
+      const baseWindow = new BaseWindow({ show: false });
+      try {
+        const fullBounds = { x: 440, y: 225, width: 500, height: 400 };
+        const nativeGetBounds = baseWindow.getBounds.bind(baseWindow);
+        let getBoundsCalled = false;
+        baseWindow.getBounds = () => {
+          getBoundsCalled = true;
+          return nativeGetBounds();
+        };
+
+        baseWindow.setBounds(fullBounds);
+        expect(getBoundsCalled).to.be.false();
+
+        const boundsUpdate = { width: 200 };
+        baseWindow.setBounds(boundsUpdate as any);
+
+        expect(getBoundsCalled).to.be.true();
+        expectBoundsEqual(nativeGetBounds(), { ...fullBounds, ...boundsUpdate });
+      } finally {
+        baseWindow.destroy();
+      }
+    });
+
+    it('treats undefined and null bounds properties as missing', () => {
+      const baseWindow = new BaseWindow({ show: false });
+      try {
+        const fullBounds = { x: 440, y: 225, width: 500, height: 400 };
+        baseWindow.setBounds(fullBounds);
+
+        baseWindow.setBounds({ x: fullBounds.x, y: fullBounds.y, width: 200, height: undefined } as any);
+
+        expectBoundsEqual(baseWindow.getBounds(), { ...fullBounds, width: 200 });
+
+        baseWindow.setBounds({ x: null, y: fullBounds.y, width: 300, height: fullBounds.height } as any);
+
+        expectBoundsEqual(baseWindow.getBounds(), { ...fullBounds, width: 300 });
+      } finally {
+        baseWindow.destroy();
+      }
+    });
+
+    it('allows undefined bounds', () => {
+      const baseWindow = new BaseWindow({ show: false });
+      try {
+        const fullBounds = { x: 440, y: 225, width: 500, height: 400 };
+        baseWindow.setBounds(fullBounds);
+
+        expect(() => baseWindow.setBounds(undefined as any)).not.to.throw();
+        expectBoundsEqual(baseWindow.getBounds(), fullBounds);
+      } finally {
+        baseWindow.destroy();
+      }
+    });
+  });
+
   describe('BrowserWindow constructor', () => {
     afterEach(closeAllWindows);
 


### PR DESCRIPTION
#### Description of Change

Moves partial-bounds normalization from `BrowserWindow` to `BaseWindow` so `BaseWindow.setBounds()` honors its documented `Partial<Rectangle>` contract. Current bounds are read only when a property is missing.

Fixes #52660

#### Checklist

- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] `npm test` passes — requires a built Electron checkout; CI will run it
- [x] tests are changed or added
- [x] PR release notes are complete

#### Release Notes

Notes: none