### PR TITLE
fix: transparent windows can be resized on Linux

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -35,8 +35,13 @@
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
-#include "shell/browser/ui/views/frameless_view.h"
 #include "ui/views/view_utils.h"
+#endif
+
+#if BUILDFLAG(IS_WIN)
+#include "shell/browser/ui/views/frameless_view.h"
+#elif BUILDFLAG(IS_LINUX)
+#include "shell/browser/ui/views/electron_frame_view_linux.h"
 #endif
 
 #if defined(USE_OZONE)
@@ -737,9 +742,16 @@ int NativeWindow::NonClientHitTest(const gfx::Point& point) {
 #if !BUILDFLAG(IS_MAC)
   // We need to ensure we account for resizing borders on Windows and Linux.
   if ((!has_frame() || has_client_frame()) && IsResizable()) {
-    auto* frame = views::AsViewClass<FramelessView>(
-        widget()->non_client_view()->frame_view());
-    if (frame) {
+    // TODO(mitchchn): bring back a cross-platform interface for
+    // frame operations. (Both Windows and Linux used to inherit
+    // from FramelessView.)
+#if BUILDFLAG(IS_WIN)
+    using ResizableFrameView = FramelessView;
+#else
+    using ResizableFrameView = ElectronFrameViewLinux;
+#endif
+    auto* frame_view = widget()->non_client_view()->frame_view();
+    if (auto* frame = views::AsViewClass<ResizableFrameView>(frame_view)) {
       int border_hit = frame->ResizingBorderHitTest(point);
       if (border_hit != HTNOWHERE)
         return border_hit;

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -18,12 +18,21 @@
 #include "ui/base/hit_test.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/frame_background.h"
 #include "ui/views/window/frame_caption_button.h"
 
 namespace electron {
+
+namespace {
+
+// Values used for internal resizing when there are no insets.
+const int kResizeAreaCornerSize = 16;
+const int kResizeInsideBoundsSize = 5;
+
+}  // namespace
 
 ElectronFrameViewLinux::ElectronFrameViewLinux(
     NativeWindowViews* window,
@@ -148,6 +157,21 @@ int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
     return contents_hit_test;
 
   return HTCLIENT;
+}
+
+int ElectronFrameViewLinux::ResizingBorderHitTest(const gfx::Point& point) {
+  // Fall back to an internal resize band only when there are no frame insets
+  // but the window is still supposed to be resizable. The main use case is
+  // transparent windows. Matches the behavior of
+  // WinFrameView::ResizingBorderHitTest.
+  if (!window_->IsResizable() ||
+      !efv_layout()->GetRestoredFrameBorderInsets().IsEmpty() ||
+      GetWidget()->IsMaximized() || GetWidget()->IsFullscreen())
+    return HTNOWHERE;
+
+  return GetHTComponentForFrame(point, gfx::Insets(kResizeInsideBoundsSize),
+                                kResizeAreaCornerSize, kResizeAreaCornerSize,
+                                /*can_resize=*/true);
 }
 
 void ElectronFrameViewLinux::Layout(PassKey) {

--- a/shell/browser/ui/views/electron_frame_view_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_linux.h
@@ -44,6 +44,10 @@ class ElectronFrameViewLinux : public views::NativeFrameViewLinux {
   bool WantsFrame() const;
   void SetWantsFrame(bool wants_frame);
 
+  // Hit test for the internal resize band used when the frame has no
+  // external frame insets (e.g., translucent windows).
+  int ResizingBorderHitTest(const gfx::Point& point);
+
   // views::FrameViewLinux:
   bool HasWindowTitle() const override;
   int NonClientHitTest(const gfx::Point& point) override;


### PR DESCRIPTION
#### Description of Change

Fixes #52452.

Similar to the approach taken by @codebytere in #51992, but only affects frames which *don't* have external insets, matching the behaviour on Windows.

Backports to 43.x.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples --> Fixed a regression preventing from transparent frameless windows from being resized on Linux.
