### PR TITLE
chore: remove usage of Profile in FullscreenController

### DIFF
--- a/patches/chromium/fix_adapt_exclusive_access_for_electron_needs.patch
+++ b/patches/chromium/fix_adapt_exclusive_access_for_electron_needs.patch
@@ -16,7 +16,7 @@ Linux or Windows to un-fullscreen in some circumstances without this
 change.
 
 diff --git a/chrome/browser/ui/exclusive_access/fullscreen_controller.cc b/chrome/browser/ui/exclusive_access/fullscreen_controller.cc
-index 5b198cf05cbfca501341e57dfc37f7b1368058b2..8bb5909d1da55eae391e147eeff5e69c096688f7 100644
+index 5b198cf05cbfca501341e57dfc37f7b1368058b2..fdc5859a111661482ec191cfb54378e294e81d15 100644
 --- a/chrome/browser/ui/exclusive_access/fullscreen_controller.cc
 +++ b/chrome/browser/ui/exclusive_access/fullscreen_controller.cc
 @@ -48,7 +48,7 @@
@@ -89,6 +89,15 @@ index 5b198cf05cbfca501341e57dfc37f7b1368058b2..8bb5909d1da55eae391e147eeff5e69c
  }
  
  void FullscreenController::RunOrDeferUntilTransitionIsComplete(
+@@ -562,7 +567,7 @@ void FullscreenController::EnterFullscreenModeInternal(
+     FullscreenInternalOption option,
+     content::RenderFrameHost* requesting_frame,
+     FullscreenTabParams fullscreen_tab_params) {
+-#if !BUILDFLAG(IS_MAC)
++#if 0
+ 
+   Profile* profile = exclusive_access_manager()->context()->GetProfile();
+   // Do not enter fullscreen mode if disallowed by pref. This prevents the user
 @@ -575,9 +580,12 @@ void FullscreenController::EnterFullscreenModeInternal(
    fullscreen_parameters_ = fullscreen_tab_params;
    started_fullscreen_transition_ = true;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This change is motivated by two reasons:
* The `profile->GetPrefs()` call builds fine on our regular builds, but fails to link under UndefinedBehaviorSanitizer (UBSan)
* The `#if !BUILDFLAG(IS_MAC)` guard is causing a slight divergence between our platforms, where non-macOS bails out early due to `profile` being `nullptr`, while macOS does not. There's no known behavior difference today as a result of this, but it's a latent footgun that could bite us in the future.

By removing the early return profile check, all platforms will use the same code path through `FullscreenController::EnterFullscreenModeInternal`. Claude is convinced there should be no functional difference for Linux/Windows as a result of this change as the remaining code in the function does not have an impact today in Electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] `npm test` passes

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
