### PR TITLE
fix: add button id range check for message boxes on windows

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -11,7 +11,9 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
 #include "base/logging.h"
+#include "base/memory/raw_ptr_exclusion.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -75,6 +77,17 @@ struct CommonButtonID {
   int button;
   int id;
 };
+
+struct TaskDialogCallbackData {
+  // Storage for the dialog's HWND, shared with CloseMessageBox across threads
+  // under GetHWNDLock(). Null when the caller does not track the HWND.
+  // Not a raw_ptr<> because it points at an HWND owned elsewhere.
+  RAW_PTR_EXCLUSION HWND* target = nullptr;
+  // The button IDs created for this dialog. Clicks for any other ID
+  // are treated as external/injected and ignored.
+  base::flat_set<int> button_ids;
+};
+
 CommonButtonID GetCommonID(const std::wstring& button) {
   std::wstring lower = base::ToLowerASCII(button);
   if (lower == L"ok")
@@ -119,19 +132,33 @@ void MapToCommonID(const std::vector<std::wstring>& buttons,
 // is possible for CloseMessageBox to be called before or all after the dialog
 // window is created.
 HRESULT CALLBACK
-TaskDialogCallback(HWND hwnd, UINT msg, WPARAM, LPARAM, LONG_PTR data) {
+TaskDialogCallback(HWND hwnd, UINT msg, WPARAM w_param, LPARAM, LONG_PTR data) {
+  auto* callback_data = reinterpret_cast<TaskDialogCallbackData*>(data);
   if (msg == TDN_CREATED) {
-    HWND* target = reinterpret_cast<HWND*>(data);
-    // Lock since CloseMessageBox might be called.
-    base::AutoLock lock(GetHWNDLock());
-    if (*target == kHwndCancel) {
-      // The dialog is cancelled before it is created, close it directly.
-      ::PostMessage(hwnd, WM_CLOSE, 0, 0);
-    } else if (*target == kHwndReserve) {
-      // Otherwise save the hwnd.
-      *target = hwnd;
-    } else {
-      NOTREACHED();
+    if (HWND* target = callback_data->target) {
+      // Lock since CloseMessageBox might be called.
+      base::AutoLock lock(GetHWNDLock());
+      if (*target == kHwndCancel) {
+        // The dialog is cancelled before it is created, close it directly.
+        ::PostMessage(hwnd, WM_CLOSE, 0, 0);
+      } else if (*target == kHwndReserve) {
+        // Otherwise save the hwnd.
+        *target = hwnd;
+      } else {
+        NOTREACHED();
+      }
+    }
+  } else if (msg == TDN_BUTTON_CLICKED) {
+    // Ignore clicks for button IDs that we never created. Some software
+    // (e.g. file-dialog enhancers) enumerates dialog (0x8002) windows and sends
+    // messages with colliding IDs, which would dismiss our message box.
+    // Returning S_FALSE keeps it open. IDCANCEL is
+    // always honored so Esc and the title-bar close keep working under
+    // TDF_ALLOW_DIALOG_CANCELLATION.
+    const int clicked_id = static_cast<int>(w_param);
+    if (clicked_id != IDCANCEL &&
+        !callback_data->button_ids.contains(clicked_id)) {
+      return S_FALSE;
     }
   }
   return S_OK;
@@ -243,23 +270,36 @@ DialogResult ShowTaskDialogWstr(gfx::AcceleratedWidget parent,
       config.dwFlags |= TDF_USE_COMMAND_LINKS;  // custom buttons as links.
   }
 
-  // Pass a callback to receive the HWND of the message box.
-  if (hwnd) {
-    config.pfCallback = &TaskDialogCallback;
-    config.lpCallbackData = reinterpret_cast<LONG_PTR>(hwnd);
-  }
+  // Always register a callback, it receives the HWND of the message box (when
+  // the caller tracks it) and rejects button clicks for IDs we never created,
+  // so an external process cannot dismiss the dialog.
+  TaskDialogCallbackData callback_data;
+  callback_data.target = hwnd;
+  for (const auto& id_and_index : id_map)
+    callback_data.button_ids.insert(id_and_index.first);
+  for (const auto& button : dialog_buttons)
+    callback_data.button_ids.insert(button.nButtonID);
+  // With no buttons configured, TaskDialogIndirect shows an implicit OK button
+  // (e.g. ShowErrorBox), so allow its click through.
+  if (callback_data.button_ids.empty())
+    callback_data.button_ids.insert(IDOK);
+  config.pfCallback = &TaskDialogCallback;
+  config.lpCallbackData = reinterpret_cast<LONG_PTR>(&callback_data);
 
   int id = 0;
   BOOL verification_flag_checked = FALSE;
   TaskDialogIndirect(&config, &id, nullptr, &verification_flag_checked);
 
   int button_id;
-  if (id_map.contains(id))  // common button.
+  if (id_map.contains(id)) {
+    // common button.
     button_id = id_map[id];
-  else if (id >= kIDStart)  // custom button.
+  } else if (id >= kIDStart && callback_data.button_ids.contains(id)) {
+    // custom button.
     button_id = id - kIDStart;
-  else
+  } else {
     button_id = cancel_id;
+  }
 
   return {button_id, static_cast<bool>(verification_flag_checked)};
 }

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -1135,4 +1135,61 @@ describe('dialog module', () => {
       });
     });
   });
+
+  ifdescribe(process.platform === 'win32' && !process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS)(
+    'external message injection (Windows)',
+    () => {
+      let dialogHelper: any;
+
+      before(() => {
+        dialogHelper = require('@electron-ci/dialog-helper');
+      });
+
+      afterEach(closeAllWindows);
+
+      // Poll for the native task dialog to appear.
+      async function waitForDialog(w: BrowserWindow): Promise<Buffer> {
+        const handle = w.getNativeWindowHandle();
+        for (let i = 0; i < 50; i++) {
+          if (dialogHelper.getDialogInfo(handle).type === 'message-box') return handle;
+          await setTimeout(100);
+        }
+        throw new Error('Timed out waiting for the message box to appear');
+      }
+
+      it('ignores button clicks for IDs it never created and keeps the dialog open', async () => {
+        const w = new BrowserWindow({ show: false });
+        const p = dialog.showMessageBox(w, {
+          message: 'External injection test',
+          buttons: ['Button A', 'Button B']
+        });
+
+        let resolvedEarly = false;
+        p.then(
+          () => {
+            resolvedEarly = true;
+          },
+          () => {
+            resolvedEarly = true;
+          }
+        );
+
+        const handle = await waitForDialog(w);
+        dialogHelper.clickMessageBoxButton(handle, 420);
+        await setTimeout(500);
+        expect(resolvedEarly, 'dialog closed on an unknown button ID').to.equal(false);
+        expect(dialogHelper.getDialogInfo(handle).type).to.equal('message-box');
+
+        // A real button still closes the dialog and returns its index.
+        dialogHelper.clickMessageBoxButton(handle, 1);
+        await setTimeout(500);
+        expect(
+          dialogHelper.getDialogInfo(handle).type,
+          'a valid button click did not close the dialog; is kIDStart in dialog_helper_win.cc in sync with message_box_win.cc ?'
+        ).to.equal('none');
+        const result = await p;
+        expect(result.response).to.equal(1);
+      });
+    }
+  );
 });

--- a/spec/fixtures/native-addon/dialog-helper/binding.gyp
+++ b/spec/fixtures/native-addon/dialog-helper/binding.gyp
@@ -1,4 +1,14 @@
 {
+  'target_defaults': {
+    'conditions': [
+      ['OS=="win"', {
+        'msvs_disabled_warnings': [
+          4530,
+          4506,
+        ],
+      }],
+    ],
+  },
   'targets': [
     {
       'target_name': 'dialog_helper',
@@ -14,7 +24,14 @@
           'xcode_settings': {
             'OTHER_CFLAGS': ['-fobjc-arc'],
           },
-        }, {
+        }],
+        ['OS=="win"', {
+          'sources': [
+            'src/main.cc',
+            'src/dialog_helper_win.cc',
+          ],
+        }],
+        ['OS not in ["mac", "win"]', {
           'type': 'none',
         }],
       ],

--- a/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_win.cc
+++ b/spec/fixtures/native-addon/dialog-helper/src/dialog_helper_win.cc
@@ -1,0 +1,82 @@
+#include "dialog_helper.h"
+
+#include <windows.h>
+
+#include <commctrl.h>
+
+namespace {
+
+// Electron assigns custom TaskDialog button IDs starting at this value; a
+// button at index |i| has ID kIDStart + i. Keep in sync with
+// shell/browser/ui/message_box_win.cc.
+constexpr int kIDStart = 100;
+
+struct FindContext {
+  DWORD process_id;
+  HWND result;
+};
+
+BOOL CALLBACK FindMessageBoxProc(HWND hwnd, LPARAM param) {
+  auto* context = reinterpret_cast<FindContext*>(param);
+  if (!::IsWindowVisible(hwnd))
+    return TRUE;
+
+  // Task dialogs (and other common dialogs) use the same window class.
+  wchar_t class_name[16] = {0};
+  ::GetClassNameW(hwnd, class_name, 16);
+  if (::lstrcmpW(class_name, L"#32770") != 0)
+    return TRUE;
+
+  DWORD process_id = 0;
+  ::GetWindowThreadProcessId(hwnd, &process_id);
+  if (process_id != context->process_id)
+    return TRUE;
+
+  context->result = hwnd;
+  return FALSE;
+}
+
+// Finds the visible task dialog owned by the current process.
+HWND FindMessageBox() {
+  FindContext context = {::GetCurrentProcessId(), nullptr};
+  ::EnumWindows(&FindMessageBoxProc, reinterpret_cast<LPARAM>(&context));
+  return context.result;
+}
+
+}  // namespace
+
+namespace dialog_helper {
+
+DialogInfo GetDialogInfo(char*, size_t) {
+  DialogInfo info;
+  info.type = FindMessageBox() ? "message-box" : "none";
+  return info;
+}
+
+bool ClickMessageBoxButton(char*, size_t, int button_index) {
+  HWND window = FindMessageBox();
+  if (!window)
+    return false;
+
+  // TDM_CLICK_BUTTON clicks the button whose command ID is in wParam. Passing
+  // an index that maps to an ID Electron never created (e.g. a large index)
+  // simulates an external process clicking a nonexistent button, which some
+  // software triggers by enumerating dialog windows.
+  ::SendMessageW(window, TDM_CLICK_BUTTON,
+                 static_cast<WPARAM>(kIDStart + button_index), 0);
+  return true;
+}
+
+bool ClickCheckbox(char*, size_t) {
+  return false;
+}
+
+bool CancelFileDialog(char*, size_t) {
+  return false;
+}
+
+bool AcceptFileDialog(char*, size_t, const std::string&) {
+  return false;
+}
+
+}  // namespace dialog_helper


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/52747
User report confirmation at https://github.com/microsoft/vscode/issues/329901#issuecomment-5280345801

On Windows, task dialogs and file dialogs share the base window class, and messages can collide, for example 0x0466 is TDM_CLICK_BUTTON for a task dialog but CDM_GETFOLDERPATH for a file dialog. Software that inspects file dialogs enumerates based on window class and sends these colliding messages which can then dismiss our message boxes.

Handle TDN_BUTTON_CLICKED in the task dialog callback and return S_FALSE for any button id Electron did not create, which keeps the dialog open. The callback is now registered for every message box, including the synchronous ones that previously passed no callback and were therefore unprotected.

Map the returned id through the exact set of created button ids as well, so an id that slips through resolves to cancelId instead of a fabricated index into the button array.

Since this change vetoes TDN_BUTTON_CLICKED for unrecognized button IDs, also verified it does not interfere with assistive technologies dismissing dialogs.

#### Release Notes

Notes:  Fixed windows native message boxes being dismissed by other applications using invalid button ID.