### PR TITLE
ci: dedupe the typescript-go fix-sync step

### DIFF
--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -41,26 +41,19 @@ runs:
         target-platform: ${{ inputs.target-platform }}
         package: infra/3pp/tools/esbuild/${platform}
     # ts_library() runs the host tsgo binary (//third_party/typescript/tsgo.gni),
-    # which DEPS only fetches when host_os == "mac".
+    # which DEPS only fetches when host_os == "mac". The DEPS key and package
+    # are literal per-arch names (no CIPD ${platform} templating), so pick the
+    # directory from the runner arch.
     # Refs https://chromium-review.googlesource.com/c/chromium/src/+/8104602
-    - name: Fix typescript-go (macOS arm64)
-      if: ${{ inputs.target-platform == 'macos' && runner.arch == 'ARM64' }}
+    - name: Fix typescript-go (macOS)
+      if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/cipd-install
       with:
         dependency: typescript-go
         deps-file: src/DEPS
-        installation-dir: src/third_party/typescript/mac-arm64/src
+        installation-dir: src/third_party/typescript/${{ runner.arch == 'ARM64' && 'mac-arm64' || 'mac-amd64' }}/src
         target-platform: ${{ inputs.target-platform }}
-        package: chromium/third_party/typescript/mac-arm64
-    - name: Fix typescript-go (macOS x64)
-      if: ${{ inputs.target-platform == 'macos' && runner.arch == 'X64' }}
-      uses: ./src/electron/.github/actions/cipd-install
-      with:
-        dependency: typescript-go
-        deps-file: src/DEPS
-        installation-dir: src/third_party/typescript/mac-amd64/src
-        target-platform: ${{ inputs.target-platform }}
-        package: chromium/third_party/typescript/mac-amd64
+        package: chromium/third_party/typescript/${{ runner.arch == 'ARM64' && 'mac-arm64' || 'mac-amd64' }}
     - name: Fix rollup
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/cipd-install

--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -51,9 +51,9 @@ runs:
       with:
         dependency: typescript-go
         deps-file: src/DEPS
-        installation-dir: src/third_party/typescript/${{ runner.arch == 'ARM64' && 'mac-arm64' || 'mac-amd64' }}/src
+        installation-dir: src/third_party/typescript/${{ case(runner.arch == 'ARM64', 'mac-arm64', 'mac-amd64') }}/src
         target-platform: ${{ inputs.target-platform }}
-        package: chromium/third_party/typescript/${{ runner.arch == 'ARM64' && 'mac-arm64' || 'mac-amd64' }}
+        package: chromium/third_party/typescript/${{ case(runner.arch == 'ARM64', 'mac-arm64', 'mac-amd64') }}
     - name: Fix rollup
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/cipd-install


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/52612#discussion_r3763086475 (@dsanders11's suggestion): collapse the two per-arch `Fix typescript-go (macOS …)` steps in `.github/actions/fix-sync` into one.

CIPD's `${platform}` templating can't be used here the way the `gn` step uses `mac-${arch}`: the Chromium DEPS entries for tsgo are literal per-arch keys (`src/third_party/typescript/mac-arm64/src` / `mac-amd64/src`) with literal package names, and `cipd-install` needs the exact DEPS key for `gclient getdep` as well as a concrete installation dir. So the arch is picked with a `runner.arch == 'ARM64' && 'mac-arm64' || 'mac-amd64'` expression instead. Behaviour is unchanged.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
