### PR TITLE
feat: roll Squirrel.Mac for streamed, resumable and delta update downloads

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,11 +8,13 @@ vars = {
   'nan_version':
     '675cefebca42410733da8a454c8d9391fcebfbc2',
   'squirrel.mac_version':
-    '8d808803bc89ec0e2aa1450474856dfee3b00c6b',
+    'fffea30e4a339a7f7d69a3391314b72548d209bd',
   'reactiveobjc_version':
     '74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76',
   'mantle_version':
     '2a8e2123a3931038179ee06105c9e6ec336b12ea',
+  'sparkle_version':
+    '79bc9e872948e47877e76f194cb0c8e0412b0b90',
   'engflow_reclient_configs_version':
     '955335c30a752e9ef7bff375baab5e0819b6c00d',
 
@@ -25,6 +27,7 @@ vars = {
   'squirrel_git': 'https://github.com/Squirrel',
   'reactiveobjc_git': 'https://github.com/ReactiveCocoa',
   'mantle_git': 'https://github.com/Mantle',
+  'sparkle_git': 'https://github.com/sparkle-project',
   'engflow_git': 'https://github.com/EngFlow',
   
   # The path of the sysroots.json file.
@@ -102,6 +105,10 @@ deps = {
   },
   'src/third_party/squirrel.mac/vendor/Mantle': {
     'url':  Var("mantle_git") + '/Mantle.git@' + Var("mantle_version"),
+    'condition': 'process_deps',
+  },
+  'src/third_party/squirrel.mac/vendor/Sparkle': {
+    'url': Var("sparkle_git") + '/Sparkle.git@' + Var("sparkle_version"),
     'condition': 'process_deps',
   },
   'src/third_party/engflow-reclient-configs': {

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -30,6 +30,24 @@ update process. Apps that need to disable ATS can add the
 > Your application must be [signed](../tutorial/code-signing.md#macos-apis-that-require-code-signing)
 > for automatic updates on macOS. This is a requirement of `Squirrel.Mac`.
 
+The update ZIP is streamed to disk rather than held in memory. When the server
+answers with an `ETag` or `Last-Modified` header and honours `Range` requests,
+a download interrupted by a network change, sleep or the app quitting continues
+from where it stopped on the next update check, including after a relaunch;
+otherwise it starts over. An update entry (the update server's response, or an
+`updateTo` object in a `serverType: 'json'` feed) may declare `sha256` (hex
+digest) and `size` (bytes) alongside `url`; a download that does not match
+them is discarded before it is unpacked and `error` is emitted.
+
+An update entry may also carry `delta`, an object with `from_version`, `url`,
+`sha256` and `size`, offering a binary patch from one earlier build. When
+`from_version` equals the running app's `CFBundleVersion`, that patch is
+downloaded instead of the ZIP, applied to a copy of the running app, and the
+result goes through the same code signing verification as an unpacked ZIP; on
+any failure the ZIP is downloaded in the same check. Patches are made with
+[Sparkle](https://sparkle-project.org)'s `BinaryDelta create` from the exact
+bundles that shipped; see Squirrel.Mac's README for the constraints.
+
 ### Windows
 
 On Windows, the `autoUpdater` module automatically selects the appropriate update mechanism

--- a/patches/chromium/add_electron_deps_to_license_credits_file.patch
+++ b/patches/chromium/add_electron_deps_to_license_credits_file.patch
@@ -7,10 +7,10 @@ Ensure that licenses for the dependencies introduced by Electron
 are included in `LICENSES.chromium.html`
 
 diff --git a/tools/licenses/licenses.py b/tools/licenses/licenses.py
-index 466e6a1751bde7d176d18dde6674aa1dc94678c0..4700ef5950966f9b666763278aecc88ac8024b30 100755
+index 466e6a1751bde7d176d18dde6674aa1dc94678c0..3adedca7ea04649a344f22ca2fd4679b1d421bde 100755
 --- a/tools/licenses/licenses.py
 +++ b/tools/licenses/licenses.py
-@@ -366,6 +366,31 @@ SPECIAL_CASES = {
+@@ -366,6 +366,37 @@ SPECIAL_CASES = {
          "License": "Apache 2.0",
          "License File": ["//third_party/sample3/the_license"],
      },
@@ -38,6 +38,12 @@ index 466e6a1751bde7d176d18dde6674aa1dc94678c0..4700ef5950966f9b666763278aecc88a
 +        "License": "MIT",
 +        "License File":
 +        ["/third_party/squirrel.mac/vendor/ReactiveObjC/LICENSE.md"],
++    },
++    os.path.join('third_party', 'squirrel.mac', 'vendor', 'Sparkle'): {
++        "Name": "Sparkle",
++        "URL": "https://github.com/sparkle-project/Sparkle",
++        "License": "MIT",
++        "License File": ["/third_party/squirrel.mac/vendor/Sparkle/LICENSE"],
 +    },
  }
  

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -25,10 +25,10 @@ index 89c499e451ecb48655cfd42b01ffa1da56998c2e..98f80aad43a87ed75ca1660ad6a178db
 +vendor
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913bad6a57e
+index 0000000000000000000000000000000000000000..8ae262dd634f9ab619a46167415acf4575fadfe9
 --- /dev/null
 +++ b/BUILD.gn
-@@ -0,0 +1,250 @@
+@@ -0,0 +1,274 @@
 +assert(is_mac)
 +
 +import("//build/config/mac/rules.gni")
@@ -233,6 +233,23 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +  outputs = [ "{{bundle_contents_dir}}/Headers/{{source_file_part}}" ]
 +}
 +
++# Same flags Squirrel's Xcode project gives these files: warnings off, its
++# config header force-included in place of Sparkle's xcconfig defines.
++source_set("sparkle_binary_delta") {
++  visibility = [ ":squirrel_framework" ]
++  sources = sparkle_binary_delta_filenames.sources
++  include_dirs = sparkle_binary_delta_filenames.include_dirs
++  configs -= [ "//build/config/compiler:chromium_code" ]
++  configs += [ "//build/config/compiler:no_chromium_code" ]
++  cflags = [
++    "-w",
++    "-include",
++    rebase_path("Squirrel/SparkleDelta/SparkleDeltaConfig.h", root_build_dir),
++  ]
++  cflags_objc = [ "-fobjc-arc" ]
++  frameworks = [ "Foundation.framework" ]
++}
++
 +mac_framework_bundle("squirrel_framework") {
 +  output_name = "Squirrel"
 +  framework_version = "A"
@@ -258,6 +275,7 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +  deps = [
 +    ":mantle_framework+link",
 +    ":reactiveobjc_framework+link",
++    ":sparkle_binary_delta",
 +  ]
 +  frameworks = [
 +    "AppKit.framework",
@@ -265,6 +283,11 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +    "IOKit.framework",
 +    "Security.framework",
 +    "ServiceManagement.framework",
++  ]
++  libs = [
++    "bz2",
++    "compression",
++    "z",
 +  ]
 +  sources = squirrel_filenames.headers + squirrel_filenames.sources
 +
@@ -277,7 +300,8 @@ index 0000000000000000000000000000000000000000..a02e5f54d923513fd0676e91a99b8913
 +
 +  ldflags = [ "-Wl,-install_name,@rpath/$output_name.framework/$output_name" ]
 +
-+  include_dirs = [ "vendor/ReactiveObjC/ReactiveObjC/extobjc" ]
++  include_dirs = [ "vendor/ReactiveObjC/ReactiveObjC/extobjc" ] +
++                 sparkle_binary_delta_filenames.include_dirs
 +}
 diff --git a/build/xcrun.gni b/build/xcrun.gni
 new file mode 100644
@@ -325,10 +349,10 @@ index 0000000000000000000000000000000000000000..a7aeeb7d3e187bd91ef12ed860d1e37e
 +    sys.exit(e.returncode)
 diff --git a/filenames.gni b/filenames.gni
 new file mode 100644
-index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c301fe589
+index 0000000000000000000000000000000000000000..1168cbbca6cb75d5746f582b3554471c2db2f2fb
 --- /dev/null
 +++ b/filenames.gni
-@@ -0,0 +1,249 @@
+@@ -0,0 +1,285 @@
 +squirrel_filenames = {
 +  headers = [
 +    "Squirrel/NSBundle+SQRLVersionExtensions.h",
@@ -339,9 +363,11 @@ index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c
 +    "Squirrel/SQRLCodeSignature.h",
 +    "Squirrel/SQRLDirectoryManager.h",
 +    "Squirrel/SQRLDownloadedUpdate.h",
++    "Squirrel/SQRLDownloader.h",
 +    "Squirrel/SQRLShipItLauncher.h",
 +    "Squirrel/SQRLShipItRequest.h",
 +    "Squirrel/SQRLUpdate.h",
++    "Squirrel/SQRLUpdateDelta.h",
 +    "Squirrel/SQRLUpdater.h",
 +    "Squirrel/SQRLZipArchiver.h",
 +    "Squirrel/Squirrel.h",
@@ -357,17 +383,51 @@ index 0000000000000000000000000000000000000000..cee305c80588ffe2234bfadd5c211a9c
 +    "Squirrel/SQRLDirectoryManager.m",
 +    "Squirrel/SQRLDownloadedUpdate.h",
 +    "Squirrel/SQRLDownloadedUpdate.m",
++    "Squirrel/SQRLDownloader.h",
++    "Squirrel/SQRLDownloader.m",
 +    "Squirrel/SQRLShipItLauncher.h",
 +    "Squirrel/SQRLShipItLauncher.m",
 +    "Squirrel/SQRLShipItRequest.h",
 +    "Squirrel/SQRLShipItRequest.m",
 +    "Squirrel/SQRLUpdate.h",
 +    "Squirrel/SQRLUpdate.m",
++    "Squirrel/SQRLUpdateDelta.h",
++    "Squirrel/SQRLUpdateDelta.m",
 +    "Squirrel/SQRLUpdater.h",
 +    "Squirrel/SQRLUpdater.m",
 +    "Squirrel/SQRLZipArchiver.h",
 +    "Squirrel/SQRLZipArchiver.m",
 +    "Squirrel/Squirrel.h",
++  ]
++}
++
++# Sparkle's BinaryDelta apply path and the bsdiff it vendors, compiled into
++# Squirrel.framework from vendor/Sparkle (Squirrel's own build takes them from
++# its Carthage/Checkouts/Sparkle submodule at the same tag).
++sparkle_binary_delta_filenames = {
++  sources = [
++    "vendor/Sparkle/Autoupdate/SPUDeltaArchive.h",
++    "vendor/Sparkle/Autoupdate/SPUDeltaArchive.m",
++    "vendor/Sparkle/Autoupdate/SPUDeltaArchiveProtocol.h",
++    "vendor/Sparkle/Autoupdate/SPUDeltaCompressionMode.h",
++    "vendor/Sparkle/Autoupdate/SPUSparkleDeltaArchive.h",
++    "vendor/Sparkle/Autoupdate/SPUSparkleDeltaArchive.m",
++    "vendor/Sparkle/Autoupdate/SPUXarDeltaArchive.h",
++    "vendor/Sparkle/Autoupdate/SUBinaryDeltaApply.h",
++    "vendor/Sparkle/Autoupdate/SUBinaryDeltaApply.m",
++    "vendor/Sparkle/Autoupdate/SUBinaryDeltaCommon.h",
++    "vendor/Sparkle/Autoupdate/SUBinaryDeltaCommon.m",
++    "vendor/Sparkle/Sparkle/AppKitPrevention.h",
++    "vendor/Sparkle/Vendor/bsdiff/bscommon.c",
++    "vendor/Sparkle/Vendor/bsdiff/bscommon.h",
++    "vendor/Sparkle/Vendor/bsdiff/bspatch.c",
++    "vendor/Sparkle/Vendor/bsdiff/bspatch.h",
++  ]
++
++  include_dirs = [
++    "vendor/Sparkle/Autoupdate",
++    "vendor/Sparkle/Vendor/bsdiff",
++    "vendor/Sparkle/Sparkle",
 +  ]
 +}
 +

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -25,7 +25,7 @@ index 89c499e451ecb48655cfd42b01ffa1da56998c2e..98f80aad43a87ed75ca1660ad6a178db
 +vendor
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..8ae262dd634f9ab619a46167415acf4575fadfe9
+index 0000000000000000000000000000000000000000..f484615ea6d344b68a2459c0197f82076da7bdaf
 --- /dev/null
 +++ b/BUILD.gn
 @@ -0,0 +1,274 @@
@@ -236,7 +236,7 @@ index 0000000000000000000000000000000000000000..8ae262dd634f9ab619a46167415acf45
 +# Same flags Squirrel's Xcode project gives these files: warnings off, its
 +# config header force-included in place of Sparkle's xcconfig defines.
 +source_set("sparkle_binary_delta") {
-+  visibility = [ ":squirrel_framework" ]
++  visibility = [ ":*" ]
 +  sources = sparkle_binary_delta_filenames.sources
 +  include_dirs = sparkle_binary_delta_filenames.include_dirs
 +  configs -= [ "//build/config/compiler:chromium_code" ]


### PR DESCRIPTION
#### Description of Change

Rolls `squirrel.mac` to Squirrel/Squirrel.Mac@fffea30, picking up Squirrel/Squirrel.Mac#327, Squirrel/Squirrel.Mac#328 and Squirrel/Squirrel.Mac#330.

On macOS the update ZIP now streams to disk through an `NSURLSession` download task instead of arriving as one in-memory `NSData`; an interrupted transfer resumes on the next check (and after a relaunch) when the server provides a validator and honours `Range`; a feed may declare `sha256`/`size` for the ZIP, checked before it is unpacked; and a feed may offer `delta`, a Sparkle BinaryDelta patch from one earlier build that Squirrel applies to a copy of the running app and puts through the same code signing verification as an unpacked ZIP, falling back to the ZIP in the same check on any failure. No API change in `autoUpdater`; `docs/api/auto-updater.md` describes the behaviour and the optional feed keys.

Squirrel compiles Sparkle's BinaryDelta apply sources and the bsdiff it vendors into the framework, and gclient does not initialise Squirrel's Sparkle submodule, so Sparkle 2.9.5 becomes a DEPS entry at `third_party/squirrel.mac/vendor/Sparkle` (beside Mantle and ReactiveObjC) with a `licenses.py` entry, and the squirrel.mac GN config gains those sources in a `sparkle_binary_delta` source_set with the flags Squirrel's Xcode project gives them, the new Squirrel sources (`SQRLDownloader`, `SQRLUpdateDelta`), the include dirs, and `-lbz2 -lcompression -lz`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation, tutorials, templates and examples are changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: The macOS `autoUpdater` now streams update downloads to disk, resumes an interrupted download on the next check instead of starting over, and applies a binary delta when the update feed offers one for the running version.
