### PR TITLE
ci: derive the depot_tools path from the runner's home on Windows

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -25,7 +25,7 @@ runs:
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         e d cipd.bat --version
         cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
-        echo "C:\Users\ContainerAdministrator\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
+        echo "$(cygpath -w "$HOME/.electron_build_tools/third_party/depot_tools")" >> $GITHUB_PATH
       else
         echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
         echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH


### PR DESCRIPTION
#### Description of Change

`install-build-tools` adds depot_tools to the PATH via a hardcoded `C:\Users\ContainerAdministrator\...`, i.e. it assumes every Windows runner is the ARC container. Derive it from the runner's actual home instead (`cygpath -w "$HOME/..."`), which is where the `npm i -g @electron/build-tools` two lines earlier put it. In the container `$HOME` is that same profile, so nothing changes there; on any other Windows runner (VM-based runners are being brought up in electron/infra#316) it currently points at a directory that doesn't exist.

Verified with full `windows-x64` and `windows-arm64` builds on a VM runner (https://github.com/electron/electron/actions/runs/31436615692); the container path is unchanged by construction.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes

#### Release Notes

Notes: none