### PR TITLE
build: run the Windows builds on the VM runners

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -25,7 +25,10 @@ runs:
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         e d cipd.bat --version
         cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
-        echo "C:\Users\ContainerAdministrator\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
+        # build-tools installs under the profile of whichever user the runner is
+        # (ContainerAdministrator in the container image, a per-VM user on the
+        # VM runners); USERPROFILE is what it uses and is already a Windows path.
+        echo "$USERPROFILE\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
       else
         echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
         echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,7 @@ jobs:
     needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       clang-tidy-runs-on: electron-arc-centralus-linux-amd64-8core
       test-runs-on: windows-latest
       clang-tidy-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-windows.outputs.build-image-sha }}","options":"--user root --device /dev/fuse --cap-add SYS_ADMIN","volumes":["/mnt/win-cache:/mnt/win-cache"]}'
@@ -438,7 +438,7 @@ jobs:
     needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       test-runs-on: windows-11-arm
       target-platform: win
       target-arch: arm64


### PR DESCRIPTION
#### Description of Change

Moves the two Windows build jobs in `build.yml` from the `windows-amd64-16core` container runners to `garm-windows-x64-32core`, the single-use VM runners from electron/infra#316 (one Azure D32ads_v7 per job, work tree on local NVMe, VM deleted when the job ends). Test and clang-tidy jobs are unchanged.

Comparison against [main's last run on the current runners before #52745](https://github.com/electron/electron/actions/runs/31416846763) — same DEPS, ~99.9% siso cache hits on both, so this is the runner overhead — vs [this PR's CI on the VMs](https://github.com/electron/electron/actions/runs/31444851919) (rebased on #52745, which removed Zip Symbols from testing builds; ~12.6 min of the baseline column is that step, so the old runners would now be ~78 min):

| windows-x64 build job | current runners | VM runners |
|---|---|---|
| **whole job** | **90.3 min** | **19.2 min** |
| Unzip and Ensure Src Cache | 11.3 min | 3.2 min |
| Get Windows toolchain | 3.4 min | 2.3 min |
| Build Electron (siso, fully cached) | 20.4 min | 6.0 min |
| Zip Symbols | 12.6 min | — (#52745) |
| Move artifacts to upload folder | 12.6 min | 0.3 min |
| Upload Out Gen Artifacts | 10.9 min | 0.7 min |

windows-arm64: 84.4 min → 21.2 min. VM queued→job start is ~3 min (single-use D32ads_v7 per job, created on demand, deleted ~1 s after the job ends); that's included in the workflow's wall clock but not in the job times above.

Also carries the one CI-action change the VMs need: `install-build-tools` hardcoded ContainerAdministrator's profile for the depot_tools PATH entry; it now uses `USERPROFILE`, which is what build-tools installs under on both the container and the VMs (an earlier `$HOME` variant, #52753, broke the container). electron/infra#318/#319 have landed, so the VM configuration this targets is the committed one; the label has been running builds since this afternoon. Publish workflows are intentionally not touched yet.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes

#### Release Notes

Notes: none

