### PR TITLE
fix: inherit nodeIntegrationInWorker from the embedder for <webview> and window.open

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -230,6 +230,12 @@ A name by itself is given a `true` boolean value.
 A preference can be set to another value by including an `=`, followed by the value.
 Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are interpreted as `false`.
 
+Security-critical preferences cannot be used to make the guest less secure than
+its embedder. When the embedder has any of `contextIsolation`, `javascript`,
+`nodeIntegration`, `nodeIntegrationInWorker`, `sandbox`, `nodeIntegrationInSubFrames`
+or `enableWebSQL` set to its more secure value, the guest inherits that value and
+the corresponding `webpreferences` entry is ignored.
+
 ### `enableblinkfeatures`
 
 ```html

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -55,6 +55,7 @@ function makeWebPreferences(embedder: Electron.WebContents, params: Record<strin
     ['contextIsolation', true],
     ['javascript', false],
     ['nodeIntegration', false],
+    ['nodeIntegrationInWorker', false],
     ['sandbox', true],
     ['nodeIntegrationInSubFrames', false],
     ['enableWebSQL', false]

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -152,6 +152,7 @@ const securityWebPreferences: { [key: string]: boolean } = {
   contextIsolation: true,
   javascript: false,
   nodeIntegration: false,
+  nodeIntegrationInWorker: false,
   sandbox: true,
   webviewTag: false,
   nodeIntegrationInSubFrames: false,

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -383,6 +383,7 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 void WebContentsPreferences::SaveLastPreferences() {
   base::DictValue dict;
   dict.Set(options::kNodeIntegration, node_integration_);
+  dict.Set(options::kNodeIntegrationInWorker, node_integration_in_worker_);
   dict.Set(options::kNodeIntegrationInSubFrames,
            node_integration_in_sub_frames_);
   dict.Set(options::kSandbox, IsSandboxed());

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -810,6 +810,63 @@ describe('<webview> tag', function () {
     });
   });
 
+  describe('webpreferences inheritance', () => {
+    afterEach(closeAllWindows);
+
+    // The guest page spins up a dedicated Worker and reports back, via the
+    // console, whether that Worker has access to Node's `require`.
+    const guestSrc =
+      'data:text/html,' +
+      encodeURIComponent(`<script>
+      const src = 'try { postMessage(typeof require) } catch (e) { postMessage("err") }';
+      const wk = new Worker(URL.createObjectURL(new Blob([src], { type: 'text/javascript' })));
+      wk.onmessage = (e) => console.log('WORKER_REQUIRE:' + e.data);
+    </script>`);
+
+    async function workerRequireTypeof(w: BrowserWindow, webpreferences: string): Promise<string> {
+      await w.loadURL('about:blank');
+      return w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const webview = new WebView()
+        webview.setAttribute('src', ${JSON.stringify(guestSrc)})
+        webview.setAttribute('webpreferences', ${JSON.stringify(webpreferences)})
+        webview.addEventListener('console-message', (e) => {
+          if (e.message.startsWith('WORKER_REQUIRE:')) {
+            resolve(e.message.slice('WORKER_REQUIRE:'.length))
+          }
+        })
+        document.body.appendChild(webview)
+      })`);
+    }
+
+    it('does not let the webpreferences attribute grant a worker Node access the embedder lacks', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          sandbox: false,
+          nodeIntegration: false,
+          contextIsolation: true
+        }
+      });
+      const typeofRequire = await workerRequireTypeof(w, 'nodeIntegrationInWorker=yes');
+      expect(typeofRequire).to.equal('undefined');
+    });
+
+    it('keeps a guest worker free of Node when the embedder is sandboxed', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          sandbox: true,
+          nodeIntegration: false,
+          contextIsolation: true
+        }
+      });
+      const typeofRequire = await workerRequireTypeof(w, 'nodeIntegrationInWorker=yes');
+      expect(typeofRequire).to.equal('undefined');
+    });
+  });
+
   describe('webpreferences attribute', () => {
     const WINDOW_BACKGROUND_COLOR = '#55ccbb';
 


### PR DESCRIPTION
The `<webview>` guest-inheritance list clamps a guest to be no less restricted than its embedder for `nodeIntegration`, `contextIsolation`, `sandbox`, and friends, but `nodeIntegrationInWorker` was missing — so a `webpreferences="nodeIntegrationInWorker=1"` attribute was honoured even when the embedder had it off. `nodeIntegrationInWorker` was also absent from `getLastWebPreferences()`, so the inheritance check had nothing to compare against.

- Add `nodeIntegrationInWorker` to the inherited web preferences for `<webview>` (and the equivalent `window.open` list).
- Emit `nodeIntegrationInWorker` from `SaveLastPreferences()` so it round-trips through `getLastWebPreferences()`, matching `nodeIntegration`.
- Document the `<webview>` inheritance behaviour; add regression coverage.

Notes: `<webview>` and `window.open` now inherit `nodeIntegrationInWorker` from the embedder, consistent with the other Node and sandbox preferences.
