### PR TITLE
fix: load the PDF viewer in in-memory sessions

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -849,20 +849,17 @@ void ElectronBrowserClient::GetAdditionalWebUISchemes(
 void ElectronBrowserClient::SiteInstanceGotProcessAndSite(
     content::SiteInstance* site_instance) {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  auto* browser_context =
-      static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
-  if (!browser_context->IsOffTheRecord()) {
-    extensions::ExtensionRegistry* registry =
-        extensions::ExtensionRegistry::Get(browser_context);
-    const extensions::Extension* extension =
-        registry->enabled_extensions().GetExtensionOrAppByURL(
-            site_instance->GetSecurityPrincipal().GetDeprecatedSiteURL());
-    if (!extension)
-      return;
+  auto* browser_context = site_instance->GetBrowserContext();
+  extensions::ExtensionRegistry* registry =
+      extensions::ExtensionRegistry::Get(browser_context);
+  const extensions::Extension* extension =
+      registry->enabled_extensions().GetExtensionOrAppByURL(
+          site_instance->GetSecurityPrincipal().GetDeprecatedSiteURL());
+  if (!extension)
+    return;
 
-    extensions::ProcessMap::Get(browser_context)
-        ->Insert(extension->id(), site_instance->GetProcess()->GetID());
-  }
+  extensions::ProcessMap::Get(browser_context)
+      ->Insert(extension->id(), site_instance->GetProcess()->GetID());
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 }
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -324,10 +324,6 @@ struct PartitionKey {
   bool in_memory_;
 };
 
-// Set while the default session's context is alive, including while the
-// other contexts are torn down ahead of it in DestroyAllContexts().
-ElectronBrowserContext* g_default_browser_context = nullptr;
-
 [[nodiscard]] auto& ContextMap() {
   static base::NoDestructor<
       std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>>
@@ -352,8 +348,11 @@ bool ElectronBrowserContext::IsValidContext(const void* context) {
 // static
 void ElectronBrowserContext::DestroyAllContexts() {
   auto& map = ContextMap();
-  // Avoid UAF by destroying the default context last. See ba629e3 for info.
-  const auto extracted = map.extract(PartitionKey{"", false});
+  // Destroy the default context last (see ba629e3) but keep it in the map
+  // meanwhile: the other contexts look it up while they are torn down.
+  std::erase_if(map, [](const auto& entry) {
+    return entry.first != PartitionKey{"", false};
+  });
   map.clear();
 }
 
@@ -916,26 +915,12 @@ ElectronBrowserContext* ElectronBrowserContext::From(
     const std::string& partition,
     bool in_memory,
     base::DictValue options) {
-  const bool is_default = partition.empty() && !in_memory;
-  // In-memory sessions are off-the-record contexts of the default session
-  // (see ElectronExtensionsBrowserClient::GetOriginalContext), so it exists
-  // first and, per DestroyAllContexts(), goes away last.
-  if (in_memory && !g_default_browser_context)
-    GetDefaultBrowserContext();
   auto& context = ContextMap()[PartitionKey(partition, in_memory)];
   if (!context) {
     context.reset(new ElectronBrowserContext{std::cref(partition), in_memory,
                                              std::move(options)});
-    if (is_default)
-      g_default_browser_context = context.get();
   }
   return context.get();
-}
-
-// static
-ElectronBrowserContext*
-ElectronBrowserContext::GetExistingDefaultBrowserContext() {
-  return g_default_browser_context;
 }
 
 // static

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -324,6 +324,10 @@ struct PartitionKey {
   bool in_memory_;
 };
 
+// Set while the default session's context is alive, including while the
+// other contexts are torn down ahead of it in DestroyAllContexts().
+ElectronBrowserContext* g_default_browser_context = nullptr;
+
 [[nodiscard]] auto& ContextMap() {
   static base::NoDestructor<
       std::map<PartitionKey, std::unique_ptr<ElectronBrowserContext>>>
@@ -912,12 +916,26 @@ ElectronBrowserContext* ElectronBrowserContext::From(
     const std::string& partition,
     bool in_memory,
     base::DictValue options) {
+  const bool is_default = partition.empty() && !in_memory;
+  // In-memory sessions are off-the-record contexts of the default session
+  // (see ElectronExtensionsBrowserClient::GetOriginalContext), so it exists
+  // first and, per DestroyAllContexts(), goes away last.
+  if (in_memory && !g_default_browser_context)
+    GetDefaultBrowserContext();
   auto& context = ContextMap()[PartitionKey(partition, in_memory)];
   if (!context) {
     context.reset(new ElectronBrowserContext{std::cref(partition), in_memory,
                                              std::move(options)});
+    if (is_default)
+      g_default_browser_context = context.get();
   }
   return context.get();
+}
+
+// static
+ElectronBrowserContext*
+ElectronBrowserContext::GetExistingDefaultBrowserContext() {
+  return g_default_browser_context;
 }
 
 // static

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -69,9 +69,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   [[nodiscard]] static bool IsValidContext(const void* context);
 
   // Get or create the default BrowserContext.
-  // The default session's context if it has been created, else nullptr.
-  static ElectronBrowserContext* GetExistingDefaultBrowserContext();
-
   static ElectronBrowserContext* GetDefaultBrowserContext(
       base::DictValue options = {});
 

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -69,6 +69,9 @@ class ElectronBrowserContext : public content::BrowserContext {
   [[nodiscard]] static bool IsValidContext(const void* context);
 
   // Get or create the default BrowserContext.
+  // The default session's context if it has been created, else nullptr.
+  static ElectronBrowserContext* GetExistingDefaultBrowserContext();
+
   static ElectronBrowserContext* GetDefaultBrowserContext(
       base::DictValue options = {});
 

--- a/shell/browser/extensions/electron_extension_system_factory.cc
+++ b/shell/browser/extensions/electron_extension_system_factory.cc
@@ -8,6 +8,7 @@
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "extensions/browser/extension_prefs_factory.h"
 #include "extensions/browser/extension_registry_factory.h"
+#include "extensions/browser/extensions_browser_client.h"
 #include "shell/browser/extensions/electron_extension_system.h"
 
 using content::BrowserContext;
@@ -43,8 +44,8 @@ ElectronExtensionSystemFactory::BuildServiceInstanceForBrowserContext(
 
 BrowserContext* ElectronExtensionSystemFactory::GetBrowserContextToUse(
     BrowserContext* context) const {
-  // Use a separate instance for incognito.
-  return context;
+  return ExtensionsBrowserClient::Get()->GetContextRedirectedToOriginal(
+      context);
 }
 
 bool ElectronExtensionSystemFactory::ServiceIsCreatedWithBrowserContext()

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -95,7 +95,8 @@ bool ElectronExtensionsBrowserClient::IsValidContext(void* context) {
 
 bool ElectronExtensionsBrowserClient::IsSameContext(BrowserContext* first,
                                                     BrowserContext* second) {
-  return first == second;
+  // In-memory sessions are off-the-record contexts of the default one.
+  return GetOriginalContext(first) == GetOriginalContext(second);
 }
 
 bool ElectronExtensionsBrowserClient::HasOffTheRecordContext(

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -113,11 +113,15 @@ BrowserContext* ElectronExtensionsBrowserClient::GetOffTheRecordContext(
 BrowserContext* ElectronExtensionsBrowserClient::GetOriginalContext(
     BrowserContext* context) {
   DCHECK(context);
+  // In-memory sessions borrow the default session's extensions. This also
+  // runs while contexts are torn down, so it must never create one.
   if (context->IsOffTheRecord()) {
-    return ElectronBrowserContext::GetDefaultBrowserContext();
-  } else {
-    return context;
+    if (auto* original =
+            ElectronBrowserContext::GetExistingDefaultBrowserContext()) {
+      return original;
+    }
   }
+  return context;
 }
 
 content::BrowserContext*

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -113,15 +113,11 @@ BrowserContext* ElectronExtensionsBrowserClient::GetOffTheRecordContext(
 BrowserContext* ElectronExtensionsBrowserClient::GetOriginalContext(
     BrowserContext* context) {
   DCHECK(context);
-  // In-memory sessions borrow the default session's extensions. This also
-  // runs while contexts are torn down, so it must never create one.
   if (context->IsOffTheRecord()) {
-    if (auto* original =
-            ElectronBrowserContext::GetExistingDefaultBrowserContext()) {
-      return original;
-    }
+    return ElectronBrowserContext::GetDefaultBrowserContext();
+  } else {
+    return context;
   }
-  return context;
 }
 
 content::BrowserContext*

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3228,6 +3228,13 @@ describe('chromium features', () => {
       expect(w.getURL()).to.equal(pdfSource);
     });
 
+    it('loads a PDF resource in an in-memory session', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { partition: 'pdf-viewer-in-memory' } });
+      await w.loadURL(pdfSource);
+      // The viewer hosts the document in a frame of its own once its plugin is up.
+      await waitUntil(() => w.webContents.mainFrame.framesInSubtree.filter((f) => f.url === pdfSource).length === 2);
+    });
+
     it('successfully loads a PDF resource in a iframe', async () => {
       const w = new BrowserWindow({ show: false });
 


### PR DESCRIPTION
#### Description of Change

Closes #27121.

The PDF viewer showed only its grey background in in-memory sessions (`partition` without `persist:`): the viewer's extension frame loaded, then every `chrome://resources` script it depends on was refused, because renderers of an in-memory session were never told the component PDF extension exists. Electron already models an in-memory session as an off-the-record context whose original is the default session (`GetOriginalContext()`, and `ExtensionRegistry`/`ProcessMap` redirect there), but three places didn't follow that model since #22772: `SiteInstanceGotProcessAndSite` skipped off-the-record contexts, `IsSameContext()` compared pointers so the default session's `RendererStartupHelper` ignored those renderers, and the `ExtensionSystem` factory handed them a separate, never-initialized instance. Those three now agree with the rest, which is also how Chrome treats a profile and its incognito twin. Because that lookup also runs while contexts are torn down, `DestroyAllContexts()` now destroys the other contexts first and keeps the default one in the map meanwhile (it is still destroyed last), instead of extracting it up front where a teardown-time lookup would have created a second default context. User-loaded extensions stay out of in-memory sessions since they remain incognito-disabled.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Fixed the built-in PDF viewer not rendering documents in in-memory sessions (partitions without the `persist:` prefix).
