### PR TITLE
fix: retarget OSR wheel gestures after direction changes

### DIFF
--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -855,6 +855,13 @@ void OffScreenRenderWidgetHostView::SendMouseWheelEvent(
   render_widget_host_->ForwardWheelEvent(event);
 }
 
+void OffScreenRenderWidgetHostView::GestureEventAck(
+    const blink::WebGestureEvent& event,
+    blink::mojom::InputEventResultSource,
+    blink::mojom::InputEventResultState ack_result) {
+  mouse_wheel_phase_handler_.GestureEventAck(event, ack_result);
+}
+
 void OffScreenRenderWidgetHostView::SetPainting(bool painting) {
   painting_ = painting;
 

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -852,7 +852,7 @@ void OffScreenRenderWidgetHostView::SendMouseWheelEvent(
   }
   if (!render_widget_host_)
     return;
-  render_widget_host_->ForwardWheelEvent(event);
+  render_widget_host_->ForwardWheelEvent(mouse_wheel_event);
 }
 
 void OffScreenRenderWidgetHostView::GestureEventAck(

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -155,6 +155,9 @@ class OffScreenRenderWidgetHostView
   bool HasSavedCompositorFrame() const override;
   std::unique_ptr<content::SyntheticGestureTarget>
   CreateSyntheticGestureTarget() override;
+  void GestureEventAck(const blink::WebGestureEvent& event,
+                       blink::mojom::InputEventResultSource ack_source,
+                       blink::mojom::InputEventResultState ack_result) override;
   void ImeCompositionRangeChanged(
       const gfx::Range&,
       const std::optional<std::vector<gfx::Rect>>& character_bounds) override {}

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7699,6 +7699,75 @@ describe('BrowserWindow module', () => {
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
     });
 
+    it('retargets a wheel gesture after an unconsumed direction change', async () => {
+      await w.loadURL(
+        `data:text/html;charset=utf-8,${encodeURIComponent(`
+        <style>
+          html, body { margin: 0; min-height: 600px; }
+          #nested { width: 80px; height: 70px; overflow: auto; }
+          #nested-content { height: 600px; }
+        </style>
+        <div id="nested"><div id="nested-content"></div></div>
+        <script>
+          window.wheelEvents = [];
+          window.addEventListener('wheel', (event) => {
+            window.wheelEvents.push({
+              deltaY: event.deltaY,
+              target: event.target.id || event.target.tagName
+            });
+          }, { capture: true });
+          window.readWheelState = () => ({
+            events: window.wheelEvents,
+            nestedScrollTop: document.getElementById('nested').scrollTop,
+            rootScrollY: window.scrollY
+          });
+        </script>
+      `)}`
+      );
+
+      const firstPaint = once(w.webContents, 'paint');
+      w.webContents.invalidate();
+      await firstPaint;
+
+      const event = {
+        type: 'mouseWheel' as const,
+        x: 40,
+        y: 35,
+        deltaX: 0,
+        deltaY: 120,
+        wheelTicksX: 0,
+        wheelTicksY: 1
+      };
+
+      // Start at both scroll boundaries, then reverse before the synthesized
+      // wheel-end. The second packet must begin a new sequence at the point
+      // under the pointer instead of remaining latched to the root scroller.
+      w.webContents.sendInputEvent(event);
+      await waitUntil(async () => {
+        const eventCount = await w.webContents.executeJavaScript('window.wheelEvents.length');
+        return eventCount === 1;
+      });
+      // The DOM event is recorded before its gesture ack reaches the browser.
+      // Advance the renderer without consuming the latching window with a fixed delay.
+      await w.webContents.executeJavaScript(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      );
+      w.webContents.sendInputEvent({ ...event, deltaY: -120, wheelTicksY: -1 });
+
+      await waitUntil(async () => {
+        const state = await w.webContents.executeJavaScript('window.readWheelState()');
+        return state.nestedScrollTop > 0 || state.rootScrollY > 0;
+      });
+
+      const state = await w.webContents.executeJavaScript('window.readWheelState()');
+      expect(state.events.at(-1)).to.deep.equal({
+        deltaY: 120,
+        target: 'nested-content'
+      });
+      expect(state.nestedScrollTop).to.be.greaterThan(0);
+      expect(state.rootScrollY).to.equal(0);
+    });
+
     describe('window.webContents.isOffscreen()', () => {
       it('is true for offscreen type', () => {
         w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7725,9 +7725,16 @@ describe('BrowserWindow module', () => {
       `)}`
       );
 
-      const firstPaint = once(w.webContents, 'paint');
-      w.webContents.invalidate();
-      await firstPaint;
+      // Let the renderer commit the page's input regions before sending input.
+      // An invalidated paint can precede the initial compositor commit.
+      await w.webContents.executeJavaScript(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      );
+
+      let wheelEventCount = 0;
+      w.webContents.on('input-event', (_event, input) => {
+        if (input.type === 'mouseWheel') wheelEventCount++;
+      });
 
       const event = {
         type: 'mouseWheel' as const,
@@ -7752,6 +7759,9 @@ describe('BrowserWindow module', () => {
       await w.webContents.executeJavaScript(
         'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
       );
+      // A synthesized wheel-end here would let the test pass without the fix.
+      // Check synchronously with the reversal so the timer cannot fire between them.
+      expect(wheelEventCount, 'wheel sequence ended before the direction change').to.equal(1);
       w.webContents.sendInputEvent({ ...event, deltaY: -120, wheelTicksY: -1 });
 
       await waitUntil(async () => {


### PR DESCRIPTION
#### Description of Change

`OffScreenRenderWidgetHostView::SendMouseWheelEvent()` creates a mutable wheel event and lets `MouseWheelPhaseHandler` add or update its phase, but forwards the original event instead. The view also does not feed gesture acknowledgements back to the phase handler. Together, these omissions can leave the synthesized wheel sequence latched to the wrong scroller after an unconsumed direction change.

This change forwards the phase-adjusted event, updates `MouseWheelPhaseHandler` from `GestureEventAck()`, and adds an offscreen `BrowserWindow` regression spec that verifies reversed wheel input is retargeted to the nested scroller.

Fixes #52777.

AI assistance disclosure: Codex (OpenAI) assisted with investigation and drafting. The signed commit includes an `Assisted-By` trailer. The changes have been human-reviewed.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] `npm test` passes
- [x] tests are changed or added
- [x] relevant API documentation, tutorials, and examples do not require changes because this restores existing input behavior
- [x] PR release notes describe the change in a way relevant to app developers

#### Testing

- The targeted regression spec passed with the patched Electron 41.7.1 build before transplanting the same change to `main`.
- JavaScript lint and formatting pass on `main`.
- C++ lint and formatting pass on `main`.
- Full `main` build and test coverage run in PR CI.

#### Release Notes

Notes: Fixed offscreen-rendered pages failing to retarget wheel gestures to nested scrollers after an unconsumed direction change.