### PR TITLE
fix: don't crash on non-UTF8 serviceName in app.setLoginItemSettings

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -63,6 +63,10 @@ std::string GetLaunchStringForError(NSError* error) {
 SMAppService* GetServiceForType(const std::string& type,
                                 const std::string& name) {
   NSString* service_name = [NSString stringWithUTF8String:name.c_str()];
+  if (!service_name) {
+    LOG(ERROR) << "Login item service name is not valid UTF-8";
+    return nullptr;
+  }
   if (type == "mainAppService") {
     return [SMAppService mainAppService];
   } else if (type == "agentService") {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -828,6 +828,16 @@ describe('app module', () => {
         }).to.throw(/'name' is required when type is not mainAppService/);
       });
 
+      it('does not crash when the service name is not valid UTF-8', () => {
+        expect(() => {
+          app.setLoginItemSettings({
+            openAtLogin: false,
+            type: 'daemonService',
+            serviceName: '\uD800'
+          });
+        }).to.not.throw();
+      });
+
       it('can unset a login item', () => {
         app.setLoginItemSettings({
           openAtLogin: true,


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This was flagged by `clang-analyzer-nullability.NullablePassedToNonnull`. Without the fix the new test case results in a `SIGSEGV`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash with `app.setLoginItemSettings` if a non-UTF8 service name is used
