### PR TITLE
build: run the Windows builds on the VM runners (42-x-y)

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -25,7 +25,10 @@ runs:
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         e d cipd.bat --version
         cp "C:\Python311\python.exe" "C:\Python311\python3.exe"
-        echo "C:\Users\ContainerAdministrator\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
+        # build-tools installs under the profile of whichever user the runner is
+        # (ContainerAdministrator in the container image, a per-VM user on the
+        # VM runners); USERPROFILE is what it uses and is already a Windows path.
+        echo "$USERPROFILE\.electron_build_tools\third_party\depot_tools" >> $GITHUB_PATH
       else
         echo "$HOME/.electron_build_tools/third_party/depot_tools" >> $GITHUB_PATH
         echo "$HOME/.electron_build_tools/third_party/depot_tools/python-bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,7 +436,7 @@ jobs:
     needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       test-runs-on: windows-latest
       target-platform: win
       target-arch: x64
@@ -455,7 +455,7 @@ jobs:
     needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       test-runs-on: windows-latest
       target-platform: win
       target-arch: x86
@@ -474,7 +474,7 @@ jobs:
     needs: [checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       test-runs-on: windows-11-arm
       target-platform: win
       target-arch: arm64

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -282,7 +282,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: [checkout-windows, build-siso-windows]
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x64
       is-release: false
@@ -301,7 +301,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: [checkout-windows, build-siso-windows]
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x86
       is-release: false
@@ -320,7 +320,7 @@ jobs:
     uses: ./.github/workflows/pipeline-segment-electron-build.yml
     needs: [checkout-windows, build-siso-windows]
     with:
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: arm64
       is-release: false

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -84,7 +84,7 @@ jobs:
     needs: [checkout-windows, build-siso]
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x64
       is-release: true
@@ -103,7 +103,7 @@ jobs:
     needs: [checkout-windows, build-siso]
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: arm64
       is-release: true
@@ -122,7 +122,7 @@ jobs:
     needs: [checkout-windows, build-siso]
     with:
       environment: production-release
-      build-runs-on: electron-arc-centralus-windows-amd64-16core
+      build-runs-on: garm-windows-x64-32core
       target-platform: win
       target-arch: x86
       is-release: true


### PR DESCRIPTION
Backport of #52754
Backport of #52765

See those PRs for details. Manual backport carrying both so this line moves all of its Windows jobs (build incl. windows-x86, publish, PGO) to the VM runners at once; two commits, one per original PR. Draft until main has soaked; this PR's own CI runs its Windows builds on the VMs, which is the verification for the line.

Notes: none