### PR TITLE
fix: don't crash on invalid reason for promptTouchID

### DIFF
--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -456,6 +456,17 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
   gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  if (reason.empty()) {
+    promise.RejectWithErrorMessage("reason must be non-empty");
+    return handle;
+  }
+
+  NSString* localized_reason = base::SysUTF8ToNSString(reason);
+  if (!localized_reason) {
+    promise.RejectWithErrorMessage("reason must be valid UTF-8");
+    return handle;
+  }
+
   LAContext* context = [[LAContext alloc] init];
   base::apple::ScopedCFTypeRef<SecAccessControlRef> access_control =
       base::apple::ScopedCFTypeRef<SecAccessControlRef>(
@@ -471,7 +482,7 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
   [context
       evaluateAccessControl:access_control.get()
                   operation:LAAccessControlOperationUseKeySign
-            localizedReason:[NSString stringWithUTF8String:reason.c_str()]
+            localizedReason:localized_reason
                       reply:^(BOOL success, NSError* error) {
                         // NOLINTBEGIN(bugprone-use-after-move)
                         if (!success) {

--- a/spec/api-system-preferences-spec.ts
+++ b/spec/api-system-preferences-spec.ts
@@ -261,6 +261,18 @@ describe('systemPreferences module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'darwin')('systemPreferences.promptTouchID(reason)', () => {
+    it('rejects an empty reason', async () => {
+      await expect(systemPreferences.promptTouchID('')).to.eventually.be.rejectedWith('reason must be non-empty');
+    });
+
+    it('rejects a reason that is not valid UTF-8', async () => {
+      await expect(systemPreferences.promptTouchID('\uD800')).to.eventually.be.rejectedWith(
+        'reason must be valid UTF-8'
+      );
+    });
+  });
+
   ifdescribe(process.platform === 'darwin')('systemPreferences.isTrustedAccessibilityClient(prompt)', () => {
     it('returns a boolean', () => {
       const trusted = systemPreferences.isTrustedAccessibilityClient(false);


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

Fixes an empty or non-UTF8 value for `systemPreferences.promptTouchID(reason)` causing a crash with `NSInvalidArgumentException`. This was flagged by the `clang-analyzer-nullability.NullablePassedToNonnull` check in `clang-tidy`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `systemPreferences.promptTouchID(reason)` when an invalid reason value is passed
