### PR TITLE
test: close the sign-in dialog the inAppPurchase suite leaves on screen

### DIFF
--- a/spec/api-in-app-purchase-spec.ts
+++ b/spec/api-in-app-purchase-spec.ts
@@ -2,12 +2,56 @@ import { inAppPurchase } from 'electron/main';
 
 import { expect } from 'chai';
 
-import { ifdescribe } from './lib/spec-helpers';
+import * as childProcess from 'node:child_process';
+
+import { ifdescribe, waitUntil } from './lib/spec-helpers';
+
+// pid -> executable for every process that owns an on-screen window. Owner
+// pids, unlike window titles, need no screen-recording permission.
+function windowOwners(): Map<number, string> {
+  const script = `ObjC.import('CoreGraphics');
+    const all = ObjC.castRefToObject($.CGWindowListCopyWindowInfo($.kCGWindowListOptionOnScreenOnly, $.kCGNullWindowID));
+    const pids = [];
+    for (let i = 0; i < all.count; i++) pids.push(ObjC.unwrap(all.objectAtIndex(i).objectForKey('kCGWindowOwnerPID')));
+    JSON.stringify(pids);`;
+  const pids: number[] = JSON.parse(
+    childProcess.execFileSync('osascript', ['-l', 'JavaScript', '-e', script]).toString()
+  );
+  const ps = childProcess.execFileSync('ps', ['-o', 'pid=,comm=', '-p', [...new Set(pids)].join(',')]).toString();
+  const owners = new Map<number, string>();
+  for (const line of ps.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(.*)$/);
+    if (match) owners.set(Number(match[1]), match[2]);
+  }
+  return owners;
+}
 
 describe('inAppPurchase module', function () {
   if (process.platform !== 'darwin') return;
 
   this.timeout(3 * 60 * 1000);
+
+  // Without an App Store session StoreKit answers restoreCompletedTransactions()
+  // with an Apple Account sign-in dialog, shown by a system agent, that nothing
+  // dismisses; left up, it covers every later screen capture in the run. Close
+  // whatever system UI this suite brought on screen.
+  let ownersBefore: Set<number>;
+  const summoned = () =>
+    [...windowOwners()].filter(
+      ([pid, executable]) => !ownersBefore.has(pid) && /^\/(System|usr\/libexec)\//.test(executable)
+    );
+  before(() => {
+    ownersBefore = new Set(windowOwners().keys());
+  });
+  after(async () => {
+    // The dialog trails the call that caused it, so give it a moment to show.
+    await waitUntil(() => summoned().length > 0, { timeout: 3000 }).catch(() => {});
+    await waitUntil(() => {
+      const left = summoned();
+      for (const [pid] of left) process.kill(pid);
+      return left.length === 0;
+    });
+  });
 
   it('canMakePayments() returns a boolean', () => {
     const canMakePayments = inAppPurchase.canMakePayments();


### PR DESCRIPTION
#### Description of Change

Without an App Store session, StoreKit answers `inAppPurchase.restoreCompletedTransactions()` with an Apple Account sign-in dialog shown by a system agent, and nothing dismisses it, so it stays centred on screen for the rest of the job. Whenever `script/split-tests.js` places `api-in-app-purchase-spec.ts` ahead of the screen-capture tests in a shard, the `<webview>` / `WebContentsView` transparency and border-radius captures read the dialog's grey (`#ececec`) instead of the page and fail; any PR that adds enough tests to reshuffle the macOS arm64 split hits it (e.g. #52807, #52808), and the uploaded `color-mismatch-*.png` artifacts show the sign-in sheet over the capture point. The suite now snapshots the processes that own on-screen windows before it runs and, afterwards, terminates any system agent that has put up a window since, until the screen is back to what it was.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
