### PR TITLE
build: run the Windows publish, release-test and PGO builds on the VM runners

### DIFF
--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -262,7 +262,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: [checkout-windows, build-siso-windows]
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x64
       is-release: false
@@ -281,7 +281,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: [checkout-windows, build-siso-windows]
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: arm64
       is-release: false

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -220,7 +220,7 @@ jobs:
           - target-arch: arm64
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: ${{ matrix.target-arch }}
       is-release: true

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -84,7 +84,7 @@ jobs:
     needs: [checkout-windows, build-siso]
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x64
       is-release: true
@@ -106,7 +106,7 @@ jobs:
     needs: [checkout-windows, build-siso]
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: arm64
       is-release: true


### PR DESCRIPTION
#### Description of Change

Follow-up to #52754, which moved the two `build.yml` Windows jobs to the single-use VM runners: this moves the remaining five Windows build jobs on main — `windows-publish.yml` (x64 + arm64 releases), `release-build.yml` (release-test builds), and `pgo-generation.yml` (two builds) — leaving nothing on `electron-arc-centralus-windows-amd64-16core` in main's workflows. Label change only; the toolchain on the VM image was built from the same list as the container image, and the publish path's tools (python3 via the same shim as before, azcopy, bsdtar, xz from Git's unix tools, node/yarn) are all present. The scale set's `max_runners` is already 60 (7-day peak demand was 41 across all Windows jobs including publish/PGO), and the VMs have 128 GB RAM and a 600 GB disk, so uncached release builds have more headroom than the containers gave them.

Draft until `build.yml` has soaked on the VMs for a few days. Publish jobs are ~2h10–2h30 today (p50 over the last 12); the first nightly on this will give the VM number for an uncached ThinLTO+PGO build. After this: the same flip plus the `install-build-tools` fix (#52754's second commit) needs backporting to each supported release line — the release lines' own workflow files still point at the old label — and only then can the old node pools go (electron/infra#332).

#### Checklist

- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] Nightly publish observed on the VMs

#### Release Notes

Notes: none