### PR TITLE
build: faster symbol archives, skip test artifacts on publish

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: 'true'
   generate-test-artifacts:
-    description: 'Generate artifacts only consumed by test jobs (src artifacts, cross-arch snapshots, mksnapshot fixup). Only disable when no test job consumes this build.'
+    description: 'Generate artifacts only consumed by test jobs (src artifacts, cross-arch snapshots; mksnapshot fixup on non-release builds). Only disable when no test job consumes this build.'
     required: false
     default: 'true'
   publish:
@@ -186,9 +186,12 @@ runs:
           fi
           electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.${{ inputs.target-arch }}.manifest
         fi
+    # mksnapshot_args is consumed by both the mksnapshot tests and by
+    # @electron/mksnapshot from the released mksnapshot.zip, so this is needed
+    # whenever either tests or a release consume this build.
     - name: Fixup Mksnapshot ${{ inputs.step-suffix }}
       shell: bash
-      if: ${{ inputs.generate-test-artifacts == 'true' }}
+      if: ${{ inputs.generate-test-artifacts == 'true' || inputs.is-release == 'true' }}
       run: |
         cd src
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG=1 e d gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -268,8 +268,12 @@ runs:
         # Needed for msdia140.dll on 64-bit windows
         cd src
         export PATH="$PATH:$(pwd)/third_party/llvm-build/Release+Asserts/bin"
+    # symbols.zip / pdb.zip / dsym archives are only consumed by the release
+    # uploader; every testing/PGO build passes generate-symbols: false and this
+    # was still spending 8-13 minutes per Windows build zipping PDBs nobody reads.
     - name: Zip Symbols ${{ inputs.step-suffix }}
       shell: bash
+      if: ${{ inputs.generate-symbols == 'true' }}
       run: |
         cd src
         export BUILD_PATH="$(pwd)/out/Default"

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -85,6 +85,8 @@ jobs:
       target-arch: x64
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -106,6 +108,8 @@ jobs:
       target-arch: arm64
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -89,6 +89,8 @@ jobs:
       target-variant: darwin
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -110,6 +112,8 @@ jobs:
       target-variant: mas
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -131,6 +135,8 @@ jobs:
       target-variant: darwin
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -152,6 +158,8 @@ jobs:
       target-variant: mas
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -177,6 +177,8 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       upload-to-storage: '0'
     secrets: inherit
 
@@ -200,6 +202,8 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       upload-to-storage: '0'
     secrets: inherit
 
@@ -222,5 +226,7 @@ jobs:
       is-release: true
       gn-build-type: release
       generate-symbols: true
+      # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       upload-to-storage: '0'
     secrets: inherit

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -89,6 +89,8 @@ jobs:
       target-arch: x64
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -109,6 +111,8 @@ jobs:
       target-arch: arm64
       is-release: true
       publish: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -66,28 +66,50 @@ def download(text, url, path):
   return path
 
 
+# Deflate level 6 is ~1.7x faster than level 9 on the multi-GB debug info
+# archives this is used for (pdb.zip, dsym-snapshot.zip, debug.zip), and the
+# output is only ~0.4% larger.
+ZIP_COMPRESSION_LEVEL = 6
+
 def make_zip(zip_file_path, files, dirs):
   safe_unlink(zip_file_path)
   if sys.platform == 'darwin':
     allfiles = files + dirs
-    execute(['zip', '-r', '-y', '-9', zip_file_path] + allfiles)
+    execute(['zip', '-r', '-y', f'-{ZIP_COMPRESSION_LEVEL}', zip_file_path]
+            + allfiles)
   else:
     with zipfile.ZipFile(zip_file_path, "w",
                          zipfile.ZIP_DEFLATED,
-                         allowZip64=True) as zip_file:
+                         allowZip64=True,
+                         compresslevel=ZIP_COMPRESSION_LEVEL) as zip_file:
       for filename in files:
-        zip_file.write(filename, filename, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+        zip_file.write(filename, filename)
       for dirname in dirs:
         for root, _, filenames in os.walk(dirname):
           for f in filenames:
-            zip_file.write(os.path.join(root, f), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+            zip_file.write(os.path.join(root, f))
       zip_file.close()
 
 
 def make_tar_xz(tar_file_path, files, dirs):
   safe_unlink(tar_file_path)
   allfiles = files + dirs
-  execute(['tar', '-cJf', tar_file_path] + allfiles)
+  # xz is single threaded by default, which takes 30+ minutes for the ~7GB of
+  # dSYMs this is used for. Multi-threaded xz splits the input into
+  # independently compressed blocks (~1% larger, still a standard .xz stream
+  # that any xz decoder can read) and scales ~linearly with core count.
+  tar_version = subprocess.run(['tar', '--version'], capture_output=True,
+                               text=True, check=False).stdout
+  if 'bsdtar' in tar_version:
+    # macOS ships bsdtar, whose xz filter is configured via --options; a
+    # thread count of 0 means "one per CPU".
+    args = ['tar', '--options', 'xz:threads=0', '-cJf', tar_file_path]
+    env = None
+  else:
+    # GNU tar shells out to the xz binary, which reads XZ_OPT.
+    args = ['tar', '-cJf', tar_file_path]
+    env = dict(os.environ, XZ_OPT='-T0')
+  execute(args + allfiles, env=env)
 
 
 def rm_rf(path):


### PR DESCRIPTION
#### Description of Change

Publish jobs spend a large chunk of their wall clock outside the build itself; this trims the two biggest non-build items without changing any released file formats.

- `dsym.tar.xz` is now written with multi-threaded xz (`bsdtar --options xz:threads=0`; `XZ_OPT=-T0` under GNU tar). "Zip Symbols" was 25–47 min on every macOS publish job because xz was single-threaded over ~7 GB of dSYMs. Output is still a plain `.xz` stream.
- Symbol zips (`pdb.zip`, `dsym-snapshot.zip`, `debug.zip`, `symbols.zip`) use deflate level 6 instead of 9. #48766 added `-9` for the 2 GB asset limit; measured below, it only buys ~0.4% (~8 MB on the 1.93 GB win-x64 `pdb.zip`) for ~1.7x the time — "Zip Symbols" was 8–16 min on Windows.
- "Zip Symbols" now only runs when the build was asked for symbols. Every testing and PGO build passes `generate-symbols: false` (the input was declared but never read), and `symbols.zip`/`pdb.zip`/dSYM archives are only consumed by the release uploader (`move-artifacts.sh` already tolerates their absence), yet each Windows PR build spent 8–13 min zipping PDBs — it's the largest remaining step on a fully cached build.
- Publish and release-build jobs pass `generate-test-artifacts: false`: nothing consumes `src_artifacts` (12.5 min of msys `cp -r` + tar per Windows publish job, 8 × 143–787 MB uploads per release) or the linux arm64 cross-arch snapshot (5.7 min) outside test jobs. The `mksnapshot_args` fixup was behind the same flag but is also read by `@electron/mksnapshot` from the released zip, so it now also runs for `is-release` builds.

Measured on a 512 MiB slice of an unstripped `electron` binary (Linux, one core unless noted):

| | time | size |
|---|---|---|
| python zipfile level 9 → 6 | 29.5 s → 17.2 s | +0.4% |
| `zip -9` → `zip` (6) | 31.3 s → 18.1 s | +0.4% |
| `tar -cJf` → `xz:threads=5` | 164 s → 38.6 s | +1.0% |

Reference timings are from the v45.0.0-nightly.20260808 / v44.0.0-beta.2 publish runs.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes

Verified `make_zip` / `make_tar_xz` locally against both GNU tar and bsdtar (archives list and `xz -t` cleanly), `lint --py` passes, and `copy-pipeline-segment-publish.js --check` is still in sync. The macOS/Windows "Zip Symbols" step time on this PR's own CI is the real check for the xz change; the publish-flag change is only exercised by a publish run.

#### Release Notes

Notes: none
