### PR TITLE
feat: re-add app.setBadgeCount and win.setProgressBar for Linux

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1471,17 +1471,25 @@ Using `basic` should be preferred if only basic information like `vendorId` or `
 
 Promise is rejected if the GPU is completely disabled, i.e. no hardware and software implementations are available.
 
-### `app.setBadgeCount([count])` _macOS_
+### `app.setBadgeCount([count])` _Linux_ _macOS_
 
-* `count` Integer (optional) - If a value is provided, set the badge to the provided value otherwise, on macOS, display a plain white dot (e.g. unknown number of notifications).
+* `count` Integer (optional) - If a value is provided, set the badge to the provided value otherwise, on macOS, display a plain white dot (e.g. unknown number of notifications). On Linux, if a value is not provided the badge will not display.
 
 Returns `boolean` - Whether the call succeeded.
 
-Sets the Dock icon counter badge for current app. Setting the count to `0` will hide the
+Sets the counter badge for current app. Setting the count to `0` will hide the
 badge.
 
+On macOS, it shows on the Dock icon. On Linux, it shows on docks and taskbars that support the LauncherEntry D-Bus API,
+
 > [!NOTE]
-> You need to ensure that your application has the permission
+> On Linux, the badge is associated with the app's `.desktop` file, so
+> [`app.setDesktopName`](#appsetdesktopnamename-linux) (or the `desktopName`
+> field in `package.json`) must match the name of the app's actual `.desktop`
+> file.
+
+> [!NOTE]
+> On macOS, you need to ensure that your application has the permission
 > to display notifications for this method to work.
 
 ### `app.getBadgeCount()` _macOS_
@@ -1867,12 +1875,12 @@ This API must be called after the `ready` event is emitted.
 A `Menu | null` property that returns [`Menu`](menu.md) if one has been set and `null` otherwise.
 Users can pass a [Menu](menu.md) to set this property.
 
-### `app.badgeCount` _macOS_
+### `app.badgeCount` _Linux_ _macOS_
 
-An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge. Setting this with any nonzero integer shows the count on the Dock icon.
+An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge. Setting this with any nonzero integer shows the count on the Dock icon on macOS, or on the launcher on Linux.
 
 > [!NOTE]
-> You need to ensure that your application has the permission
+> On macOS, you need to ensure that your application has the permission
 > to display notifications for this property to take effect.
 
 ### `app.commandLine` _Readonly_

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1154,7 +1154,7 @@ Sets the `menu` as the window's menu bar.
 
 Remove the window's menu bar.
 
-#### `win.setProgressBar(progress[, options])` _Windows_ _macOS_
+#### `win.setProgressBar(progress[, options])`
 
 * `progress` Double
 * `options` Object (optional)
@@ -1168,6 +1168,11 @@ Change to indeterminate mode when progress > 1.
 On Windows, a mode can be passed. Accepted values are `none`, `normal`,
 `indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
 mode set (but with a value within the valid range), `normal` will be assumed.
+
+On Linux, the progress bar shows on docks and taskbars that support the
+LauncherEntry D-Bus API. It is associated with the app's `.desktop` file, so
+[`app.setDesktopName`](app.md#appsetdesktopnamename-linux) must match the name
+of the app's actual `.desktop` file. Indeterminate mode is not supported.
 
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1343,7 +1343,7 @@ Sets the `menu` as the window's menu bar.
 
 Remove the window's menu bar.
 
-#### `win.setProgressBar(progress[, options])` _Windows_ _macOS_
+#### `win.setProgressBar(progress[, options])`
 
 * `progress` Double
 * `options` Object (optional)
@@ -1357,6 +1357,11 @@ Change to indeterminate mode when progress > 1.
 On Windows, a mode can be passed. Accepted values are `none`, `normal`,
 `indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
 mode set (but with a value within the valid range), `normal` will be assumed.
+
+On Linux, the progress bar shows on docks and taskbars that support the
+LauncherEntry D-Bus API. It is associated with the app's `.desktop` file, so
+[`app.setDesktopName`](app.md#appsetdesktopnamename-linux) must match the name
+of the app's actual `.desktop` file. Indeterminate mode is not supported.
 
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -109,4 +109,4 @@ when using [Mission Control](https://support.apple.com/en-us/HT204100):
 
 ![Mission Control Progress Bar](../images/mission-control-progress-bar.png)
 
-[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options-windows-macos
+[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options

--- a/filenames.gni
+++ b/filenames.gni
@@ -25,6 +25,8 @@ filenames = {
     "shell/browser/browser_linux.cc",
     "shell/browser/lib/power_observer_linux.cc",
     "shell/browser/lib/power_observer_linux.h",
+    "shell/browser/linux/launcher_entry.cc",
+    "shell/browser/linux/launcher_entry.h",
     "shell/browser/notifications/linux/libnotify_notification.cc",
     "shell/browser/notifications/linux/libnotify_notification.h",
     "shell/browser/notifications/linux/notification_presenter_linux.cc",

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -20,6 +20,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "electron/electron_version.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/browser/linux/launcher_entry.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
@@ -252,7 +253,12 @@ v8::Local<v8::Promise> Browser::GetApplicationInfoForProtocol(
 }
 
 bool Browser::SetBadgeCount(std::optional<int> count) {
-  return false;
+  if (!count.has_value())
+    return false;
+  if (!launcher_entry::SetBadgeCount(count.value()))
+    return false;
+  badge_count_ = count.value();
+  return true;
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {}

--- a/shell/browser/linux/launcher_entry.cc
+++ b/shell/browser/linux/launcher_entry.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/linux/launcher_entry.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/task/sequenced_task_runner.h"
+#include "components/dbus/thread_linux/dbus_thread_linux.h"
+#include "components/dbus/utils/variant.h"
+#include "components/dbus/utils/write_value.h"
+#include "dbus/bus.h"
+#include "dbus/message.h"
+#include "dbus/object_path.h"
+#include "shell/common/platform_util.h"
+
+namespace electron::launcher_entry {
+
+namespace {
+
+constexpr char kLauncherEntryInterface[] = "com.canonical.Unity.LauncherEntry";
+constexpr char kLauncherEntryPath[] = "/com/canonical/unity/launcherentry";
+
+using Properties = std::map<std::string, dbus_utils::Variant>;
+
+std::optional<std::string> GetAppUri() {
+  std::optional<std::string> desktop_id = platform_util::GetDesktopName();
+  if (!desktop_id || desktop_id->empty())
+    return std::nullopt;
+  return "application://" + *desktop_id;
+}
+
+void ConnectAndSend(scoped_refptr<dbus::Bus> bus,
+                    std::unique_ptr<dbus::Signal> signal) {
+  if (!bus->Connect())
+    return;
+  uint32_t serial = 0;
+  bus->Send(signal->raw_message(), &serial);
+}
+
+bool EmitUpdate(const Properties& properties) {
+  std::optional<std::string> app_uri = GetAppUri();
+  if (!app_uri)
+    return false;
+
+  auto signal =
+      std::make_unique<dbus::Signal>(kLauncherEntryInterface, "Update");
+  CHECK(signal->SetPath(dbus::ObjectPath(kLauncherEntryPath)));
+  dbus::MessageWriter writer(signal.get());
+  writer.AppendString(*app_uri);
+  dbus_utils::WriteValue(writer, properties);
+
+  scoped_refptr<dbus::Bus> bus = dbus_thread_linux::GetSharedSessionBus();
+  bus->GetDBusTaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce(&ConnectAndSend, bus, std::move(signal)));
+  return true;
+}
+
+}  // namespace
+
+bool SetBadgeCount(int64_t count) {
+  Properties props;
+  props.emplace("count", dbus_utils::Variant::Wrap<"x">(count));
+  props.emplace("count-visible", dbus_utils::Variant::Wrap<"b">(count != 0));
+  return EmitUpdate(props);
+}
+
+bool SetProgress(double progress) {
+  Properties props;
+  props.emplace("progress", dbus_utils::Variant::Wrap<"d">(progress));
+  props.emplace("progress-visible", dbus_utils::Variant::Wrap<"b">(
+                                        progress > 0.0 && progress < 1.0));
+  return EmitUpdate(props);
+}
+
+}  // namespace electron::launcher_entry

--- a/shell/browser/linux/launcher_entry.h
+++ b/shell/browser/linux/launcher_entry.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_
+#define ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_
+
+#include <cstdint>
+
+// Emits com.canonical.Unity.LauncherEntry Update signals on the session bus.
+// Despite the name, this D-Bus API is the de facto protocol for taskbar badge
+// counts and progress bars on Linux.
+namespace electron::launcher_entry {
+
+// Sets the badge count on the app's launcher entry. A count of zero hides
+// the badge. Returns false when the app's desktop name is not known.
+// Otherwise the signal is emitted best-effort and whether anything renders
+// it depends on the desktop environment.
+bool SetBadgeCount(int64_t count);
+
+// Sets the progress bar on the app's launcher entry. Values outside (0, 1)
+// hide the progress bar. Returns false under the same conditions as
+// SetBadgeCount().
+bool SetProgress(double progress);
+
+}  // namespace electron::launcher_entry
+
+#endif  // ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -57,6 +57,7 @@
 #if BUILDFLAG(IS_LINUX)
 #include "base/notimplemented.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/linux/launcher_entry.h"
 #include "shell/browser/linux/x11_util.h"
 #include "shell/browser/ui/electron_desktop_window_tree_host_linux.h"
 #include "shell/browser/ui/views/electron_frame_view_layout_linux.h"
@@ -1592,6 +1593,8 @@ void NativeWindowViews::SetProgressBar(double progress,
                                        NativeWindow::ProgressState state) {
 #if BUILDFLAG(IS_WIN)
   taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, state);
+#elif BUILDFLAG(IS_LINUX)
+  launcher_entry::SetProgress(progress);
 #endif
 }
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -660,7 +660,7 @@ describe('app module', () => {
   });
 
   describe('app.badgeCount', () => {
-    const platformIsNotSupported = process.platform === 'win32' || process.platform === 'linux';
+    const platformIsSupported = process.platform === 'darwin' || process.platform === 'linux';
 
     const expectedBadgeCount = 42;
 
@@ -668,7 +668,7 @@ describe('app module', () => {
       app.badgeCount = 0;
     });
 
-    ifdescribe(!platformIsNotSupported)('on supported platform', () => {
+    ifdescribe(platformIsSupported)('on supported platform', () => {
       describe('with properties', () => {
         it('sets a badge count', function () {
           app.badgeCount = expectedBadgeCount;
@@ -681,25 +681,11 @@ describe('app module', () => {
           app.setBadgeCount(expectedBadgeCount);
           expect(app.getBadgeCount()).to.equal(expectedBadgeCount);
         });
-        it('sets an non numeric (dot) badge count', function () {
+        // A badge count is required on Linux; only macOS displays a plain
+        // dot when no count is provided.
+        ifit(process.platform === 'darwin')('sets an non numeric (dot) badge count', function () {
           app.setBadgeCount();
           // Badge count should be zero when non numeric (dot) is requested
-          expect(app.getBadgeCount()).to.equal(0);
-        });
-      });
-    });
-
-    ifdescribe(process.platform !== 'win32' && platformIsNotSupported)('on unsupported platform', () => {
-      describe('with properties', () => {
-        it('does not set a badge count', function () {
-          app.badgeCount = 9999;
-          expect(app.badgeCount).to.equal(0);
-        });
-      });
-
-      describe('with functions', () => {
-        it('does not set a badge count)', function () {
-          app.setBadgeCount(9999);
           expect(app.getBadgeCount()).to.equal(0);
         });
       });


### PR DESCRIPTION
#### Description of Change

Restores the APIs `app.setBadgeCount` and `win.setProgressBar` to Linux using a pure D-Bus API. The previous implementation was removed in #51649 because it depended on libunity, an obsolete and unmaintained library.

Resolves #51668.

Example in KDE Plasma on Ubuntu (Kubuntu):

<img width="218" height="104" alt="image" src="https://github.com/user-attachments/assets/533847b6-05d6-45d6-977b-2ace822f9389" />


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Restored `app.setBadgeCount` and `win.setProgressBar` for Linux. These APIs now support any dock or taskbar which implements the LauncherEntry D-Bus API, and they no longer require `libunity`. 
