### PR TITLE
fix: don't destroy contentTracing.stopRecording() promise off the UI thread (43-x-y)

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/files/file_util.h"
+#include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/trace_event/trace_config.h"
@@ -85,7 +86,7 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
           promise.Resolve(path);
         }
       },
-      std::move(promise), *file_path);
+      std::move(promise), file_path.value_or(base::FilePath()));
 
   auto* instance = TracingController::GetInstance();
   if (!instance->IsTracing()) {
@@ -93,8 +94,13 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
         .Run("Failed to stop tracing - no trace in progress"sv);
   } else if (file_path) {
     auto split_callback = base::SplitOnceCallback(std::move(resolve_or_reject));
+    // The file endpoint hands this closure to a thread pool sequence and, if
+    // it fails to write the trace file, drops it there without running it. The
+    // promise it owns must be destroyed on the thread that created it, so make
+    // sure both running and destroying the closure happen back on this thread.
     auto endpoint = TracingController::CreateFileEndpoint(
-        *file_path, base::BindOnce(std::move(split_callback.first), ""sv));
+        *file_path, base::BindPostTaskToCurrentDefault(
+                        base::BindOnce(std::move(split_callback.first), ""sv)));
     if (!instance->StopTracing(endpoint)) {
       std::move(split_callback.second).Run("Failed to stop tracing"sv);
     }

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -2,6 +2,7 @@ import { app, contentTracing, EnableHeapProfilingOptions, TraceConfig, TraceCate
 
 import { expect } from 'chai';
 
+import { randomUUID } from 'node:crypto';
 import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -28,11 +29,16 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
     return resultFilePath;
   };
 
-  const outputFilePath = path.join(app.getPath('temp'), 'trace.json');
+  // Every test attempt (including mocha retries) writes to its own file. A
+  // previous attempt that timed out can still have a trace endpoint writing to
+  // its output path in the background, and two endpoints finalizing the same
+  // path race on the final rename.
+  let outputFilePath: string;
   beforeEach(() => {
-    if (fs.existsSync(outputFilePath)) {
-      fs.unlinkSync(outputFilePath);
-    }
+    outputFilePath = path.join(app.getPath('temp'), `electron-content-tracing-${randomUUID()}.json`);
+  });
+  afterEach(() => {
+    fs.rmSync(outputFilePath, { force: true });
   });
 
   describe('startRecording', function () {


### PR DESCRIPTION
Backport of #52793

See that PR for details. Only conflict was include context; the change is identical.

Notes: Fixed a potential crash in `contentTracing.stopRecording()` when the trace file could not be written to the requested path.