### PR TITLE
build: persist siso deps/fs state between CI builds (experiment)

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -272,6 +272,29 @@ jobs:
         codesign -s - "$SISO_BIN" || true
         echo "SISO_PATH=$SISO_BIN" >> "$GITHUB_ENV"
         echo "Using custom siso binary at $SISO_BIN"
+    # EXPERIMENT: carry siso's incremental-build state (deps log + hashfs
+    # state) from the previous build of this configuration into this fresh
+    # out dir, so siso can skip include scanning / re-hashing for the steps
+    # that end up as remote cache hits anyway. Prefer state from a build with
+    # the same DEPS hash, fall back to any build of this configuration.
+    - name: Set siso state cache key
+      run: |
+        echo "SISO_STATE_KEY=siso-state-v1-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.target-variant }}-${{ inputs.gn-build-type }}-${{ inputs.is-asan }}" >> $GITHUB_ENV
+    - name: Restore siso state
+      id: restore-siso-state
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          src/out/Default/.siso_deps
+          src/out/Default/.siso_fs_state
+        key: ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-
+          ${{ env.SISO_STATE_KEY }}-
+    - name: Report restored siso state
+      run: |
+        echo "matched key: '${{ steps.restore-siso-state.outputs.cache-matched-key }}'"
+        ls -la src/out/Default/.siso_deps src/out/Default/.siso_fs_state 2>/dev/null || echo "no siso state restored (cold)"
     - name: Build Electron
       if: ${{ inputs.target-platform != 'macos' || (inputs.target-variant == 'all' || inputs.target-variant == 'darwin') }}
       uses: ./src/electron/.github/actions/build-electron
@@ -307,3 +330,24 @@ jobs:
         upload-to-storage: '${{ inputs.upload-to-storage }}'
         step-suffix: '(mas)'
         publish: '${{ inputs.publish }}'
+    # EXPERIMENT: how much of the restored state did siso actually reuse?
+    # siso.INFO is the last invocation (chromedriver); the rotated *.0.INFO
+    # is the main build.
+    - name: Report siso state reuse
+      if: ${{ !cancelled() }}
+      run: |
+        cd src/out/Default
+        ls -la .siso_deps .siso_fs_state 2>/dev/null || true
+        for f in siso*.0.INFO siso*.INFO; do
+          [ -e "$f" ] || continue
+          echo "===== $f"
+          grep -E 'load state done|deps_log|deps log|depslog|fastdeps|fast deps|scandeps|ninja_deps|fs state|missing_digests|set state done' "$f" | head -60 || true
+        done
+    - name: Save siso state
+      if: ${{ !cancelled() }}
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          src/out/Default/.siso_deps
+          src/out/Default/.siso_fs_state
+        key: ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -278,6 +278,30 @@ jobs:
           codesign -s - "$SISO_BIN" || true
           echo "SISO_PATH=$SISO_BIN" >> "$GITHUB_ENV"
           echo "Using custom siso binary at $SISO_BIN"
+      - name: Set siso state cache key
+        run: >
+          echo "SISO_STATE_KEY=siso-state-v1-${{ inputs.target-platform }}-${{
+          inputs.target-arch }}-${{ inputs.target-variant }}-${{
+          inputs.gn-build-type }}-${{ inputs.is-asan }}" >> $GITHUB_ENV
+      - name: Restore siso state
+        id: restore-siso-state
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: |
+            src/out/Default/.siso_deps
+            src/out/Default/.siso_fs_state
+          key: ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-${{ github.run_id }}-${{
+            github.run_attempt }}
+          restore-keys: |
+            ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-
+            ${{ env.SISO_STATE_KEY }}-
+      - name: Report restored siso state
+        run: >
+          echo "matched key: '${{
+          steps.restore-siso-state.outputs.cache-matched-key }}'"
+
+          ls -la src/out/Default/.siso_deps src/out/Default/.siso_fs_state
+          2>/dev/null || echo "no siso state restored (cold)"
       - name: Build Electron
         if: ${{ inputs.target-platform != 'macos' || (inputs.target-variant == 'all' ||
           inputs.target-variant == 'darwin') }}
@@ -317,3 +341,24 @@ jobs:
           upload-to-storage: ${{ inputs.upload-to-storage }}
           step-suffix: (mas)
           publish: ${{ inputs.publish }}
+      - name: Report siso state reuse
+        if: ${{ !cancelled() }}
+        run: >
+          cd src/out/Default
+
+          ls -la .siso_deps .siso_fs_state 2>/dev/null || true
+
+          for f in siso*.0.INFO siso*.INFO; do
+            [ -e "$f" ] || continue
+            echo "===== $f"
+            grep -E 'load state done|deps_log|deps log|depslog|fastdeps|fast deps|scandeps|ninja_deps|fs state|missing_digests|set state done' "$f" | head -60 || true
+          done
+      - name: Save siso state
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: |
+            src/out/Default/.siso_deps
+            src/out/Default/.siso_fs_state
+          key: ${{ env.SISO_STATE_KEY }}-${{ env.DEPSHASH }}-${{ github.run_id }}-${{
+            github.run_attempt }}


### PR DESCRIPTION
#### Description of Change

Experiment: CI builds start from an empty `out/`, so siso include-scans every TU and hashes every input even though ~96–99% of compile steps on mac/win end up as remote cache hits. In the 20260808 mac arm64 publish build's `siso_metrics`, that scanning was 5544 CPU-seconds on a 5-core runner — most of the ~27 min compile phase (~20 min on Windows, ~4 min on the 32-core Linux runners). Testing builds are the same shape: mac arm64 spends ~10.7 of its 13.7 min siso wall processing cache-hit `.o` steps, win x64 ~14 of 18 min.

This restores `.siso_deps` + `.siso_fs_state` from the previous build of the same platform/arch/variant/build-type (preferring the same DEPS hash) via `actions/cache` before the build, saves them after, and logs what siso reused. First CI run of this PR is the cold baseline that seeds the cache; the re-run measures the warm case. Comparing "Build Electron" step time and the siso summary between the two runs is the result.

Not intended to land as-is. If it holds up, the real version should be limited to non-publish builds: restored deps/hashfs state steers which inputs siso hashes and therefore which remote-cache entries a build consumes, so release builds should keep starting cold rather than trusting a cache entry (GitHub scopes cache reads to the same branch / default branch, so PR runs can't seed it, but the release pipeline shouldn't depend on that). The autogenerated publish segment picks these steps up here only because it is copied from the build segment.

#### Release Notes

Notes: none