### PR TITLE
fix: don't destroy contentTracing.stopRecording() promise off the UI thread

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -10,6 +10,7 @@
 
 #include "base/files/file_util.h"
 #include "base/functional/callback_helpers.h"
+#include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/trace_event/trace_config.h"
@@ -86,7 +87,7 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
           promise.Resolve(path);
         }
       },
-      std::move(promise), *file_path);
+      std::move(promise), file_path.value_or(base::FilePath()));
 
   auto* instance = TracingController::GetInstance();
   if (!instance->IsTracing()) {
@@ -94,8 +95,13 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
         .Run("Failed to stop tracing - no trace in progress"sv);
   } else if (file_path) {
     auto split_callback = base::SplitOnceCallback(std::move(resolve_or_reject));
+    // The file endpoint hands this closure to a thread pool sequence and, if
+    // it fails to write the trace file, drops it there without running it. The
+    // promise it owns must be destroyed on the thread that created it, so make
+    // sure both running and destroying the closure happen back on this thread.
     auto endpoint = TracingController::CreateFileEndpoint(
-        *file_path, base::BindOnce(std::move(split_callback.first), ""sv));
+        *file_path, base::BindPostTaskToCurrentDefault(
+                        base::BindOnce(std::move(split_callback.first), ""sv)));
     if (!instance->StopTracing(endpoint)) {
       std::move(split_callback.second).Run("Failed to stop tracing"sv);
     }

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -2,6 +2,7 @@ import { app, contentTracing, EnableHeapProfilingOptions, TraceConfig, TraceCate
 
 import { expect } from 'chai';
 
+import { randomUUID } from 'node:crypto';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -28,11 +29,16 @@ ifdescribe(process.arch !== 'arm64' || process.platform !== 'linux')('contentTra
     return resultFilePath;
   };
 
-  const outputFilePath = path.join(app.getPath('temp'), 'trace.json');
+  // Every test attempt (including mocha retries) writes to its own file. A
+  // previous attempt that timed out can still have a trace endpoint writing to
+  // its output path in the background, and two endpoints finalizing the same
+  // path race on the final rename.
+  let outputFilePath: string;
   beforeEach(() => {
-    if (fs.existsSync(outputFilePath)) {
-      fs.unlinkSync(outputFilePath);
-    }
+    outputFilePath = path.join(app.getPath('temp'), `electron-content-tracing-${randomUUID()}.json`);
+  });
+  afterEach(() => {
+    fs.rmSync(outputFilePath, { force: true });
   });
 
   describe('startRecording', function () {


### PR DESCRIPTION
#### Description of Change

Seen as the win-x64 test shard crash in https://github.com/electron/electron/actions/runs/31624457326/job/94214475444 (`Cannot replace file '...\trace.json' : FILE_ERROR_EXISTS` followed by `persistent-node.h:162 Debug check failed: IsCreationThread()`).

- `stopRecording(path)`: when Chromium's `FileTraceDataEndpoint` fails to rename the finished trace into place it destroys its completion closure on the thread pool without running it. That closure owns the `gin_helper::Promise`, which since #51386 is a `cppgc::Persistent` and must die on the creating thread — DCHECK in testing builds, unsynchronized persistent-region mutation in release. Wrap the closure in `BindPostTaskToCurrentDefault` so it is run and destroyed on the UI thread either way. (The promise stays pending on that path, as before; the endpoint gives us no failure signal.)
- `StopTracing()` dereferenced the optional path before checking it, so a failed temp-file creation would crash instead of rejecting.
- Spec: every test attempt now gets its own output file. A timed-out attempt can leave an endpoint still writing to `trace.json`; two endpoints finalizing the same path race on the rename, which is how CI reached the failure path above.

Reproduced locally by pointing `stopRecording()` at a non-empty directory: pre-fix binary dies on the same DCHECK, fixed binary logs the endpoint error and carries on, subsequent sessions still work.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes (relevant subset of `api-content-tracing-spec`)

#### Release Notes

Notes: Fixed a potential crash in `contentTracing.stopRecording()` when the trace file could not be written to the requested path.