### PR TITLE
test: capture only the window under test in color capture specs

### DIFF
--- a/spec/api-browser-view-spec.ts
+++ b/spec/api-browser-view-spec.ts
@@ -96,8 +96,8 @@ describe('BrowserView module', () => {
       w.setBrowserView(view);
       await view.webContents.loadURL('data:text/html,hello there');
 
-      const screenCapture = new ScreenCapture(display);
-      await screenCapture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
     });
 
     ifit(hasCapturableScreen())('successfully applies the background color', async () => {
@@ -116,8 +116,8 @@ describe('BrowserView module', () => {
       w.setBackgroundColor(VIEW_BACKGROUND_COLOR);
       await view.webContents.loadURL('data:text/html,hello there');
 
-      const screenCapture = new ScreenCapture(display);
-      await screenCapture.expectColorAtCenterMatches(VIEW_BACKGROUND_COLOR);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(VIEW_BACKGROUND_COLOR);
     });
   });
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7778,12 +7778,14 @@ describe('BrowserWindow module', () => {
         const colorFile = path.join(__dirname, 'fixtures', 'pages', 'half-background-color.html');
         await foregroundWindow.loadFile(colorFile);
 
+        // This verifies how the transparent window composites over the window
+        // behind it, so it has to capture the display rather than one window.
         const screenCapture = new ScreenCapture(display);
-        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.GREEN, (size) => ({
+        await screenCapture.expectColorAtPointMatches(HexColors.GREEN, (size) => ({
           x: size.width / 4,
           y: size.height / 2
         }));
-        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.RED, (size) => ({
+        await screenCapture.expectColorAtPointMatches(HexColors.RED, (size) => ({
           x: (size.width * 3) / 4,
           y: size.height / 2
         }));
@@ -7819,6 +7821,8 @@ describe('BrowserWindow module', () => {
         foregroundWindow.loadFile(path.join(__dirname, 'fixtures', 'pages', 'css-transparent.html'));
         await once(ipcMain, 'set-transparent');
 
+        // This verifies how the transparent window composites over the window
+        // behind it, so it has to capture the display rather than one window.
         const screenCapture = new ScreenCapture(display);
         await screenCapture.expectColorAtCenterMatches(HexColors.PURPLE);
       }
@@ -7836,9 +7840,9 @@ describe('BrowserWindow module', () => {
         await once(window, 'show');
         await window.webContents.loadURL('data:text/html,<head><meta name="color-scheme" content="dark"></head>');
 
-        const screenCapture = new ScreenCapture(display);
+        const capture = ScreenCapture.forWindow(window);
         // color-scheme is set to dark so background should not be white
-        await screenCapture.expectColorAtCenterDoesNotMatch(HexColors.WHITE);
+        await capture.expectColorAtCenterDoesNotMatch(HexColors.WHITE);
 
         window.close();
       }
@@ -7860,8 +7864,8 @@ describe('BrowserWindow module', () => {
       w.loadURL('data:text/html,<html></html>');
       await once(w, 'ready-to-show');
 
-      const screenCapture = new ScreenCapture(display);
-      await screenCapture.expectColorAtCenterMatches(HexColors.BLUE);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(HexColors.BLUE);
     });
   });
 

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -434,16 +434,22 @@ describe('WebContentsView', () => {
     ifdescribe(hasCapturableScreen())('capture', () => {
       let w: Electron.BaseWindow;
       let v: Electron.WebContentsView;
-      let display: Electron.Display;
-      let corners: Electron.Point[];
 
       const backgroundUrl = `data:text/html,<style>html{background:${encodeURIComponent(HexColors.GREEN)}}</style>`;
 
-      beforeEach(async () => {
-        display = screen.getPrimaryDisplay();
+      // Points just inside each corner of the captured window, which lie
+      // within the cutout while a border radius is applied.
+      const inset = 10;
+      const corners: Array<(size: Electron.Size) => Electron.Point> = [
+        () => ({ x: inset, y: inset }), // top-left
+        ({ width }) => ({ x: width - inset, y: inset }), // top-right
+        ({ width, height }) => ({ x: width - inset, y: height - inset }), // bottom-right
+        ({ height }) => ({ x: inset, y: height - inset }) // bottom-left
+      ];
 
+      beforeEach(async () => {
         w = new BaseWindow({
-          ...display.workArea,
+          ...screen.getPrimaryDisplay().workArea,
           show: true,
           frame: false,
           hasShadow: false,
@@ -457,21 +463,6 @@ describe('WebContentsView', () => {
 
         const readyForCapture = once(v.webContents, 'ready-to-show');
         v.webContents.loadURL(backgroundUrl);
-
-        const inset = 10;
-        // Adjust for macOS menu bar height which seems to be about 24px
-        // based on the results from accessibility inspector.
-        const platformInset = process.platform === 'darwin' ? 15 : 0;
-        corners = [
-          { x: display.workArea.x + inset, y: display.workArea.y + inset + platformInset }, // top-left
-          { x: display.workArea.x + display.workArea.width - inset, y: display.workArea.y + inset + platformInset }, // top-right
-          {
-            x: display.workArea.x + display.workArea.width - inset,
-            y: display.workArea.y + display.workArea.height - inset
-          }, // bottom-right
-          { x: display.workArea.x + inset, y: display.workArea.y + display.workArea.height - inset } // bottom-left
-        ];
-
         await readyForCapture;
       });
 
@@ -481,24 +472,23 @@ describe('WebContentsView', () => {
       });
 
       it('should render with cutout corners', async () => {
-        const screenCapture = new ScreenCapture(display);
+        const capture = ScreenCapture.forWindow(w);
 
         for (const corner of corners) {
-          await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.BLUE, () => corner);
+          await capture.expectColorAtPointMatches(HexColors.BLUE, corner);
         }
 
         // Center should be WebContents page background color
-        await screenCapture.expectColorAtCenterMatches(HexColors.GREEN);
+        await capture.expectColorAtCenterMatches(HexColors.GREEN);
       });
 
       it('should allow resetting corners', async () => {
-        const corner = corners[0];
         v.setBorderRadius(0);
 
         await nextFrameTime();
-        const screenCapture = new ScreenCapture(display);
-        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.GREEN, () => corner);
-        await screenCapture.expectColorAtCenterMatches(HexColors.GREEN);
+        const capture = ScreenCapture.forWindow(w);
+        await capture.expectColorAtPointMatches(HexColors.GREEN, corners[0]);
+        await capture.expectColorAtCenterMatches(HexColors.GREEN);
       });
 
       it('should render when set before attached', async () => {
@@ -511,10 +501,9 @@ describe('WebContentsView', () => {
         v.webContents.loadURL(backgroundUrl);
         await readyForCapture;
 
-        const corner = corners[0];
-        const screenCapture = new ScreenCapture(display);
-        await screenCapture.expectColorAtPointOnDisplayMatches(HexColors.BLUE, () => corner);
-        await screenCapture.expectColorAtCenterMatches(HexColors.GREEN);
+        const capture = ScreenCapture.forWindow(w);
+        await capture.expectColorAtPointMatches(HexColors.BLUE, corners[0]);
+        await capture.expectColorAtCenterMatches(HexColors.GREEN);
       });
     });
 

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -424,9 +424,9 @@ describe('webContents.setWindowOpenHandler', () => {
       await childWindow.webContents.executeJavaScript(
         "const meta = document.createElement('meta'); meta.name = 'color-scheme'; meta.content = 'dark'; document.head.appendChild(meta); true;"
       );
-      const screenCapture = new ScreenCapture(display);
+      const capture = ScreenCapture.forWindow(childWindow);
       // color-scheme is set to dark so background should not be white
-      await screenCapture.expectColorAtCenterDoesNotMatch(HexColors.WHITE);
+      await capture.expectColorAtCenterDoesNotMatch(HexColors.WHITE);
     });
   });
 

--- a/spec/lib/screen-helpers.ts
+++ b/spec/lib/screen-helpers.ts
@@ -66,12 +66,14 @@ function areColorsSimilar(hexColorA: string, hexColorB: string, distanceThreshol
   return distance <= distanceThreshold;
 }
 
-function displayCenter(display: Electron.Display): Electron.Point {
+function centerOf(size: Electron.Size): Electron.Point {
   return {
-    x: display.size.width / 2,
-    y: display.size.height / 2
+    x: size.width / 2,
+    y: size.height / 2
   };
 }
+
+type CaptureTarget = { display: Electron.Display } | { window: Electron.BaseWindow };
 
 /** Resolve when approx. one frame has passed (30FPS) */
 export async function nextFrameTime(): Promise<void> {
@@ -81,10 +83,22 @@ export async function nextFrameTime(): Promise<void> {
 }
 
 /**
- * Utilities for creating and inspecting a screen capture.
+ * Utilities for creating and inspecting a capture of a display or of a single
+ * window.
  *
- * Set `PAUSE_CAPTURE_TESTS` env var to briefly pause during screen
- * capture for easier inspection.
+ * Prefer `ScreenCapture.forWindow()` whenever the test only cares about what
+ * one window renders: a window capture contains just that window's own
+ * composited contents, so anything else on the screen — other test windows, or
+ * a stray system dialog left behind by an earlier test on CI — cannot affect
+ * the result. Only tests that verify how one of our windows composites *over*
+ * other windows (e.g. `transparent: true`) need to capture the whole display.
+ *
+ * Points passed to the `expectColorAt*` methods are relative to the captured
+ * frame, i.e. the display for a display capture and the window for a window
+ * capture.
+ *
+ * Set `PAUSE_CAPTURE_TESTS` env var to briefly pause during capture for easier
+ * inspection.
  *
  * NOTE: Not yet supported on Linux in CI due to empty sources list.
  */
@@ -92,42 +106,67 @@ export class ScreenCapture {
   /** Timeout to wait for expected color to match. */
   static TIMEOUT = 3000;
 
+  /** Capture the whole of `display` (defaults to the primary display). */
   constructor(display?: Electron.Display) {
-    this.display = display || screen.getPrimaryDisplay();
+    this.target = { display: display || screen.getPrimaryDisplay() };
+  }
+
+  /** Capture only `window`, regardless of what else is on screen. */
+  static forWindow(window: Electron.BaseWindow): ScreenCapture {
+    const capture = new ScreenCapture();
+    capture.target = { window };
+    return capture;
   }
 
   public async expectColorAtCenterMatches(hexColor: string) {
-    return this._expectImpl(displayCenter(this.display), hexColor, true);
+    return this._expectImpl(centerOf, hexColor, true);
   }
 
   public async expectColorAtCenterDoesNotMatch(hexColor: string) {
-    return this._expectImpl(displayCenter(this.display), hexColor, false);
+    return this._expectImpl(centerOf, hexColor, false);
   }
 
-  public async expectColorAtPointOnDisplayMatches(
-    hexColor: string,
-    findPoint: (displaySize: Electron.Size) => Electron.Point
-  ) {
-    return this._expectImpl(findPoint(this.display.size), hexColor, true);
+  /**
+   * `findPoint` receives the size of the captured frame (the display or the
+   * window, depending on how this capture was created).
+   */
+  public async expectColorAtPointMatches(hexColor: string, findPoint: (frameSize: Electron.Size) => Electron.Point) {
+    return this._expectImpl(findPoint, hexColor, true);
   }
 
   public async takeScreenshot(filePrefix: string) {
     const frame = await this.captureFrame();
+    if (!frame) throw new Error(`Unable to capture ${this.describeTarget()}`);
     return await createArtifactWithRandomId((id) => `${filePrefix}-${id}.png`, frame.toPNG());
   }
 
-  private async captureFrame(): Promise<NativeImage> {
-    const sources = await desktopCapturer.getSources({
-      types: ['screen'],
-      thumbnailSize: this.display.size
-    });
+  /**
+   * Returns the current frame, or `undefined` if the target can't be found
+   * right now (e.g. a window which has not finished appearing yet).
+   */
+  private async captureFrame(): Promise<NativeImage | undefined> {
+    let captureSource: Electron.DesktopCapturerSource | undefined;
 
-    const captureSource = sources.find((source) => source.display_id === this.display.id.toString());
-    if (captureSource === undefined) {
-      const displayIds = sources.map((source) => source.display_id).join(', ');
-      throw new Error(
-        `Unable to find screen capture for display '${this.display.id}'\n\tAvailable displays: ${displayIds}`
-      );
+    if ('display' in this.target) {
+      const { display } = this.target;
+      const sources = await desktopCapturer.getSources({
+        types: ['screen'],
+        thumbnailSize: display.size
+      });
+      captureSource = sources.find((source) => source.display_id === display.id.toString());
+    } else {
+      const { window } = this.target;
+      const { width, height } = window.getBounds();
+      const sources = await desktopCapturer.getSources({
+        types: ['window'],
+        thumbnailSize: { width, height }
+      });
+      const mediaSourceId = window.getMediaSourceId();
+      captureSource = sources.find((source) => source.id === mediaSourceId);
+    }
+
+    if (captureSource === undefined || captureSource.thumbnail.isEmpty()) {
+      return undefined;
     }
 
     if (process.env.PAUSE_CAPTURE_TESTS) {
@@ -137,9 +176,20 @@ export class ScreenCapture {
     return captureSource.thumbnail;
   }
 
-  private async _expectImpl(point: Electron.Point, expectedColor: string, matchIsExpected: boolean) {
-    let frame: Electron.NativeImage;
-    let actualColor: string;
+  private describeTarget(): string {
+    return 'display' in this.target
+      ? `display '${this.target.display.id}'`
+      : `window '${this.target.window.getMediaSourceId()}'`;
+  }
+
+  private async _expectImpl(
+    findPoint: (frameSize: Electron.Size) => Electron.Point,
+    expectedColor: string,
+    matchIsExpected: boolean
+  ) {
+    let frame: Electron.NativeImage | undefined;
+    let point: Electron.Point | undefined;
+    let actualColor: string | undefined;
     let gotExpectedResult: boolean = false;
     const expiration = Date.now() + ScreenCapture.TIMEOUT;
 
@@ -147,34 +197,42 @@ export class ScreenCapture {
     // reach a timeout. This helps avoid flaky tests in which a short waiting
     // period is required for the expected result.
     do {
-      frame = await this.captureFrame();
-      actualColor = getPixelColor(frame, point);
-      const colorsMatch = areColorsSimilar(expectedColor, actualColor);
-      gotExpectedResult = matchIsExpected ? colorsMatch : !colorsMatch;
-      if (gotExpectedResult) break;
+      // Keep the last frame we managed to capture for the failure artifact.
+      frame = (await this.captureFrame()) ?? frame;
+      if (frame) {
+        point = findPoint(frame.getSize());
+        actualColor = getPixelColor(frame, point);
+        const colorsMatch = areColorsSimilar(expectedColor, actualColor);
+        gotExpectedResult = matchIsExpected ? colorsMatch : !colorsMatch;
+        if (gotExpectedResult) break;
+      }
 
       await nextFrameTime(); // limit framerate
     } while (Date.now() < expiration);
 
-    if (!gotExpectedResult) {
-      // Limit image to 720p to save on storage space
-      if (process.env.CI) {
-        const width = Math.floor(Math.min(frame.getSize().width, 720));
-        frame = frame.resize({ width });
-      }
+    if (gotExpectedResult) return;
 
-      // Save the image as an artifact for better debugging
-      const artifactName = await createArtifactWithRandomId((id) => `color-mismatch-${id}.png`, frame.toPNG());
-
-      throw new AssertionError(
-        `Expected color at (${point.x}, ${point.y}) to ${
-          matchIsExpected ? 'match' : '*not* match'
-        } '${expectedColor}', but got '${actualColor}'. See the artifact '${artifactName}' for more information.`
-      );
+    if (!frame || !point) {
+      throw new AssertionError(`Unable to capture ${this.describeTarget()} within ${ScreenCapture.TIMEOUT}ms`);
     }
+
+    // Limit image to 720p to save on storage space
+    if (process.env.CI) {
+      const width = Math.floor(Math.min(frame.getSize().width, 720));
+      frame = frame.resize({ width });
+    }
+
+    // Save the image as an artifact for better debugging
+    const artifactName = await createArtifactWithRandomId((id) => `color-mismatch-${id}.png`, frame.toPNG());
+
+    throw new AssertionError(
+      `Expected color at (${point.x}, ${point.y}) of ${this.describeTarget()} to ${
+        matchIsExpected ? 'match' : '*not* match'
+      } '${expectedColor}', but got '${actualColor}'. See the artifact '${artifactName}' for more information.`
+    );
   }
 
-  private display: Electron.Display;
+  private target: CaptureTarget;
 }
 
 /**

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -837,8 +837,8 @@ describe('<webview> tag', function () {
         src: 'data:text/html,foo'
       });
 
-      const screenCapture = new ScreenCapture();
-      await screenCapture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
     });
 
     ifit(hasCapturableScreen())('remains transparent when set', async () => {
@@ -847,8 +847,8 @@ describe('<webview> tag', function () {
         webpreferences: 'transparent=yes'
       });
 
-      const screenCapture = new ScreenCapture();
-      await screenCapture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(WINDOW_BACKGROUND_COLOR);
     });
 
     ifit(hasCapturableScreen())('can disable transparency', async () => {
@@ -857,8 +857,8 @@ describe('<webview> tag', function () {
         webpreferences: 'transparent=no'
       });
 
-      const screenCapture = new ScreenCapture();
-      await screenCapture.expectColorAtCenterMatches(HexColors.WHITE);
+      const capture = ScreenCapture.forWindow(w);
+      await capture.expectColorAtCenterMatches(HexColors.WHITE);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Seen in https://github.com/electron/electron/actions/runs/31655880471/job/94316569679: `api-in-app-purchase-spec` leaves an App Store sign-in dialog in the middle of the screen for the rest of the run, and any display-capture spec sharded after it (here the three `WebContentsView setBorderRadius capture` specs) reads the dialog instead of the window.

- `ScreenCapture.forWindow(win)` captures just that window's own composited contents (`desktopCapturer` window source matched by `getMediaSourceId()`), so nothing else on screen can affect the result. Every spec that only inspects one window now uses it (`WebContentsView`, `BrowserView`, `<webview>`, `setWindowOpenHandler`, `BrowserWindow` `backgroundColor` / `transparent: false`).
- `expectColorAt*` points are resolved against the captured frame's size, so the border radius corners are computed from the window itself; this drops the hard-coded macOS menu bar offset.
- Missing source (window not on screen yet) is retried within the existing timeout instead of throwing immediately.
- The two `BrowserWindow` `transparent: true` specs still capture the display on purpose — they check compositing over the window behind.

Only exercised on the darwin CI jobs, so those are the verification for this change.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none