### PR TITLE
fix: report screen and tab capture as display-capture permission requests

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -981,11 +981,11 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
   * `permission` string - The type of requested permission.
     * `clipboard-read` - Request access to read from the clipboard.
     * `clipboard-sanitized-write` - Request access to write to the clipboard.
-    * `display-capture` - Request access to capture the screen via the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API).
+    * `display-capture` - Request access to capture the screen, a window or a tab via the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API) (`navigator.mediaDevices.getDisplayMedia`) or via `getUserMedia` with the `chromeMediaSource` constraints described in [desktopCapturer](desktop-capturer.md). Requests for camera or microphone devices are reported as `media` instead.
     * `fullscreen` - Request control of the app's fullscreen state via the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API).
     * `geolocation` - Request access to the user's location via the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API)
     * `idle-detection` - Request access to the user's idle state via the [IdleDetector API](https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector).
-    * `media` -  Request access to media devices such as camera, microphone and speakers.
+    * `media` -  Request access to media devices such as camera, microphone and speakers. Screen, window and tab capture is reported as `display-capture` instead.
     * `mediaKeySystem` - Request access to DRM protected content.
     * `midi` - Request MIDI access in the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API).
     * `midiSysex` - Request the use of system exclusive messages in the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API).
@@ -1018,6 +1018,31 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
   }
 
   callback(true)
+})
+```
+
+Both `media` and `display-capture` requests carry a
+[MediaAccessPermissionRequest](structures/media-access-permission-request.md) as
+`details`. A `media` request is for camera and/or microphone devices, while a
+`display-capture` request is for the screen, a window or a tab (whether made
+through `getDisplayMedia` or through `getUserMedia` with `chromeMediaSource`
+constraints). Applications that allow camera and microphone access but want to
+control screen sharing separately should handle the two permissions
+individually:
+
+```js
+const { session } = require('electron')
+
+session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+  if (permission === 'media') {
+    // Camera / microphone. `details.mediaTypes` lists which of them was requested.
+    return callback(true)
+  }
+  if (permission === 'display-capture') {
+    // Screen, window or tab capture.
+    return callback(new URL(details.requestingUrl).origin === 'https://meet.example.com')
+  }
+  callback(false)
 })
 ```
 

--- a/docs/api/structures/media-access-permission-request.md
+++ b/docs/api/structures/media-access-permission-request.md
@@ -2,4 +2,5 @@
 
 * `securityOrigin` string (optional) - The security origin of the request.
 * `mediaTypes` string[] (optional) - The types of media access being requested - elements can be `video`
-  or `audio`.
+  or `audio`. For a `media` permission request these are the camera and microphone respectively; for a
+  `display-capture` permission request they are the screen, window or tab video and its audio.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -43,6 +43,12 @@ For `display-capture` requests, `details.mediaTypes` now lists `video` and/or
 The `setDisplayMediaRequestHandler` flow for `getDisplayMedia()` is unchanged and
 still runs after the permission request has been granted.
 
+The [`display-capture` Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/display-capture)
+is now also applied to `getUserMedia()` calls that use the `chromeMediaSource`
+constraints, matching `getDisplayMedia()`. Its default allowlist is `self`, so a
+cross-origin `<iframe>` that captures the screen this way now needs
+`allow="display-capture"` on the iframe element.
+
 ## Planned Breaking API Changes (44.0)
 
 ### Behavior Changed: `window.open()` children of unsandboxed windows get their own sandboxed process

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,37 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (45.0)
+
+### Behavior Changed: screen capture requests are reported as `display-capture` in `setPermissionRequestHandler`
+
+Requests to capture the screen, a window or a tab -- made through
+`navigator.mediaDevices.getDisplayMedia()` or through `getUserMedia()` with the
+`chromeMediaSource` / `chromeMediaSourceId` constraints used with
+[`desktopCapturer`](api/desktop-capturer.md) -- are now passed to
+[`session.setPermissionRequestHandler`](api/session.md#sessetpermissionrequesthandlerhandler)
+with the documented `display-capture` permission. Previously they were reported as
+`media` with an empty `details.mediaTypes` array, indistinguishable from a camera
+or microphone request other than by that empty array. `media` is now only used for
+camera and microphone devices.
+
+Applications with a permission request handler that grants `media` and denies
+everything else must also grant `display-capture` to keep screen sharing working:
+
+```js
+session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
+  if (permission === 'media' || permission === 'display-capture') {
+    return callback(true)
+  }
+  callback(false)
+})
+```
+
+For `display-capture` requests, `details.mediaTypes` now lists `video` and/or
+`audio` to indicate whether display video and/or display audio was requested.
+The `setDisplayMediaRequestHandler` flow for `getDisplayMedia()` is unchanged and
+still runs after the permission request has been granted.
+
 ## Planned Breaking API Changes (44.0)
 
 ### Behavior Changed: `window.open()` children of unsandboxed windows get their own sandboxed process

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -13,6 +13,7 @@
 #include "content/public/browser/permission_descriptor_util.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents_user_data.h"
+#include "services/network/public/mojom/permissions_policy/permissions_policy_feature.mojom.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/media/media_capture_devices_dispatcher.h"
@@ -260,15 +261,31 @@ void WebContentsPermissionHelper::RequestFullscreenPermission(
 void WebContentsPermissionHelper::RequestMediaAccessPermission(
     const content::MediaStreamRequest& request,
     content::MediaResponseCallback response_callback) {
-  auto callback = base::BindOnce(&MediaAccessAllowed, request,
-                                 std::move(response_callback));
-
   // Screen, window and tab capture (getDisplayMedia and legacy getUserMedia
   // with chromeMediaSource desktop/screen/tab constraints) is surfaced to the
   // app as the "display-capture" permission; camera and microphone access is
   // surfaced as "media". The two are different capabilities and apps must be
   // able to tell them apart in setPermissionRequestHandler.
   const bool is_display_capture = IsDisplayCaptureRequest(request);
+
+  auto* requesting_frame = content::RenderFrameHost::FromID(
+      request.render_process_id, request.render_frame_id);
+
+  // Blink only enforces the `display-capture` permissions policy for
+  // getDisplayMedia(); apply it to the legacy getUserMedia() desktop/tab
+  // capture path as well so that a frame the embedder has not allowed to
+  // capture the display cannot do so through the older API either.
+  if (is_display_capture && requesting_frame &&
+      !requesting_frame->IsFeatureEnabled(
+          network::mojom::PermissionsPolicyFeature::kDisplayCapture)) {
+    std::move(response_callback)
+        .Run(blink::mojom::StreamDevicesSet(),
+             MediaStreamRequestResult::CAPTURE_NOT_ALLOWED_BY_POLICY, nullptr);
+    return;
+  }
+
+  auto callback = base::BindOnce(&MediaAccessAllowed, request,
+                                 std::move(response_callback));
 
   base::DictValue details;
   base::ListValue media_types;
@@ -282,8 +299,7 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
   // For device capture the permission type doesn't matter here,
   // AUDIO_CAPTURE/VIDEO_CAPTURE are presented as same type in
   // content_converter.h.
-  RequestPermission(content::RenderFrameHost::FromID(request.render_process_id,
-                                                     request.render_frame_id),
+  RequestPermission(requesting_frame,
                     is_display_capture ? blink::PermissionType::DISPLAY_CAPTURE
                                        : blink::PermissionType::AUDIO_CAPTURE,
                     std::move(callback), false, std::move(details));

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -80,6 +80,17 @@ bool SystemMediaPermissionDenied(const content::MediaStreamRequest& request) {
 }
 #endif
 
+// Whether the request is for screen, window or tab capture rather than for a
+// camera or microphone device. This covers both `getDisplayMedia()` and legacy
+// `getUserMedia()` calls that use the chromeMediaSource desktop/screen/tab
+// constraints.
+[[nodiscard]] bool IsDisplayCaptureRequest(
+    const content::MediaStreamRequest& request) {
+  return blink::IsScreenCaptureMediaType(request.audio_type) ||
+         blink::IsScreenCaptureMediaType(request.video_type) ||
+         request.audio_type == MediaStreamType::DISPLAY_AUDIO_CAPTURE;
+}
+
 // Handles requests for legacy-style `navigator.getUserMedia(...)` calls.
 // This includes desktop capture through the chromeMediaSource /
 // chromeMediaSourceId constraints.
@@ -252,25 +263,30 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
   auto callback = base::BindOnce(&MediaAccessAllowed, request,
                                  std::move(response_callback));
 
+  // Screen, window and tab capture (getDisplayMedia and legacy getUserMedia
+  // with chromeMediaSource desktop/screen/tab constraints) is surfaced to the
+  // app as the "display-capture" permission; camera and microphone access is
+  // surfaced as "media". The two are different capabilities and apps must be
+  // able to tell them apart in setPermissionRequestHandler.
+  const bool is_display_capture = IsDisplayCaptureRequest(request);
+
   base::DictValue details;
   base::ListValue media_types;
-  if (request.audio_type ==
-      blink::mojom::MediaStreamType::DEVICE_AUDIO_CAPTURE) {
+  if (blink::IsAudioInputMediaType(request.audio_type))
     media_types.Append("audio");
-  }
-  if (request.video_type ==
-      blink::mojom::MediaStreamType::DEVICE_VIDEO_CAPTURE) {
+  if (blink::IsVideoInputMediaType(request.video_type))
     media_types.Append("video");
-  }
   details.Set("mediaTypes", std::move(media_types));
   details.Set("securityOrigin", request.security_origin.spec());
 
-  // The permission type doesn't matter here, AUDIO_CAPTURE/VIDEO_CAPTURE
-  // are presented as same type in content_converter.h.
+  // For device capture the permission type doesn't matter here,
+  // AUDIO_CAPTURE/VIDEO_CAPTURE are presented as same type in
+  // content_converter.h.
   RequestPermission(content::RenderFrameHost::FromID(request.render_process_id,
                                                      request.render_frame_id),
-                    blink::PermissionType::AUDIO_CAPTURE, std::move(callback),
-                    false, std::move(details));
+                    is_display_capture ? blink::PermissionType::DISPLAY_CAPTURE
+                                       : blink::PermissionType::AUDIO_CAPTURE,
+                    std::move(callback), false, std::move(details));
 }
 
 void WebContentsPermissionHelper::RequestWebNotificationPermission(

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2880,6 +2880,98 @@ describe('chromium features', () => {
       expect(ok).to.be.false();
       expect(err).to.equal('Not supported');
     });
+
+    describe('permission requests', () => {
+      const deviceGetUserMedia = `navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+        .then(s => ({ ok: true }), e => ({ ok: false, err: e.message }))`;
+      const desktopGetUserMedia = `navigator.mediaDevices.getUserMedia({
+          video: { mandatory: { chromeMediaSource: 'desktop' } }
+        }).then(s => ({ ok: true, kinds: s.getTracks().map(t => t.kind) }), e => ({ ok: false, err: e.message }))`;
+      const getDisplayMedia = `navigator.mediaDevices.getDisplayMedia({ video: true, audio: true })
+        .then(s => ({ ok: true }), e => ({ ok: false, err: e.message }))`;
+
+      type SeenRequest = { permission: string, mediaTypes: string[] | undefined, securityOrigin: string | undefined };
+      const collectRequests = (ses: Electron.Session, grant: (permission: string) => boolean) => {
+        const seen: SeenRequest[] = [];
+        ses.setPermissionRequestHandler((wc, permission, callback, details) => {
+          const { mediaTypes, securityOrigin } = details as MediaAccessPermissionRequest;
+          seen.push({ permission, mediaTypes, securityOrigin });
+          callback(grant(permission));
+        });
+        return seen;
+      };
+
+      it('reports camera and microphone getUserMedia as a media request', async () => {
+        const seen = collectRequests(session.defaultSession, () => true);
+        const w = new BrowserWindow({ show: false });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+        const { ok, err } = await w.webContents.executeJavaScript(deviceGetUserMedia, true);
+        expect(ok).to.be.true(err);
+        expect(seen).to.have.lengthOf(1);
+        expect(seen[0].permission).to.equal('media');
+        expect(seen[0].mediaTypes).to.have.members(['audio', 'video']);
+        expect(seen[0].securityOrigin).to.be.a('string');
+      });
+
+      it('reports desktop getUserMedia as a display-capture request', async () => {
+        const seen = collectRequests(session.defaultSession, () => true);
+        const w = new BrowserWindow({ show: false });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+        const { ok, err, kinds } = await w.webContents.executeJavaScript(desktopGetUserMedia, true);
+        expect(ok).to.be.true(err);
+        expect(kinds).to.deep.equal(['video']);
+        expect(seen).to.have.lengthOf(1);
+        expect(seen[0].permission).to.equal('display-capture');
+        expect(seen[0].mediaTypes).to.deep.equal(['video']);
+        expect(seen[0].securityOrigin).to.be.a('string');
+      });
+
+      it('denies desktop getUserMedia when display-capture is denied', async () => {
+        const seen = collectRequests(session.defaultSession, (permission) => permission === 'media');
+        const w = new BrowserWindow({ show: false });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+        const { ok, err } = await w.webContents.executeJavaScript(desktopGetUserMedia, true);
+        expect(ok).to.be.false();
+        expect(err).to.equal('Permission denied');
+        expect(seen.map(r => r.permission)).to.deep.equal(['display-capture']);
+      });
+
+      it('reports getDisplayMedia as a display-capture request before the display media handler runs', async () => {
+        const ses = session.fromPartition('' + Math.random());
+        const seen = collectRequests(ses, () => true);
+        let requestsSeenByDisplayHandler = -1;
+        ses.setDisplayMediaRequestHandler((request, callback) => {
+          requestsSeenByDisplayHandler = seen.length;
+          callback({ video: request.frame! });
+        });
+        const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+        const { ok, err } = await w.webContents.executeJavaScript(getDisplayMedia, true);
+        expect(ok).to.be.true(err);
+        expect(requestsSeenByDisplayHandler).to.equal(1);
+        expect(seen).to.have.lengthOf(1);
+        expect(seen[0].permission).to.equal('display-capture');
+        expect(seen[0].mediaTypes).to.have.members(['audio', 'video']);
+        expect(seen[0].securityOrigin).to.be.a('string');
+      });
+
+      it('does not run the display media handler for getDisplayMedia when display-capture is denied', async () => {
+        const ses = session.fromPartition('' + Math.random());
+        const seen = collectRequests(ses, (permission) => permission === 'media');
+        let displayHandlerCalled = false;
+        ses.setDisplayMediaRequestHandler((request, callback) => {
+          displayHandlerCalled = true;
+          callback({ video: request.frame! });
+        });
+        const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+        const { ok, err } = await w.webContents.executeJavaScript(getDisplayMedia, true);
+        expect(ok).to.be.false();
+        expect(err).to.equal('Permission denied');
+        expect(displayHandlerCalled).to.be.false();
+        expect(seen.map(r => r.permission)).to.deep.equal(['display-capture']);
+      });
+    });
   });
 
   describe('window.opener access', () => {

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -2890,7 +2890,7 @@ describe('chromium features', () => {
       const getDisplayMedia = `navigator.mediaDevices.getDisplayMedia({ video: true, audio: true })
         .then(s => ({ ok: true }), e => ({ ok: false, err: e.message }))`;
 
-      type SeenRequest = { permission: string, mediaTypes: string[] | undefined, securityOrigin: string | undefined };
+      type SeenRequest = { permission: string; mediaTypes: string[] | undefined; securityOrigin: string | undefined };
       const collectRequests = (ses: Electron.Session, grant: (permission: string) => boolean) => {
         const seen: SeenRequest[] = [];
         ses.setPermissionRequestHandler((wc, permission, callback, details) => {
@@ -2933,7 +2933,7 @@ describe('chromium features', () => {
         const { ok, err } = await w.webContents.executeJavaScript(desktopGetUserMedia, true);
         expect(ok).to.be.false();
         expect(err).to.equal('Permission denied');
-        expect(seen.map(r => r.permission)).to.deep.equal(['display-capture']);
+        expect(seen.map((r) => r.permission)).to.deep.equal(['display-capture']);
       });
 
       it('reports getDisplayMedia as a display-capture request before the display media handler runs', async () => {
@@ -2955,6 +2955,48 @@ describe('chromium features', () => {
         expect(seen[0].securityOrigin).to.be.a('string');
       });
 
+      it('applies the display-capture permissions policy to desktop getUserMedia from a cross-origin iframe', async () => {
+        const iframeServer = http.createServer((req, res) => {
+          res.setHeader('Content-Type', 'text/html');
+          res.end('<body>iframe</body>');
+        });
+        const { url: iframeUrl } = await listen(iframeServer);
+        defer(() => iframeServer.close());
+
+        const seen = collectRequests(session.defaultSession, () => true);
+        const w = new BrowserWindow({ show: false });
+        await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+
+        const loadIframe = async (allow: string) => {
+          w.webContents.executeJavaScript(`(() => {
+            for (const f of document.querySelectorAll('iframe')) f.remove();
+            const iframe = document.createElement('iframe');
+            iframe.src = ${JSON.stringify(iframeUrl)};
+            iframe.allow = ${JSON.stringify(allow)};
+            document.body.appendChild(iframe);
+          })()`);
+          const [, , frameProcessId, frameRoutingId] = await once(w.webContents, 'did-frame-finish-load');
+          return webFrameMain.fromId(frameProcessId, frameRoutingId)!;
+        };
+
+        // Without allow="display-capture" the policy defaults to 'self', so the
+        // cross-origin iframe is denied without the app being asked.
+        const denied = (await (await loadIframe('')).executeJavaScript(desktopGetUserMedia, true)) as {
+          ok: boolean;
+          err: string;
+        };
+        expect(denied.ok).to.be.false();
+        expect(denied.err).to.equal('Permission denied');
+        expect(seen).to.be.empty();
+
+        const allowed = (await (await loadIframe('display-capture')).executeJavaScript(desktopGetUserMedia, true)) as {
+          ok: boolean;
+          err: string;
+        };
+        expect(allowed.ok).to.be.true(allowed.err);
+        expect(seen.map((r) => r.permission)).to.deep.equal(['display-capture']);
+      });
+
       it('does not run the display media handler for getDisplayMedia when display-capture is denied', async () => {
         const ses = session.fromPartition('' + Math.random());
         const seen = collectRequests(ses, (permission) => permission === 'media');
@@ -2969,7 +3011,7 @@ describe('chromium features', () => {
         expect(ok).to.be.false();
         expect(err).to.equal('Permission denied');
         expect(displayHandlerCalled).to.be.false();
-        expect(seen.map(r => r.permission)).to.deep.equal(['display-capture']);
+        expect(seen.map((r) => r.permission)).to.deep.equal(['display-capture']);
       });
     });
   });


### PR DESCRIPTION
`session.setPermissionRequestHandler` documents `display-capture` as the permission for screen/window/tab capture, distinct from `media` (camera/microphone). In practice, desktop `getUserMedia` (`chromeMediaSource`) and `getDisplayMedia` arrived as `media` with an empty `mediaTypes`, indistinguishable from a camera/microphone request, and the `display-capture` Permissions-Policy was not applied to the legacy `getUserMedia` path.

- Report screen, window and tab capture as the `display-capture` permission; keep `media` for camera/microphone. Populate `mediaTypes` (`video`/`audio`) for both.
- Apply the frame's `display-capture` Permissions-Policy to `getUserMedia` calls using `chromeMediaSource` constraints, matching `getDisplayMedia`.
- Docs + a Breaking Changes (45.0) entry; regression coverage.

Notes: Screen, window and tab capture requests are now reported to `setPermissionRequestHandler` as `display-capture` instead of `media`; a handler that allows only `media` must also allow `display-capture` to keep screen sharing working.
