### PR TITLE
fix: re-extract asar entries whose temporary copy was removed

### DIFF
--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -359,8 +359,14 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
 
   auto it = external_files_.find(path.value());
   if (it != external_files_.end()) {
-    *out = it->second->path();
-    return true;
+    // The OS may have cleaned the temporary copy up since it was extracted
+    // (e.g. macOS's periodic $TMPDIR sweep); extract it again if so.
+    electron::ScopedAllowBlockingForElectron allow_blocking;
+    if (base::PathExists(it->second->path())) {
+      *out = it->second->path();
+      return true;
+    }
+    external_files_.erase(it);
   }
 
   FileInfo info;

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 
 import { once } from 'node:events';
 import * as importedFs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as url from 'node:url';
 import { Worker } from 'node:worker_threads';
@@ -84,6 +85,30 @@ describe('asar package', () => {
       } else if (message === 'error') {
         throw new Error(error);
       }
+    });
+  });
+
+  describe('fs.createReadStream', () => {
+    it('reads a packed file again after its extracted copy was deleted', async () => {
+      const p = path.join(asarDir, 'a.asar', 'file1');
+      const read = async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of importedFs.createReadStream(p)) chunks.push(chunk as Buffer);
+        return Buffer.concat(chunks).toString();
+      };
+      const expected = importedFs.readFileSync(p, 'utf8');
+      expect(await read()).to.equal(expected);
+      // Streams read from an extracted temporary copy; remove every copy the
+      // way an OS temp sweep would.
+      const originalFs = require('original-fs');
+      const tmp = os.tmpdir();
+      for (const name of originalFs.readdirSync(tmp)) {
+        const candidate = path.join(tmp, name);
+        try {
+          if (originalFs.statSync(candidate).size === expected.length && originalFs.readFileSync(candidate, 'utf8') === expected) originalFs.unlinkSync(candidate);
+        } catch {}
+      }
+      expect(await read()).to.equal(expected);
     });
   });
 

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -105,7 +105,10 @@ describe('asar package', () => {
       for (const name of originalFs.readdirSync(tmp)) {
         const candidate = path.join(tmp, name);
         try {
-          if (originalFs.statSync(candidate).size === expected.length && originalFs.readFileSync(candidate, 'utf8') === expected) originalFs.unlinkSync(candidate);
+          const stat = originalFs.statSync(candidate);
+          if (stat.size === expected.length && originalFs.readFileSync(candidate, 'utf8') === expected) {
+            originalFs.unlinkSync(candidate);
+          }
         } catch {}
       }
       expect(await read()).to.equal(expected);


### PR DESCRIPTION
#### Description of Change

Closes #52804.

`Archive::CopyFileOut()` caches the temporary copy it extracts for each entry and returned the cached path without checking the file was still there. Since #29293 archives live for the whole process, so once the OS cleans the temp directory under a long-running app (macOS sweeps `$TMPDIR` periodically) every later `fs.open`/`createReadStream`/`execFile` of that entry failed with `ENOENT`, while `readFile` kept working through the retained archive handle. The cache hit now checks the copy exists and extracts the entry again when it doesn't.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Fixed an issue where reading a file inside an asar archive with `fs.createReadStream` or `child_process` could fail with ENOENT in long-running apps after the OS cleared the temporary directory.
