### PR TITLE
build: don't build the crowdsourced V8 compile hints producer

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -73,6 +73,16 @@ enable_linux_installer = false
 # Disable "Save to Drive" feature in PDF viewer
 enable_pdf_save_to_drive = false
 
+# Blink's crowdsourced V8 compile hints producer randomly selects 0.5% of
+# renderer processes (Windows only) to compile every http(s) script from
+# source -- deliberately not consuming an existing code cache, and neither
+# consuming nor producing local compile hints -- so that it can record which
+# functions were compiled to UKM. The consumer half lives in chrome/browser
+# and needs OptimizationGuide, and there is no UKM backend here, so this only
+# ever costs a cold-cache page load. Build the stub producer (as Android
+# does) instead.
+produce_v8_compile_hints = false
+
 # Track which grit resource IDs the linked binary actually references and
 # repack the locale .pak files with only those strings. Enabled for both
 # testing and release builds so that a reference to an unshipped resource


### PR DESCRIPTION
#### Description of Change

* Sets `produce_v8_compile_hints = false` so Blink builds the stub `V8CrowdsourcedCompileHintsProducer` (the configuration Android already ships) instead of the real one.
* The real producer picks 0.5% of renderer processes on Windows ([`v8_compile_hints_producer.cc`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/bindings/core/v8/v8_compile_hints_producer.cc)) and, for the first page in that process, compiles every http(s) classic script from source: an existing V8 code cache is deliberately not consumed and local compile hints are neither consumed nor produced ([`v8_code_cache.cc`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/bindings/core/v8/v8_code_cache.cc)), so it can record which functions were compiled to UKM.
* The consuming half lives in `chrome/browser/v8_compile_hints/` and requires OptimizationGuide, and Electron has no UKM backend, so the recorded data is never used; the only observable effect of the producer is a cold-cache load for 1 in 200 renderer processes on Windows.
* Verified locally on Linux: `gn` regenerates `bindings/buildflags.h` with `PRODUCE_V8_COMPILE_HINTS=0`, `v8_compile_hints_producer.o` compiles down to the stub, and the build links and runs.

#### Checklist

* [x] PR description included and stakeholders cc'd
* [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)
* [x] PR release notes describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a 1-in-200 chance per renderer process on Windows of scripts on the first page load being compiled without their V8 code cache.