### PR TITLE
fix: load the zip extractor only when extraction runs

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -2,8 +2,6 @@
 
 const { downloadArtifact } = require('@electron/get');
 
-const { extract } = require('@electron-internal/extract-zip');
-
 const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
@@ -77,6 +75,12 @@ function isInstalled() {
 
 // unzips and makes path.txt point at the correct executable
 function extractFile(zipPath) {
+  // Loaded here, not at the top of the file: the extractor has a native
+  // binding, and an OS policy can block its load (see electron/electron#52481).
+  // A lazy require keeps `isInstalled()` working in that case, so an
+  // already-installed dist does not need the extractor at all.
+  const { extract } = require('@electron-internal/extract-zip');
+
   const distPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist');
 
   return extract(zipPath, { dir: path.join(__dirname, 'dist') }).then(() => {


### PR DESCRIPTION
#### Description of Change

This implements fix 1 of #52481.

`install.js` requires `@electron-internal/extract-zip` at the module level.
The extractor has a native .node binding.
When something, in my case, Windows Smart App Control, blocks its `dlopen`, the require throws and `install.js` stops immediately.

This change moves the require into `extractFile()`. An already-installed dist now passes `isInstalled()` and exits 0 without the extractor.

Follow-up fixes 2 and 3 from the issue (better error reports, JS fallback extraction) are PR'd to extract-zip:
electron/extract-zip#15
electron/extract-zip#16

I ran tests with a stubbed package tree. The stubbed extractor throws `ERR_DLOPEN_FAILED` on require, the same failure that a blocked binding causes.

##### Installed dist, blocked extractor
before: `install.js` exits 1 at line 5
after: exits 0

#### Backports

The bug is in every release line that uses `@electron-internal/extract-zip` (41 through 45). 

Ideally, just toss `target/44-x-y`, `target/43-x-y`, `target/42-x-y`, and `target/41-x-y` labels on.
If manual backports are faster, clean signed cherry-picks are staged on my fork:

- https://github.com/ethernet8023/electron/tree/fix/lazy-extract-zip-require-44-x-y
- https://github.com/ethernet8023/electron/tree/fix/lazy-extract-zip-require-43-x-y
- https://github.com/ethernet8023/electron/tree/fix/lazy-extract-zip-require-42-x-y
- https://github.com/ethernet8023/electron/tree/fix/lazy-extract-zip-require-41-x-y

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Fixed an `npm install` failure with no recovery path when the OS blocked the native zip extractor from loading (for example, Windows Smart App Control).
