### PR TITLE
feat: serve asar file descriptors, streams and copies from the archive

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,24 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (44.0)
 
+### Behavior Changed: file descriptors for files inside ASAR archives are only usable through `fs`
+
+`fs.open`, `fs.openSync` and `fs.promises.open` on a file inside an ASAR archive
+used to extract the file to a temporary copy and return a descriptor for that
+copy. They now return a descriptor that is backed by the archive itself, so
+`fs.read`, `fs.readv`, `fs.fstat`, `fs.readFile(fd)`, `fs.createReadStream`
+and the `FileHandle` methods read directly out of the archive with no
+temporary file. Such a descriptor is only meaningful through Node's `fs`
+module: passing it to code that reads the raw descriptor itself (a native
+addon, `child_process` `stdio`, `net.Socket({ fd })`, ...) is not supported.
+Opening a file inside an archive with a flag that allows writing (`w`, `a`,
+`r+`, ...) now fails with `EACCES` instead of silently writing to the
+temporary copy, and `fs.fchmod`, `fs.fchown` and `fs.futimes` on these
+descriptors fail with `EACCES`.
+
+`fs.stat` on a symbolic link inside an archive now follows the link like it
+does on a real filesystem (`fs.lstat` still describes the link itself).
+
 ### Behavior Changed: `window.open()` children of unsandboxed windows get their own sandboxed process
 
 A `window.open()` child normally shares its opener's renderer process, and the OS sandbox

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -23,7 +23,9 @@ copy. They now return a descriptor that is backed by the archive itself, so
 and the `FileHandle` methods read directly out of the archive with no
 temporary file. Such a descriptor is only meaningful through Node's `fs`
 module: passing it to code that reads the raw descriptor itself (a native
-addon, `child_process` `stdio`, `net.Socket({ fd })`, ...) is not supported.
+addon, `child_process` `stdio`, `net.Socket({ fd })`,
+`http2stream.respondWithFile()` / `respondWithFD()`, a `FileHandle`
+transferred to a worker, ...) is not supported.
 Opening a file inside an archive with a flag that allows writing (`w`, `a`,
 `r+`, ...) now fails with `EACCES` instead of silently writing to the
 temporary copy, and `fs.fchmod`, `fs.fchown` and `fs.futimes` on these

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -18,14 +18,14 @@ This document uses the following convention to categorize breaking changes:
 
 `fs.open`, `fs.openSync` and `fs.promises.open` on a file inside an ASAR archive
 used to extract the file to a temporary copy and return a descriptor for that
-copy. They now return a descriptor that is backed by the archive itself, so
-`fs.read`, `fs.readv`, `fs.fstat`, `fs.readFile(fd)`, `fs.createReadStream`
-and the `FileHandle` methods read directly out of the archive with no
-temporary file. Such a descriptor is only meaningful through Node's `fs`
-module: passing it to code that reads the raw descriptor itself (a native
-addon, `child_process` `stdio`, `net.Socket({ fd })`,
+copy. They now return a descriptor that only identifies the entry to Node's
+`fs` module, which reads directly out of the archive with no temporary file
+(`fs.read`, `fs.readv`, `fs.fstat`, `fs.readFile(fd)`, `fs.createReadStream`
+and the `FileHandle` methods). The descriptor itself is not backed by the
+file's contents: code that reads the raw descriptor (a native addon,
+`child_process` `stdio`, `net.Socket({ fd })`,
 `http2stream.respondWithFile()` / `respondWithFD()`, a `FileHandle`
-transferred to a worker, ...) is not supported.
+transferred to a worker, ...) fails with `EBADF` and is not supported.
 Opening a file inside an archive with a flag that allows writing (`w`, `a`,
 `r+`, ...) now fails with `EACCES` instead of silently writing to the
 temporary copy, and `fs.fchmod`, `fs.fchown` and `fs.futimes` on these

--- a/docs/tutorial/asar-archives.md
+++ b/docs/tutorial/asar-archives.md
@@ -144,8 +144,10 @@ Because archives are read-only, opening a file inside an archive with any
 flag that allows writing (`w`, `a`, `r+`, ...) fails with `EACCES`, and
 `fs.fchmod`, `fs.fchown` and `fs.futimes` on such a descriptor fail with
 `EACCES` too. Passing one of these descriptors to code outside of Node's `fs`
-module (for example a native addon that reads from the raw descriptor) is not
-supported: the descriptor refers to the archive file, not to the entry.
+module (for example a native addon that reads from the raw descriptor,
+`child_process` `stdio`, `net.Socket({ fd })` or
+`http2stream.respondWithFile()`) is not supported: the descriptor refers to
+the archive file, not to the entry.
 
 ### Extra Unpacking on Some APIs
 

--- a/docs/tutorial/asar-archives.md
+++ b/docs/tutorial/asar-archives.md
@@ -60,6 +60,10 @@ Use a module from the archive:
 require('./path/to/example.asar/dir/module.js')
 ```
 
+Directories in an archive can also be iterated with `fs.opendir`, and
+symbolic links stored in an archive can be inspected with `fs.readlink`, which
+returns the link's target relative to the link, like a real filesystem would.
+
 You can also display a web page in an ASAR archive with `BrowserWindow`:
 
 ```js
@@ -126,20 +130,34 @@ directories in the filesystem, so you can never set the working directory to
 directories in ASAR archives. Passing them as the `cwd` option of some APIs
 will also cause errors.
 
+### File Descriptors for Files in Archives
+
+`fs.open`, `fs.openSync` and `fs.promises.open` return real file descriptors
+(and `FileHandle`s) for files in ASAR archives, backed by the archive itself,
+so APIs built on top of them - `fs.read`, `fs.readv`, `fs.fstat`,
+`fs.readFile(fd)`, `fs.createReadStream`, `FileHandle#readFile`,
+`FileHandle#createReadStream`, and so on - read directly out of the archive
+without any temporary copy. Likewise `fs.copyFile`, `fs.cp` and their sync
+and promise variants copy straight from the archive to the destination.
+
+Because archives are read-only, opening a file inside an archive with any
+flag that allows writing (`w`, `a`, `r+`, ...) fails with `EACCES`, and
+`fs.fchmod`, `fs.fchown` and `fs.futimes` on such a descriptor fail with
+`EACCES` too. Passing one of these descriptors to code outside of Node's `fs`
+module (for example a native addon that reads from the raw descriptor) is not
+supported: the descriptor refers to the archive file, not to the entry.
+
 ### Extra Unpacking on Some APIs
 
-Most `fs` APIs can read a file or get a file's information from ASAR archives
-without unpacking, but for some APIs that rely on passing the real file path to
-underlying system calls, Electron will extract the needed file into a
-temporary file and pass the path of the temporary file to the APIs to make them
-work. This adds a little overhead for those APIs.
+For APIs that rely on passing the real file path to underlying system calls,
+Electron will extract the needed file into a temporary file and pass the path
+of the temporary file to the APIs to make them work. This adds a little
+overhead for those APIs.
 
 APIs that require extra unpacking are:
 
 * `child_process.execFile`
 * `child_process.execFileSync`
-* `fs.open`
-* `fs.openSync`
 * `process.dlopen` - Used by `require` on native modules
 
 ### Fake Stat Information of `fs.stat`

--- a/docs/tutorial/asar-archives.md
+++ b/docs/tutorial/asar-archives.md
@@ -143,11 +143,11 @@ and promise variants copy straight from the archive to the destination.
 Because archives are read-only, opening a file inside an archive with any
 flag that allows writing (`w`, `a`, `r+`, ...) fails with `EACCES`, and
 `fs.fchmod`, `fs.fchown` and `fs.futimes` on such a descriptor fail with
-`EACCES` too. Passing one of these descriptors to code outside of Node's `fs`
-module (for example a native addon that reads from the raw descriptor,
+`EACCES` too. The descriptor only identifies the entry to Node's `fs` module;
+it is not backed by the file's contents, so passing it to code outside of
+`fs` (for example a native addon that reads from the raw descriptor,
 `child_process` `stdio`, `net.Socket({ fd })` or
-`http2stream.respondWithFile()`) is not supported: the descriptor refers to
-the archive file, not to the entry.
+`http2stream.respondWithFile()`) fails with `EBADF` and is not supported.
 
 ### Extra Unpacking on Some APIs
 

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -24,6 +24,10 @@ const nextTick = (functionToCall: Function, args: any[] = []) => {
 
 const binding = internalBinding('fs');
 const dirBinding = internalBinding('fs_dir');
+// libuv's error numbers differ from POSIX errno on Windows (UV_EACCES is
+// -4092 there, not -13); Node decodes `errno` through libuv's table, so the
+// errors created here must carry libuv's values.
+const uvBinding = internalBinding('uv');
 const { kUsePromises } = binding;
 
 // Cache asar archive objects.
@@ -195,22 +199,22 @@ const createError = (
     case AsarError.NOT_FOUND:
       error = new Error(`ENOENT, ${filePath} not found in ${asarPath}`);
       error.code = 'ENOENT';
-      error.errno = -2;
+      error.errno = uvBinding.UV_ENOENT;
       break;
     case AsarError.NOT_DIR:
       error = new Error('ENOTDIR, not a directory');
       error.code = 'ENOTDIR';
-      error.errno = -20;
+      error.errno = uvBinding.UV_ENOTDIR;
       break;
     case AsarError.IS_DIR:
       error = new Error(`EISDIR: illegal operation on a directory, ${filePath} in ${asarPath}`);
       error.code = 'EISDIR';
-      error.errno = -21;
+      error.errno = uvBinding.UV_EISDIR;
       break;
     case AsarError.NO_ACCESS:
       error = new Error(`EACCES: permission denied, access '${filePath}'`);
       error.code = 'EACCES';
-      error.errno = -13;
+      error.errno = uvBinding.UV_EACCES;
       break;
     case AsarError.INVALID_ARCHIVE:
       error = new Error(`Invalid package ${asarPath}`);
@@ -218,22 +222,22 @@ const createError = (
     case AsarError.NOT_LINK:
       error = new Error(`EINVAL: invalid argument, ${filePath} in ${asarPath} is not a symbolic link`);
       error.code = 'EINVAL';
-      error.errno = -22;
+      error.errno = uvBinding.UV_EINVAL;
       break;
     case AsarError.EXISTS:
       error = new Error(`EEXIST: file already exists, ${filePath}`);
       error.code = 'EEXIST';
-      error.errno = -17;
+      error.errno = uvBinding.UV_EEXIST;
       break;
     case AsarError.NOT_SUPPORTED:
       error = new Error(`ENOTSUP: operation not supported on asar archive entry ${filePath}`);
       error.code = 'ENOTSUP';
-      error.errno = -45;
+      error.errno = uvBinding.UV_ENOTSUP;
       break;
     case AsarError.TOO_MANY_OPEN:
       error = new Error(`EMFILE: too many open files, could not open ${filePath} in ${asarPath}`);
       error.code = 'EMFILE';
-      error.errno = -24;
+      error.errno = uvBinding.UV_EMFILE;
       break;
     default:
       throw new Error(`Invalid error type "${errorType}" passed to createError.`);
@@ -2004,6 +2008,10 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   binding.writeFileUtf8 = function (...args: any[]) {
     const pathOrFd = args[0];
     const flags = args[2];
+    // The fast path also accepts a descriptor.
+    if (lookupAsarFd(pathOrFd) !== undefined) {
+      throw createError(AsarError.NO_ACCESS, { filePath: `fd ${pathOrFd}`, syscall: 'write' });
+    }
     const pathInfo = splitPath(pathOrFd);
     if (!pathInfo.isAsar) return originalBinding.writeFileUtf8.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -169,7 +169,7 @@ function makeStatArray(type: AsarFileType, size: number, ino: number, useBigint:
 
 const asarStatsToFsStats = function (stats: NodeJS.AsarFileStat, options?: any) {
   const useBigint = Boolean(options && typeof options === 'object' && options.bigint);
-  return getStatsFromBinding(makeStatArray(stats.type, stats.size, ++nextInode, useBigint));
+  return getStatsFromBinding(makeStatArray(stats.type, stats.size, ++nextInode, useBigint, stats.executable));
 };
 
 const enum AsarError {
@@ -691,6 +691,40 @@ function forgetAsarFd(fd: number) {
   if (entry === undefined) return;
   openAsarFiles.delete(fd);
   entry.reader.dispose();
+}
+
+// A descriptor number handed out (or handed back) by native fs may still have
+// an entry here if the previous owner of that number was closed behind our
+// back (a native FileHandle built on it, e.g. by http2's respondWithFile, a
+// FileHandle transferred to a worker, or one dropped and closed on GC).  Such
+// an entry must never capture the new owner's reads.
+function forgetStaleAsarFd(fd: unknown) {
+  if (openAsarFiles.size !== 0 && typeof fd === 'number') forgetAsarFd(fd);
+}
+
+// Calls a native open-like binding (args[3] being its request) and drops any
+// stale entry for the descriptor it produces.  The check is only wired up
+// while entries exist, so the common case stays a plain pass-through.
+function passThroughOpen(fn: Function, args: any[], getFd: (value: any) => unknown) {
+  if (openAsarFiles.size === 0) return fn.apply(undefined, args);
+  const req = args[3];
+  if (req === undefined) {
+    const fd = fn.apply(undefined, args);
+    forgetStaleAsarFd(getFd(fd));
+    return fd;
+  }
+  if (req === kUsePromises) {
+    return fn.apply(undefined, args).then((value: any) => {
+      forgetStaleAsarFd(getFd(value));
+      return value;
+    });
+  }
+  const oncomplete = req.oncomplete;
+  req.oncomplete = function (this: any, error: any, value: any) {
+    if (!error) forgetStaleAsarFd(getFd(value));
+    return oncomplete.call(this, error, value);
+  };
+  return fn.apply(undefined, args);
 }
 
 function sweepStaleAsarFds() {
@@ -1763,7 +1797,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const flags = args[1];
     const req = args[3];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalBinding.open.apply(undefined, args);
+    if (!pathInfo.isAsar) return passThroughOpen(originalBinding.open, args, (fd) => fd);
     const { asarPath, filePath } = pathInfo;
 
     let opened;
@@ -1774,11 +1808,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
-      return originalBinding.open.apply(undefined, args);
+      return passThroughOpen(originalBinding.open, args, (fd) => fd);
     }
 
     const { reader } = opened;
     if (openAsarFiles.size > 256) sweepStaleAsarFds();
+    // The number may have belonged to a handle that was closed behind our
+    // back; make sure its entry (and retained block) is released first.
+    forgetAsarFd(reader.fd);
     openAsarFiles.set(reader.fd, { reader });
     return completeRequest(req, null, reader.fd);
   };
@@ -1788,7 +1825,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const flags = args[1];
     const req = args[3];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalBinding.openFileHandle.apply(undefined, args);
+    if (!pathInfo.isAsar) return passThroughOpen(originalBinding.openFileHandle, args, (handle) => handle?.fd);
     const { asarPath, filePath } = pathInfo;
 
     let opened;
@@ -1799,7 +1836,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
-      return originalBinding.openFileHandle.apply(undefined, args);
+      return passThroughOpen(originalBinding.openFileHandle, args, (handle) => handle?.fd);
     }
 
     const { reader } = opened;
@@ -1817,6 +1854,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       return close.apply(this, closeArgs);
     };
     if (openAsarFiles.size > 256) sweepStaleAsarFds();
+    forgetAsarFd(reader.fd);
     openAsarFiles.set(reader.fd, { reader, handle: new WeakRef(handle) });
     return completeRequest(req, null, handle);
   };

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -129,8 +129,11 @@ const fileTypeToMode = new Map<AsarFileType, number>([
   [AsarFileType.kLink, constants.S_IFLNK]
 ]);
 
-const kReadOnlyMode = constants.S_IROTH | constants.S_IRGRP | constants.S_IRUSR | constants.S_IWUSR;
-const kExecuteMode = constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH;
+// Literal permission bits rather than fs.constants.S_I*: the group/other and
+// execute constants are not defined on Windows, and these fake modes should
+// look the same on every platform.
+const kReadOnlyMode = 0o644;
+const kExecuteMode = 0o111;
 
 // Builds the raw stat array that node's fs binding would have produced, so
 // that node's own getStatsFromBinding() can turn it into a (BigInt)Stats.
@@ -140,7 +143,7 @@ const kExecuteMode = constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH;
 function makeStatArray(type: AsarFileType, size: number, ino: number, useBigint: boolean, executable = false) {
   let mode = kReadOnlyMode | fileTypeToMode.get(type)!;
   if (executable || type !== AsarFileType.kFile) mode |= kExecuteMode;
-  if (type === AsarFileType.kLink) mode |= constants.S_IWGRP | constants.S_IWOTH;
+  if (type === AsarFileType.kLink) mode |= 0o022;
   const values = [
     1, // dev
     mode,
@@ -1751,11 +1754,16 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   // Node's native fs functions CHECK() their exact argument count to decide
   // between sync and async forms, so pass-through calls must forward the
   // original argument list untouched (in particular, never append a trailing
-  // `undefined`).
+  // `undefined`).  Forwarding uses Function#apply and index access rather
+  // than spread / array destructuring: those depend on Array.prototype's
+  // iterator, which user code is allowed to delete (Node's own internals use
+  // primordials for the same reason) and fs must keep working when it does.
   binding.open = function (...args: any[]) {
-    const [pathArgument, flags, , req] = args;
+    const pathArgument = args[0];
+    const flags = args[1];
+    const req = args[3];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalBinding.open(...args);
+    if (!pathInfo.isAsar) return originalBinding.open.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
     let opened;
@@ -1766,7 +1774,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
-      return originalBinding.open(...args);
+      return originalBinding.open.apply(undefined, args);
     }
 
     const { reader } = opened;
@@ -1776,9 +1784,11 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.openFileHandle = function (...args: any[]) {
-    const [pathArgument, flags, , req] = args;
+    const pathArgument = args[0];
+    const flags = args[1];
+    const req = args[3];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalBinding.openFileHandle(...args);
+    if (!pathInfo.isAsar) return originalBinding.openFileHandle.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
     let opened;
@@ -1789,7 +1799,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
-      return originalBinding.openFileHandle(...args);
+      return originalBinding.openFileHandle.apply(undefined, args);
     }
 
     const { reader } = opened;
@@ -1812,9 +1822,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.read = function (...args: any[]) {
-    const [fd, buffer, offset, length, position, req] = args;
+    const fd = args[0];
+    const buffer = args[1];
+    const offset = args[2];
+    const length = args[3];
+    const position = args[4];
+    const req = args[5];
     const reader = lookupAsarFd(fd);
-    if (reader === undefined) return originalBinding.read(...args);
+    if (reader === undefined) return originalBinding.read.apply(undefined, args);
 
     const pos = normalizePosition(position);
     if (reader.integrity === null) {
@@ -1825,36 +1840,39 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       if (count === 0) return completeRequest(req, null, 0);
       args[3] = count;
       args[4] = reader.offset + start;
-      return originalBinding.read(...args);
+      return originalBinding.read.apply(undefined, args);
     }
     if (req === undefined) return reader.readSync(buffer, offset, length, pos);
     return completeRequestWithPromise(req, reader.read(buffer, offset, length, pos));
   };
 
   binding.readBuffers = function (...args: any[]) {
-    const [fd, buffers, position, req] = args as [number, Uint8Array[], number | bigint | null, any];
+    const fd: number = args[0];
+    const buffers: Uint8Array[] = args[1];
+    const position: number | bigint | null = args[2];
+    const req = args[3];
     const reader = lookupAsarFd(fd);
-    if (reader === undefined) return originalBinding.readBuffers(...args);
+    if (reader === undefined) return originalBinding.readBuffers.apply(undefined, args);
 
     const pos = normalizePosition(position);
     if (reader.integrity === null) {
       // Fast path (see binding.read): when every buffer fits inside the
       // entry the native readv can be used as-is with a translated position.
       let wanted = 0;
-      for (const buffer of buffers) wanted += buffer.byteLength;
+      for (let i = 0; i < buffers.length; i++) wanted += buffers[i].byteLength;
       const { start, count } = reader.resolveRange(wanted, pos);
       if (count === 0) return completeRequest(req, null, 0);
       if (count === wanted) {
         args[2] = reader.offset + start;
-        return originalBinding.readBuffers(...args);
+        return originalBinding.readBuffers.apply(undefined, args);
       }
       // Otherwise the tail must be clamped; the read position was already
       // advanced by resolveRange, so serve the buffers positionally from
       // `start`.
       const filled: number[] = [];
       let remaining = count;
-      for (const buffer of buffers) {
-        const take = Math.min(remaining, buffer.byteLength);
+      for (let i = 0; i < buffers.length; i++) {
+        const take = Math.min(remaining, buffers[i].byteLength);
         filled.push(take);
         remaining -= take;
       }
@@ -1878,7 +1896,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     if (req === undefined) {
       let total = 0;
-      for (const buffer of buffers) {
+      for (let i = 0; i < buffers.length; i++) {
+        const buffer = buffers[i];
         const n = reader.readSync(buffer, 0, buffer.byteLength, pos < 0 ? -1 : pos + total);
         total += n;
         if (n < buffer.byteLength) break;
@@ -1887,7 +1906,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
     const readAll = async () => {
       let total = 0;
-      for (const buffer of buffers) {
+      for (let i = 0; i < buffers.length; i++) {
+        const buffer = buffers[i];
         const n = await reader.read(buffer, 0, buffer.byteLength, pos < 0 ? -1 : pos + total);
         total += n;
         if (n < buffer.byteLength) break;
@@ -1898,21 +1918,23 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.fstat = function (...args: any[]) {
-    const [fd, useBigint, req] = args;
+    const fd = args[0];
+    const useBigint = args[1];
+    const req = args[2];
     const reader = lookupAsarFd(fd);
-    if (reader === undefined) return originalBinding.fstat(...args);
+    if (reader === undefined) return originalBinding.fstat.apply(undefined, args);
     return completeRequest(req, null, reader.statArray(Boolean(useBigint)));
   };
 
   binding.close = function (...args: any[]) {
     const fd = args[0];
     if (lookupAsarFd(fd) !== undefined) forgetAsarFd(fd);
-    return originalBinding.close(...args);
+    return originalBinding.close.apply(undefined, args);
   };
 
   binding.readFileUtf8 = function (...args: any[]) {
     const reader = lookupAsarFd(args[0]);
-    if (reader === undefined) return originalBinding.readFileUtf8(...args);
+    if (reader === undefined) return originalBinding.readFileUtf8.apply(undefined, args);
     return reader.readToEndSync().toString('utf8');
   };
 
@@ -1921,15 +1943,16 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   // EACCES (or land in the real file for unpacked entries) instead of
   // whatever the OS says about a path that goes through a file.
   binding.writeFileUtf8 = function (...args: any[]) {
-    const [pathOrFd, , flags] = args;
+    const pathOrFd = args[0];
+    const flags = args[2];
     const pathInfo = splitPath(pathOrFd);
-    if (!pathInfo.isAsar) return originalBinding.writeFileUtf8(...args);
+    if (!pathInfo.isAsar) return originalBinding.writeFileUtf8.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
     const opened = openAsarEntry(asarPath, filePath, flags, 'open');
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
-      return originalBinding.writeFileUtf8(...args);
+      return originalBinding.writeFileUtf8.apply(undefined, args);
     }
     // Only reachable with read-only flags, which writeFile never uses.
     originalBinding.close(opened.reader.fd);
@@ -1944,7 +1967,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const original = originalBinding[name];
     binding[name] = function (...args: any[]) {
       const fd = args[0];
-      if (lookupAsarFd(fd) === undefined) return original(...args);
+      if (lookupAsarFd(fd) === undefined) return original.apply(undefined, args);
       const req = args[args.length - 1];
       const hasReq = req !== undefined && (req === kUsePromises || typeof req === 'object');
       const error = createError(AsarError.NO_ACCESS, { filePath: `fd ${fd}`, syscall: name });
@@ -2017,9 +2040,12 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   }
 
   binding.copyFile = function (...args: any[]) {
-    const [src, dest, mode, req] = args;
+    const src = args[0];
+    const dest = args[1];
+    const mode = args[2];
+    const req = args[3];
     const pathInfo = splitPath(src);
-    if (!pathInfo.isAsar) return originalBinding.copyFile(...args);
+    if (!pathInfo.isAsar) return originalBinding.copyFile.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
     let opened;
@@ -2040,7 +2066,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       // Unpacked entries are real files: let native fs handle them, including
       // copy-on-write clones.
       args[0] = opened.unpackedPath;
-      return originalBinding.copyFile(...args);
+      return originalBinding.copyFile.apply(undefined, args);
     }
 
     const { reader } = opened;
@@ -2071,9 +2097,11 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   //
 
   binding.readlink = function (...args: any[]) {
-    const [pathArgument, encoding, req] = args;
+    const pathArgument = args[0];
+    const encoding = args[1];
+    const req = args[2];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalBinding.readlink(...args);
+    if (!pathInfo.isAsar) return originalBinding.readlink.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
     const archive = getOrCreateArchive(asarPath);
@@ -2164,15 +2192,16 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   }
 
   dirBinding.opendir = function (...args: any[]) {
-    const [pathArgument, , req] = args;
+    const pathArgument = args[0];
+    const req = args[2];
     const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return originalDirBinding.opendir(...args);
+    if (!pathInfo.isAsar) return originalDirBinding.opendir.apply(undefined, args);
     return openAsarDir(pathInfo, req);
   };
 
   dirBinding.opendirSync = function (...args: any[]) {
     const pathInfo = splitPath(args[0]);
-    if (!pathInfo.isAsar) return originalDirBinding.opendirSync(...args);
+    if (!pathInfo.isAsar) return originalDirBinding.opendirSync.apply(undefined, args);
     return openAsarDir(pathInfo, undefined);
   };
 
@@ -2192,8 +2221,11 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.cpSyncCheckPaths = function (...args: any[]) {
-    const [src, dest, dereference, recursive] = args;
-    if (!splitPath(src).isAsar) return originalBinding.cpSyncCheckPaths(...args);
+    const src = args[0];
+    const dest = args[1];
+    const dereference = args[2];
+    const recursive = args[3];
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncCheckPaths.apply(undefined, args);
 
     const statFn = dereference ? fs.statSync : fs.lstatSync;
     const srcStat = statFn(src);
@@ -2241,8 +2273,11 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.cpSyncOverrideFile = function (...args: any[]) {
-    const [src, dest, mode, preserveTimestamps] = args;
-    if (!splitPath(src).isAsar) return originalBinding.cpSyncOverrideFile(...args);
+    const src = args[0];
+    const dest = args[1];
+    const mode = args[2];
+    const preserveTimestamps = args[3];
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncOverrideFile.apply(undefined, args);
     fs.unlinkSync(dest);
     fs.copyFileSync(src, dest, mode);
     if (preserveTimestamps) {
@@ -2252,8 +2287,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   binding.cpSyncCopyDir = function (...args: any[]) {
-    const [src, dest, force, dereference, errorOnExist, verbatimSymlinks, preserveTimestamps] = args;
-    if (!splitPath(src).isAsar) return originalBinding.cpSyncCopyDir(...args);
+    const src = args[0];
+    const dest = args[1];
+    const force = args[2];
+    const dereference = args[3];
+    const errorOnExist = args[4];
+    const verbatimSymlinks = args[5];
+    const preserveTimestamps = args[6];
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncCopyDir.apply(undefined, args);
 
     const copyDir = (srcDir: string, destDir: string) => {
       fs.mkdirSync(destDir, { recursive: true });
@@ -2342,8 +2383,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     overrideChildProcess(require('child_process'));
   } else {
     const originalModuleLoad = Module._load;
-    Module._load = (request: string, ...args: any[]) => {
-      const loadResult = originalModuleLoad(request, ...args);
+    Module._load = function (this: any, request: string) {
+      const loadResult = originalModuleLoad.apply(this, arguments as any);
       if (request === 'child_process' || request === 'node:child_process') {
         if (!asarReady.has(loadResult)) {
           asarReady.add(loadResult);

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -313,6 +313,9 @@ const originalBinding = {
   copyFile: binding.copyFile,
   readlink: binding.readlink,
   writeBuffer: binding.writeBuffer,
+  writeBuffers: binding.writeBuffers,
+  writeString: binding.writeString,
+  ftruncate: binding.ftruncate,
   cpSyncCheckPaths: binding.cpSyncCheckPaths,
   cpSyncOverrideFile: binding.cpSyncOverrideFile,
   cpSyncCopyDir: binding.cpSyncCopyDir
@@ -469,9 +472,13 @@ const makePromiseFunction = function (orig: Function, pathArgumentIndex: number)
 //
 // Direct, integrity-validated reads of packed entries.
 //
-// An AsarEntryReader owns a read-only file descriptor duplicated from the
-// archive's retained handle and serves reads of a single packed entry from
-// it: positions are translated to archive offsets and clamped to the entry.
+// An AsarEntryReader serves reads of a single packed entry straight from the
+// archive's retained file handle: positions are translated to archive offsets
+// and clamped to the entry.  The descriptor number the caller gets back from
+// open() is a separate sentinel (a write-only handle on the null device) that
+// only identifies the reader within this module: reading it directly fails
+// with EBADF, so code that bypasses fs fails loudly rather than being handed
+// archive bytes, and no handle to the archive itself is ever exposed.
 // When the archive carries integrity information, bytes are only ever handed
 // out from a buffer whose block hash has just been verified - the reader
 // keeps the most recently validated block so that sequential consumers such
@@ -516,7 +523,11 @@ async function readFully(fd: number, buffer: Uint8Array, offset: number, length:
 }
 
 class AsarEntryReader {
+  // The sentinel descriptor handed to the caller; owned by whoever owns the
+  // open (fs.close / FileHandle), never read or written by this module.
   readonly fd: number;
+  // The archive's retained handle; all reads go through it, positionally.
+  readonly archiveFd: number;
   readonly size: number;
   readonly offset: number;
   readonly executable: boolean;
@@ -529,8 +540,9 @@ class AsarEntryReader {
   private validatedBlock: ValidatedBlock | null = null;
   private closed = false;
 
-  constructor(fd: number, info: NodeJS.AsarFileInfo) {
+  constructor(fd: number, archiveFd: number, info: NodeJS.AsarFileInfo) {
     this.fd = fd;
+    this.archiveFd = archiveFd;
     this.size = info.size;
     this.offset = info.offset;
     this.executable = info.executable;
@@ -583,14 +595,14 @@ class AsarEntryReader {
   private validateBlockSync(index: number): ValidatedBlock {
     const { start, length } = this.blockRange(index);
     const buffer = Buffer.allocUnsafeSlow(length);
-    readFullySync(this.fd, buffer, 0, length, this.offset + start);
+    readFullySync(this.archiveFd, buffer, 0, length, this.offset + start);
     return this.checkBlock(index, buffer, sha256HexSync(buffer));
   }
 
   private async validateBlock(index: number): Promise<ValidatedBlock> {
     const { start, length } = this.blockRange(index);
     const buffer = Buffer.allocUnsafeSlow(length);
-    await readFully(this.fd, buffer, 0, length, this.offset + start);
+    await readFully(this.archiveFd, buffer, 0, length, this.offset + start);
     return this.checkBlock(index, buffer, await sha256HexAsync(buffer));
   }
 
@@ -620,14 +632,14 @@ class AsarEntryReader {
   readSync(buffer: Uint8Array, bufferOffset: number, length: number, position: number): number {
     const { start, count } = this.resolveRange(length, position);
     if (count === 0) return 0;
-    if (!this.integrity) return readFullySync(this.fd, buffer, bufferOffset, count, this.offset + start);
+    if (!this.integrity) return readFullySync(this.archiveFd, buffer, bufferOffset, count, this.offset + start);
     return this.copyFromBlocks(buffer, bufferOffset, start, count, (i) => this.validateBlockSync(i));
   }
 
   async read(buffer: Uint8Array, bufferOffset: number, length: number, position: number): Promise<number> {
     const { start, count } = this.resolveRange(length, position);
     if (count === 0) return 0;
-    if (!this.integrity) return readFully(this.fd, buffer, bufferOffset, count, this.offset + start);
+    if (!this.integrity) return readFully(this.archiveFd, buffer, bufferOffset, count, this.offset + start);
 
     // Validate every block the read touches up front (asynchronously), then
     // copy out synchronously.
@@ -758,11 +770,15 @@ const kWriteFlags = constants.O_WRONLY | constants.O_RDWR | constants.O_APPEND |
 
 // Resolves an asar path for open()-like calls.  Returns either a reader for
 // a packed entry, the real path of an unpacked entry, or throws.
+// `withSentinel: false` is for internal consumers (copyFile) that read the
+// entry themselves and never hand a descriptor number to anyone; the reader's
+// `fd` is -1 then.
 function openAsarEntry(
   asarPath: string,
   filePath: string,
   flags: number,
-  syscall: string
+  syscall: string,
+  withSentinel = true
 ): { unpackedPath: string } | { reader: AsarEntryReader } {
   const archive = getOrCreateArchive(asarPath);
   if (!archive) throw createError(AsarError.INVALID_ARCHIVE, { asarPath, syscall });
@@ -785,9 +801,12 @@ function openAsarEntry(
     throw createError(AsarError.EXISTS, { asarPath, filePath, syscall });
   }
 
-  const fd = archive.dupFd();
+  const archiveFd = archive.getFdAndValidateIntegrityLater();
+  if (!(archiveFd >= 0)) throw createError(AsarError.INVALID_ARCHIVE, { asarPath, syscall });
+  if (!withSentinel) return { reader: new AsarEntryReader(-1, archiveFd, info) };
+  const fd = asar.createSentinelFd();
   if (!(fd >= 0)) throw createError(AsarError.TOO_MANY_OPEN, { asarPath, filePath, syscall });
-  return { reader: new AsarEntryReader(fd, info) };
+  return { reader: new AsarEntryReader(fd, archiveFd, info) };
 }
 
 // Override fs APIs.
@@ -1876,6 +1895,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       // the native binding with the caller's own request object.
       const { start, count } = reader.resolveRange(length, pos);
       if (count === 0) return completeRequest(req, null, 0);
+      args[0] = reader.archiveFd;
       args[3] = count;
       args[4] = reader.offset + start;
       return originalBinding.read.apply(undefined, args);
@@ -1901,6 +1921,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       const { start, count } = reader.resolveRange(wanted, pos);
       if (count === 0) return completeRequest(req, null, 0);
       if (count === wanted) {
+        args[0] = reader.archiveFd;
         args[2] = reader.offset + start;
         return originalBinding.readBuffers.apply(undefined, args);
       }
@@ -1919,14 +1940,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       const readAllClamped = async () => {
         let total = 0;
         for (let i = 0; i < buffers.length; i++) {
-          total += await readFully(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
+          total += await readFully(reader.archiveFd, buffers[i], 0, filled[i], reader.offset + start + total);
         }
         return total;
       };
       if (req === undefined) {
         let total = 0;
         for (let i = 0; i < buffers.length; i++) {
-          total += readFullySync(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
+          total += readFullySync(reader.archiveFd, buffers[i], 0, filled[i], reader.offset + start + total);
         }
         return total;
       }
@@ -1987,34 +2008,54 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     if (!pathInfo.isAsar) return originalBinding.writeFileUtf8.apply(undefined, args);
     const { asarPath, filePath } = pathInfo;
 
-    const opened = openAsarEntry(asarPath, filePath, flags, 'open');
+    const opened = openAsarEntry(asarPath, filePath, flags, 'open', false);
     if ('unpackedPath' in opened) {
       args[0] = opened.unpackedPath;
       return originalBinding.writeFileUtf8.apply(undefined, args);
     }
     // Only reachable with read-only flags, which writeFile never uses.
-    originalBinding.close(opened.reader.fd);
     opened.reader.dispose();
     throw createError(AsarError.NO_ACCESS, { asarPath, filePath, syscall: 'open' });
   };
 
-  // A dup'd archive fd is O_RDONLY, so writes and truncation already fail
-  // natively (EBADF); metadata changes would go through to the archive file
-  // itself though, so refuse them explicitly.
-  const refuseMetadataChange = (name: 'fchmod' | 'fchown' | 'futimes') => {
-    const original = originalBinding[name];
+  // The sentinel descriptor is a write-only null device: reads through
+  // anything but fs fail (EBADF), but writes, truncation and metadata changes
+  // would quietly succeed against the null device.  Archives are read-only,
+  // so refuse all of those explicitly with EACCES.  The sync write bindings
+  // still use the legacy (..., undefined, ctx) convention where errors are
+  // reported through `ctx` instead of being thrown.
+  const refuseMutation = (name: keyof typeof originalBinding) => {
+    const original = originalBinding[name] as Function;
     binding[name] = function (...args: any[]) {
       const fd = args[0];
       if (lookupAsarFd(fd) === undefined) return original.apply(undefined, args);
-      const req = args[args.length - 1];
-      const hasReq = req !== undefined && (req === kUsePromises || typeof req === 'object');
       const error = createError(AsarError.NO_ACCESS, { filePath: `fd ${fd}`, syscall: name });
-      return completeRequest(hasReq ? req : undefined, error);
+      const last = args[args.length - 1];
+      const isObject = last !== null && typeof last === 'object';
+      if (last === kUsePromises || (isObject && 'oncomplete' in last)) {
+        return completeRequest(last, error);
+      }
+      if (args.length >= 2 && args[args.length - 2] === undefined && isObject) {
+        // (…, undefined, ctx): report through ctx like the native sync path.
+        last.errno = error.errno;
+        last.code = error.code;
+        last.syscall = name;
+        return;
+      }
+      throw error;
     };
   };
-  refuseMetadataChange('fchmod');
-  refuseMetadataChange('fchown');
-  refuseMetadataChange('futimes');
+  for (const name of [
+    'fchmod',
+    'fchown',
+    'futimes',
+    'ftruncate',
+    'writeBuffer',
+    'writeBuffers',
+    'writeString'
+  ] as const) {
+    refuseMutation(name);
+  }
 
   //
   // fs.copyFile / fs.copyFileSync / fs.promises.copyFile from a packed entry:
@@ -2096,7 +2137,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       if (modeFlags < 0 || modeFlags > kMaxCopyFileMode) {
         throw new (errorCodes as any).ERR_OUT_OF_RANGE('mode', `>= 0 && <= ${kMaxCopyFileMode}`, mode);
       }
-      opened = openAsarEntry(asarPath, filePath, constants.O_RDONLY, 'copyfile');
+      opened = openAsarEntry(asarPath, filePath, constants.O_RDONLY, 'copyfile', false);
     } catch (error) {
       return completeRequest(req, error as Error);
     }
@@ -2108,22 +2149,16 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
 
     const { reader } = opened;
-    const closeSourceFd = () => originalBinding.close(reader.fd);
     if ((modeFlags & constants.COPYFILE_FICLONE_FORCE) !== 0) {
       // A packed entry can never be reflinked.
-      closeSourceFd();
       reader.dispose();
       return completeRequest(req, createError(AsarError.NOT_SUPPORTED, { asarPath, filePath, syscall: 'copyfile' }));
     }
     if (req === undefined) {
-      try {
-        copyPackedFileSync(reader, dest, mode ?? 0);
-      } finally {
-        closeSourceFd();
-      }
+      copyPackedFileSync(reader, dest, mode ?? 0);
       return;
     }
-    return completeRequestWithPromise(req, copyPackedFile(reader, dest, mode ?? 0).finally(closeSourceFd));
+    return completeRequestWithPromise(req, copyPackedFile(reader, dest, mode ?? 0));
   };
 
   //

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -698,6 +698,14 @@ function sweepStaleAsarFds() {
   }
 }
 
+// Applies an fs `encoding` option to a name the way the native bindings do:
+// 'buffer' yields a Buffer, other encodings re-encode the UTF-8 name.
+const encodeName = (name: string, encoding: any) => {
+  if (encoding === 'buffer') return Buffer.from(name);
+  if (encoding && encoding !== 'utf8' && encoding !== 'utf-8') return Buffer.from(name).toString(encoding);
+  return name;
+};
+
 // The fs binding accepts a position as a number, a bigint, or null /
 // undefined / -1 for "the current file position".
 const normalizePosition = (position: number | bigint | null | undefined) => {
@@ -724,8 +732,10 @@ function openAsarEntry(
 
   const info = archive.getFileInfo(filePath);
   if (!info) {
-    const stats = archive.stat(filePath);
-    if (stats && stats.type === AsarFileType.kDirectory) {
+    // getFileInfo follows links itself, so a link to a directory ends up here
+    // as well; resolve links to tell EISDIR from ENOENT.
+    const resolved = resolveAsarLinks(archive, filePath);
+    if (resolved && resolved.stats.type === AsarFileType.kDirectory) {
       throw createError(AsarError.IS_DIR, { asarPath, filePath, syscall });
     }
     throw createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall });
@@ -1244,7 +1254,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       let type = result[1][i];
       if (info.isAsar) {
         const archive = getOrCreateArchive(info.asarPath);
-        if (!archive) return;
+        if (!archive) continue;
         const stats = archive.stat(info.filePath);
         if (!stats) continue;
         type = stats.type;
@@ -1786,6 +1796,16 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     // Node's C++ FileHandle takes ownership of the fd (and closes it on
     // close() or garbage collection); the JS FileHandle wraps this object.
     const handle = new binding.FileHandle(reader.fd);
+    // close() runs the actual close(2) on the threadpool and only resets the
+    // handle's fd to -1 afterwards, on the loop thread; forget the entry as
+    // soon as close is requested so that a real file opened in between and
+    // handed the same descriptor number can never be routed through this
+    // reader.
+    const { close } = handle;
+    handle.close = function (this: any, ...closeArgs: any[]) {
+      forgetAsarFd(reader.fd);
+      return close.apply(this, closeArgs);
+    };
     if (openAsarFiles.size > 256) sweepStaleAsarFds();
     openAsarFiles.set(reader.fd, { reader, handle: new WeakRef(handle) });
     return completeRequest(req, null, handle);
@@ -1838,16 +1858,18 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
         filled.push(take);
         remaining -= take;
       }
+      // (Zero-length buffers must not end the loop: like preadv, they are
+      // skipped and later buffers are still filled.)
       const readAllClamped = async () => {
         let total = 0;
-        for (let i = 0; i < buffers.length && filled[i] > 0; i++) {
+        for (let i = 0; i < buffers.length; i++) {
           total += await readFully(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
         }
         return total;
       };
       if (req === undefined) {
         let total = 0;
-        for (let i = 0; i < buffers.length && filled[i] > 0; i++) {
+        for (let i = 0; i < buffers.length; i++) {
           total += readFullySync(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
         }
         return total;
@@ -2001,29 +2023,34 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const { asarPath, filePath } = pathInfo;
 
     let opened;
+    const modeFlags = mode ?? 0;
     try {
       // Same validation as node's native CopyFile (GetValidFileMode).
       if (mode !== null && mode !== undefined && (typeof mode !== 'number' || (mode | 0) !== mode)) {
         throw new (errorCodes as any).ERR_INVALID_ARG_TYPE('mode', 'int32', mode);
       }
-      const modeFlags = mode ?? 0;
       if (modeFlags < 0 || modeFlags > kMaxCopyFileMode) {
         throw new (errorCodes as any).ERR_OUT_OF_RANGE('mode', `>= 0 && <= ${kMaxCopyFileMode}`, mode);
-      }
-      if ((modeFlags & constants.COPYFILE_FICLONE_FORCE) !== 0) {
-        throw createError(AsarError.NOT_SUPPORTED, { asarPath, filePath, syscall: 'copyfile' });
       }
       opened = openAsarEntry(asarPath, filePath, constants.O_RDONLY, 'copyfile');
     } catch (error) {
       return completeRequest(req, error as Error);
     }
     if ('unpackedPath' in opened) {
+      // Unpacked entries are real files: let native fs handle them, including
+      // copy-on-write clones.
       args[0] = opened.unpackedPath;
       return originalBinding.copyFile(...args);
     }
 
     const { reader } = opened;
     const closeSourceFd = () => originalBinding.close(reader.fd);
+    if ((modeFlags & constants.COPYFILE_FICLONE_FORCE) !== 0) {
+      // A packed entry can never be reflinked.
+      closeSourceFd();
+      reader.dispose();
+      return completeRequest(req, createError(AsarError.NOT_SUPPORTED, { asarPath, filePath, syscall: 'copyfile' }));
+    }
     if (req === undefined) {
       try {
         copyPackedFileSync(reader, dest, mode ?? 0);
@@ -2069,7 +2096,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     // Both sides are archive-relative; anchor them at a root so that the
     // computation does not depend on the process's working directory.
     const target = path.relative(path.join(path.sep, path.dirname(filePath)), path.join(path.sep, linkTarget)) || '.';
-    return completeRequest(req, null, encoding === 'buffer' ? Buffer.from(target) : target);
+    return completeRequest(req, null, encodeName(target, encoding));
   };
 
   //
@@ -2095,7 +2122,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
         const taken = this.entries.splice(0, count);
         result = [];
         for (const [name, type] of taken) {
-          result.push(encoding === 'buffer' ? Buffer.from(name) : name, type);
+          result.push(encodeName(name, encoding), type);
         }
       }
       return completeRequest(req, null, result);

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -23,6 +23,8 @@ const nextTick = (functionToCall: Function, args: any[] = []) => {
 };
 
 const binding = internalBinding('fs');
+const dirBinding = internalBinding('fs_dir');
+const { kUsePromises } = binding;
 
 // Cache asar archive objects.
 const cachedArchives = new Map<string, NodeJS.AsarArchive>();
@@ -46,7 +48,7 @@ process._getOrCreateArchive = getOrCreateArchive;
 
 const asarRe = /\.asar/i;
 
-const { getValidatedPath, getOptions, getDirent } = __non_webpack_require__(
+const { getValidatedPath, getOptions, getDirent, getStatsFromBinding } = __non_webpack_require__(
   'internal/fs/utils'
 ) as typeof import('@node/lib/internal/fs/utils');
 
@@ -55,6 +57,8 @@ const { assignFunctionName } = __non_webpack_require__('internal/util') as typeo
 const { validateBoolean, validateFunction } = __non_webpack_require__(
   'internal/validators'
 ) as typeof import('@node/lib/internal/validators');
+
+const { codes: errorCodes } = __non_webpack_require__('internal/errors') as typeof import('@node/lib/internal/errors');
 
 // In the renderer node internals use the node global URL but we do not set that to be
 // the global URL instance.  We need to do instanceof checks against the internal URL impl
@@ -79,6 +83,30 @@ const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
   return asar.splitPath(path.normalize(archivePath));
 };
 
+// The on-disk location of an entry that was left outside of the archive
+// (`asar.unpacked`) by the packager.  Mirrors what the native
+// Archive::CopyFileOut() computes for unpacked entries, without taking the
+// archive's external-files lock.
+const getUnpackedPath = (asarPath: string, filePath: string) => path.join(`${asarPath}.unpacked`, filePath);
+
+// Symbolic links inside an archive are stored with their target relative to
+// the archive root.  Follows a chain of them (bounded, like the kernel's
+// ELOOP limit) and returns the final entry and its stats, or null if any hop
+// is missing or the chain is too long.
+const kMaxSymlinkHops = 40;
+function resolveAsarLinks(archive: NodeJS.AsarArchive, filePath: string) {
+  let current = filePath;
+  for (let hop = 0; hop < kMaxSymlinkHops; hop++) {
+    const stats = archive.stat(current);
+    if (!stats) return null;
+    if (stats.type !== AsarFileType.kLink) return { filePath: current, stats };
+    const target = archive.realpath(current);
+    if (target === false) return null;
+    current = target;
+  }
+  return null;
+}
+
 // Convert asar archive's Stats object to fs's Stats object.
 let nextInode = 0;
 
@@ -86,23 +114,8 @@ const uid = process.getuid?.() ?? 0;
 const gid = process.getgid?.() ?? 0;
 
 const fakeTime = new Date();
-
-function getDirents(p: string, { 0: names, 1: types }: any[][]): Dirent[] {
-  for (let i = 0; i < names.length; i++) {
-    let type = types[i];
-    const info = splitPath(path.join(p, names[i]));
-    if (info.isAsar) {
-      const archive = getOrCreateArchive(info.asarPath);
-      if (!archive) continue;
-      const stats = archive.stat(info.filePath);
-      if (!stats) continue;
-      type = stats.type;
-    }
-    names[i] = getDirent(p, names[i], type);
-  }
-
-  return names;
-}
+const fakeTimeSec = Math.floor(fakeTime.getTime() / 1000);
+const fakeTimeNsec = (fakeTime.getTime() % 1000) * 1e6;
 
 enum AsarFileType {
   kFile = (constants as any).UV_DIRENT_FILE,
@@ -116,40 +129,64 @@ const fileTypeToMode = new Map<AsarFileType, number>([
   [AsarFileType.kLink, constants.S_IFLNK]
 ]);
 
-const asarStatsToFsStats = function (stats: NodeJS.AsarFileStat) {
-  const { Stats } = require('fs');
+const kReadOnlyMode = constants.S_IROTH | constants.S_IRGRP | constants.S_IRUSR | constants.S_IWUSR;
+const kExecuteMode = constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH;
 
-  const mode =
-    constants.S_IROTH | constants.S_IRGRP | constants.S_IRUSR | constants.S_IWUSR | fileTypeToMode.get(stats.type)!;
-
-  return new Stats(
+// Builds the raw stat array that node's fs binding would have produced, so
+// that node's own getStatsFromBinding() can turn it into a (BigInt)Stats.
+// Permissions follow the usual defaults (0644 files, 0755 directories and
+// executables, 0777 symlinks) so that copies of these entries made with the
+// reported mode remain usable.
+function makeStatArray(type: AsarFileType, size: number, ino: number, useBigint: boolean, executable = false) {
+  let mode = kReadOnlyMode | fileTypeToMode.get(type)!;
+  if (executable || type !== AsarFileType.kFile) mode |= kExecuteMode;
+  if (type === AsarFileType.kLink) mode |= constants.S_IWGRP | constants.S_IWOTH;
+  const values = [
     1, // dev
-    mode, // mode
+    mode,
     1, // nlink
     uid,
     gid,
     0, // rdev
     4096, // blksize
-    ++nextInode, // ino
-    stats.size,
-    Math.ceil(stats.size / 512), // blocks (512-byte units)
-    fakeTime.getTime(), // atim_msec
-    fakeTime.getTime(), // mtim_msec
-    fakeTime.getTime(), // ctim_msec
-    fakeTime.getTime() // birthtim_msec
-  );
+    ino,
+    size,
+    Math.ceil(size / 512), // blocks (512-byte units)
+    fakeTimeSec,
+    fakeTimeNsec, // atime
+    fakeTimeSec,
+    fakeTimeNsec, // mtime
+    fakeTimeSec,
+    fakeTimeNsec, // ctime
+    fakeTimeSec,
+    fakeTimeNsec // birthtime
+  ];
+  return useBigint ? new BigInt64Array(values.map(BigInt)) : new Float64Array(values);
+}
+
+const asarStatsToFsStats = function (stats: NodeJS.AsarFileStat, options?: any) {
+  const useBigint = Boolean(options && typeof options === 'object' && options.bigint);
+  return getStatsFromBinding(makeStatArray(stats.type, stats.size, ++nextInode, useBigint));
 };
 
 const enum AsarError {
   NOT_FOUND = 'NOT_FOUND',
   NOT_DIR = 'NOT_DIR',
+  IS_DIR = 'IS_DIR',
   NO_ACCESS = 'NO_ACCESS',
-  INVALID_ARCHIVE = 'INVALID_ARCHIVE'
+  INVALID_ARCHIVE = 'INVALID_ARCHIVE',
+  NOT_LINK = 'NOT_LINK',
+  EXISTS = 'EXISTS',
+  NOT_SUPPORTED = 'NOT_SUPPORTED',
+  TOO_MANY_OPEN = 'TOO_MANY_OPEN'
 }
 
-type AsarErrorObject = Error & { code?: string; errno?: number };
+type AsarErrorObject = Error & { code?: string; errno?: number; syscall?: string; path?: string };
 
-const createError = (errorType: AsarError, { asarPath, filePath }: { asarPath?: string; filePath?: string } = {}) => {
+const createError = (
+  errorType: AsarError,
+  { asarPath, filePath, syscall }: { asarPath?: string; filePath?: string; syscall?: string } = {}
+) => {
   let error: AsarErrorObject;
   switch (errorType) {
     case AsarError.NOT_FOUND:
@@ -162,6 +199,11 @@ const createError = (errorType: AsarError, { asarPath, filePath }: { asarPath?: 
       error.code = 'ENOTDIR';
       error.errno = -20;
       break;
+    case AsarError.IS_DIR:
+      error = new Error(`EISDIR: illegal operation on a directory, ${filePath} in ${asarPath}`);
+      error.code = 'EISDIR';
+      error.errno = -21;
+      break;
     case AsarError.NO_ACCESS:
       error = new Error(`EACCES: permission denied, access '${filePath}'`);
       error.code = 'EACCES';
@@ -170,10 +212,111 @@ const createError = (errorType: AsarError, { asarPath, filePath }: { asarPath?: 
     case AsarError.INVALID_ARCHIVE:
       error = new Error(`Invalid package ${asarPath}`);
       break;
+    case AsarError.NOT_LINK:
+      error = new Error(`EINVAL: invalid argument, ${filePath} in ${asarPath} is not a symbolic link`);
+      error.code = 'EINVAL';
+      error.errno = -22;
+      break;
+    case AsarError.EXISTS:
+      error = new Error(`EEXIST: file already exists, ${filePath}`);
+      error.code = 'EEXIST';
+      error.errno = -17;
+      break;
+    case AsarError.NOT_SUPPORTED:
+      error = new Error(`ENOTSUP: operation not supported on asar archive entry ${filePath}`);
+      error.code = 'ENOTSUP';
+      error.errno = -45;
+      break;
+    case AsarError.TOO_MANY_OPEN:
+      error = new Error(`EMFILE: too many open files, could not open ${filePath} in ${asarPath}`);
+      error.code = 'EMFILE';
+      error.errno = -24;
+      break;
     default:
       throw new Error(`Invalid error type "${errorType}" passed to createError.`);
   }
+  if (syscall) error.syscall = syscall;
+  if (asarPath !== undefined && filePath !== undefined && errorType !== AsarError.INVALID_ARCHIVE) {
+    error.path = path.join(asarPath, filePath);
+  }
   return error;
+};
+
+// Delivers a result the way a native fs binding call would have: thrown /
+// returned synchronously when there is no request object, as a promise when
+// node passed `kUsePromises`, and via `req.oncomplete` for an FSReqCallback.
+// `oncomplete` must be invoked as a method so that handlers which read
+// `this.context` (e.g. readFile's internals) keep working.
+function completeRequest<T>(req: any, error: Error | null, value?: T): any {
+  if (req === undefined) {
+    if (error) throw error;
+    return value;
+  }
+  if (req === kUsePromises) {
+    return error ? Promise.reject(error) : Promise.resolve(value);
+  }
+  process.nextTick(() => {
+    if (error) req.oncomplete(error);
+    else req.oncomplete(null, value);
+  });
+}
+
+// Like completeRequest, but for a value that is produced asynchronously.
+function completeRequestWithPromise<T>(req: any, promise: globalThis.Promise<T>): any {
+  if (req === kUsePromises) return promise;
+  promise.then(
+    (value) => req.oncomplete(null, value),
+    (error) => req.oncomplete(error)
+  );
+}
+
+// A faithful copy of a native binding object (own properties, including
+// symbols and non-enumerables, with their descriptors).
+function cloneBinding<T extends object>(source: T): T {
+  const clone = Object.create(Object.getPrototypeOf(source));
+  for (const key of Reflect.ownKeys(source)) {
+    Object.defineProperty(clone, key, Object.getOwnPropertyDescriptor(source, key)!);
+  }
+  return clone;
+}
+
+// `original-fs` is generated from the same sources as `fs` and would
+// otherwise share these binding objects (and therefore the archive-aware
+// overrides installed below).  Stash pristine copies for it to use instead;
+// script/node/generate_original_fs.py points the generated modules here.
+if (!Object.prototype.hasOwnProperty.call(binding, '_electronOriginalBindings')) {
+  Object.defineProperty(binding, '_electronOriginalBindings', {
+    value: Object.freeze({ fs: cloneBinding(binding), fs_dir: cloneBinding(dirBinding) }),
+    enumerable: false,
+    configurable: false,
+    writable: false
+  });
+}
+
+// The subset of the original fs binding we call into.  Captured before any of
+// them are overridden below.
+const originalBinding = {
+  open: binding.open,
+  openFileHandle: binding.openFileHandle,
+  read: binding.read,
+  readBuffers: binding.readBuffers,
+  fstat: binding.fstat,
+  close: binding.close,
+  readFileUtf8: binding.readFileUtf8,
+  writeFileUtf8: binding.writeFileUtf8,
+  fchmod: binding.fchmod,
+  fchown: binding.fchown,
+  futimes: binding.futimes,
+  copyFile: binding.copyFile,
+  readlink: binding.readlink,
+  writeBuffer: binding.writeBuffer,
+  cpSyncCheckPaths: binding.cpSyncCheckPaths,
+  cpSyncOverrideFile: binding.cpSyncOverrideFile,
+  cpSyncCopyDir: binding.cpSyncCopyDir
+};
+const originalDirBinding = {
+  opendir: dirBinding.opendir,
+  opendirSync: dirBinding.opendirSync
 };
 
 const overrideAPISync = function (
@@ -250,17 +393,52 @@ const overrideAPI = function (module: Record<string, any>, name: string, pathArg
 };
 
 let crypto: typeof Crypto;
+// Delay load crypto to improve app boot performance
+// when integrity protection is not enabled
+const getCrypto = () => {
+  crypto = crypto || require('crypto');
+  return crypto;
+};
+
+// Terminates the process on an integrity failure.  This must be synchronous
+// and must never return to the caller: in the main process `process.exit()`
+// is mapped to the graceful, asynchronous `app.exit()`, which would let JS
+// keep running (and consume the tampered bytes) until the quit lands.  The
+// message is written with a blocking write so it is not lost on the way out.
+const integrityViolation = (actual: string, expected: string): never => {
+  const message = `ASAR Integrity Violation: got a hash mismatch (${actual} vs ${expected})\n`;
+  try {
+    (require('fs') as typeof import('fs')).writeSync(2, message);
+  } catch {
+    console.error(message);
+  }
+  const reallyExit = (process as any).reallyExit;
+  if (typeof reallyExit === 'function') reallyExit(1);
+  process.exit(1);
+  // Neither call above returns; keep TypeScript (and any monkey-patched
+  // process.exit) honest by never continuing.
+  throw new Error('ASAR Integrity Violation');
+};
+
+const sha256HexSync = (buffer: Uint8Array) => getCrypto().createHash('sha256').update(buffer).digest('hex');
+
+// Hashes off the JS thread; used by the asynchronous read paths so that
+// validating a block never stalls the event loop.
+const sha256HexAsync = async (buffer: Uint8Array) => {
+  const digest = await getCrypto().webcrypto.subtle.digest('SHA-256', buffer);
+  return Buffer.from(digest).toString('hex');
+};
+
 function validateBufferIntegrity(buffer: Buffer, integrity: NodeJS.AsarFileInfo['integrity']) {
   if (!integrity) return;
+  const actual = sha256HexSync(buffer);
+  if (actual !== integrity.hash.toLowerCase()) integrityViolation(actual, integrity.hash);
+}
 
-  // Delay load crypto to improve app boot performance
-  // when integrity protection is not enabled
-  crypto = crypto || require('crypto');
-  const actual = crypto.createHash(integrity.algorithm).update(buffer).digest('hex');
-  if (actual !== integrity.hash) {
-    console.error(`ASAR Integrity Violation: got a hash mismatch (${actual} vs ${integrity.hash})`);
-    process.exit(1);
-  }
+async function validateBufferIntegrityAsync(buffer: Buffer, integrity: NodeJS.AsarFileInfo['integrity']) {
+  if (!integrity) return;
+  const actual = await sha256HexAsync(buffer);
+  if (actual !== integrity.hash.toLowerCase()) integrityViolation(actual, integrity.hash);
 }
 
 const makePromiseFunction = function (orig: Function, pathArgumentIndex: number) {
@@ -285,6 +463,286 @@ const makePromiseFunction = function (orig: Function, pathArgumentIndex: number)
   };
 };
 
+//
+// Direct, integrity-validated reads of packed entries.
+//
+// An AsarEntryReader owns a read-only file descriptor duplicated from the
+// archive's retained handle and serves reads of a single packed entry from
+// it: positions are translated to archive offsets and clamped to the entry.
+// When the archive carries integrity information, bytes are only ever handed
+// out from a buffer whose block hash has just been verified - the reader
+// keeps the most recently validated block so that sequential consumers such
+// as streams pay for one read and one hash per block, and never re-reads a
+// block from disk without re-validating it.
+//
+
+interface ValidatedBlock {
+  index: number;
+  buffer: Buffer;
+}
+
+// Upper bound on the number of validated blocks retained across all live
+// readers, so that many concurrently open handles cannot pin unbounded
+// memory. Past this, readers still validate every block they serve, they
+// just do not keep it around for the next read.
+const kMaxRetainedBlocks = 32;
+let retainedBlockCount = 0;
+
+// Reads exactly `length` bytes at `position` from `fd`, looping over short
+// reads. Returns the number of bytes actually read (less than `length` only
+// at end of file).
+function readFullySync(fd: number, buffer: Uint8Array, offset: number, length: number, position: number) {
+  let total = 0;
+  while (total < length) {
+    const n = originalBinding.read(fd, buffer, offset + total, length - total, position + total);
+    if (n === 0) break;
+    total += n;
+  }
+  return total;
+}
+
+async function readFully(fd: number, buffer: Uint8Array, offset: number, length: number, position: number) {
+  let total = 0;
+  while (total < length) {
+    const n =
+      (await originalBinding.read(fd, buffer, offset + total, length - total, position + total, kUsePromises)) || 0;
+    if (n === 0) break;
+    total += n;
+  }
+  return total;
+}
+
+class AsarEntryReader {
+  readonly fd: number;
+  readonly size: number;
+  readonly offset: number;
+  readonly executable: boolean;
+  readonly ino: number;
+  // Position used by reads that do not specify one (like a kernel file
+  // position).  Advanced when such a read is issued.
+  position = 0;
+
+  readonly integrity: NonNullable<NodeJS.AsarFileInfo['integrity']> | null;
+  private validatedBlock: ValidatedBlock | null = null;
+  private closed = false;
+
+  constructor(fd: number, info: NodeJS.AsarFileInfo) {
+    this.fd = fd;
+    this.size = info.size;
+    this.offset = info.offset;
+    this.executable = info.executable;
+    this.ino = ++nextInode;
+    this.integrity = info.integrity && info.integrity.blockSize > 0 ? info.integrity : null;
+  }
+
+  statArray(useBigint: boolean) {
+    return makeStatArray(AsarFileType.kFile, this.size, this.ino, useBigint, this.executable);
+  }
+
+  // Resolves the (position, length) of a read: `position < 0` means "use and
+  // advance the reader's own position".
+  resolveRange(length: number, position: number) {
+    const start = position < 0 ? this.position : position;
+    const available = Math.max(0, this.size - start);
+    const count = Math.min(length, available);
+    if (position < 0) this.position = start + count;
+    return { start, count };
+  }
+
+  private retainBlock(block: ValidatedBlock) {
+    if (this.validatedBlock !== null) {
+      this.validatedBlock = null;
+      retainedBlockCount--;
+    }
+    // A validation that completes after the reader was closed must not pin
+    // anything.
+    if (!this.closed && retainedBlockCount < kMaxRetainedBlocks) {
+      this.validatedBlock = block;
+      retainedBlockCount++;
+    }
+  }
+
+  private blockRange(index: number) {
+    const start = index * this.integrity!.blockSize;
+    return { start, length: Math.min(this.integrity!.blockSize, this.size - start) };
+  }
+
+  private checkBlock(index: number, buffer: Buffer, actual: string) {
+    const expected = this.integrity!.blocks[index];
+    if (typeof expected !== 'string' || actual !== expected.toLowerCase()) {
+      integrityViolation(actual, String(expected));
+    }
+    const block = { index, buffer };
+    this.retainBlock(block);
+    return block;
+  }
+
+  private validateBlockSync(index: number): ValidatedBlock {
+    const { start, length } = this.blockRange(index);
+    const buffer = Buffer.allocUnsafeSlow(length);
+    readFullySync(this.fd, buffer, 0, length, this.offset + start);
+    return this.checkBlock(index, buffer, sha256HexSync(buffer));
+  }
+
+  private async validateBlock(index: number): Promise<ValidatedBlock> {
+    const { start, length } = this.blockRange(index);
+    const buffer = Buffer.allocUnsafeSlow(length);
+    await readFully(this.fd, buffer, 0, length, this.offset + start);
+    return this.checkBlock(index, buffer, await sha256HexAsync(buffer));
+  }
+
+  // Copies `count` bytes starting at entry offset `start` out of validated
+  // blocks into `buffer`.
+  private copyFromBlocks(
+    buffer: Uint8Array,
+    bufferOffset: number,
+    start: number,
+    count: number,
+    getBlock: (i: number) => ValidatedBlock
+  ) {
+    const { blockSize } = this.integrity!;
+    let done = 0;
+    while (done < count) {
+      const current = start + done;
+      const index = Math.floor(current / blockSize);
+      const block = this.validatedBlock?.index === index ? this.validatedBlock : getBlock(index);
+      const inBlock = current - index * blockSize;
+      const take = Math.min(count - done, block.buffer.length - inBlock);
+      block.buffer.copy(buffer, bufferOffset + done, inBlock, inBlock + take);
+      done += take;
+    }
+    return count;
+  }
+
+  readSync(buffer: Uint8Array, bufferOffset: number, length: number, position: number): number {
+    const { start, count } = this.resolveRange(length, position);
+    if (count === 0) return 0;
+    if (!this.integrity) return readFullySync(this.fd, buffer, bufferOffset, count, this.offset + start);
+    return this.copyFromBlocks(buffer, bufferOffset, start, count, (i) => this.validateBlockSync(i));
+  }
+
+  async read(buffer: Uint8Array, bufferOffset: number, length: number, position: number): Promise<number> {
+    const { start, count } = this.resolveRange(length, position);
+    if (count === 0) return 0;
+    if (!this.integrity) return readFully(this.fd, buffer, bufferOffset, count, this.offset + start);
+
+    // Validate every block the read touches up front (asynchronously), then
+    // copy out synchronously.
+    const { blockSize } = this.integrity;
+    const first = Math.floor(start / blockSize);
+    const last = Math.floor((start + count - 1) / blockSize);
+    const blocks = new Map<number, ValidatedBlock>();
+    for (let index = first; index <= last; index++) {
+      blocks.set(index, this.validatedBlock?.index === index ? this.validatedBlock : await this.validateBlock(index));
+    }
+    return this.copyFromBlocks(buffer, bufferOffset, start, count, (i) => blocks.get(i)!);
+  }
+
+  // Reads from the current position to the end of the entry.
+  readToEndSync() {
+    const buffer = Buffer.allocUnsafeSlow(Math.max(0, this.size - this.position));
+    const n = this.readSync(buffer, 0, buffer.length, -1);
+    return n === buffer.length ? buffer : buffer.subarray(0, n);
+  }
+
+  // Releases retained validation state; does not close the fd.
+  dispose() {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.validatedBlock !== null) {
+      this.validatedBlock = null;
+      retainedBlockCount--;
+    }
+  }
+}
+
+// Every fd handed out by open()/openSync()/promises.open() for a packed
+// entry, keyed by fd number.  For FileHandles the fd is owned by node's C++
+// FileHandle (which also closes it on GC), so the entry additionally holds a
+// weak reference to that handle and is only considered live while the handle
+// is alive and still owns that fd number - a stale entry can therefore never
+// capture reads of an unrelated file that later reuses the number.
+interface OpenAsarFile {
+  reader: AsarEntryReader;
+  handle?: WeakRef<{ fd: number }>;
+}
+const openAsarFiles = new Map<number, OpenAsarFile>();
+
+function lookupAsarFd(fd: number): AsarEntryReader | undefined {
+  if (openAsarFiles.size === 0 || typeof fd !== 'number') return undefined;
+  const entry = openAsarFiles.get(fd);
+  if (entry === undefined) return undefined;
+  if (entry.handle !== undefined) {
+    const handle = entry.handle.deref();
+    if (handle === undefined || handle.fd !== fd) {
+      openAsarFiles.delete(fd);
+      entry.reader.dispose();
+      return undefined;
+    }
+  }
+  return entry.reader;
+}
+
+function forgetAsarFd(fd: number) {
+  const entry = openAsarFiles.get(fd);
+  if (entry === undefined) return;
+  openAsarFiles.delete(fd);
+  entry.reader.dispose();
+}
+
+function sweepStaleAsarFds() {
+  for (const [fd, entry] of openAsarFiles) {
+    if (entry.handle === undefined) continue;
+    const handle = entry.handle.deref();
+    if (handle === undefined || handle.fd !== fd) forgetAsarFd(fd);
+  }
+}
+
+// The fs binding accepts a position as a number, a bigint, or null /
+// undefined / -1 for "the current file position".
+const normalizePosition = (position: number | bigint | null | undefined) => {
+  if (position == null) return -1;
+  if (typeof position === 'bigint') return Number(position);
+  return position;
+};
+
+// Node's fs.constants values for the "opens for writing" bits.  Any of these
+// on a packed entry is refused: archives are read-only, and silently
+// redirecting the write elsewhere would be worse than failing.
+const kWriteFlags = constants.O_WRONLY | constants.O_RDWR | constants.O_APPEND | constants.O_TRUNC;
+
+// Resolves an asar path for open()-like calls.  Returns either a reader for
+// a packed entry, the real path of an unpacked entry, or throws.
+function openAsarEntry(
+  asarPath: string,
+  filePath: string,
+  flags: number,
+  syscall: string
+): { unpackedPath: string } | { reader: AsarEntryReader } {
+  const archive = getOrCreateArchive(asarPath);
+  if (!archive) throw createError(AsarError.INVALID_ARCHIVE, { asarPath, syscall });
+
+  const info = archive.getFileInfo(filePath);
+  if (!info) {
+    const stats = archive.stat(filePath);
+    if (stats && stats.type === AsarFileType.kDirectory) {
+      throw createError(AsarError.IS_DIR, { asarPath, filePath, syscall });
+    }
+    throw createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall });
+  }
+
+  if (info.unpacked) return { unpackedPath: getUnpackedPath(asarPath, filePath) };
+
+  if (flags & kWriteFlags) throw createError(AsarError.NO_ACCESS, { asarPath, filePath, syscall });
+  if ((flags & constants.O_CREAT) !== 0 && (flags & constants.O_EXCL) !== 0) {
+    throw createError(AsarError.EXISTS, { asarPath, filePath, syscall });
+  }
+
+  const fd = archive.dupFd();
+  if (!(fd >= 0)) throw createError(AsarError.TOO_MANY_OPEN, { asarPath, filePath, syscall });
+  return { reader: new AsarEntryReader(fd, info) };
+}
+
 // Override fs APIs.
 export const wrapFsWithAsar = (fs: Record<string, any>) => {
   const logFDs = new Map<string, number>();
@@ -304,6 +762,22 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
 
     return true;
+  };
+
+  // internalModuleStat-shaped check (1 = directory, 0 = file, negative =
+  // missing) used by the recursive readdir implementations below.  Unlike
+  // internalModuleStat itself, symbolic links inside archives are not
+  // followed: recursive readdir descends into whatever this reports as a
+  // directory, and archives may legitimately contain link cycles (a real
+  // filesystem walk would only be stopped by ENAMETOOLONG).
+  const statTypeForReaddir = (pathArgument: string): number => {
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return internalModuleStat(pathArgument);
+    const archive = getOrCreateArchive(pathInfo.asarPath);
+    if (!archive) return -34;
+    const stats = archive.stat(pathInfo.filePath);
+    if (!stats) return -34;
+    return stats.type === AsarFileType.kDirectory ? 1 : 0;
   };
 
   const { lstatSync } = fs;
@@ -328,7 +802,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       return null;
     }
 
-    return asarStatsToFsStats(stats);
+    return asarStatsToFsStats(stats, options);
   };
 
   const { lstat } = fs;
@@ -355,7 +829,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       return;
     }
 
-    const fsStats = asarStatsToFsStats(stats);
+    const fsStats = asarStatsToFsStats(stats, options);
     nextTick(callback, [null, fsStats]);
   };
 
@@ -363,24 +837,52 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
 
   const { statSync } = fs;
   fs.statSync = (pathArgument: string, options: any) => {
-    const { isAsar } = splitPath(pathArgument);
-    if (!isAsar) return statSync(pathArgument, options);
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return statSync(pathArgument, options);
+    const { asarPath, filePath } = pathInfo;
 
-    // Do not distinguish links for now.
-    return fs.lstatSync(pathArgument, options);
+    const archive = getOrCreateArchive(asarPath);
+    if (!archive) {
+      if (shouldThrowStatError(options)) {
+        throw createError(AsarError.INVALID_ARCHIVE, { asarPath });
+      }
+      return null;
+    }
+
+    const resolved = resolveAsarLinks(archive, filePath);
+    if (!resolved) {
+      if (shouldThrowStatError(options)) {
+        throw createError(AsarError.NOT_FOUND, { asarPath, filePath });
+      }
+      return null;
+    }
+
+    return asarStatsToFsStats(resolved.stats, options);
   };
 
   const { stat } = fs;
   fs.stat = (pathArgument: string, options: any, callback: any) => {
-    const { isAsar } = splitPath(pathArgument);
+    const pathInfo = splitPath(pathArgument);
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
-    if (!isAsar) return stat(pathArgument, options, callback);
+    if (!pathInfo.isAsar) return stat(pathArgument, options, callback);
+    const { asarPath, filePath } = pathInfo;
 
-    // Do not distinguish links for now.
-    process.nextTick(() => fs.lstat(pathArgument, options, callback));
+    const archive = getOrCreateArchive(asarPath);
+    if (!archive) {
+      nextTick(callback, [createError(AsarError.INVALID_ARCHIVE, { asarPath })]);
+      return;
+    }
+
+    const resolved = resolveAsarLinks(archive, filePath);
+    if (!resolved) {
+      nextTick(callback, [createError(AsarError.NOT_FOUND, { asarPath, filePath })]);
+      return;
+    }
+
+    nextTick(callback, [null, asarStatsToFsStats(resolved.stats, options)]);
   };
 
   fs.promises.stat = util.promisify(fs.stat);
@@ -465,8 +967,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
 
     const archive = getOrCreateArchive(asarPath);
     if (!archive) {
-      const error = createError(AsarError.INVALID_ARCHIVE, { asarPath });
-      nextTick(callback, [error]);
+      nextTick(callback, [false]);
       return;
     }
 
@@ -481,8 +982,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
 
     const archive = getOrCreateArchive(asarPath);
     if (!archive) {
-      const error = createError(AsarError.INVALID_ARCHIVE, { asarPath });
-      return Promise.reject(error);
+      return Promise.resolve(false);
     }
 
     return Promise.resolve(archive.stat(filePath) !== false);
@@ -531,8 +1031,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
 
     if (info.unpacked) {
-      const realPath = archive.copyFileOut(filePath);
-      return fs.access(realPath, mode, callback);
+      return fs.access(getUnpackedPath(asarPath, filePath), mode, callback);
     }
 
     const stats = archive.stat(filePath);
@@ -552,14 +1051,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   const { access: accessPromise } = fs.promises;
+  const promisifiedAccess = util.promisify(fs.access);
   fs.promises.access = function (pathArgument: string, mode: number) {
     const pathInfo = splitPath(pathArgument);
     if (!pathInfo.isAsar) {
       return accessPromise.apply(this, arguments);
     }
 
-    const p = util.promisify(fs.access);
-    return p(pathArgument, mode);
+    return promisifiedAccess(pathArgument, mode);
   };
 
   const { accessSync } = fs;
@@ -581,8 +1080,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
 
     if (info.unpacked) {
-      const realPath = archive.copyFileOut(filePath);
-      return fs.accessSync(realPath, mode);
+      return fs.accessSync(getUnpackedPath(asarPath, filePath), mode);
     }
 
     const stats = archive.stat(filePath);
@@ -595,6 +1093,17 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
   };
 
+  function normalizeReadFileOptions(options: any) {
+    if (typeof options === 'string') {
+      options = { encoding: options };
+    } else if (options === null || options === undefined) {
+      options = { encoding: null };
+    } else if (typeof options !== 'object') {
+      throw new TypeError('Bad arguments');
+    }
+    return options;
+  }
+
   function fsReadFileAsar(pathArgument: string, options: any, callback: any) {
     const pathInfo = splitPath(pathArgument);
     if (pathInfo.isAsar) {
@@ -603,12 +1112,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       if (typeof options === 'function') {
         callback = options;
         options = { encoding: null };
-      } else if (typeof options === 'string') {
-        options = { encoding: options };
-      } else if (options === null || options === undefined) {
-        options = { encoding: null };
-      } else if (typeof options !== 'object') {
-        throw new TypeError('Bad arguments');
+      } else {
+        options = normalizeReadFileOptions(options);
       }
 
       const { encoding } = options;
@@ -632,11 +1137,9 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       }
 
       if (info.unpacked) {
-        const realPath = archive.copyFileOut(filePath);
-        return fs.readFile(realPath, options, callback);
+        return fs.readFile(getUnpackedPath(asarPath, filePath), options, callback);
       }
 
-      const buffer = Buffer.alloc(info.size);
       const fd = archive.getFdAndValidateIntegrityLater();
       if (!(fd >= 0)) {
         const error = createError(AsarError.NOT_FOUND, { asarPath, filePath });
@@ -645,10 +1148,19 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       }
 
       logASARAccess(asarPath, filePath, info.offset);
-      fs.read(fd, buffer, 0, info.size, info.offset, (error: Error) => {
-        validateBufferIntegrity(buffer, info.integrity);
-        callback(error, encoding ? buffer.toString(encoding) : buffer);
-      });
+      const buffer = Buffer.allocUnsafeSlow(info.size);
+      readFully(fd, buffer, 0, info.size, info.offset)
+        .then(async (bytesRead) => {
+          // Only what was actually read gets validated and returned; a
+          // truncated archive must not surface as a spurious hash mismatch.
+          const data = bytesRead === info.size ? buffer : buffer.subarray(0, bytesRead);
+          await validateBufferIntegrityAsync(data, info.integrity);
+          return data;
+        })
+        .then(
+          (data) => callback(null, encoding ? data.toString(encoding) : data),
+          (error) => callback(error)
+        );
     }
   }
 
@@ -663,14 +1175,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
   };
 
   const { readFile: readFilePromise } = fs.promises;
+  const promisifiedReadFileAsar = util.promisify(fsReadFileAsar);
   fs.promises.readFile = function (pathArgument: string, options: any) {
     const pathInfo = splitPath(pathArgument);
     if (!pathInfo.isAsar) {
       return readFilePromise.apply(this, arguments);
     }
 
-    const p = util.promisify(fsReadFileAsar);
-    return p(pathArgument, options);
+    return promisifiedReadFileAsar(pathArgument, options);
   };
 
   function readFileFromArchiveSync(
@@ -685,29 +1197,23 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const info = archive.getFileInfo(filePath);
     if (!info) throw createError(AsarError.NOT_FOUND, { asarPath, filePath });
 
-    if (info.size === 0) return options ? '' : Buffer.alloc(0);
-    if (info.unpacked) {
-      const realPath = archive.copyFileOut(filePath);
-      return fs.readFileSync(realPath, options);
-    }
-
-    if (!options) {
-      options = { encoding: null };
-    } else if (typeof options === 'string') {
-      options = { encoding: options };
-    } else if (typeof options !== 'object') {
-      throw new TypeError('Bad arguments');
-    }
-
+    options = normalizeReadFileOptions(options);
     const { encoding } = options;
-    const buffer = Buffer.alloc(info.size);
+
+    if (info.size === 0) return encoding ? '' : Buffer.alloc(0);
+    if (info.unpacked) {
+      return fs.readFileSync(getUnpackedPath(asarPath, filePath), options);
+    }
+
     const fd = archive.getFdAndValidateIntegrityLater();
     if (!(fd >= 0)) {
       throw createError(AsarError.NOT_FOUND, { asarPath, filePath });
     }
 
     logASARAccess(asarPath, filePath, info.offset);
-    fs.readSync(fd, buffer, 0, info.size, info.offset);
+    let buffer = Buffer.allocUnsafeSlow(info.size);
+    const bytesRead = readFullySync(fd, buffer, 0, info.size, info.offset);
+    if (bytesRead !== info.size) buffer = buffer.subarray(0, bytesRead);
     validateBufferIntegrity(buffer, info.integrity);
     return encoding ? buffer.toString(encoding) : buffer;
   }
@@ -745,7 +1251,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       }
 
       const dirent = getDirent(currentPath, result[0][i], type);
-      const stat = internalBinding('fs').internalModuleStat(resultPath);
+      const stat = statTypeForReaddir(resultPath);
 
       context.readdirResults.push(dirent);
       if (dirent!.isDirectory() || stat === 1) {
@@ -758,7 +1264,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     for (let i = 0; i < result.length; i++) {
       const resultPath = path.join(currentPath, result[i]);
       const relativeResultPath = path.relative(context.basePath, resultPath);
-      const stat = internalBinding('fs').internalModuleStat(resultPath);
+      const stat = statTypeForReaddir(resultPath);
       context.readdirResults.push(relativeResultPath);
 
       if (stat === 1) {
@@ -829,7 +1335,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
           readdirResult = [
             [...readdirResult],
             readdirResult.map((p: string) => {
-              return internalBinding('fs').internalModuleStat(path.join(pathArg, p));
+              return statTypeForReaddir(path.join(pathArg, p));
             })
           ];
         }
@@ -1024,14 +1530,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     const archive = getOrCreateArchive(asarPath);
     if (!archive) return -34;
 
-    const stats = archive.stat(filePath);
-    const result = !stats ? -34 : stats.type === AsarFileType.kDirectory ? 1 : 0;
+    // Like a real stat, follow symbolic links inside the archive.
+    const resolved = resolveAsarLinks(archive, filePath);
+    const result = !resolved ? -34 : resolved.stats.type === AsarFileType.kDirectory ? 1 : 0;
     if (moduleStatCache.size >= kModuleStatCacheLimit) moduleStatCache.clear();
     moduleStatCache.set(pathArgument, result);
     return result;
   };
 
-  const { kUsePromises } = binding;
   async function readdirRecursivePromises(originalPath: string, options: ReaddirOptions) {
     const result: any[] = [];
 
@@ -1053,7 +1559,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
         initialItem = [
           [...initialItem],
           initialItem.map((p: string) => {
-            return internalBinding('fs').internalModuleStat(path.join(originalPath, p));
+            return statTypeForReaddir(path.join(originalPath, p));
           })
         ];
       }
@@ -1087,7 +1593,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
               readdirResult = [
                 [...files],
                 files.map((p: string) => {
-                  return internalBinding('fs').internalModuleStat(path.join(direntPath, p));
+                  return statTypeForReaddir(path.join(direntPath, p));
                 })
               ];
             } else {
@@ -1103,7 +1609,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
         const { 0: pathArg, 1: readDir } = queue.pop();
         for (const ent of readDir) {
           const direntPath = path.join(pathArg, ent);
-          const stat = internalBinding('fs').internalModuleStat(direntPath);
+          const stat = statTypeForReaddir(direntPath);
           result.push(path.relative(originalPath, direntPath));
 
           if (stat === 1) {
@@ -1153,7 +1659,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
           readdirResult = [
             [...readdirResult],
             readdirResult.map((p: string) => {
-              return internalBinding('fs').internalModuleStat(path.join(pathArg, p));
+              return statTypeForReaddir(path.join(pathArg, p));
             })
           ];
         }
@@ -1221,18 +1727,565 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     };
   }
 
-  // Strictly implementing the flags of fs.copyFile is hard, just do a simple
-  // implementation for now. Doing 2 copies won't spend much time more as OS
-  // has filesystem caching.
-  overrideAPI(fs, 'copyFile');
-  overrideAPISync(fs, 'copyFileSync');
-  overrideAPI(fs, 'cp');
-  overrideAPISync(fs, 'cpSync');
+  //
+  // fd-based access to packed entries: fs.open / fs.openSync /
+  // fs.promises.open and everything built on them (fs.createReadStream,
+  // fs.readFile(fd), FileHandle#read/readFile/stat/createReadStream, ...).
+  //
+  // These are hooked at the fs binding layer, below node's own argument
+  // parsing, so that every JS entry point in node that funnels down to
+  // binding.read / binding.fstat / binding.close for one of our fds is
+  // covered without re-implementing node's overload handling.
+  //
 
-  overrideAPI(fs, 'open');
+  // Node's native fs functions CHECK() their exact argument count to decide
+  // between sync and async forms, so pass-through calls must forward the
+  // original argument list untouched (in particular, never append a trailing
+  // `undefined`).
+  binding.open = function (...args: any[]) {
+    const [pathArgument, flags, , req] = args;
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return originalBinding.open(...args);
+    const { asarPath, filePath } = pathInfo;
+
+    let opened;
+    try {
+      opened = openAsarEntry(asarPath, filePath, flags, 'open');
+    } catch (error) {
+      return completeRequest(req, error as Error);
+    }
+    if ('unpackedPath' in opened) {
+      args[0] = opened.unpackedPath;
+      return originalBinding.open(...args);
+    }
+
+    const { reader } = opened;
+    if (openAsarFiles.size > 256) sweepStaleAsarFds();
+    openAsarFiles.set(reader.fd, { reader });
+    return completeRequest(req, null, reader.fd);
+  };
+
+  binding.openFileHandle = function (...args: any[]) {
+    const [pathArgument, flags, , req] = args;
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return originalBinding.openFileHandle(...args);
+    const { asarPath, filePath } = pathInfo;
+
+    let opened;
+    try {
+      opened = openAsarEntry(asarPath, filePath, flags, 'open');
+    } catch (error) {
+      return completeRequest(req, error as Error);
+    }
+    if ('unpackedPath' in opened) {
+      args[0] = opened.unpackedPath;
+      return originalBinding.openFileHandle(...args);
+    }
+
+    const { reader } = opened;
+    // Node's C++ FileHandle takes ownership of the fd (and closes it on
+    // close() or garbage collection); the JS FileHandle wraps this object.
+    const handle = new binding.FileHandle(reader.fd);
+    if (openAsarFiles.size > 256) sweepStaleAsarFds();
+    openAsarFiles.set(reader.fd, { reader, handle: new WeakRef(handle) });
+    return completeRequest(req, null, handle);
+  };
+
+  binding.read = function (...args: any[]) {
+    const [fd, buffer, offset, length, position, req] = args;
+    const reader = lookupAsarFd(fd);
+    if (reader === undefined) return originalBinding.read(...args);
+
+    const pos = normalizePosition(position);
+    if (reader.integrity === null) {
+      // Fast path: without integrity information the read only needs its
+      // position translated and clamped to the entry, so hand it straight to
+      // the native binding with the caller's own request object.
+      const { start, count } = reader.resolveRange(length, pos);
+      if (count === 0) return completeRequest(req, null, 0);
+      args[3] = count;
+      args[4] = reader.offset + start;
+      return originalBinding.read(...args);
+    }
+    if (req === undefined) return reader.readSync(buffer, offset, length, pos);
+    return completeRequestWithPromise(req, reader.read(buffer, offset, length, pos));
+  };
+
+  binding.readBuffers = function (...args: any[]) {
+    const [fd, buffers, position, req] = args as [number, Uint8Array[], number | bigint | null, any];
+    const reader = lookupAsarFd(fd);
+    if (reader === undefined) return originalBinding.readBuffers(...args);
+
+    const pos = normalizePosition(position);
+    if (reader.integrity === null) {
+      // Fast path (see binding.read): when every buffer fits inside the
+      // entry the native readv can be used as-is with a translated position.
+      let wanted = 0;
+      for (const buffer of buffers) wanted += buffer.byteLength;
+      const { start, count } = reader.resolveRange(wanted, pos);
+      if (count === 0) return completeRequest(req, null, 0);
+      if (count === wanted) {
+        args[2] = reader.offset + start;
+        return originalBinding.readBuffers(...args);
+      }
+      // Otherwise the tail must be clamped; the read position was already
+      // advanced by resolveRange, so serve the buffers positionally from
+      // `start`.
+      const filled: number[] = [];
+      let remaining = count;
+      for (const buffer of buffers) {
+        const take = Math.min(remaining, buffer.byteLength);
+        filled.push(take);
+        remaining -= take;
+      }
+      const readAllClamped = async () => {
+        let total = 0;
+        for (let i = 0; i < buffers.length && filled[i] > 0; i++) {
+          total += await readFully(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
+        }
+        return total;
+      };
+      if (req === undefined) {
+        let total = 0;
+        for (let i = 0; i < buffers.length && filled[i] > 0; i++) {
+          total += readFullySync(reader.fd, buffers[i], 0, filled[i], reader.offset + start + total);
+        }
+        return total;
+      }
+      return completeRequestWithPromise(req, readAllClamped());
+    }
+    if (req === undefined) {
+      let total = 0;
+      for (const buffer of buffers) {
+        const n = reader.readSync(buffer, 0, buffer.byteLength, pos < 0 ? -1 : pos + total);
+        total += n;
+        if (n < buffer.byteLength) break;
+      }
+      return total;
+    }
+    const readAll = async () => {
+      let total = 0;
+      for (const buffer of buffers) {
+        const n = await reader.read(buffer, 0, buffer.byteLength, pos < 0 ? -1 : pos + total);
+        total += n;
+        if (n < buffer.byteLength) break;
+      }
+      return total;
+    };
+    return completeRequestWithPromise(req, readAll());
+  };
+
+  binding.fstat = function (...args: any[]) {
+    const [fd, useBigint, req] = args;
+    const reader = lookupAsarFd(fd);
+    if (reader === undefined) return originalBinding.fstat(...args);
+    return completeRequest(req, null, reader.statArray(Boolean(useBigint)));
+  };
+
+  binding.close = function (...args: any[]) {
+    const fd = args[0];
+    if (lookupAsarFd(fd) !== undefined) forgetAsarFd(fd);
+    return originalBinding.close(...args);
+  };
+
+  binding.readFileUtf8 = function (...args: any[]) {
+    const reader = lookupAsarFd(args[0]);
+    if (reader === undefined) return originalBinding.readFileUtf8(...args);
+    return reader.readToEndSync().toString('utf8');
+  };
+
+  // fs.writeFileSync's utf8 fast path opens the file natively by path; route
+  // it through the same checks as open() so writes into archives fail with
+  // EACCES (or land in the real file for unpacked entries) instead of
+  // whatever the OS says about a path that goes through a file.
+  binding.writeFileUtf8 = function (...args: any[]) {
+    const [pathOrFd, , flags] = args;
+    const pathInfo = splitPath(pathOrFd);
+    if (!pathInfo.isAsar) return originalBinding.writeFileUtf8(...args);
+    const { asarPath, filePath } = pathInfo;
+
+    const opened = openAsarEntry(asarPath, filePath, flags, 'open');
+    if ('unpackedPath' in opened) {
+      args[0] = opened.unpackedPath;
+      return originalBinding.writeFileUtf8(...args);
+    }
+    // Only reachable with read-only flags, which writeFile never uses.
+    originalBinding.close(opened.reader.fd);
+    opened.reader.dispose();
+    throw createError(AsarError.NO_ACCESS, { asarPath, filePath, syscall: 'open' });
+  };
+
+  // A dup'd archive fd is O_RDONLY, so writes and truncation already fail
+  // natively (EBADF); metadata changes would go through to the archive file
+  // itself though, so refuse them explicitly.
+  const refuseMetadataChange = (name: 'fchmod' | 'fchown' | 'futimes') => {
+    const original = originalBinding[name];
+    binding[name] = function (...args: any[]) {
+      const fd = args[0];
+      if (lookupAsarFd(fd) === undefined) return original(...args);
+      const req = args[args.length - 1];
+      const hasReq = req !== undefined && (req === kUsePromises || typeof req === 'object');
+      const error = createError(AsarError.NO_ACCESS, { filePath: `fd ${fd}`, syscall: name });
+      return completeRequest(hasReq ? req : undefined, error);
+    };
+  };
+  refuseMetadataChange('fchmod');
+  refuseMetadataChange('fchown');
+  refuseMetadataChange('futimes');
+
+  //
+  // fs.copyFile / fs.copyFileSync / fs.promises.copyFile from a packed entry:
+  // stream the (validated) bytes straight into the destination instead of
+  // materialising a temporary copy first.
+  //
+
+  const kCopyChunkSize = 1024 * 1024;
+  const kMaxCopyFileMode = constants.COPYFILE_EXCL | constants.COPYFILE_FICLONE | constants.COPYFILE_FICLONE_FORCE;
+
+  function copyFileFlagsToOpenFlags(mode: number) {
+    return (
+      constants.O_WRONLY |
+      constants.O_CREAT |
+      ((mode & constants.COPYFILE_EXCL) !== 0 ? constants.O_EXCL : constants.O_TRUNC)
+    );
+  }
+
+  function copyPackedFileSync(reader: AsarEntryReader, dest: string, mode: number) {
+    const destMode = reader.executable ? 0o755 : 0o644;
+    const destFd = originalBinding.open(dest, copyFileFlagsToOpenFlags(mode), destMode);
+    try {
+      const chunk = Buffer.allocUnsafeSlow(Math.min(kCopyChunkSize, Math.max(reader.size, 1)));
+      let position = 0;
+      while (position < reader.size) {
+        const n = reader.readSync(chunk, 0, Math.min(chunk.length, reader.size - position), position);
+        if (n === 0) break;
+        let written = 0;
+        while (written < n) {
+          // The synchronous writeBuffer binding still uses the legacy ctx
+          // calling convention, so go through fs.writeSync (not overridden here).
+          written += fs.writeSync(destFd, chunk, written, n - written);
+        }
+        position += n;
+      }
+    } finally {
+      originalBinding.close(destFd);
+      reader.dispose();
+    }
+  }
+
+  async function copyPackedFile(reader: AsarEntryReader, dest: string, mode: number) {
+    const destMode = reader.executable ? 0o755 : 0o644;
+    const destFd = await originalBinding.open(dest, copyFileFlagsToOpenFlags(mode), destMode, kUsePromises);
+    try {
+      const chunk = Buffer.allocUnsafeSlow(Math.min(kCopyChunkSize, Math.max(reader.size, 1)));
+      let position = 0;
+      while (position < reader.size) {
+        const n = await reader.read(chunk, 0, Math.min(chunk.length, reader.size - position), position);
+        if (n === 0) break;
+        let written = 0;
+        while (written < n) {
+          written += (await originalBinding.writeBuffer(destFd, chunk, written, n - written, null, kUsePromises)) || 0;
+        }
+        position += n;
+      }
+    } finally {
+      await originalBinding.close(destFd, kUsePromises);
+      reader.dispose();
+    }
+  }
+
+  binding.copyFile = function (...args: any[]) {
+    const [src, dest, mode, req] = args;
+    const pathInfo = splitPath(src);
+    if (!pathInfo.isAsar) return originalBinding.copyFile(...args);
+    const { asarPath, filePath } = pathInfo;
+
+    let opened;
+    try {
+      // Same validation as node's native CopyFile (GetValidFileMode).
+      if (mode !== null && mode !== undefined && (typeof mode !== 'number' || (mode | 0) !== mode)) {
+        throw new (errorCodes as any).ERR_INVALID_ARG_TYPE('mode', 'int32', mode);
+      }
+      const modeFlags = mode ?? 0;
+      if (modeFlags < 0 || modeFlags > kMaxCopyFileMode) {
+        throw new (errorCodes as any).ERR_OUT_OF_RANGE('mode', `>= 0 && <= ${kMaxCopyFileMode}`, mode);
+      }
+      if ((modeFlags & constants.COPYFILE_FICLONE_FORCE) !== 0) {
+        throw createError(AsarError.NOT_SUPPORTED, { asarPath, filePath, syscall: 'copyfile' });
+      }
+      opened = openAsarEntry(asarPath, filePath, constants.O_RDONLY, 'copyfile');
+    } catch (error) {
+      return completeRequest(req, error as Error);
+    }
+    if ('unpackedPath' in opened) {
+      args[0] = opened.unpackedPath;
+      return originalBinding.copyFile(...args);
+    }
+
+    const { reader } = opened;
+    const closeSourceFd = () => originalBinding.close(reader.fd);
+    if (req === undefined) {
+      try {
+        copyPackedFileSync(reader, dest, mode ?? 0);
+      } finally {
+        closeSourceFd();
+      }
+      return;
+    }
+    return completeRequestWithPromise(req, copyPackedFile(reader, dest, mode ?? 0).finally(closeSourceFd));
+  };
+
+  //
+  // fs.readlink / fs.readlinkSync / fs.promises.readlink for symbolic links
+  // stored in an archive.  Archives store link targets relative to the
+  // archive root; what a real filesystem would report is the target relative
+  // to the link's own directory, so that is what gets returned (which also
+  // makes trees copied out with fs.cp({ verbatimSymlinks: true }) work).
+  //
+
+  binding.readlink = function (...args: any[]) {
+    const [pathArgument, encoding, req] = args;
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return originalBinding.readlink(...args);
+    const { asarPath, filePath } = pathInfo;
+
+    const archive = getOrCreateArchive(asarPath);
+    if (!archive) {
+      return completeRequest(req, createError(AsarError.INVALID_ARCHIVE, { asarPath, syscall: 'readlink' }));
+    }
+
+    const stats = archive.stat(filePath);
+    if (!stats) {
+      return completeRequest(req, createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall: 'readlink' }));
+    }
+    if (stats.type !== AsarFileType.kLink) {
+      return completeRequest(req, createError(AsarError.NOT_LINK, { asarPath, filePath, syscall: 'readlink' }));
+    }
+
+    const linkTarget = archive.realpath(filePath);
+    if (linkTarget === false) {
+      return completeRequest(req, createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall: 'readlink' }));
+    }
+    // Both sides are archive-relative; anchor them at a root so that the
+    // computation does not depend on the process's working directory.
+    const target = path.relative(path.join(path.sep, path.dirname(filePath)), path.join(path.sep, linkTarget)) || '.';
+    return completeRequest(req, null, encoding === 'buffer' ? Buffer.from(target) : target);
+  };
+
+  //
+  // fs.opendir / fs.opendirSync / fs.promises.opendir on archive directories.
+  // Node's Dir class drives a native DirHandle through a small protocol
+  // (read(encoding, bufferSize[, req]) -> [name, type, name, type, ...] |
+  // null; close([req])); provide the same over the archive header.  Because
+  // Dir also opens sub-directories through this binding when `recursive` is
+  // set, recursive iteration works too.
+  //
+
+  class AsarDirHandle {
+    private entries: [string, number][] | null;
+
+    constructor(entries: [string, number][]) {
+      this.entries = entries;
+    }
+
+    read(encoding: any, bufferSize: number, req?: any) {
+      let result: any[] | null = null;
+      if (this.entries !== null && this.entries.length > 0) {
+        const count = Math.max(1, bufferSize | 0);
+        const taken = this.entries.splice(0, count);
+        result = [];
+        for (const [name, type] of taken) {
+          result.push(encoding === 'buffer' ? Buffer.from(name) : name, type);
+        }
+      }
+      return completeRequest(req, null, result);
+    }
+
+    close(req?: any) {
+      this.entries = null;
+      return completeRequest(req, null, undefined);
+    }
+  }
+
+  function openAsarDir(pathInfo: { asarPath: string; filePath: string }, req: any) {
+    const { asarPath, filePath } = pathInfo;
+
+    const archive = getOrCreateArchive(asarPath);
+    if (!archive) return completeRequest(req, createError(AsarError.INVALID_ARCHIVE, { asarPath, syscall: 'opendir' }));
+
+    // opendir follows symbolic links.
+    const resolved = resolveAsarLinks(archive, filePath);
+    if (!resolved) {
+      return completeRequest(req, createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall: 'opendir' }));
+    }
+    if (resolved.stats.type !== AsarFileType.kDirectory) {
+      return completeRequest(req, createError(AsarError.NOT_DIR, { asarPath, filePath, syscall: 'opendir' }));
+    }
+
+    const names = archive.readdir(filePath);
+    if (!names) {
+      return completeRequest(req, createError(AsarError.NOT_FOUND, { asarPath, filePath, syscall: 'opendir' }));
+    }
+
+    const entries: [string, number][] = [];
+    for (const name of names) {
+      const childStats = archive.stat(path.join(filePath, name));
+      if (!childStats) continue;
+      entries.push([name, childStats.type]);
+    }
+    return completeRequest(req, null, new AsarDirHandle(entries));
+  }
+
+  dirBinding.opendir = function (...args: any[]) {
+    const [pathArgument, , req] = args;
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return originalDirBinding.opendir(...args);
+    return openAsarDir(pathInfo, req);
+  };
+
+  dirBinding.opendirSync = function (...args: any[]) {
+    const pathInfo = splitPath(args[0]);
+    if (!pathInfo.isAsar) return originalDirBinding.opendirSync(...args);
+    return openAsarDir(pathInfo, undefined);
+  };
+
+  //
+  // fs.cpSync from an archive.  Node's cp() (async) is written on top of
+  // fs.promises and works against the overrides above; cpSync() calls into
+  // native helpers that resolve paths themselves, so those are given
+  // archive-aware equivalents.
+  //
+
+  const { ERR_FS_CP_EINVAL, ERR_FS_CP_DIR_TO_NON_DIR, ERR_FS_CP_NON_DIR_TO_DIR, ERR_FS_EISDIR, ERR_FS_CP_EEXIST } =
+    errorCodes as any;
+
+  const isSubdirectory = (parent: string, child: string) => {
+    const relative = path.relative(parent, child);
+    return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+  };
+
+  binding.cpSyncCheckPaths = function (...args: any[]) {
+    const [src, dest, dereference, recursive] = args;
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncCheckPaths(...args);
+
+    const statFn = dereference ? fs.statSync : fs.lstatSync;
+    const srcStat = statFn(src);
+    const destStat = statFn(dest, { throwIfNoEntry: false });
+    const srcIsDir = srcStat.isDirectory();
+    if (destStat) {
+      const destIsDir = destStat.isDirectory();
+      if (srcIsDir && !destIsDir) {
+        throw new ERR_FS_CP_DIR_TO_NON_DIR({
+          message: `Cannot overwrite non-directory ${dest} with directory ${src}`,
+          path: dest,
+          syscall: 'cp',
+          errno: -22,
+          code: 'EINVAL'
+        });
+      }
+      if (!srcIsDir && destIsDir) {
+        throw new ERR_FS_CP_NON_DIR_TO_DIR({
+          message: `Cannot overwrite directory ${dest} with non-directory ${src}`,
+          path: dest,
+          syscall: 'cp',
+          errno: -22,
+          code: 'EINVAL'
+        });
+      }
+    }
+    if (srcIsDir && isSubdirectory(path.resolve(src), path.resolve(dest))) {
+      throw new ERR_FS_CP_EINVAL({
+        message: `Cannot copy ${src} to a subdirectory of self ${dest}`,
+        path: dest,
+        syscall: 'cp',
+        errno: -22,
+        code: 'EINVAL'
+      });
+    }
+    if (srcIsDir && !recursive) {
+      throw new ERR_FS_EISDIR({
+        message: `Recursive option not enabled, cannot copy a directory: ${src}`,
+        path: src,
+        syscall: 'cp',
+        errno: -21,
+        code: 'EISDIR'
+      });
+    }
+  };
+
+  binding.cpSyncOverrideFile = function (...args: any[]) {
+    const [src, dest, mode, preserveTimestamps] = args;
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncOverrideFile(...args);
+    fs.unlinkSync(dest);
+    fs.copyFileSync(src, dest, mode);
+    if (preserveTimestamps) {
+      const srcStat = fs.statSync(src);
+      fs.utimesSync(dest, srcStat.atime, srcStat.mtime);
+    }
+  };
+
+  binding.cpSyncCopyDir = function (...args: any[]) {
+    const [src, dest, force, dereference, errorOnExist, verbatimSymlinks, preserveTimestamps] = args;
+    if (!splitPath(src).isAsar) return originalBinding.cpSyncCopyDir(...args);
+
+    const copyDir = (srcDir: string, destDir: string) => {
+      fs.mkdirSync(destDir, { recursive: true });
+      for (const dirent of fs.readdirSync(srcDir, { withFileTypes: true }) as Dirent[]) {
+        const srcItem = path.join(srcDir, dirent.name);
+        const destItem = path.join(destDir, dirent.name);
+        let isDirectory = dirent.isDirectory();
+        if (dirent.isSymbolicLink()) {
+          if (!dereference) {
+            let target = fs.readlinkSync(srcItem);
+            if (!verbatimSymlinks && !path.isAbsolute(target)) target = path.resolve(srcDir, target);
+            // Like node's native implementation: an existing symlink at the
+            // destination is replaced, anything else is an error.
+            const existing = fs.lstatSync(destItem, { throwIfNoEntry: false });
+            if (existing) {
+              if (!existing.isSymbolicLink()) {
+                throw createError(AsarError.EXISTS, { asarPath: dest, filePath: dirent.name, syscall: 'cp' });
+              }
+              fs.unlinkSync(destItem);
+            }
+            fs.symlinkSync(target, destItem);
+            continue;
+          }
+          isDirectory = fs.statSync(srcItem).isDirectory();
+        }
+        if (isDirectory) {
+          copyDir(srcItem, destItem);
+          continue;
+        }
+        const destStat = fs.lstatSync(destItem, { throwIfNoEntry: false });
+        if (destStat) {
+          if (!force) {
+            if (errorOnExist) {
+              throw new ERR_FS_CP_EEXIST({
+                message: `${destItem} already exists`,
+                path: destItem,
+                syscall: 'cp',
+                errno: -17,
+                code: 'EEXIST'
+              });
+            }
+            continue;
+          }
+          fs.unlinkSync(destItem);
+        }
+        fs.copyFileSync(srcItem, destItem);
+        if (preserveTimestamps) {
+          const srcStat = fs.statSync(srcItem);
+          fs.utimesSync(destItem, srcStat.atime, srcStat.mtime);
+        }
+      }
+    };
+    copyDir(src, dest);
+  };
+
+  // Native modules and child processes need a real file on disk, so these
+  // are the only remaining consumers of Archive::CopyFileOut.
   overrideAPISync(process, 'dlopen', 1);
   overrideAPISync(Module._extensions, '.node', 1);
-  overrideAPISync(fs, 'openSync');
 
   const overrideChildProcess = (childProcess: Record<string, any>) => {
     // Executing a command string containing a path to an asar archive
@@ -1277,3 +2330,20 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     };
   }
 };
+
+function getDirents(p: string, { 0: names, 1: types }: any[][]): Dirent[] {
+  for (let i = 0; i < names.length; i++) {
+    let type = types[i];
+    const info = splitPath(path.join(p, names[i]));
+    if (info.isAsar) {
+      const archive = getOrCreateArchive(info.asarPath);
+      if (!archive) continue;
+      const stats = archive.stat(info.filePath);
+      if (!stats) continue;
+      type = stats.type;
+    }
+    names[i] = getDirent(p, names[i], type);
+  }
+
+  return names;
+}

--- a/script/node/generate_original_fs.py
+++ b/script/node/generate_original_fs.py
@@ -21,4 +21,17 @@ for fs_file in fs_files:
             transformed_contents = contents.replace('internal/fs/',
                     'internal/original-fs/').replace('require(\'fs',
                     'require(\'original-fs')
+            # The asar fs wrapper (lib/node/asar-fs-wrapper.ts) intercepts
+            # some functions on the shared `fs` / `fs_dir` bindings so that
+            # every entry point of the `fs` module handles archives. It keeps
+            # a snapshot of the pristine bindings on the `fs` binding under
+            # `_electronOriginalBindings`; original-fs must always use that
+            # snapshot (falling back to the live binding when the wrapper is
+            # not installed, e.g. ELECTRON_RUN_AS_NODE) so that it keeps
+            # behaving like unmodified Node.js.
+            for name in ('fs', 'fs_dir'):
+                transformed_contents = transformed_contents.replace(
+                        f"internalBinding('{name}')",
+                        "(internalBinding('fs')._electronOriginalBindings"
+                        f"?.{name} ?? internalBinding('{name}'))")
             transformed_f.write(transformed_contents)

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -4,11 +4,22 @@
 
 #include <vector>
 
+#include "build/build_config.h"
 #include "shell/common/asar/archive.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+
+#if BUILDFLAG(IS_WIN)
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
+
+#include "base/posix/eintr_wrapper.h"
+#endif
 
 namespace {
 
@@ -27,7 +38,6 @@ class Archive : public node::ObjectWrap {
     NODE_SET_PROTOTYPE_METHOD(tpl, "copyFileOut", &Archive::CopyFileOut);
     NODE_SET_PROTOTYPE_METHOD(tpl, "getFdAndValidateIntegrityLater",
                               &Archive::GetFD);
-    NODE_SET_PROTOTYPE_METHOD(tpl, "dupFd", &Archive::DupFd);
 
     return tpl;
   }
@@ -189,17 +199,44 @@ class Archive : public node::ObjectWrap {
         isolate, wrap->archive_ ? wrap->archive_->GetUnsafeFD() : -1));
   }
 
-  // Return a new caller-owned read-only file descriptor for the archive.
-  static void DupFd(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    auto* isolate = args.GetIsolate();
-    auto* wrap = node::ObjectWrap::Unwrap<Archive>(args.This());
-
-    args.GetReturnValue().Set(gin::ConvertToV8(
-        isolate, wrap->archive_ ? wrap->archive_->DuplicateFd() : -1));
-  }
-
   std::shared_ptr<asar::Archive> archive_;
 };
+
+// Returns a new, caller-owned, non-inheritable file descriptor that refers
+// to the null device opened write-only, or -1 on failure.
+//
+// The fs wrapper hands one of these out for every open() of a packed entry
+// and keeps the mapping from it to the entry on the JavaScript side, so the
+// descriptor a caller sees is only meaningful through Node's fs module. Code
+// that reads the raw descriptor itself (a native addon, a child's stdio, a
+// socket, ...) fails with EBADF instead of being handed bytes of the archive
+// at the wrong offset, and no handle to the archive itself ever escapes.
+static void CreateSentinelFd(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  auto* isolate = args.GetIsolate();
+#if BUILDFLAG(IS_WIN)
+  static const HANDLE null_device = ::CreateFileW(
+      L"NUL", GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  int fd = -1;
+  if (null_device != INVALID_HANDLE_VALUE) {
+    HANDLE handle = nullptr;
+    if (::DuplicateHandle(::GetCurrentProcess(), null_device,
+                          ::GetCurrentProcess(), &handle, 0,
+                          /*bInheritHandle=*/FALSE, DUPLICATE_SAME_ACCESS)) {
+      fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), _O_WRONLY);
+      if (fd == -1)
+        ::CloseHandle(handle);
+    }
+  }
+#else
+  static const int null_device =
+      HANDLE_EINTR(open("/dev/null", O_WRONLY | O_CLOEXEC));
+  int fd = -1;
+  if (null_device >= 0)
+    fd = HANDLE_EINTR(fcntl(null_device, F_DUPFD_CLOEXEC, 0));
+#endif
+  args.GetReturnValue().Set(gin::ConvertToV8(isolate, fd));
+}
 
 static void SplitPath(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto* isolate = args.GetIsolate();
@@ -237,6 +274,7 @@ void Initialize(v8::Local<v8::Object> exports,
   exports->Set(context, node::FIXED_ONE_BYTE_STRING(isolate, "Archive"), cons)
       .Check();
   NODE_SET_METHOD(exports, "splitPath", &SplitPath);
+  NODE_SET_METHOD(exports, "createSentinelFd", &CreateSentinelFd);
 }
 
 }  // namespace

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -214,9 +214,9 @@ class Archive : public node::ObjectWrap {
 static void CreateSentinelFd(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto* isolate = args.GetIsolate();
 #if BUILDFLAG(IS_WIN)
-  static const HANDLE null_device = ::CreateFileW(
-      L"NUL", GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
-      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  static const HANDLE null_device =
+      ::CreateFileW(L"NUL", GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   int fd = -1;
   if (null_device != INVALID_HANDLE_VALUE) {
     HANDLE handle = nullptr;

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -27,6 +27,7 @@ class Archive : public node::ObjectWrap {
     NODE_SET_PROTOTYPE_METHOD(tpl, "copyFileOut", &Archive::CopyFileOut);
     NODE_SET_PROTOTYPE_METHOD(tpl, "getFdAndValidateIntegrityLater",
                               &Archive::GetFD);
+    NODE_SET_PROTOTYPE_METHOD(tpl, "dupFd", &Archive::DupFd);
 
     return tpl;
   }
@@ -82,17 +83,20 @@ class Archive : public node::ObjectWrap {
     dict.Set("size", info.size);
     dict.Set("unpacked", info.unpacked);
     dict.Set("offset", info.offset);
+    dict.Set("executable", info.executable);
     if (info.integrity.has_value()) {
+      const asar::IntegrityPayload& payload = info.integrity.value();
       gin_helper::Dictionary integrity(isolate, v8::Object::New(isolate));
-      asar::HashAlgorithm algorithm = info.integrity.value().algorithm;
-      switch (algorithm) {
+      switch (payload.algorithm) {
         case asar::HashAlgorithm::kSHA256:
           integrity.Set("algorithm", "SHA256");
           break;
         case asar::HashAlgorithm::kNone:
           NOTREACHED();
       }
-      integrity.Set("hash", info.integrity.value().hash);
+      integrity.Set("hash", payload.hash);
+      integrity.Set("blockSize", payload.block_size);
+      integrity.Set("blocks", payload.blocks);
       dict.Set("integrity", integrity);
     }
     args.GetReturnValue().Set(dict.GetHandle());
@@ -182,6 +186,15 @@ class Archive : public node::ObjectWrap {
 
     args.GetReturnValue().Set(gin::ConvertToV8(
         isolate, wrap->archive_ ? wrap->archive_->GetUnsafeFD() : -1));
+  }
+
+  // Return a new caller-owned read-only file descriptor for the archive.
+  static void DupFd(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    auto* isolate = args.GetIsolate();
+    auto* wrap = node::ObjectWrap::Unwrap<Archive>(args.This());
+
+    args.GetReturnValue().Set(gin::ConvertToV8(
+        isolate, wrap->archive_ ? wrap->archive_->DuplicateFd() : -1));
   }
 
   std::shared_ptr<asar::Archive> archive_;

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -122,6 +122,7 @@ class Archive : public node::ObjectWrap {
     dict.Set("size", stats.size);
     dict.Set("offset", stats.offset);
     dict.Set("type", static_cast<int>(stats.type));
+    dict.Set("executable", stats.executable);
     args.GetReturnValue().Set(dict.GetHandle());
   }
 

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -24,13 +24,7 @@
 #include "shell/common/thread_restrictions.h"
 
 #if BUILDFLAG(IS_WIN)
-#include <fcntl.h>
 #include <io.h>
-#include <windows.h>
-#else
-#include <fcntl.h>
-
-#include "base/posix/eintr_wrapper.h"
 #endif
 
 namespace asar {
@@ -450,27 +444,6 @@ base::File Archive::DuplicateFile() {
 
 int Archive::GetUnsafeFD() const {
   return fd_;
-}
-
-int Archive::DuplicateFd() {
-  if (!file_.IsValid())
-    return -1;
-
-  electron::ScopedAllowBlockingForElectron allow_blocking;
-#if BUILDFLAG(IS_WIN)
-  HANDLE handle = nullptr;
-  if (!::DuplicateHandle(::GetCurrentProcess(), file_.GetPlatformFile(),
-                         ::GetCurrentProcess(), &handle, 0,
-                         /*bInheritHandle=*/FALSE, DUPLICATE_SAME_ACCESS)) {
-    return -1;
-  }
-  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), _O_RDONLY);
-  if (fd == -1)
-    ::CloseHandle(handle);
-  return fd;
-#else
-  return HANDLE_EINTR(fcntl(fd_, F_DUPFD_CLOEXEC, 0));
-#endif
 }
 
 }  // namespace asar

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -413,11 +413,14 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
     return false;
 
 #if BUILDFLAG(IS_POSIX)
-  // The temporary file is a cached, integrity-validated copy that may be
-  // handed out again for the lifetime of this process, so make it read-only
-  // to keep it from being modified out from under later consumers.
-  base::SetPosixFilePermissions(temp_file->path(),
-                                info.executable ? 0555 : 0444);
+  {
+    // The temporary file is a cached, integrity-validated copy that may be
+    // handed out again for the lifetime of this process, so make it read-only
+    // to keep it from being modified out from under later consumers.
+    electron::ScopedAllowBlockingForElectron allow_blocking;
+    base::SetPosixFilePermissions(temp_file->path(),
+                                  info.executable ? 0555 : 0444);
+  }
 #endif
 
   *out = temp_file->path();

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -24,7 +24,13 @@
 #include "shell/common/thread_restrictions.h"
 
 #if BUILDFLAG(IS_WIN)
+#include <fcntl.h>
 #include <io.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
+
+#include "base/posix/eintr_wrapper.h"
 #endif
 
 namespace asar {
@@ -407,10 +413,11 @@ bool Archive::CopyFileOut(const base::FilePath& path, base::FilePath* out) {
     return false;
 
 #if BUILDFLAG(IS_POSIX)
-  if (info.executable) {
-    // chmod a+x temp_file;
-    base::SetPosixFilePermissions(temp_file->path(), 0755);
-  }
+  // The temporary file is a cached, integrity-validated copy that may be
+  // handed out again for the lifetime of this process, so make it read-only
+  // to keep it from being modified out from under later consumers.
+  base::SetPosixFilePermissions(temp_file->path(),
+                                info.executable ? 0555 : 0444);
 #endif
 
   *out = temp_file->path();
@@ -440,6 +447,27 @@ base::File Archive::DuplicateFile() {
 
 int Archive::GetUnsafeFD() const {
   return fd_;
+}
+
+int Archive::DuplicateFd() {
+  if (!file_.IsValid())
+    return -1;
+
+  electron::ScopedAllowBlockingForElectron allow_blocking;
+#if BUILDFLAG(IS_WIN)
+  HANDLE handle = nullptr;
+  if (!::DuplicateHandle(::GetCurrentProcess(), file_.GetPlatformFile(),
+                         ::GetCurrentProcess(), &handle, 0,
+                         /*bInheritHandle=*/FALSE, DUPLICATE_SAME_ACCESS)) {
+    return -1;
+  }
+  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), _O_RDONLY);
+  if (fd == -1)
+    ::CloseHandle(handle);
+  return fd;
+#else
+  return HANDLE_EINTR(fcntl(fd_, F_DUPFD_CLOEXEC, 0));
+#endif
 }
 
 }  // namespace asar

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -111,13 +111,6 @@ class Archive {
   // for integrity validation after this fd is handed over.
   int GetUnsafeFD() const;
 
-  // Returns a new, caller-owned, read-only, non-inheritable file descriptor
-  // that refers to the same open archive as |file_| (a dup of the retained
-  // handle, so it is unaffected by the on-disk file being replaced). Returns
-  // -1 on failure. As with GetUnsafeFD(), reads through this fd are not
-  // integrity-validated; the caller must validate what it reads.
-  int DuplicateFd();
-
  private:
   // Resolves |path|, following at most a bounded number of chained "link"
   // entries so that a cyclic link in the header cannot recurse forever.

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -111,6 +111,13 @@ class Archive {
   // for integrity validation after this fd is handed over.
   int GetUnsafeFD() const;
 
+  // Returns a new, caller-owned, read-only, non-inheritable file descriptor
+  // that refers to the same open archive as |file_| (a dup of the retained
+  // handle, so it is unaffected by the on-disk file being replaced). Returns
+  // -1 on failure. As with GetUnsafeFD(), reads through this fd are not
+  // integrity-validated; the caller must validate what it reads.
+  int DuplicateFd();
+
  private:
   // Resolves |path|, following at most a bounded number of chained "link"
   // entries so that a cyclic link in the header cannot recurse forever.

--- a/spec/asar-integrity-spec.ts
+++ b/spec/asar-integrity-spec.ts
@@ -1,4 +1,4 @@
-import { getRawHeader } from '@electron/asar';
+import { createPackage, getRawHeader } from '@electron/asar';
 import { flipFuses, FuseV1Config, FuseV1Options, FuseVersion } from '@electron/fuses';
 import { resedit } from '@electron/packager/resedit';
 
@@ -13,6 +13,9 @@ import * as path from 'node:path';
 
 import { copyApp } from './lib/fs-helpers';
 import { ifdescribe } from './lib/spec-helpers';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const plist = require('plist');
 
 const bufferReplace = (haystack: Buffer, needle: string, replacement: string, throwOnMissing = true): Buffer => {
   const needleBuffer = Buffer.from(needle);
@@ -66,11 +69,18 @@ describe('fuses', function () {
   let tmpDir: string;
   let appPath: string;
 
-  const launchApp = (args: string[] = []) => {
+  const launchApp = (args: string[] = [], opts: any = {}) => {
     if (process.platform === 'darwin') {
-      return spawn(path.resolve(appPath, 'Contents/MacOS/Electron'), args);
+      // Several of these apps terminate abnormally on purpose; tell AppKit
+      // not to save/restore window state for them so macOS does not show the
+      // "unexpectedly quit while reopening windows" dialog on the next launch
+      // of an app with the same bundle identifier.
+      // (Only when a script/flag is given: with no arguments the default app
+      // would otherwise treat 'YES' as the app path.)
+      const macArgs = args.length > 0 ? [...args, '-ApplePersistenceIgnoreState', 'YES'] : args;
+      return spawn(path.resolve(appPath, 'Contents/MacOS/Electron'), macArgs, opts);
     }
-    return spawn(appPath, args);
+    return spawn(appPath, args, opts);
   };
 
   const ensureFusesBeforeEach = (
@@ -101,27 +111,77 @@ describe('fuses', function () {
     }
   });
 
+  // Layout of the archive used by fixtures/apps/asar-integrity-reads: a
+  // multi-block entry (with a recognisable marker at the start of every 4MB
+  // integrity block so tests can corrupt a specific block), an entry that is
+  // exactly one block, and a small one.  Keep in sync with the fixture.
+  const kIntegrityBlockSize = 4 * 1024 * 1024;
+  const kMultiSize = 2 * kIntegrityBlockSize + 1024 * 1024 + 5;
+  const patternByte = (i: number) => (i * 7 + (i >> 8)) & 0xff;
+  const blockMarker = (n: number) => `ASARBLOCK${n}MAGIC!`;
+  const buildIntegrityReadsAsar = async (dest: string) => {
+    const src = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'electron-asar-integrity-reads-src-'));
+    const multi = Buffer.alloc(kMultiSize);
+    for (let i = 0; i < kMultiSize; i++) multi[i] = patternByte(i);
+    for (let n = 0; n * kIntegrityBlockSize < kMultiSize; n++) {
+      multi.write(blockMarker(n), n * kIntegrityBlockSize, 'latin1');
+    }
+    const exact = Buffer.alloc(kIntegrityBlockSize);
+    for (let i = 0; i < exact.length; i++) exact[i] = patternByte(i);
+    const small = Buffer.alloc(1000);
+    for (let i = 0; i < small.length; i++) small[i] = patternByte(i);
+    await fs.promises.writeFile(path.join(src, 'multi.bin'), multi);
+    await fs.promises.writeFile(path.join(src, 'exact.bin'), exact);
+    await fs.promises.writeFile(path.join(src, 'small.bin'), small);
+    await createPackage(src, dest);
+    await fs.promises.rm(src, { recursive: true, force: true });
+  };
+  const headerHash = (asarPath: string) =>
+    nodeCrypto.createHash('sha256').update(getRawHeader(asarPath).headerString).digest('hex');
+
   ifdescribe((process.platform === 'win32' && process.arch !== 'arm64') || process.platform === 'darwin')(
     'ASAR Integrity',
     () => {
       let pathToAsar: string;
+      let pathToReadsAsar: string;
 
       beforeEach(async () => {
+        let resourcesDir: string;
         if (process.platform === 'darwin') {
-          pathToAsar = path.resolve(appPath, 'Contents', 'Resources', 'default_app.asar');
+          resourcesDir = path.resolve(appPath, 'Contents', 'Resources');
         } else {
-          pathToAsar = path.resolve(path.dirname(appPath), 'resources', 'default_app.asar');
+          resourcesDir = path.resolve(path.dirname(appPath), 'resources');
         }
+        pathToAsar = path.resolve(resourcesDir, 'default_app.asar');
+        pathToReadsAsar = path.resolve(resourcesDir, 'integrity-reads.asar');
+        await buildIntegrityReadsAsar(pathToReadsAsar);
 
+        // Register both archives in the app's integrity table.  This has to
+        // happen before the fuses are flipped, which re-signs the app.
         if (process.platform === 'win32') {
           await resedit(appPath, {
             asarIntegrity: {
               'resources\\default_app.asar': {
                 algorithm: 'SHA256',
-                hash: nodeCrypto.createHash('sha256').update(getRawHeader(pathToAsar).headerString).digest('hex')
+                hash: headerHash(pathToAsar)
+              },
+              'resources\\integrity-reads.asar': {
+                algorithm: 'SHA256',
+                hash: headerHash(pathToReadsAsar)
               }
             }
           });
+        } else {
+          const infoPlistPath = path.resolve(appPath, 'Contents', 'Info.plist');
+          const info = plist.parse(await fs.promises.readFile(infoPlistPath, 'utf8'));
+          info.ElectronAsarIntegrity = {
+            ...info.ElectronAsarIntegrity,
+            'Resources/integrity-reads.asar': {
+              algorithm: 'SHA256',
+              hash: headerHash(pathToReadsAsar)
+            }
+          };
+          await fs.promises.writeFile(infoPlistPath, plist.build(info));
         }
       });
 
@@ -178,6 +238,101 @@ describe('fuses', function () {
           const res = await launchApp();
           expectToHaveCrashed(res);
           expect(res.out).to.include('Failed to validate block while ending ASAR file stream');
+        });
+
+        const fdReadModes = ['fd', 'stream', 'handle', 'copy'];
+        const fdReadsApp = path.resolve(__dirname, 'fixtures/apps/asar-fd-reads/main.js');
+
+        for (const mode of fdReadModes) {
+          it(`serves unmodified files through fs.open-style APIs (${mode})`, async () => {
+            const res = await launchApp([fdReadsApp], { env: { ...process.env, ASAR_FD_READ_MODE: mode } });
+            expect(res.out).to.include(`${mode}-read-ok`);
+            expect(res.code).to.equal(0);
+            expect(res.signal).to.equal(null);
+          });
+
+          it(`fatals if a file read through fs.open-style APIs does not match (${mode})`, async () => {
+            const asar = await originalFs.promises.readFile(pathToAsar);
+            expect(asar.toString()).to.contain('require-trusted-types-for');
+            await originalFs.promises.writeFile(
+              pathToAsar,
+              bufferReplace(asar, 'require-trusted-types-for', 'require-trusted-types-not')
+            );
+
+            const res = await launchApp([fdReadsApp], { env: { ...process.env, ASAR_FD_READ_MODE: mode } });
+            expect(res.code).to.equal(1);
+            expect(res.signal).to.equal(null);
+            expect(res.out).to.include('ASAR Integrity Violation: got a hash mismatch');
+            expect(res.out).to.not.include(`${mode}-read-ok`);
+          });
+        }
+
+        describe('block validated reads of a multi-block entry', () => {
+          const readsApp = path.resolve(__dirname, 'fixtures/apps/asar-integrity-reads/main.js');
+          const runReads = (mode: string) =>
+            launchApp([readsApp], { env: { ...process.env, ASAR_INTEGRITY_READS_MODE: mode } });
+          const corruptBlock = async (n: number) => {
+            const asar = await originalFs.promises.readFile(pathToReadsAsar);
+            const marker = blockMarker(n);
+            expect(asar.indexOf(marker)).to.not.equal(-1);
+            await originalFs.promises.writeFile(
+              pathToReadsAsar,
+              bufferReplace(asar, marker, `TAMPERED${n}MAGIC!!`.slice(0, marker.length))
+            );
+          };
+          const expectViolation = (res: SpawnResult) => {
+            expect(res.code).to.equal(1);
+            expect(res.signal).to.equal(null);
+            expect(res.out).to.include('ASAR Integrity Violation: got a hash mismatch');
+          };
+
+          it('serves streams, ranged reads, fds, handles, readv and copies correctly when unmodified', async () => {
+            const res = await runReads('sweep');
+            expect(res.out).to.include('sweep-streams-ok');
+            expect(res.out).to.include('sweep-ranges-ok');
+            expect(res.out).to.include('sweep-fd-ok');
+            expect(res.out).to.include('sweep-handle-ok');
+            expect(res.out).to.include('sweep-concurrent-ok');
+            expect(res.out).to.include('sweep-copy-ok');
+            expect(res.out).to.include('sweep-ok');
+            expect(res.code).to.equal(0);
+            expect(res.signal).to.equal(null);
+          });
+
+          for (const block of [0, 1, 2]) {
+            it(`terminates a stream when it reaches corrupted block ${block}`, async () => {
+              await corruptBlock(block);
+              const res = await runReads('block-stream');
+              expectViolation(res);
+              expect(res.out).to.not.include('stream-ok');
+              // Every block before the corrupted one streamed successfully...
+              for (let n = 0; n < block; n++) expect(res.out).to.include(`reached-block-${n}`);
+              // ...and no byte from the corrupted block was ever delivered.
+              expect(res.out).to.not.include(`reached-block-${block}`);
+            });
+          }
+
+          it('still serves ranges that only touch intact blocks when a later block is corrupted', async () => {
+            await corruptBlock(2);
+            const res = await runReads('range-block0');
+            expect(res.out).to.include('range-block0-ok');
+            expect(res.code).to.equal(0);
+            expect(res.signal).to.equal(null);
+          });
+
+          it('fatals whole-file reads of an entry with a corrupted block', async () => {
+            await corruptBlock(1);
+            const res = await runReads('readfile');
+            expectViolation(res);
+            expect(res.out).to.not.include('readfile-ok');
+          });
+
+          it('detects a block that is corrupted in place after it was already read once', async () => {
+            const res = await runReads('tamper-after-read');
+            expect(res.out).to.include('tamper-after-read-A-ok');
+            expect(res.out).to.not.include('tamper-after-read-B-unexpectedly-ok');
+            expectViolation(res);
+          });
         });
       });
 

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1575,6 +1575,25 @@ describe('asar package', function () {
         fs.closeSync(fd);
       });
 
+      itremote('hands out a descriptor that is not usable outside of fs', function () {
+        // The number identifies the entry to fs only; it must never expose the
+        // archive's bytes to code that reads the raw descriptor, and that code
+        // should fail loudly rather than get data from the wrong offset.
+        const originalFs = require('node:original-fs');
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        const buffer = Buffer.alloc(16);
+        expect(() => originalFs.readSync(fd, buffer, 0, 16, 0)).to.throw(/EBADF|EPERM|EACCES/);
+        expect(() => originalFs.readSync(fd, buffer, 0, 16, null)).to.throw(/EBADF|EPERM|EACCES/);
+        expect(originalFs.fstatSync(fd).isFile()).to.be.false();
+        expect(originalFs.fstatSync(fd).size).to.not.equal(fs.fstatSync(fd).size);
+        expect(buffer.equals(Buffer.alloc(16))).to.be.true();
+        // ...while fs itself still serves the entry.
+        expect(fs.readSync(fd, buffer, 0, 6, 0)).to.equal(6);
+        expect(buffer.subarray(0, 6).toString()).to.equal('file1\n');
+        fs.closeSync(fd);
+      });
+
       itremote('does not leak file descriptors', function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         const first = fs.openSync(p, 'r');
@@ -2009,9 +2028,15 @@ describe('asar package', function () {
         }
         const err = await new Promise<any>((resolve) => fs.fchmod(fd, 0o777, resolve));
         expect(err.code).to.equal('EACCES');
-        // Writes fail because the descriptor is read-only.
-        expect(() => fs.writeSync(fd, 'x')).to.throw(/EBADF|EACCES|EPERM/);
-        expect(() => fs.ftruncateSync(fd, 0)).to.throw(/EBADF|EACCES|EPERM|EINVAL/);
+        // Every mutation through the descriptor is refused.
+        expect(() => fs.writeSync(fd, 'x')).to.throw(/EACCES/);
+        expect(() => fs.writeSync(fd, Buffer.from('x'))).to.throw(/EACCES/);
+        expect(() => fs.writevSync(fd, [Buffer.from('x')])).to.throw(/EACCES/);
+        expect(() => fs.ftruncateSync(fd, 0)).to.throw(/EACCES/);
+        const werr = await new Promise<any>((resolve) => fs.write(fd, 'x', resolve));
+        expect(werr.code).to.equal('EACCES');
+        const terr = await new Promise<any>((resolve) => fs.ftruncate(fd, 0, resolve));
+        expect(terr.code).to.equal('EACCES');
         fs.closeSync(fd);
         // The archive is intact.
         expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
@@ -2359,20 +2384,12 @@ describe('asar package', function () {
         if (process.platform !== 'win32') {
           await expectToThrowErrorWithCode(() => handle.chown(process.getuid!(), process.getgid!()), 'EACCES');
         }
-        let error: any;
-        try {
-          await handle.write('x');
-        } catch (e) {
-          error = e;
-        }
-        expect(error).to.have.property('code').that.is.oneOf(['EBADF', 'EACCES', 'EPERM']);
-        error = undefined;
-        try {
-          await handle.truncate(0);
-        } catch (e) {
-          error = e;
-        }
-        expect(error).to.have.property('code').that.is.oneOf(['EBADF', 'EACCES', 'EPERM', 'EINVAL']);
+        await expectToThrowErrorWithCode(() => handle.write('x'), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.write(Buffer.from('x')), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.writev([Buffer.from('x')]), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.writeFile('x'), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.appendFile('x'), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.truncate(0), 'EACCES');
         await handle.close();
         expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
       });

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1552,6 +1552,9 @@ describe('asar package', function () {
       itremote('throws EISDIR when opening a directory', function () {
         expect(() => fs.openSync(path.join(asarDir, 'a.asar', 'dir1'), 'r')).to.throw(/EISDIR/);
         expect(() => fs.openSync(path.join(asarDir, 'a.asar'), 'r')).to.throw(/EISDIR/);
+        // ...including through a symbolic link to a directory.
+        expect(() => fs.openSync(path.join(asarDir, 'a.asar', 'link2'), 'r')).to.throw(/EISDIR/);
+        expect(() => fs.openSync(path.join(asarDir, 'a.asar', 'link2', 'link2'), 'r')).to.throw(/EISDIR/);
       });
 
       itremote('opens files with an empty size', function () {
@@ -1848,6 +1851,43 @@ describe('asar package', function () {
           const { bytesRead } = await handle.readv(buffers, 0);
           expect(bytesRead).to.equal(expected.length);
           expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          await handle.close();
+        }
+      });
+
+      itremote('skips zero-length buffers and clamps at the end of the entry like preadv', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1'); // 6 bytes: 'file1\n'
+        {
+          // Zero-length buffers do not stop the read, whether or not the tail is clamped.
+          const fd = fs.openSync(p, 'r');
+          const buffers = [Buffer.alloc(0), Buffer.alloc(3), Buffer.alloc(0), Buffer.alloc(3)];
+          expect(fs.readvSync(fd, buffers, 0)).to.equal(6);
+          expect(Buffer.concat(buffers).toString()).to.equal('file1\n');
+          const clamped = [Buffer.alloc(0), Buffer.alloc(20)];
+          expect(fs.readvSync(fd, clamped, 2)).to.equal(4);
+          expect(clamped[1].subarray(0, 4).toString()).to.equal('le1\n');
+          expect(clamped[1][4]).to.equal(0);
+          const clampedMore = [Buffer.alloc(2), Buffer.alloc(0), Buffer.alloc(2), Buffer.alloc(100)];
+          expect(fs.readvSync(fd, clampedMore, 3)).to.equal(3);
+          expect(Buffer.concat(clampedMore).subarray(0, 3).toString()).to.equal('e1\n');
+          fs.closeSync(fd);
+        }
+        {
+          // Same through the file position and the async / promise forms.
+          const fd = fs.openSync(p, 'r');
+          const first = [Buffer.alloc(0), Buffer.alloc(4)];
+          expect(await promisify(fs.readv)(fd, first)).to.equal(4);
+          expect(first[1].toString()).to.equal('file');
+          const rest = [Buffer.alloc(0), Buffer.alloc(10)];
+          expect(await promisify(fs.readv)(fd, rest)).to.equal(2);
+          expect(rest[1].subarray(0, 2).toString()).to.equal('1\n');
+          expect(await promisify(fs.readv)(fd, [Buffer.alloc(0), Buffer.alloc(10)])).to.equal(0);
+          fs.closeSync(fd);
+          const handle = await fs.promises.open(p, 'r');
+          const buffers = [Buffer.alloc(0), Buffer.alloc(3), Buffer.alloc(0), Buffer.alloc(30)];
+          const { bytesRead } = await handle.readv(buffers, 1);
+          expect(bytesRead).to.equal(5);
+          expect(Buffer.concat(buffers).subarray(0, 5).toString()).to.equal('ile1\n');
           await handle.close();
         }
       });
@@ -2245,6 +2285,27 @@ describe('asar package', function () {
         await handle.close();
       });
 
+      itremote('stops routing a descriptor number as soon as close() is requested', async function () {
+        // FileHandle#close() runs close(2) on the threadpool; until then a real
+        // file opened right after may be handed the same number. It must never
+        // be served from the archive-backed reader.
+        const temp = require('temp').track();
+        const real = temp.path();
+        fs.writeFileSync(real, 'real-file-content');
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        for (let i = 0; i < 200; i++) {
+          const handle = await fs.promises.open(p, 'r');
+          const closing = handle.close();
+          const fd = fs.openSync(real, 'r');
+          const buffer = Buffer.alloc(17);
+          expect(fs.readSync(fd, buffer, 0, 17, 0)).to.equal(17);
+          expect(buffer.toString()).to.equal('real-file-content');
+          expect(fs.fstatSync(fd).size).to.equal(17);
+          fs.closeSync(fd);
+          await closing;
+        }
+      });
+
       itremote('close semantics match Node', async function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         const handle = await fs.promises.open(p, 'r');
@@ -2330,6 +2391,29 @@ describe('asar package', function () {
         fs.copyFileSync(p, dest, fs.constants.COPYFILE_FICLONE);
         expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
         expect(() => fs.copyFileSync(p, dest, fs.constants.COPYFILE_FICLONE_FORCE)).to.throw(/ENOTSUP/);
+      });
+
+      itremote('lets native fs decide about copy-on-write clones of unpacked files', function () {
+        const originalFs = require('node:original-fs');
+        const temp = require('temp').track();
+        const unpacked = path.join(asarDir, 'unpack.asar', 'a.txt');
+        const real = path.join(asarDir, 'unpack.asar.unpacked', 'a.txt');
+        const outcome = (fn: () => void) => {
+          try {
+            fn();
+            return 'ok';
+          } catch (e: any) {
+            return e.code;
+          }
+        };
+        const viaAsar = temp.path();
+        const viaOriginal = temp.path();
+        // Whatever the filesystem says about reflinks, the answer for an unpacked
+        // entry must match the answer for the real file behind it.
+        expect(outcome(() => fs.copyFileSync(unpacked, viaAsar, fs.constants.COPYFILE_FICLONE_FORCE))).to.equal(
+          outcome(() => originalFs.copyFileSync(real, viaOriginal, fs.constants.COPYFILE_FICLONE_FORCE))
+        );
+        if (fs.existsSync(viaAsar)) expect(fs.readFileSync(viaAsar).equals(fs.readFileSync(real))).to.be.true();
       });
 
       itremote('validates the mode argument like Node', function () {
@@ -2690,11 +2774,22 @@ describe('asar package', function () {
         empty.closeSync();
       });
 
-      itremote('supports the buffer encoding', function () {
+      itremote('supports the buffer and other name encodings', function () {
         const dir = fs.opendirSync(path.join(asarDir, 'a.asar'), { encoding: 'buffer' as any });
         const dirent = dir.readSync()!;
         expect(Buffer.isBuffer(dirent.name)).to.be.true();
         dir.closeSync();
+        const hex = fs.opendirSync(path.join(asarDir, 'a.asar'), { encoding: 'hex' as any });
+        const names: string[] = [];
+        let d;
+        while ((d = hex.readSync()) !== null) names.push(d.name as any);
+        hex.closeSync();
+        expect(names.sort()).to.deep.equal(
+          fs
+            .readdirSync(path.join(asarDir, 'a.asar'))
+            .map((n) => Buffer.from(n).toString('hex'))
+            .sort()
+        );
       });
 
       itremote('reports ENOTDIR and ENOENT', async function () {
@@ -2726,6 +2821,10 @@ describe('asar package', function () {
         expect(Buffer.isBuffer(asBuffer)).to.be.true();
         expect(asBuffer.toString()).to.equal('file1');
         expect(fs.readlinkSync(path.join(a, 'link1'), { encoding: 'utf8' })).to.equal('file1');
+        expect(fs.readlinkSync(path.join(a, 'link1'), 'hex')).to.equal(Buffer.from('file1').toString('hex'));
+        expect(fs.readlinkSync(path.join(a, 'link1'), { encoding: 'base64' })).to.equal(
+          Buffer.from('file1').toString('base64')
+        );
         // Resolving the target against the link's directory gives a readable path.
         const resolve = (link: string) => path.resolve(path.dirname(link), fs.readlinkSync(link));
         expect(fs.readFileSync(resolve(path.join(a, 'link1'))).toString()).to.equal('file1\n');

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1480,6 +1480,1442 @@ describe('asar package', function () {
       });
     });
 
+    // The tests below cover the fs APIs that read packed archive entries
+    // through file descriptors, streams, handles and copies (i.e. without
+    // extracting them to a temporary file first), plus the directory and
+    // symlink APIs.  Where a corresponding Node.js test exists
+    // (test/parallel/test-fs-*), its expectations are mirrored here.
+
+    describe('fs.openSync (fd semantics)', function () {
+      itremote('returns a usable, closable file descriptor', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        expect(fd).to.be.a('number').that.is.greaterThan(2);
+        fs.closeSync(fd);
+        expect(() => fs.fstatSync(fd)).to.throw(/EBADF/);
+        expect(() => fs.closeSync(fd)).to.throw(/EBADF/);
+      });
+
+      itremote('accepts default, string and numeric read-only flags', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        for (const flags of [
+          undefined,
+          'r',
+          'rs',
+          fs.constants.O_RDONLY,
+          fs.constants.O_RDONLY | fs.constants.O_CREAT
+        ]) {
+          const fd = flags === undefined ? fs.openSync(p, 'r') : fs.openSync(p, flags as any);
+          const buffer = Buffer.alloc(6);
+          expect(fs.readSync(fd, buffer, 0, 6, 0)).to.equal(6);
+          expect(String(buffer).trim()).to.equal('file1');
+          fs.closeSync(fd);
+        }
+      });
+
+      itremote('accepts a mode argument', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r', 0o644);
+        fs.closeSync(fd);
+      });
+
+      itremote('refuses to open a packed file for writing', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const writeFlags = [
+          'w',
+          'w+',
+          'wx',
+          'a',
+          'a+',
+          'ax',
+          'r+',
+          'rs+',
+          fs.constants.O_WRONLY,
+          fs.constants.O_RDWR,
+          fs.constants.O_RDONLY | fs.constants.O_TRUNC,
+          fs.constants.O_RDONLY | fs.constants.O_APPEND
+        ];
+        for (const flags of writeFlags) {
+          expect(() => fs.openSync(p, flags as any), String(flags)).to.throw(/EACCES/);
+        }
+        // Nothing was written or corrupted.
+        expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
+      });
+
+      itremote('throws EEXIST for O_CREAT | O_EXCL on an existing packed file', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        expect(() => fs.openSync(p, fs.constants.O_RDONLY | fs.constants.O_CREAT | fs.constants.O_EXCL)).to.throw(
+          /EEXIST/
+        );
+      });
+
+      itremote('throws EISDIR when opening a directory', function () {
+        expect(() => fs.openSync(path.join(asarDir, 'a.asar', 'dir1'), 'r')).to.throw(/EISDIR/);
+        expect(() => fs.openSync(path.join(asarDir, 'a.asar'), 'r')).to.throw(/EISDIR/);
+      });
+
+      itremote('opens files with an empty size', function () {
+        const fd = fs.openSync(path.join(asarDir, 'empty.asar', 'file1'), 'r');
+        expect(fs.fstatSync(fd).size).to.equal(0);
+        expect(fs.readSync(fd, Buffer.alloc(8), 0, 8, 0)).to.equal(0);
+        expect(fs.readFileSync(fd).length).to.equal(0);
+        fs.closeSync(fd);
+      });
+
+      itremote('opens unpacked files as regular files', function () {
+        const originalFs = require('node:original-fs');
+        const fd = fs.openSync(path.join(asarDir, 'unpack.asar', 'a.txt'), 'r');
+        const stats = fs.fstatSync(fd);
+        const realStats = originalFs.statSync(path.join(asarDir, 'unpack.asar.unpacked', 'a.txt'));
+        expect(stats.ino).to.equal(realStats.ino);
+        expect(stats.size).to.equal(realStats.size);
+        fs.closeSync(fd);
+      });
+
+      itremote('does not leak file descriptors', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const first = fs.openSync(p, 'r');
+        fs.closeSync(first);
+        for (let i = 0; i < 2000; i++) {
+          const fd = fs.openSync(p, 'r');
+          fs.closeSync(fd);
+        }
+        const last = fs.openSync(p, 'r');
+        fs.closeSync(last);
+        // With no leak the descriptor number is reused.
+        expect(last).to.equal(first);
+      });
+
+      itremote('gives every open its own file position', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd1 = fs.openSync(p, 'r');
+        const fd2 = fs.openSync(p, 'r');
+        const b1 = Buffer.alloc(3);
+        const b2 = Buffer.alloc(3);
+        fs.readSync(fd1, b1, 0, 3, null);
+        fs.readSync(fd2, b2, 0, 3, null);
+        expect(b1.toString()).to.equal('fil');
+        expect(b2.toString()).to.equal('fil');
+        fs.readSync(fd1, b1, 0, 3, null);
+        expect(b1.toString()).to.equal('e1\n');
+        fs.closeSync(fd1);
+        fs.closeSync(fd2);
+      });
+    });
+
+    describe('fs.open (callback forms)', function () {
+      itremote('supports (path, cb), (path, flags, cb) and (path, flags, mode, cb)', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fds = [
+          await new Promise<number>((resolve, reject) => fs.open(p, (e, fd) => (e ? reject(e) : resolve(fd)))),
+          await new Promise<number>((resolve, reject) => fs.open(p, 'r', (e, fd) => (e ? reject(e) : resolve(fd)))),
+          await new Promise<number>((resolve, reject) =>
+            fs.open(p, 'r', 0o666, (e, fd) => (e ? reject(e) : resolve(fd)))
+          )
+        ];
+        for (const fd of fds) {
+          const buffer = Buffer.alloc(6);
+          await promisify(fs.read)(fd, buffer, 0, 6, 0);
+          expect(String(buffer).trim()).to.equal('file1');
+          await promisify(fs.close)(fd);
+        }
+      });
+
+      itremote('reports EACCES for write flags asynchronously', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const err = await new Promise<any>((resolve) => fs.open(p, 'w', resolve));
+        expect(err.code).to.equal('EACCES');
+      });
+
+      itremote('reports EISDIR for directories asynchronously', async function () {
+        const err = await new Promise<any>((resolve) => fs.open(path.join(asarDir, 'a.asar', 'dir1'), 'r', resolve));
+        expect(err.code).to.equal('EISDIR');
+      });
+    });
+
+    describe('fs.readSync / fs.read on packed files', function () {
+      // Mirrors test-fs-read.js.
+      itremote('reads into Buffers and Uint8Arrays with an explicit position', async function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        const expected = Buffer.from('file1\n');
+        for (const make of [() => Buffer.allocUnsafe(expected.length), () => new Uint8Array(expected.length)]) {
+          const bufferSync = make();
+          expect(fs.readSync(fd, bufferSync, 0, expected.length, 0)).to.equal(expected.length);
+          expect(Buffer.from(bufferSync).equals(expected)).to.be.true();
+          const bufferAsync = make();
+          const bytesRead = await new Promise<number>((resolve, reject) =>
+            fs.read(fd, bufferAsync, 0, expected.length, 0, (e, n) => (e ? reject(e) : resolve(n)))
+          );
+          expect(bytesRead).to.equal(expected.length);
+          expect(Buffer.from(bufferAsync).equals(expected)).to.be.true();
+        }
+        fs.closeSync(fd);
+      });
+
+      itremote('returns 0 bytes when reading beyond the end of the file', async function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        expect(fs.readSync(fd, Buffer.alloc(1), 0, 1, 6)).to.equal(0);
+        expect(fs.readSync(fd, Buffer.alloc(1), 0, 1, 0xffffffff + 1)).to.equal(0);
+        const n = await new Promise<number>((resolve, reject) =>
+          fs.read(fd, Buffer.alloc(1), 0, 1, 0xffffffff + 1, (e, n) => (e ? reject(e) : resolve(n)))
+        );
+        expect(n).to.equal(0);
+        fs.closeSync(fd);
+      });
+
+      itremote('clamps reads that run past the end of the entry', function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        const buffer = Buffer.alloc(100);
+        expect(fs.readSync(fd, buffer, 0, 100, 4)).to.equal(2);
+        expect(buffer.subarray(0, 2).toString()).to.equal('1\n');
+        // Untouched bytes stay untouched.
+        expect(buffer[2]).to.equal(0);
+        fs.closeSync(fd);
+      });
+
+      itremote('honours a null position by using and advancing the file position', function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        const chunk = Buffer.alloc(2);
+        const parts: string[] = [];
+        let n;
+        while ((n = fs.readSync(fd, chunk, 0, 2, null)) > 0) parts.push(chunk.subarray(0, n).toString());
+        expect(parts.join('')).to.equal('file1\n');
+        // An explicit position does not disturb the file position.
+        const fd2 = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        const b = Buffer.alloc(3);
+        fs.readSync(fd2, b, 0, 3, null);
+        fs.readSync(fd2, b, 0, 3, 0);
+        expect(b.toString()).to.equal('fil');
+        fs.readSync(fd2, b, 0, 3, null);
+        expect(b.toString()).to.equal('e1\n');
+        fs.closeSync(fd);
+        fs.closeSync(fd2);
+      });
+
+      itremote('accepts a bigint position', function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        const buffer = Buffer.alloc(2);
+        expect(fs.readSync(fd, buffer, 0, 2, 4n as any)).to.equal(2);
+        expect(buffer.toString()).to.equal('1\n');
+        fs.closeSync(fd);
+      });
+
+      // Mirrors test-fs-read-optional-params.js and test-fs-readSync-optional-params.js.
+      itremote('supports the options-object forms', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const expected = Buffer.from('file1\n');
+        {
+          const fd = fs.openSync(p, 'r');
+          const buffer = Buffer.alloc(expected.length);
+          expect(fs.readSync(fd, buffer, { offset: 0, length: expected.length, position: 0 })).to.equal(
+            expected.length
+          );
+          expect(buffer.equals(expected)).to.be.true();
+          // The explicit position above did not move the file position.
+          buffer.fill(0);
+          expect(fs.readSync(fd, buffer, {})).to.equal(expected.length);
+          expect(buffer.equals(expected)).to.be.true();
+          expect(fs.readSync(fd, buffer, {})).to.equal(0);
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          const buffer = Buffer.alloc(expected.length);
+          // cursor read via options without position
+          expect(fs.readSync(fd, buffer, { offset: 0, length: expected.length })).to.equal(expected.length);
+          expect(buffer.equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+        for (const options of [undefined, null, {}, { offset: 0, position: 0 }]) {
+          const fd = fs.openSync(p, 'r');
+          const { bytesRead, buffer } = await new Promise<{ bytesRead: number; buffer: Buffer }>((resolve, reject) => {
+            const cb = (e: any, bytesRead: number, buffer: Buffer) => (e ? reject(e) : resolve({ bytesRead, buffer }));
+            if (options === undefined) fs.read(fd, cb);
+            else fs.read(fd, options as any, cb);
+          });
+          expect(bytesRead).to.equal(expected.length);
+          expect(buffer.subarray(0, bytesRead).equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          const buffer = Buffer.alloc(expected.length);
+          const bytesRead = await new Promise<number>((resolve, reject) =>
+            fs.read(fd, buffer, { position: 0 }, (e, n) => (e ? reject(e) : resolve(n)))
+          );
+          expect(bytesRead).to.equal(expected.length);
+          expect(buffer.equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+      });
+
+      // Mirrors test-fs-read-zero-length.js and test-fs-read-empty-buffer.js.
+      itremote('handles zero-length reads and rejects empty buffers like Node', async function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        expect(fs.readSync(fd, Buffer.alloc(4), 0, 0, 0)).to.equal(0);
+        const n = await new Promise<number>((resolve, reject) =>
+          fs.read(fd, Buffer.alloc(4), 0, 0, 0, (e, n) => (e ? reject(e) : resolve(n)))
+        );
+        expect(n).to.equal(0);
+        expect(() => fs.readSync(fd, Buffer.alloc(0), 0, 1, 0))
+          .to.throw()
+          .with.property('code')
+          .that.is.oneOf(['ERR_INVALID_ARG_VALUE', 'ERR_OUT_OF_RANGE']);
+        fs.closeSync(fd);
+      });
+
+      itremote('validates arguments like Node', function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        expect(() => (fs.read as any)(fd, Buffer.alloc(1), 0, 1, 0))
+          .to.throw()
+          .with.property('code', 'ERR_INVALID_ARG_TYPE');
+        expect(() => fs.readSync(fd, Buffer.alloc(1), 0, 2, 0))
+          .to.throw()
+          .with.property('code', 'ERR_OUT_OF_RANGE');
+        expect(() => fs.readSync(fd, Buffer.alloc(1), 0, 1, -2))
+          .to.throw()
+          .with.property('code', 'ERR_OUT_OF_RANGE');
+        fs.closeSync(fd);
+      });
+
+      itremote('reads a larger packed file back byte-for-byte in odd sized chunks', function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        expect(expected.length).to.be.greaterThan(100000);
+        const fd = fs.openSync(p, 'r');
+        const out = Buffer.alloc(expected.length);
+        let read = 0;
+        while (read < expected.length) {
+          const n = fs.readSync(fd, out, read, Math.min(4097, expected.length - read), null);
+          if (n === 0) break;
+          read += n;
+        }
+        fs.closeSync(fd);
+        expect(read).to.equal(expected.length);
+        expect(out.equals(expected)).to.be.true();
+      });
+    });
+
+    // Mirrors test-fs-readv-sync.js / test-fs-readv.js / test-fs-readv-promises.js.
+    describe('fs.readvSync / fs.readv / FileHandle.readv on packed files', function () {
+      itremote('reads into an array of buffers with and without a position', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        const allocate = () => [
+          Buffer.alloc(Math.floor(expected.length / 2)),
+          Buffer.alloc(Math.ceil(expected.length / 2))
+        ];
+        {
+          const fd = fs.openSync(p, 'r');
+          expect(fs.readvSync(fd, [Buffer.from('')], 0)).to.equal(0);
+          const buffers = allocate();
+          expect(fs.readvSync(fd, buffers, 0)).to.equal(expected.length);
+          expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          expect(fs.readvSync(fd, [Buffer.from('')])).to.equal(0);
+          const buffers = allocate();
+          expect(fs.readvSync(fd, buffers)).to.equal(expected.length);
+          expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          expect(fs.readvSync(fd, allocate())).to.equal(0);
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          const buffers = allocate();
+          const bytesRead = await new Promise<number>((resolve, reject) =>
+            fs.readv(fd, buffers, 0, (e, n) => (e ? reject(e) : resolve(n)))
+          );
+          expect(bytesRead).to.equal(expected.length);
+          expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          const buffers = allocate();
+          const bytesRead = await new Promise<number>((resolve, reject) =>
+            fs.readv(fd, buffers, (e, n) => (e ? reject(e) : resolve(n)))
+          );
+          expect(bytesRead).to.equal(expected.length);
+          expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          fs.closeSync(fd);
+        }
+        {
+          const handle = await fs.promises.open(p, 'r');
+          const buffers = allocate();
+          const { bytesRead } = await handle.readv(buffers, 0);
+          expect(bytesRead).to.equal(expected.length);
+          expect(Buffer.concat(buffers).equals(expected)).to.be.true();
+          await handle.close();
+        }
+      });
+
+      itremote('rejects invalid buffer arguments like Node', function () {
+        const fd = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        for (const wrong of [false, 'test', {}, [{}], ['sdf'], null, undefined]) {
+          expect(() => (fs.readvSync as any)(fd, wrong, null))
+            .to.throw()
+            .with.property('code', 'ERR_INVALID_ARG_TYPE');
+        }
+        fs.closeSync(fd);
+      });
+    });
+
+    describe('fs.fstat on packed files', function () {
+      itremote('describes the entry', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        const stats = fs.fstatSync(fd);
+        expect(stats.isFile()).to.be.true();
+        expect(stats.isDirectory()).to.be.false();
+        expect(stats.isSymbolicLink()).to.be.false();
+        expect(stats.size).to.equal(6);
+        expect(stats.mtime).to.be.an.instanceOf(Date);
+        const bigint = fs.fstatSync(fd, { bigint: true });
+        expect(bigint.size).to.equal(6n);
+        expect(typeof bigint.mtimeMs).to.equal('bigint');
+        const async = await promisify(fs.fstat)(fd);
+        expect(async.size).to.equal(6);
+        const asyncBig = await new Promise<any>((resolve, reject) =>
+          fs.fstat(fd, { bigint: true }, (e, s) => (e ? reject(e) : resolve(s)))
+        );
+        expect(asyncBig.size).to.equal(6n);
+        // Stable across calls on the same descriptor.
+        expect(fs.fstatSync(fd).ino).to.equal(stats.ino);
+        fs.closeSync(fd);
+      });
+
+      itremote('reports executable entries as executable', function () {
+        const fd = fs.openSync(path.join(asarDir, 'echo.asar', 'echo'), 'r');
+        const stats = fs.fstatSync(fd);
+        expect(stats.mode & 0o111).to.not.equal(0);
+        fs.closeSync(fd);
+        const fd2 = fs.openSync(path.join(asarDir, 'a.asar', 'file1'), 'r');
+        expect(fs.fstatSync(fd2).mode & 0o111).to.equal(0);
+        fs.closeSync(fd2);
+      });
+
+      itremote('reports conventional permission bits for stat/lstat', function () {
+        const a = path.join(asarDir, 'a.asar');
+        expect(fs.statSync(path.join(a, 'file1')).mode & 0o777).to.equal(0o644);
+        expect(fs.statSync(path.join(a, 'dir1')).mode & 0o777).to.equal(0o755);
+        expect(fs.statSync(a).mode & 0o777).to.equal(0o755);
+        expect(fs.lstatSync(path.join(a, 'link1')).mode & 0o777).to.equal(0o777);
+      });
+    });
+
+    // Mirrors test-fs-readfile-fd.js.
+    describe('fs.readFile / fs.readFileSync with a packed file descriptor', function () {
+      itremote('reads from the current file position', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        {
+          const fd = fs.openSync(p, 'r');
+          expect(fs.readFileSync(fd).toString()).to.equal('file1\n');
+          expect(fs.readFileSync(fd).toString()).to.equal('');
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          fs.readSync(fd, Buffer.alloc(2), 0, 2, null);
+          expect(fs.readFileSync(fd, 'utf8')).to.equal('le1\n');
+          expect(fs.readFileSync(fd, 'utf8')).to.equal('');
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          fs.readSync(fd, Buffer.alloc(3), 0, 3, null);
+          expect((await promisify(fs.readFile)(fd)).toString()).to.equal('e1\n');
+          expect(await promisify(fs.readFile)(fd, 'utf8')).to.equal('');
+          fs.closeSync(fd);
+        }
+        {
+          const fd = fs.openSync(p, 'r');
+          expect(await promisify(fs.readFile)(fd, { encoding: 'utf8' })).to.equal('file1\n');
+          fs.closeSync(fd);
+        }
+      });
+
+      itremote('reads an empty file through a descriptor', async function () {
+        const fd = fs.openSync(path.join(asarDir, 'empty.asar', 'file1'), 'r');
+        expect(fs.readFileSync(fd, 'utf8')).to.equal('');
+        expect((await promisify(fs.readFile)(fd)).length).to.equal(0);
+        fs.closeSync(fd);
+      });
+    });
+
+    describe('fs.close / fs.closeSync of packed file descriptors', function () {
+      itremote('closes and rejects further use', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        await promisify(fs.close)(fd);
+        expect(() => fs.readSync(fd, Buffer.alloc(1), 0, 1, 0)).to.throw(/EBADF/);
+        const err = await new Promise<any>((resolve) => fs.close(fd, resolve));
+        expect(err.code).to.equal('EBADF');
+      });
+    });
+
+    describe('fchmod / fchown / futimes on packed file descriptors', function () {
+      itremote('are refused so the archive itself cannot be modified through them', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        expect(() => fs.fchmodSync(fd, 0o777)).to.throw(/EACCES/);
+        expect(() => fs.futimesSync(fd, new Date(), new Date())).to.throw(/EACCES/);
+        if (process.platform !== 'win32') {
+          expect(() => fs.fchownSync(fd, process.getuid!(), process.getgid!())).to.throw(/EACCES/);
+        }
+        const err = await new Promise<any>((resolve) => fs.fchmod(fd, 0o777, resolve));
+        expect(err.code).to.equal('EACCES');
+        // Writes fail because the descriptor is read-only.
+        expect(() => fs.writeSync(fd, 'x')).to.throw(/EBADF|EACCES|EPERM/);
+        expect(() => fs.ftruncateSync(fd, 0)).to.throw(/EBADF|EACCES|EPERM|EINVAL/);
+        fs.closeSync(fd);
+        // The archive is intact.
+        expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
+      });
+    });
+
+    // Mirrors test-fs-read-stream.js, test-fs-read-stream-pos.js,
+    // test-fs-read-stream-fd.js and test-fs-read-stream-file-handle.js.
+    describe('fs.createReadStream on packed files', function () {
+      itremote('streams a whole file, emitting open/ready/end/close', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const events: string[] = [];
+        const content = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          const stream = fs.createReadStream(p);
+          stream.on('open', (fd) => {
+            events.push('open');
+            expect(fd).to.be.a('number');
+          });
+          stream.on('ready', () => events.push('ready'));
+          stream.on('data', (chunk) => chunks.push(chunk as Buffer));
+          stream.on('error', reject);
+          stream.on('end', () => events.push('end'));
+          stream.on('close', () => {
+            events.push('close');
+            expect(stream.bytesRead).to.equal(6);
+            resolve(Buffer.concat(chunks));
+          });
+        });
+        expect(content.toString()).to.equal('file1\n');
+        expect(events).to.deep.equal(['open', 'ready', 'end', 'close']);
+      });
+
+      itremote('honours encoding, highWaterMark, start and end', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const read = (options: any) =>
+          new Promise<any[]>((resolve, reject) => {
+            const chunks: any[] = [];
+            fs.createReadStream(p, options)
+              .on('data', (c) => chunks.push(c))
+              .on('error', reject)
+              .on('end', () => resolve(chunks));
+          });
+        expect((await read({ encoding: 'utf8' })).join('')).to.equal('file1\n');
+        const small = await read({ highWaterMark: 2 });
+        expect(small.length).to.equal(3);
+        expect(Buffer.concat(small).toString()).to.equal('file1\n');
+        expect(Buffer.concat(await read({ start: 1, end: 3 })).toString()).to.equal('ile');
+        expect(Buffer.concat(await read({ start: 4 })).toString()).to.equal('1\n');
+        expect(Buffer.concat(await read({ end: 0 })).toString()).to.equal('f');
+        expect(Buffer.concat(await read({ start: 5, end: 100 })).toString()).to.equal('\n');
+        expect(Buffer.concat(await read({ start: 6 })).toString()).to.equal('');
+      });
+
+      itremote('streams a larger file identically to readFileSync', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        for (const highWaterMark of [1024, 16 * 1024, 1024 * 1024]) {
+          const content = await new Promise<Buffer>((resolve, reject) => {
+            const chunks: Buffer[] = [];
+            fs.createReadStream(p, { highWaterMark })
+              .on('data', (c) => chunks.push(c as Buffer))
+              .on('error', reject)
+              .on('end', () => resolve(Buffer.concat(chunks)));
+          });
+          expect(content.equals(expected)).to.be.true();
+        }
+      });
+
+      itremote('streams linked files and files in linked directories', async function () {
+        for (const file of ['link1', path.join('link2', 'file1'), path.join('link2', 'link2', 'file1')]) {
+          const content = await new Promise<Buffer>((resolve, reject) => {
+            const chunks: Buffer[] = [];
+            fs.createReadStream(path.join(asarDir, 'a.asar', file))
+              .on('data', (c) => chunks.push(c as Buffer))
+              .on('error', reject)
+              .on('end', () => resolve(Buffer.concat(chunks)));
+          });
+          expect(content.toString().trim()).to.equal('file1');
+        }
+      });
+
+      itremote('streams unpacked files', async function () {
+        const p = path.join(asarDir, 'unpack.asar', 'a.txt');
+        const content = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          fs.createReadStream(p)
+            .on('data', (c) => chunks.push(c as Buffer))
+            .on('error', reject)
+            .on('end', () => resolve(Buffer.concat(chunks)));
+        });
+        expect(content.equals(fs.readFileSync(p))).to.be.true();
+      });
+
+      itremote('emits errors for missing files and directories', async function () {
+        const errorFor = (p: string) =>
+          new Promise<any>((resolve) => {
+            fs.createReadStream(p)
+              .on('error', resolve)
+              .on('data', () => {});
+          });
+        expect((await errorFor(path.join(asarDir, 'a.asar', 'not-exist'))).code).to.equal('ENOENT');
+        expect((await errorFor(path.join(asarDir, 'a.asar', 'dir1'))).code).to.equal('EISDIR');
+      });
+
+      itremote('can be created from an already open packed fd', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const fd = fs.openSync(p, 'r');
+        const content = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          fs.createReadStream(null as any, { fd, autoClose: false })
+            .on('data', (c) => chunks.push(c as Buffer))
+            .on('error', reject)
+            .on('end', () => resolve(Buffer.concat(chunks)));
+        });
+        expect(content.toString()).to.equal('file1\n');
+        // Not closed by the stream, and the position was consumed.
+        expect(fs.readSync(fd, Buffer.alloc(1), 0, 1, null)).to.equal(0);
+        expect(fs.readSync(fd, Buffer.alloc(1), 0, 1, 0)).to.equal(1);
+        fs.closeSync(fd);
+        // With autoClose the stream closes the descriptor.
+        const fd2 = fs.openSync(p, 'r');
+        await new Promise<void>((resolve, reject) => {
+          fs.createReadStream(null as any, { fd: fd2 })
+            .on('error', reject)
+            .on('data', () => {})
+            .on('close', resolve);
+        });
+        expect(() => fs.fstatSync(fd2)).to.throw(/EBADF/);
+      });
+
+      itremote('can be created from a FileHandle', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const handle = await fs.promises.open(p, 'r');
+        const content = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          fs.createReadStream(null as any, { fd: handle })
+            .on('data', (c) => chunks.push(c as Buffer))
+            .on('error', reject)
+            .on('end', () => resolve(Buffer.concat(chunks)));
+        });
+        expect(content.toString()).to.equal('file1\n');
+      });
+
+      itremote('supports many concurrent streams of the same entry', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        const streams = [];
+        for (let i = 0; i < 50; i++) {
+          streams.push(
+            new Promise<Buffer>((resolve, reject) => {
+              const chunks: Buffer[] = [];
+              fs.createReadStream(p, { highWaterMark: 1000 + i })
+                .on('data', (c) => chunks.push(c as Buffer))
+                .on('error', reject)
+                .on('end', () => resolve(Buffer.concat(chunks)));
+            })
+          );
+        }
+        for (const content of await Promise.all(streams)) expect(content.equals(expected)).to.be.true();
+      });
+
+      itremote('works with pipe()', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const os = require('node:os');
+        const dest = path.join(os.tmpdir(), `asar-pipe-${process.pid}-${Date.now()}`);
+        await new Promise<void>((resolve, reject) => {
+          fs.createReadStream(p)
+            .on('error', reject)
+            .pipe(fs.createWriteStream(dest))
+            .on('error', reject)
+            .on('finish', resolve);
+        });
+        expect(fs.readFileSync(dest).equals(fs.readFileSync(p))).to.be.true();
+        fs.unlinkSync(dest);
+      });
+    });
+
+    describe('fs.createWriteStream on packed files', function () {
+      itremote('fails with EACCES', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const err = await new Promise<any>((resolve) => {
+          fs.createWriteStream(p).on('error', resolve).end('x');
+        });
+        expect(err.code).to.equal('EACCES');
+        expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
+      });
+    });
+
+    describe('write APIs on packed files', function () {
+      itremote('fail without touching the archive', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        expect(() => fs.writeFileSync(p, 'x')).to.throw(/EACCES/);
+        expect(() => fs.appendFileSync(p, 'x')).to.throw(/EACCES/);
+        await expectToThrowErrorWithCode(() => fs.promises.writeFile(p, 'x'), 'EACCES');
+        await expectToThrowErrorWithCode(() => fs.promises.appendFile(p, 'x'), 'EACCES');
+        const err = await new Promise<any>((resolve) => fs.writeFile(p, 'x', resolve));
+        expect(err.code).to.equal('EACCES');
+        expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
+      });
+    });
+
+    // Mirrors test-fs-promises-file-handle-read.js, -readFile.js, -stat.js,
+    // -readLines.mjs, -stream.js, -close.js, -dispose.js and -chmod.js.
+    describe('fs.promises.open FileHandle on packed files', function () {
+      itremote('exposes a numeric fd and supports all read forms', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const handle = await fs.promises.open(p, 'r');
+        expect(handle.fd).to.be.a('number').that.is.greaterThan(2);
+
+        let r = await handle.read(Buffer.alloc(3), 0, 3, 0);
+        expect(r.bytesRead).to.equal(3);
+        expect(r.buffer.toString()).to.equal('fil');
+
+        r = await handle.read({ buffer: Buffer.alloc(3), offset: 0, length: 3, position: 3 });
+        expect(r.bytesRead).to.equal(3);
+        expect(r.buffer.toString()).to.equal('e1\n');
+
+        r = await handle.read(Buffer.alloc(3), { offset: 0, length: 3, position: 1 });
+        expect(r.buffer.toString()).to.equal('ile');
+
+        // Default arguments read from the current position into a fresh buffer.
+        r = await handle.read();
+        expect(r.bytesRead).to.equal(6);
+        expect(r.buffer.subarray(0, 6).toString()).to.equal('file1\n');
+        r = await handle.read();
+        expect(r.bytesRead).to.equal(0);
+
+        // Null position advances; explicit position does not.
+        const h2 = await fs.promises.open(p, 'r');
+        expect((await h2.read(Buffer.alloc(2), 0, 2, null)).buffer.toString()).to.equal('fi');
+        expect((await h2.read(Buffer.alloc(2), 0, 2, 0)).buffer.toString()).to.equal('fi');
+        expect((await h2.read(Buffer.alloc(2), 0, 2, null)).buffer.toString()).to.equal('le');
+        await h2.close();
+
+        await handle.close();
+      });
+
+      itremote('supports readFile, stat and readLines', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const handle = await fs.promises.open(p, 'r');
+        const stats = await handle.stat();
+        expect(stats.isFile()).to.be.true();
+        expect(stats.size).to.equal(6);
+        expect((await handle.stat({ bigint: true })).size).to.equal(6n);
+        expect((await handle.readFile()).toString()).to.equal('file1\n');
+        // Like Node, readFile continues from the current position.
+        expect(await handle.readFile('utf8')).to.equal('');
+        await handle.close();
+
+        const h2 = await fs.promises.open(p, 'r');
+        expect(await fs.promises.readFile(h2, 'utf8')).to.equal('file1\n');
+        await h2.close();
+
+        const h3 = await fs.promises.open(path.join(asarDir, 'a.asar', 'ping.js'), 'r');
+        const lines: string[] = [];
+        for await (const line of h3.readLines()) lines.push(line);
+        expect(lines.join('\n')).to.equal(fs.readFileSync(path.join(asarDir, 'a.asar', 'ping.js'), 'utf8').trimEnd());
+      });
+
+      itremote('supports createReadStream and readableWebStream', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        const handle = await fs.promises.open(p, 'r');
+        const chunks: Buffer[] = [];
+        for await (const chunk of handle.createReadStream({ start: 10, end: 1009, autoClose: false })) {
+          chunks.push(chunk);
+        }
+        expect(Buffer.concat(chunks).equals(expected.subarray(10, 1010))).to.be.true();
+        let total = 0;
+        for await (const chunk of handle.readableWebStream()) total += (chunk as Uint8Array).byteLength;
+        expect(total).to.equal(expected.length);
+        await handle.close();
+      });
+
+      itremote('close semantics match Node', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const handle = await fs.promises.open(p, 'r');
+        await handle.close();
+        expect(handle.fd).to.equal(-1);
+        await expectToThrowErrorWithCode(() => handle.read(Buffer.alloc(1), 0, 1, 0), 'EBADF');
+        // Closing twice resolves (Node returns the same promise / a resolved one).
+        await handle.close();
+
+        const disposable = await fs.promises.open(p, 'r');
+        await disposable[Symbol.asyncDispose]();
+        expect(disposable.fd).to.equal(-1);
+      });
+
+      itremote('refuses metadata and write operations', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const handle = await fs.promises.open(p, 'r');
+        await expectToThrowErrorWithCode(() => handle.chmod(0o777), 'EACCES');
+        await expectToThrowErrorWithCode(() => handle.utimes(new Date(), new Date()), 'EACCES');
+        if (process.platform !== 'win32') {
+          await expectToThrowErrorWithCode(() => handle.chown(process.getuid!(), process.getgid!()), 'EACCES');
+        }
+        let error: any;
+        try {
+          await handle.write('x');
+        } catch (e) {
+          error = e;
+        }
+        expect(error).to.have.property('code').that.is.oneOf(['EBADF', 'EACCES', 'EPERM']);
+        error = undefined;
+        try {
+          await handle.truncate(0);
+        } catch (e) {
+          error = e;
+        }
+        expect(error).to.have.property('code').that.is.oneOf(['EBADF', 'EACCES', 'EPERM', 'EINVAL']);
+        await handle.close();
+        expect(fs.readFileSync(p).toString().trim()).to.equal('file1');
+      });
+
+      itremote('rejects write flags, missing files and directories', async function () {
+        await expectToThrowErrorWithCode(() => fs.promises.open(path.join(asarDir, 'a.asar', 'file1'), 'w'), 'EACCES');
+        await expectToThrowErrorWithCode(() => fs.promises.open(path.join(asarDir, 'a.asar', 'file1'), 'a+'), 'EACCES');
+        await expectToThrowErrorWithCode(() => fs.promises.open(path.join(asarDir, 'a.asar', 'dir1'), 'r'), 'EISDIR');
+        await expectToThrowErrorWithCode(() => fs.promises.open(path.join(asarDir, 'a.asar', 'nope'), 'r'), 'ENOENT');
+      });
+
+      itremote('opens unpacked files as regular handles', async function () {
+        const originalFs = require('node:original-fs');
+        const handle = await fs.promises.open(path.join(asarDir, 'unpack.asar', 'a.txt'), 'r');
+        const stats = await handle.stat();
+        expect(stats.ino).to.equal(originalFs.statSync(path.join(asarDir, 'unpack.asar.unpacked', 'a.txt')).ino);
+        await handle.close();
+      });
+
+      itremote('lets many handles coexist and be read concurrently', async function () {
+        const p = path.join(asarDir, 'video.asar', 'video.mp4');
+        const expected = fs.readFileSync(p);
+        const handles = await Promise.all(Array.from({ length: 40 }, () => fs.promises.open(p, 'r')));
+        const contents = await Promise.all(handles.map((h) => h.readFile()));
+        for (const c of contents) expect(c.equals(expected)).to.be.true();
+        await Promise.all(handles.map((h) => h.close()));
+      });
+    });
+
+    // Mirrors test-fs-copyfile.js.
+    describe('fs.copyFile flags and errors', function () {
+      itremote('honours COPYFILE_EXCL and overwrites otherwise', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const temp = require('temp').track();
+        const dest = temp.path();
+        fs.copyFileSync(p, dest);
+        expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
+        expect(() => fs.copyFileSync(p, dest, fs.constants.COPYFILE_EXCL)).to.throw(/EEXIST/);
+        await expectToThrowErrorWithCode(() => fs.promises.copyFile(p, dest, fs.constants.COPYFILE_EXCL), 'EEXIST');
+        const err = await new Promise<any>((resolve) => fs.copyFile(p, dest, fs.constants.COPYFILE_EXCL, resolve));
+        expect(err.code).to.equal('EEXIST');
+        // Overwrite a longer existing file: no trailing garbage.
+        fs.writeFileSync(dest, 'a much longer file than the source');
+        fs.copyFileSync(p, dest);
+        expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
+        // FICLONE is best-effort, FICLONE_FORCE cannot be honoured.
+        fs.copyFileSync(p, dest, fs.constants.COPYFILE_FICLONE);
+        expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
+        expect(() => fs.copyFileSync(p, dest, fs.constants.COPYFILE_FICLONE_FORCE)).to.throw(/ENOTSUP/);
+      });
+
+      itremote('validates the mode argument like Node', function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const temp = require('temp').track();
+        expect(() => fs.copyFileSync(p, temp.path(), 8))
+          .to.throw()
+          .with.property('code', 'ERR_OUT_OF_RANGE');
+        expect(() => (fs.copyFileSync as any)(p, temp.path(), 'x'))
+          .to.throw()
+          .with.property('code', 'ERR_INVALID_ARG_TYPE');
+      });
+
+      itremote('reports ENOENT / EISDIR for bad sources', async function () {
+        const temp = require('temp').track();
+        expect(() => fs.copyFileSync(path.join(asarDir, 'a.asar', 'nope'), temp.path())).to.throw(/ENOENT/);
+        expect(() => fs.copyFileSync(path.join(asarDir, 'a.asar', 'dir1'), temp.path())).to.throw(/EISDIR/);
+        await expectToThrowErrorWithCode(
+          () => fs.promises.copyFile(path.join(asarDir, 'a.asar', 'nope'), temp.path()),
+          'ENOENT'
+        );
+        const err = await new Promise<any>((resolve) =>
+          fs.copyFile(path.join(asarDir, 'a.asar', 'dir1'), temp.path(), resolve)
+        );
+        expect(err.code).to.equal('EISDIR');
+      });
+
+      itremote('copies linked files, larger files and executable bits', async function () {
+        const temp = require('temp').track();
+        const link = path.join(asarDir, 'a.asar', 'link1');
+        const d1 = temp.path();
+        fs.copyFileSync(link, d1);
+        expect(fs.readFileSync(d1).toString()).to.equal('file1\n');
+
+        const big = path.join(asarDir, 'video.asar', 'video.mp4');
+        const d2 = temp.path();
+        await fs.promises.copyFile(big, d2);
+        expect(fs.readFileSync(d2).equals(fs.readFileSync(big))).to.be.true();
+        const d3 = temp.path();
+        await promisify(fs.copyFile)(big, d3);
+        expect(fs.readFileSync(d3).equals(fs.readFileSync(big))).to.be.true();
+
+        if (process.platform !== 'win32') {
+          const d4 = temp.path();
+          fs.copyFileSync(path.join(asarDir, 'echo.asar', 'echo'), d4);
+          expect(fs.statSync(d4).mode & 0o111).to.not.equal(0);
+          const d5 = temp.path();
+          fs.copyFileSync(path.join(asarDir, 'a.asar', 'file1'), d5);
+          expect(fs.statSync(d5).mode & 0o111).to.equal(0);
+        }
+      });
+
+      itremote('fails when the destination is inside an archive', async function () {
+        const temp = require('temp').track();
+        const src = temp.path();
+        fs.writeFileSync(src, 'x');
+        expect(() => fs.copyFileSync(src, path.join(asarDir, 'a.asar', 'new-file'))).to.throw(/ENOTDIR|EACCES|ENOENT/);
+        expect(() =>
+          fs.copyFileSync(path.join(asarDir, 'a.asar', 'file1'), path.join(asarDir, 'a.asar', 'file2'))
+        ).to.throw(/ENOTDIR|EACCES|ENOENT/);
+      });
+    });
+
+    // Mirrors the test-fs-cp-* family (subset applicable to read-only sources).
+    describe('fs.cp / fs.cpSync / fs.promises.cp from archives', function () {
+      itremote('copies a directory tree recursively (sync, callback, promises)', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar');
+        const expectedTop = ['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js'];
+        for (const variant of ['sync', 'callback', 'promises']) {
+          const dest = temp.path();
+          if (variant === 'sync') fs.cpSync(src, dest, { recursive: true });
+          else if (variant === 'callback') await promisify(fs.cp)(src, dest, { recursive: true });
+          else await fs.promises.cp(src, dest, { recursive: true });
+          expect(fs.readdirSync(dest).sort(), variant).to.deep.equal(expectedTop);
+          for (const dir of ['dir1', 'dir2', 'dir3']) {
+            expect(fs.statSync(path.join(dest, dir)).isDirectory(), variant).to.be.true();
+            for (const file of ['file1', 'file2', 'file3']) {
+              expect(
+                fs.readFileSync(path.join(dest, dir, file)).equals(fs.readFileSync(path.join(src, dir, file))),
+                `${variant} ${dir}/${file}`
+              ).to.be.true();
+            }
+          }
+          expect(
+            fs.readFileSync(path.join(dest, 'ping.js')).equals(fs.readFileSync(path.join(src, 'ping.js')))
+          ).to.be.true();
+          // Like Node's cp of a real tree, symlinks are preserved and (without
+          // verbatimSymlinks) made absolute, i.e. they point back into the archive.
+          expect(fs.lstatSync(path.join(dest, 'link1')).isSymbolicLink(), variant).to.be.true();
+          expect(fs.readlinkSync(path.join(dest, 'link1')), variant).to.equal(path.join(src, 'file1'));
+          expect(fs.lstatSync(path.join(dest, 'link2')).isSymbolicLink(), variant).to.be.true();
+          expect(fs.readlinkSync(path.join(dest, 'link2')), variant).to.equal(path.join(src, 'dir1'));
+          expect(fs.lstatSync(path.join(dest, 'dir1', 'link2')).isSymbolicLink(), variant).to.be.true();
+          expect(fs.readlinkSync(path.join(dest, 'dir1', 'link2')), variant).to.equal(path.join(src, 'dir1'));
+        }
+      });
+
+      itremote('copies symlinks verbatim when asked, producing a self-contained tree', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar');
+        for (const variant of ['sync', 'promises']) {
+          const dest = temp.path();
+          if (variant === 'sync') fs.cpSync(src, dest, { recursive: true, verbatimSymlinks: true });
+          else await fs.promises.cp(src, dest, { recursive: true, verbatimSymlinks: true });
+          expect(fs.readlinkSync(path.join(dest, 'link1')), variant).to.equal('file1');
+          expect(fs.readlinkSync(path.join(dest, 'link2')), variant).to.equal('dir1');
+          expect(fs.readlinkSync(path.join(dest, 'dir1', 'link1')), variant).to.equal(path.join('..', 'file1'));
+          expect(fs.readlinkSync(path.join(dest, 'dir1', 'link2')), variant).to.equal('.');
+          expect(fs.readFileSync(path.join(dest, 'dir1', 'link1')).toString(), variant).to.equal('file1\n');
+          // ...which resolve on the real filesystem.
+          expect(fs.readFileSync(path.join(dest, 'link1')).toString(), variant).to.equal('file1\n');
+          expect(fs.readdirSync(path.join(dest, 'link2')).sort(), variant).to.deep.equal(
+            fs.readdirSync(path.join(src, 'dir1')).sort()
+          );
+          expect(fs.readFileSync(path.join(dest, 'link2', 'link2', 'file1')).toString(), variant).to.equal('file1\n');
+        }
+      });
+
+      itremote('requires recursive for directories', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar');
+        // Node reports this as the ERR_FS_EISDIR system error (with EISDIR as its info code).
+        expect(() => fs.cpSync(src, temp.path()))
+          .to.throw()
+          .with.property('code', 'ERR_FS_EISDIR');
+        await expectToThrowErrorWithCode(() => fs.promises.cp(src, temp.path()), 'ERR_FS_EISDIR');
+        const err = await new Promise<any>((resolve) => fs.cp(src, temp.path(), resolve));
+        expect(err.code).to.equal('ERR_FS_EISDIR');
+        expect(err.info.code).to.equal('EISDIR');
+      });
+
+      itremote('honours errorOnExist and force', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar', 'file1');
+        const dest = temp.path();
+        fs.writeFileSync(dest, 'existing');
+        // force defaults to true
+        fs.cpSync(src, dest);
+        expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
+        fs.writeFileSync(dest, 'existing');
+        fs.cpSync(src, dest, { force: false });
+        expect(fs.readFileSync(dest).toString()).to.equal('existing');
+        expect(() => fs.cpSync(src, dest, { force: false, errorOnExist: true }))
+          .to.throw()
+          .with.property('code', 'ERR_FS_CP_EEXIST');
+        await expectToThrowErrorWithCode(
+          () => fs.promises.cp(src, dest, { force: false, errorOnExist: true }),
+          'ERR_FS_CP_EEXIST'
+        );
+        await fs.promises.cp(src, dest, { force: false });
+        expect(fs.readFileSync(dest).toString()).to.equal('existing');
+        await fs.promises.cp(src, dest);
+        expect(fs.readFileSync(dest).toString()).to.equal('file1\n');
+
+        // Directory variants
+        const dir = temp.path();
+        fs.mkdirSync(path.join(dir, 'dir1'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'dir1', 'file1'), 'existing');
+        fs.cpSync(path.join(asarDir, 'a.asar'), dir, { recursive: true, force: false });
+        expect(fs.readFileSync(path.join(dir, 'dir1', 'file1')).toString()).to.equal('existing');
+        expect(fs.readFileSync(path.join(dir, 'dir1', 'file2')).toString()).to.equal('file2\n');
+        expect(() =>
+          fs.cpSync(path.join(asarDir, 'a.asar'), dir, { recursive: true, force: false, errorOnExist: true })
+        ).to.throw(/EEXIST/);
+        fs.cpSync(path.join(asarDir, 'a.asar'), dir, { recursive: true });
+        expect(fs.readFileSync(path.join(dir, 'dir1', 'file1')).toString()).to.equal('file1\n');
+      });
+
+      itremote('applies filter functions', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar');
+        const dest = temp.path();
+        fs.cpSync(src, dest, { recursive: true, filter: (p: string) => !p.endsWith('file2') });
+        expect(fs.existsSync(path.join(dest, 'file1'))).to.be.true();
+        expect(fs.existsSync(path.join(dest, 'file2'))).to.be.false();
+        expect(fs.existsSync(path.join(dest, 'dir1', 'file2'))).to.be.false();
+        const dest2 = temp.path();
+        await fs.promises.cp(src, dest2, {
+          recursive: true,
+          filter: async (p: string) => !path.basename(p).startsWith('dir')
+        });
+        expect(fs.readdirSync(dest2).sort()).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+        // Symlink to a filtered-out directory still gets created as a link.
+        expect(fs.lstatSync(path.join(dest2, 'link2')).isSymbolicLink()).to.be.true();
+      });
+
+      itremote('dereferences symlinks when asked', async function () {
+        const temp = require('temp').track();
+        const src = path.join(asarDir, 'a.asar');
+        // Note: a.asar's directory links form a cycle (dir1/link2 -> dir1), so a
+        // dereferencing copy of the whole tree cannot terminate (Node behaves
+        // the same on a real tree); dereference the acyclic parts instead.
+        for (const variant of ['sync', 'promises']) {
+          const single = temp.path();
+          if (variant === 'sync') fs.cpSync(path.join(src, 'link1'), single, { dereference: true });
+          else await fs.promises.cp(path.join(src, 'link1'), single, { dereference: true });
+          expect(fs.lstatSync(single).isFile(), variant).to.be.true();
+          expect(fs.readFileSync(single).toString(), variant).to.equal('file1\n');
+
+          const dir = temp.path();
+          if (variant === 'sync') fs.cpSync(path.join(src, 'dir2'), dir, { recursive: true, dereference: true });
+          else await fs.promises.cp(path.join(src, 'dir2'), dir, { recursive: true, dereference: true });
+          expect(fs.readdirSync(dir).sort(), variant).to.deep.equal(['file1', 'file2', 'file3']);
+        }
+      });
+
+      itremote('errors on non-existent sources and file-to-directory mismatches', async function () {
+        const temp = require('temp').track();
+        expect(() => fs.cpSync(path.join(asarDir, 'a.asar', 'nope'), temp.path())).to.throw(/ENOENT/);
+        await expectToThrowErrorWithCode(
+          () => fs.promises.cp(path.join(asarDir, 'a.asar', 'nope'), temp.path()),
+          'ENOENT'
+        );
+        const dir = temp.path();
+        fs.mkdirSync(dir);
+        expect(() => fs.cpSync(path.join(asarDir, 'a.asar', 'file1'), dir))
+          .to.throw()
+          .with.property('code', 'ERR_FS_CP_NON_DIR_TO_DIR');
+        await expectToThrowErrorWithCode(
+          () => fs.promises.cp(path.join(asarDir, 'a.asar', 'file1'), dir),
+          'ERR_FS_CP_NON_DIR_TO_DIR'
+        );
+        const file = temp.path();
+        fs.writeFileSync(file, 'x');
+        expect(() => fs.cpSync(path.join(asarDir, 'a.asar'), file, { recursive: true }))
+          .to.throw()
+          .with.property('code', 'ERR_FS_CP_DIR_TO_NON_DIR');
+        await expectToThrowErrorWithCode(
+          () => fs.promises.cp(path.join(asarDir, 'a.asar'), file, { recursive: true }),
+          'ERR_FS_CP_DIR_TO_NON_DIR'
+        );
+      });
+
+      itremote('copies unpacked files and mixed archives', async function () {
+        const temp = require('temp').track();
+        const dest = temp.path();
+        fs.cpSync(path.join(asarDir, 'unpack.asar'), dest, { recursive: true });
+        expect(
+          fs.readFileSync(path.join(dest, 'a.txt')).equals(fs.readFileSync(path.join(asarDir, 'unpack.asar', 'a.txt')))
+        ).to.be.true();
+        expect(
+          fs
+            .readFileSync(path.join(dest, 'atom.png'))
+            .equals(fs.readFileSync(path.join(asarDir, 'unpack.asar', 'atom.png')))
+        ).to.be.true();
+      });
+    });
+
+    // Mirrors test-fs-opendir.js.
+    describe('fs.opendir / fs.opendirSync / fs.promises.opendir on archives', function () {
+      itremote('lists entries with correct types (sync)', function () {
+        const dir = fs.opendirSync(path.join(asarDir, 'a.asar'));
+        expect(dir.path).to.equal(path.join(asarDir, 'a.asar'));
+        const entries: Record<string, string> = {};
+        let dirent;
+        while ((dirent = dir.readSync()) !== null) {
+          expect(dirent).to.be.an.instanceOf(fs.Dirent);
+          expect(dirent.parentPath).to.equal(path.join(asarDir, 'a.asar'));
+          entries[dirent.name] = dirent.isDirectory()
+            ? 'dir'
+            : dirent.isSymbolicLink()
+              ? 'link'
+              : dirent.isFile()
+                ? 'file'
+                : '?';
+        }
+        dir.closeSync();
+        expect(entries).to.deep.equal({
+          dir1: 'dir',
+          dir2: 'dir',
+          dir3: 'dir',
+          file1: 'file',
+          file2: 'file',
+          file3: 'file',
+          link1: 'link',
+          link2: 'link',
+          'ping.js': 'file'
+        });
+        expect(() => dir.readSync())
+          .to.throw()
+          .with.property('code', 'ERR_DIR_CLOSED');
+        expect(() => dir.closeSync())
+          .to.throw()
+          .with.property('code', 'ERR_DIR_CLOSED');
+      });
+
+      itremote('lists entries via callbacks, promises and async iteration', async function () {
+        const p = path.join(asarDir, 'a.asar');
+        const expected = fs.readdirSync(p).sort();
+
+        const dir1 = await promisify(fs.opendir)(p);
+        const names1: string[] = [];
+        for (;;) {
+          const dirent = await promisify(dir1.read.bind(dir1))();
+          if (dirent === null) break;
+          names1.push(dirent.name);
+        }
+        await promisify(dir1.close.bind(dir1))();
+        expect(names1.sort()).to.deep.equal(expected);
+
+        const dir2 = await fs.promises.opendir(p);
+        const names2: string[] = [];
+        for await (const dirent of dir2) names2.push(dirent.name);
+        expect(names2.sort()).to.deep.equal(expected);
+        await expectToThrowErrorWithCode(() => dir2.close(), 'ERR_DIR_CLOSED');
+
+        const dir3 = await fs.promises.opendir(p, { bufferSize: 2 });
+        const names3: string[] = [];
+        let dirent;
+        while ((dirent = await dir3.read()) !== null) names3.push(dirent.name);
+        await dir3.close();
+        expect(names3.sort()).to.deep.equal(expected);
+
+        // Breaking out of iteration closes the handle.
+        const dir4 = await fs.promises.opendir(p);
+        // eslint-disable-next-line no-unreachable-loop
+        for await (const _ of dir4) {
+          expect(_).to.be.an.instanceOf(fs.Dirent);
+          break;
+        }
+        await expectToThrowErrorWithCode(() => dir4.read(), 'ERR_DIR_CLOSED');
+      });
+
+      itremote('supports recursive iteration', async function () {
+        const p = path.join(asarDir, 'a.asar');
+        const dir = await fs.promises.opendir(p, { recursive: true });
+        const found: string[] = [];
+        for await (const dirent of dir) found.push(path.relative(p, path.join(dirent.parentPath, dirent.name)));
+        expect(found).to.include(path.join('dir1', 'file1'));
+        expect(found).to.include(path.join('dir3', 'file3'));
+        expect(found).to.include('link2');
+        // Symlinked directories are not followed (like Node).
+        expect(found).to.not.include(path.join('link2', 'file1'));
+        const sync = fs.opendirSync(p, { recursive: true });
+        const foundSync: string[] = [];
+        let dirent;
+        while ((dirent = sync.readSync()) !== null) {
+          foundSync.push(path.relative(p, path.join(dirent.parentPath, dirent.name)));
+        }
+        sync.closeSync();
+        expect(foundSync.sort()).to.deep.equal(found.sort());
+      });
+
+      itremote('lists sub directories, linked directories and empty archives', async function () {
+        expect(
+          Array.from({ length: 5 }, () => fs.opendirSync(path.join(asarDir, 'a.asar', 'dir1')).readSync()!.name).sort()
+        ).to.deep.equal(['file1', 'file1', 'file1', 'file1', 'file1']);
+        const linked = fs.opendirSync(path.join(asarDir, 'a.asar', 'link2'));
+        const names: string[] = [];
+        let dirent;
+        while ((dirent = linked.readSync()) !== null) names.push(dirent.name);
+        linked.closeSync();
+        expect(names.sort()).to.deep.equal(fs.readdirSync(path.join(asarDir, 'a.asar', 'dir1')).sort());
+        const empty = fs.opendirSync(path.join(asarDir, 'empty.asar'));
+        expect(empty.readSync()!.name).to.equal('file1');
+        expect(empty.readSync()).to.equal(null);
+        empty.closeSync();
+      });
+
+      itremote('supports the buffer encoding', function () {
+        const dir = fs.opendirSync(path.join(asarDir, 'a.asar'), { encoding: 'buffer' as any });
+        const dirent = dir.readSync()!;
+        expect(Buffer.isBuffer(dirent.name)).to.be.true();
+        dir.closeSync();
+      });
+
+      itremote('reports ENOTDIR and ENOENT', async function () {
+        expect(() => fs.opendirSync(path.join(asarDir, 'a.asar', 'file1'))).to.throw(/ENOTDIR/);
+        expect(() => fs.opendirSync(path.join(asarDir, 'a.asar', 'nope'))).to.throw(/ENOENT/);
+        await expectToThrowErrorWithCode(() => fs.promises.opendir(path.join(asarDir, 'a.asar', 'file1')), 'ENOTDIR');
+        const err = await new Promise<any>((resolve) => fs.opendir(path.join(asarDir, 'a.asar', 'nope'), resolve));
+        expect(err.code).to.equal('ENOENT');
+        expect(() => fs.opendirSync(path.join(asarDir, 'a.asar'), { bufferSize: 0 }))
+          .to.throw()
+          .with.property('code', 'ERR_OUT_OF_RANGE');
+      });
+    });
+
+    describe('fs.readlink / fs.readlinkSync / fs.promises.readlink on archives', function () {
+      itremote('returns link targets relative to the link, like a real filesystem', async function () {
+        const a = path.join(asarDir, 'a.asar');
+        // In this fixture every link points at a root entry (dir1/link1 -> /file1,
+        // dir1/link2 -> /dir1), and asar stores targets relative to the archive
+        // root; readlink reports them relative to the link's directory.
+        expect(fs.readlinkSync(path.join(a, 'link1'))).to.equal('file1');
+        expect(fs.readlinkSync(path.join(a, 'link2'))).to.equal('dir1');
+        expect(fs.readlinkSync(path.join(a, 'dir1', 'link1'))).to.equal(path.join('..', 'file1'));
+        expect(fs.readlinkSync(path.join(a, 'dir1', 'link2'))).to.equal('.');
+        expect(fs.readlinkSync(path.join(a, 'link2', 'link1'))).to.equal(path.join('..', 'file1'));
+        expect(await fs.promises.readlink(path.join(a, 'link1'))).to.equal('file1');
+        expect(await promisify(fs.readlink)(path.join(a, 'link1'))).to.equal('file1');
+        const asBuffer = fs.readlinkSync(path.join(a, 'link1'), 'buffer');
+        expect(Buffer.isBuffer(asBuffer)).to.be.true();
+        expect(asBuffer.toString()).to.equal('file1');
+        expect(fs.readlinkSync(path.join(a, 'link1'), { encoding: 'utf8' })).to.equal('file1');
+        // Resolving the target against the link's directory gives a readable path.
+        const resolve = (link: string) => path.resolve(path.dirname(link), fs.readlinkSync(link));
+        expect(fs.readFileSync(resolve(path.join(a, 'link1'))).toString()).to.equal('file1\n');
+        expect(fs.readdirSync(resolve(path.join(a, 'link2'))).sort()).to.deep.equal(
+          fs.readdirSync(path.join(a, 'dir1')).sort()
+        );
+        expect(fs.readFileSync(resolve(path.join(a, 'link2', 'link1'))).toString()).to.equal('file1\n');
+      });
+
+      itremote('reports EINVAL for non-links and ENOENT for missing paths', async function () {
+        const a = path.join(asarDir, 'a.asar');
+        expect(() => fs.readlinkSync(path.join(a, 'file1'))).to.throw(/EINVAL/);
+        expect(() => fs.readlinkSync(path.join(a, 'dir1'))).to.throw(/EINVAL/);
+        expect(() => fs.readlinkSync(path.join(a, 'nope'))).to.throw(/ENOENT/);
+        await expectToThrowErrorWithCode(() => fs.promises.readlink(path.join(a, 'file1')), 'EINVAL');
+        const err = await new Promise<any>((resolve) => fs.readlink(path.join(a, 'nope'), resolve));
+        expect(err.code).to.equal('ENOENT');
+      });
+    });
+
+    describe('fs.stat follows symbolic links inside archives', function () {
+      itremote('reports the link target for stat and the link itself for lstat', async function () {
+        const a = path.join(asarDir, 'a.asar');
+        for (const [link, expected] of [
+          ['link1', 'file'],
+          ['link2', 'dir'],
+          [path.join('dir1', 'link1'), 'file'],
+          [path.join('dir1', 'link2'), 'dir'],
+          [path.join('link2', 'link1'), 'file'],
+          [path.join('link2', 'link2'), 'dir'],
+          [path.join('link2', 'link2', 'link1'), 'file']
+        ] as [string, string][]) {
+          const p = path.join(a, link);
+          for (const stats of [
+            fs.statSync(p),
+            await promisify(fs.stat)(p),
+            await fs.promises.stat(p),
+            fs.statSync(p, { bigint: true })
+          ]) {
+            expect(stats.isSymbolicLink(), link).to.be.false();
+            expect(stats.isFile(), link).to.equal(expected === 'file');
+            expect(stats.isDirectory(), link).to.equal(expected === 'dir');
+            if (expected === 'file') expect(Number(stats.size), link).to.equal(6);
+          }
+          expect(fs.lstatSync(p).isSymbolicLink(), link).to.be.true();
+          expect((await fs.promises.lstat(p)).isSymbolicLink(), link).to.be.true();
+        }
+        expect(fs.statSync(path.join(a, 'link1'), { throwIfNoEntry: false })!.isFile()).to.be.true();
+        expect(fs.statSync(path.join(a, 'nope'), { throwIfNoEntry: false })).to.equal(null as any);
+        expect(() => fs.statSync(path.join(a, 'nope'))).to.throw(/ENOENT/);
+        await expectToThrowErrorWithCode(() => fs.promises.stat(path.join(a, 'nope')), 'ENOENT');
+      });
+
+      itremote('resolves paths through symlinked directories for module loading', function () {
+        // require() relies on internalModuleStat, which must follow links to
+        // recognise directories.
+        expect(fs.readdirSync(path.join(asarDir, 'a.asar', 'link2'))).to.include('file1');
+        expect(fs.readFileSync(path.join(asarDir, 'a.asar', 'link2', 'link2', 'file1')).toString()).to.equal('file1\n');
+        expect(fs.existsSync(path.join(asarDir, 'a.asar', 'link2', 'link1'))).to.be.true();
+      });
+    });
+
+    describe('fs.stat / fs.lstat with bigint on archives', function () {
+      itremote('returns BigIntStats when requested', async function () {
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        const s = fs.statSync(p, { bigint: true });
+        expect(typeof s.size).to.equal('bigint');
+        expect(s.size).to.equal(6n);
+        expect(typeof s.mtimeMs).to.equal('bigint');
+        expect(typeof s.mtimeNs).to.equal('bigint');
+        expect(s.isFile()).to.be.true();
+        expect(fs.lstatSync(path.join(asarDir, 'a.asar', 'link1'), { bigint: true }).isSymbolicLink()).to.be.true();
+        expect(fs.lstatSync(path.join(asarDir, 'a.asar', 'dir1'), { bigint: true }).isDirectory()).to.be.true();
+        expect((await fs.promises.stat(p, { bigint: true })).size).to.equal(6n);
+        expect((await fs.promises.lstat(p, { bigint: true })).size).to.equal(6n);
+        const cb = await new Promise<any>((resolve, reject) =>
+          fs.stat(p, { bigint: true }, (e, s) => (e ? reject(e) : resolve(s)))
+        );
+        expect(cb.size).to.equal(6n);
+        // Plain stats are still numbers.
+        expect(typeof fs.statSync(p).size).to.equal('number');
+        expect(fs.statSync(p).mtime).to.be.an.instanceOf(Date);
+        expect(fs.statSync(p, { bigint: false }).size).to.equal(6);
+      });
+    });
+
+    describe('fs.exists on an invalid archive', function () {
+      itremote('reports false rather than an error object', async function () {
+        const p = path.join(asarDir, 'not-an-archive.asar', 'file');
+        expect(fs.existsSync(p)).to.be.false();
+        // eslint-disable-next-line n/no-deprecated-api
+        const exists = await new Promise((resolve) => fs.exists(p, resolve));
+        expect(exists).to.be.false();
+      });
+    });
+
+    describe('fs.readFileSync options handling', function () {
+      itremote('returns a Buffer for empty files when options is an object without an encoding', function () {
+        const p = path.join(asarDir, 'empty.asar', 'file1');
+        expect(Buffer.isBuffer(fs.readFileSync(p, { flag: 'r' }))).to.be.true();
+        expect(Buffer.isBuffer(fs.readFileSync(p, { encoding: null }))).to.be.true();
+        expect(fs.readFileSync(p, { encoding: 'utf8' })).to.equal('');
+      });
+    });
+
+    describe('original-fs is not affected by the archive-aware fs overrides', function () {
+      itremote('treats archives as plain files through every fd, stream, copy and dir API', async function () {
+        const originalFs = require('node:original-fs');
+        const archive = path.join(asarDir, 'a.asar');
+        const rawSize = originalFs.statSync(archive).size;
+        expect(originalFs.statSync(archive).isFile()).to.be.true();
+        expect(rawSize).to.be.greaterThan(1000);
+        const raw = originalFs.readFileSync(archive);
+        expect(raw.length).to.equal(rawSize);
+        expect(raw.subarray(0, 4).readUInt32LE(0)).to.equal(4); // asar pickle header
+
+        // fd-based access reads the archive itself.
+        const fd = originalFs.openSync(archive, 'r');
+        expect(originalFs.fstatSync(fd).size).to.equal(rawSize);
+        const head = Buffer.alloc(16);
+        expect(originalFs.readSync(fd, head, 0, 16, 0)).to.equal(16);
+        expect(head.equals(raw.subarray(0, 16))).to.be.true();
+        expect(originalFs.readFileSync(fd).length).to.equal(rawSize);
+        expect(originalFs.readvSync(fd, [Buffer.alloc(8)], 0)).to.equal(8);
+        originalFs.closeSync(fd);
+
+        const handle = await originalFs.promises.open(archive, 'r');
+        expect((await handle.stat()).size).to.equal(rawSize);
+        expect((await handle.readFile()).length).to.equal(rawSize);
+        await handle.close();
+
+        const streamed = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          originalFs
+            .createReadStream(archive)
+            .on('data', (c: Buffer) => chunks.push(c))
+            .on('error', reject)
+            .on('end', () => resolve(Buffer.concat(chunks)));
+        });
+        expect(streamed.equals(raw)).to.be.true();
+
+        // Paths "inside" the archive are just non-existent for original-fs.
+        expect(() => originalFs.openSync(path.join(archive, 'file1'), 'r')).to.throw(/ENOTDIR|ENOENT/);
+        expect(() => originalFs.readlinkSync(path.join(archive, 'link1'))).to.throw(/ENOTDIR|ENOENT/);
+        expect(() => originalFs.opendirSync(path.join(archive, 'dir1'))).to.throw(/ENOTDIR|ENOENT/);
+        expect(() => originalFs.opendirSync(archive)).to.throw(/ENOTDIR/);
+        await expectToThrowErrorWithCode(
+          () => originalFs.promises.open(path.join(archive, 'file1'), 'r'),
+          process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR'
+        );
+
+        // Copies copy the archive file itself.
+        const temp = require('temp').track();
+        const d1 = temp.path();
+        originalFs.copyFileSync(archive, d1);
+        expect(originalFs.readFileSync(d1).equals(raw)).to.be.true();
+        const d2 = temp.path();
+        await originalFs.promises.copyFile(archive, d2);
+        expect(originalFs.readFileSync(d2).equals(raw)).to.be.true();
+        const d3 = temp.path();
+        originalFs.cpSync(archive, d3);
+        expect(originalFs.readFileSync(d3).equals(raw)).to.be.true();
+        const d4 = temp.path();
+        await originalFs.promises.cp(archive, d4);
+        expect(originalFs.readFileSync(d4).equals(raw)).to.be.true();
+
+        // And a directory listing of the fixtures dir shows the archive as a file.
+        const dir = originalFs.opendirSync(asarDir);
+        let dirent;
+        let seen = false;
+        while ((dirent = dir.readSync()) !== null) {
+          if (dirent.name === 'a.asar') {
+            seen = true;
+            expect(dirent.isFile()).to.be.true();
+          }
+        }
+        dir.closeSync();
+        expect(seen).to.be.true();
+
+        // Writing through original-fs to a path that merely mentions .asar works.
+        const scratch = path.join(temp.mkdirSync('asar-original-fs'), 'not-really.asar');
+        originalFs.writeFileSync(scratch, 'hello');
+        expect(originalFs.readFileSync(scratch, 'utf8')).to.equal('hello');
+        const wfd = originalFs.openSync(scratch, 'w');
+        originalFs.writeSync(wfd, 'bye');
+        originalFs.closeSync(wfd);
+        expect(originalFs.readFileSync(scratch, 'utf8')).to.equal('bye');
+      });
+    });
+
     describe('fs.mkdir', function () {
       itremote('throws error when calling inside asar archive', async function () {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
@@ -1716,7 +3152,7 @@ describe('asar package', function () {
 
     describe('util.promisify', function () {
       itremote('can promisify all fs functions', function () {
-        const originalFs = require('original-fs');
+        const originalFs = require('node:original-fs');
         const util = require('node:util');
 
         for (const [propertyName, originalValue] of Object.entries(originalFs)) {
@@ -1846,7 +3282,7 @@ describe('asar package', function () {
       );
 
       itremote('treats *.asar as normal file', function () {
-        const originalFs = require('original-fs');
+        const originalFs = require('node:original-fs');
         const asar = path.join(asarDir, 'a.asar');
         const content1 = fs.readFileSync(asar);
         const content2 = originalFs.readFileSync(asar);
@@ -1954,7 +3390,7 @@ describe('asar package', function () {
   describe('original-fs module', function () {
     itremote('treats .asar as file', function () {
       const file = path.join(asarDir, 'a.asar');
-      const originalFs = require('original-fs');
+      const originalFs = require('node:original-fs');
       const stats = originalFs.statSync(file);
       expect(stats.isFile()).to.be.true();
     });
@@ -1970,7 +3406,7 @@ describe('asar package', function () {
     */
 
     itremote('can be used with streams', () => {
-      const originalFs = require('original-fs');
+      const originalFs = require('node:original-fs');
       originalFs.createReadStream(path.join(asarDir, 'a.asar'));
     });
 
@@ -1978,7 +3414,7 @@ describe('asar package', function () {
       const deleteDir = path.join(asarDir, 'deleteme');
       fs.mkdirSync(deleteDir);
 
-      const originalFs = require('original-fs');
+      const originalFs = require('node:original-fs');
       originalFs.rmdirSync(deleteDir, { recursive: true });
 
       expect(fs.existsSync(deleteDir)).to.be.false();
@@ -1988,15 +3424,15 @@ describe('asar package', function () {
       const deleteDir = path.join(asarDir, 'deleteme');
       fs.mkdirSync(deleteDir);
 
-      const originalFs = require('original-fs');
+      const originalFs = require('node:original-fs');
       await originalFs.promises.rmdir(deleteDir, { recursive: true });
 
       expect(fs.existsSync(deleteDir)).to.be.false();
     });
 
     itremote('has the same APIs as fs', function () {
-      expect(Object.keys(require('node:fs'))).to.deep.equal(Object.keys(require('original-fs')));
-      expect(Object.keys(require('node:fs').promises)).to.deep.equal(Object.keys(require('original-fs').promises));
+      expect(Object.keys(require('node:fs'))).to.deep.equal(Object.keys(require('node:original-fs')));
+      expect(Object.keys(require('node:fs').promises)).to.deep.equal(Object.keys(require('node:original-fs').promises));
     });
   });
 

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1940,6 +1940,8 @@ describe('asar package', function () {
       itremote('reports conventional permission bits for stat/lstat', function () {
         const a = path.join(asarDir, 'a.asar');
         expect(fs.statSync(path.join(a, 'file1')).mode & 0o777).to.equal(0o644);
+        expect(fs.statSync(path.join(asarDir, 'echo.asar', 'echo')).mode & 0o777).to.equal(0o755);
+        expect(fs.lstatSync(path.join(asarDir, 'echo.asar', 'echo')).mode & 0o777).to.equal(0o755);
         expect(fs.statSync(path.join(a, 'dir1')).mode & 0o777).to.equal(0o755);
         expect(fs.statSync(a).mode & 0o777).to.equal(0o755);
         expect(fs.lstatSync(path.join(a, 'link1')).mode & 0o777).to.equal(0o777);
@@ -2306,6 +2308,35 @@ describe('asar package', function () {
         }
       });
 
+      itremote('does not capture a descriptor number that was closed behind its back', async function () {
+        // Something outside fs (a native FileHandle built on the number, a
+        // handle moved to a worker, ...) can close a packed descriptor
+        // without going through fs.close. Simulate that with original-fs and
+        // check the next owner of the number is served natively.
+        const originalFs = require('node:original-fs');
+        const temp = require('temp').track();
+        const real = temp.path();
+        fs.writeFileSync(real, 'real-file-content');
+        const p = path.join(asarDir, 'a.asar', 'file1');
+        for (const variant of ['sync', 'async', 'handle']) {
+          const stale = fs.openSync(p, 'r');
+          originalFs.closeSync(stale);
+          let fd: number;
+          if (variant === 'sync') fd = fs.openSync(real, 'r');
+          else if (variant === 'async') fd = await promisify(fs.open)(real, 'r');
+          else fd = (await fs.promises.open(real, 'r')).fd;
+          const buffer = Buffer.alloc(17);
+          expect(fs.readSync(fd, buffer, 0, 17, 0)).to.equal(17);
+          expect(buffer.toString()).to.equal('real-file-content');
+          expect(fs.fstatSync(fd).size).to.equal(17);
+          if (variant !== 'handle') fs.closeSync(fd);
+          // A packed open that gets the same number again works too.
+          const again = fs.openSync(p, 'r');
+          expect(fs.readFileSync(again).toString()).to.equal('file1\n');
+          fs.closeSync(again);
+        }
+      });
+
       itremote('close semantics match Node', async function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         const handle = await fs.promises.open(p, 'r');
@@ -2463,6 +2494,17 @@ describe('asar package', function () {
           const d5 = temp.path();
           fs.copyFileSync(path.join(asarDir, 'a.asar', 'file1'), d5);
           expect(fs.statSync(d5).mode & 0o111).to.equal(0);
+          // cp chmods the destination to the source's stat mode afterwards, so
+          // stat must agree with what copyFile preserved.
+          const d6 = temp.path();
+          fs.cpSync(path.join(asarDir, 'echo.asar', 'echo'), d6);
+          expect(fs.statSync(d6).mode & 0o111).to.not.equal(0);
+          const d7 = temp.path();
+          await fs.promises.cp(path.join(asarDir, 'echo.asar', 'echo'), d7);
+          expect(fs.statSync(d7).mode & 0o111).to.not.equal(0);
+          const d8 = temp.path();
+          fs.cpSync(path.join(asarDir, 'echo.asar'), d8, { recursive: true, filter: () => true });
+          expect(fs.statSync(path.join(d8, 'echo')).mode & 0o111).to.not.equal(0);
         }
       });
 

--- a/spec/fixtures/apps/asar-fd-reads/main.js
+++ b/spec/fixtures/apps/asar-fd-reads/main.js
@@ -1,0 +1,76 @@
+// Reads a file out of default_app.asar through the fd / stream / copy based
+// fs APIs (which serve bytes directly from the archive) rather than
+// fs.readFile, so that the block-based integrity validation gets exercised.
+// The mode is chosen with the ASAR_FD_READ_MODE environment variable.
+const { app } = require('electron');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Keep this app's profile away from the default Electron userData directory,
+// which the test runner (another Electron instance) may be using.
+app.setPath('userData', fs.mkdtempSync(path.join(os.tmpdir(), 'asar-fixture-userdata-')));
+
+const target = path.join(process.resourcesPath, 'default_app.asar', 'index.html');
+const mode = process.env.ASAR_FD_READ_MODE || 'fd';
+
+async function readViaFd() {
+  const fd = fs.openSync(target, 'r');
+  const { size } = fs.fstatSync(fd);
+  const buffer = Buffer.alloc(size);
+  let read = 0;
+  while (read < size) {
+    const n = fs.readSync(fd, buffer, read, Math.min(1024, size - read), null);
+    if (n === 0) break;
+    read += n;
+  }
+  fs.closeSync(fd);
+  return buffer.subarray(0, read);
+}
+
+function readViaStream() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    fs.createReadStream(target, { highWaterMark: 1024 })
+      .on('data', (chunk) => chunks.push(chunk))
+      .on('error', reject)
+      .on('end', () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+async function readViaFileHandle() {
+  const handle = await fs.promises.open(target, 'r');
+  try {
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readViaCopy() {
+  const dest = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'asar-fd-reads-')), 'index.html');
+  await fs.promises.copyFile(target, dest);
+  return fs.readFileSync(dest);
+}
+
+const readers = { fd: readViaFd, stream: readViaStream, handle: readViaFileHandle, copy: readViaCopy };
+
+// app.exit() (which process.exit() maps to in the main process) is only
+// reliable once the app is ready; exiting during startup can be lost.
+const exitWhenReady = (code) => app.whenReady().then(() => process.exit(code));
+
+(async () => {
+  const content = await readers[mode]();
+  // Only after the fd-based read succeeded do we compare against fs.readFile,
+  // which validates the whole-file hash independently.
+  const expected = fs.readFileSync(target);
+  if (!content.equals(expected)) {
+    console.log(`mismatch: ${mode} read ${content.length} bytes, expected ${expected.length}`);
+    return exitWhenReady(3);
+  }
+  console.log(`${mode}-read-ok`);
+  return exitWhenReady(0);
+})().catch((error) => {
+  console.log(`${mode}-read-failed: ${error && error.stack}`);
+  return exitWhenReady(4);
+});

--- a/spec/fixtures/apps/asar-integrity-reads/main.js
+++ b/spec/fixtures/apps/asar-integrity-reads/main.js
@@ -1,0 +1,256 @@
+// Exercises the block-validated, fd/stream based read paths of the asar fs
+// wrapper against a multi-block archive (integrity-reads.asar) that the spec
+// generates next to default_app.asar and registers in the app's integrity
+// table.  ASAR_INTEGRITY_READS_MODE selects the scenario; progress markers
+// are printed so the spec can tell how far a run got before an integrity
+// violation terminated it.
+const { app } = require('electron');
+const fs = require('node:fs');
+const originalFs = require('node:original-fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Keep this app's profile away from the default Electron userData directory,
+// which the test runner (another Electron instance) may be using.
+app.setPath('userData', fs.mkdtempSync(path.join(os.tmpdir(), 'asar-fixture-userdata-')));
+
+const mode = process.env.ASAR_INTEGRITY_READS_MODE || 'sweep';
+const archive = path.join(process.resourcesPath, 'integrity-reads.asar');
+const multi = path.join(archive, 'multi.bin');
+const exact = path.join(archive, 'exact.bin');
+const small = path.join(archive, 'small.bin');
+
+const BLOCK = 4 * 1024 * 1024;
+// Must match the generator in asar-integrity-spec.ts.
+const MULTI_SIZE = 2 * BLOCK + 1024 * 1024 + 5;
+const EXACT_SIZE = BLOCK;
+const SMALL_SIZE = 1000;
+const patternByte = (i) => (i * 7 + (i >> 8)) & 0xff;
+const MARKER = (n) => `ASARBLOCK${n}MAGIC!`;
+
+function expectedRange(start, end) {
+  const buf = Buffer.alloc(end - start);
+  for (let i = start; i < end; i++) buf[i - start] = patternByte(i);
+  for (let n = 0; n * BLOCK < MULTI_SIZE; n++) {
+    const marker = Buffer.from(MARKER(n));
+    for (let j = 0; j < marker.length; j++) {
+      const pos = n * BLOCK + j;
+      if (pos >= start && pos < end) buf[pos - start] = marker[j];
+    }
+  }
+  return buf;
+}
+function expectedFile(size) {
+  const buf = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) buf[i] = patternByte(i);
+  return buf;
+}
+
+const assert = (cond, msg) => {
+  if (!cond) {
+    throw new Error(`assertion failed: ${msg}`);
+  }
+};
+const streamAll = (p, opts) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    fs.createReadStream(p, opts)
+      .on('data', (c) => chunks.push(c))
+      .on('error', reject)
+      .on('end', () => resolve(Buffer.concat(chunks)));
+  });
+
+async function sweep() {
+  const multiExpected = expectedRange(0, MULTI_SIZE);
+  const exactExpected = expectedFile(EXACT_SIZE);
+  const smallExpected = expectedFile(SMALL_SIZE);
+
+  // Whole-file streams with chunk sizes that do and don't divide the block size.
+  for (const hwm of [64 * 1024, 1000, 1 << 20]) {
+    assert((await streamAll(multi, { highWaterMark: hwm })).equals(multiExpected), `stream hwm=${hwm}`);
+  }
+  assert((await streamAll(exact, { highWaterMark: 12345 })).equals(exactExpected), 'stream exact');
+  assert((await streamAll(small)).equals(smallExpected), 'stream small');
+  console.log('sweep-streams-ok');
+
+  // Ranged streams around block boundaries and the tail.
+  const ranges = [
+    [0, 0],
+    [BLOCK - 3, BLOCK + 2],
+    [BLOCK, BLOCK],
+    [2 * BLOCK - 1, 2 * BLOCK],
+    [BLOCK - 1, MULTI_SIZE - 1],
+    [MULTI_SIZE - 5, MULTI_SIZE - 1],
+    [MULTI_SIZE - 1, MULTI_SIZE - 1],
+    [1, 2 * BLOCK + 7]
+  ];
+  for (const [start, end] of ranges) {
+    const got = await streamAll(multi, { start, end, highWaterMark: 777 });
+    assert(got.equals(expectedRange(start, end + 1)), `ranged stream ${start}-${end}`);
+  }
+  console.log('sweep-ranges-ok');
+
+  // Sync fd reads: odd chunk sizes, cursor semantics, positional jumps across blocks, EOF.
+  {
+    const fd = fs.openSync(multi, 'r');
+    const st = fs.fstatSync(fd);
+    assert(st.size === MULTI_SIZE && st.isFile(), 'fstat');
+    const out = Buffer.alloc(MULTI_SIZE);
+    let read = 0;
+    while (read < MULTI_SIZE) {
+      const n = fs.readSync(fd, out, read, Math.min(4097, MULTI_SIZE - read), null);
+      if (n === 0) break;
+      read += n;
+    }
+    assert(read === MULTI_SIZE && out.equals(multiExpected), 'readSync loop');
+    assert(fs.readSync(fd, Buffer.alloc(10), 0, 10, null) === 0, 'readSync at EOF');
+    for (const pos of [2 * BLOCK + 10, 0, BLOCK - 1, MULTI_SIZE - 3, BLOCK * 2 - 5, 12345]) {
+      const buf = Buffer.alloc(9);
+      const n = fs.readSync(fd, buf, 0, 9, pos);
+      const exp = expectedRange(pos, Math.min(pos + 9, MULTI_SIZE));
+      assert(n === exp.length && buf.subarray(0, n).equals(exp), `positional read @${pos}`);
+    }
+    assert(fs.readSync(fd, Buffer.alloc(1), 0, 1, MULTI_SIZE + 100) === 0, 'read past EOF');
+    // readv crossing a block boundary
+    const bufs = [Buffer.alloc(100), Buffer.alloc(200), Buffer.alloc(BLOCK)];
+    const n = fs.readvSync(fd, bufs, BLOCK - 150);
+    assert(n === 300 + BLOCK, `readv bytes ${n}`);
+    assert(Buffer.concat(bufs).equals(expectedRange(BLOCK - 150, BLOCK - 150 + n)), 'readv content');
+    fs.closeSync(fd);
+  }
+  console.log('sweep-fd-ok');
+
+  // Async fd reads and readFile(fd) from a moved cursor.
+  {
+    const fd = await fs.promises.open(multi, 'r');
+    const { bytesRead, buffer } = await fd.read(Buffer.alloc(BLOCK + 3), 0, BLOCK + 3, BLOCK - 1);
+    assert(bytesRead === BLOCK + 3 && buffer.equals(expectedRange(BLOCK - 1, 2 * BLOCK + 2)), 'handle.read');
+    const stat = await fd.stat();
+    assert(stat.size === MULTI_SIZE, 'handle.stat');
+    // Move the cursor with a null-position read, then readFile from there.
+    await fd.read(Buffer.alloc(2 * BLOCK + 5), 0, 2 * BLOCK + 5, null);
+    const rest = await fd.readFile();
+    assert(rest.equals(expectedRange(2 * BLOCK + 5, MULTI_SIZE)), 'handle.readFile from cursor');
+    const web = fd.readableWebStream();
+    let webTotal = 0;
+    for await (const chunk of web) webTotal += chunk.byteLength;
+    assert(webTotal === 0, 'web stream at EOF');
+    await fd.close();
+
+    const fd2 = fs.openSync(multi, 'r');
+    fs.readSync(fd2, Buffer.alloc(BLOCK + 1), 0, BLOCK + 1, null);
+    const rest2 = fs.readFileSync(fd2);
+    assert(rest2.equals(expectedRange(BLOCK + 1, MULTI_SIZE)), 'readFileSync(fd) from cursor');
+    fs.closeSync(fd2);
+
+    const fd3 = fs.openSync(small, 'r');
+    fs.readSync(fd3, Buffer.alloc(10), 0, 10, null);
+    assert(fs.readFileSync(fd3, 'latin1') === smallExpected.subarray(10).toString('latin1'), 'readFileSync(fd, enc)');
+    fs.closeSync(fd3);
+  }
+  console.log('sweep-handle-ok');
+
+  // Concurrent consumers of the same entry, more than the retained-block cap.
+  {
+    const streams = [];
+    for (let i = 0; i < 40; i++) streams.push(streamAll(multi, { highWaterMark: 65536 + i }));
+    const results = await Promise.all(streams);
+    for (const r of results) assert(r.equals(multiExpected), 'concurrent stream');
+  }
+  console.log('sweep-concurrent-ok');
+
+  // Copies.
+  {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'asar-integrity-reads-'));
+    fs.copyFileSync(multi, path.join(dir, 'a'));
+    await fs.promises.copyFile(multi, path.join(dir, 'b'));
+    fs.cpSync(archive, path.join(dir, 'c'), { recursive: true });
+    assert(fs.readFileSync(path.join(dir, 'a')).equals(multiExpected), 'copyFileSync');
+    assert(fs.readFileSync(path.join(dir, 'b')).equals(multiExpected), 'promises.copyFile');
+    assert(fs.readFileSync(path.join(dir, 'c', 'multi.bin')).equals(multiExpected), 'cpSync');
+    assert(fs.readFileSync(path.join(dir, 'c', 'small.bin')).equals(smallExpected), 'cpSync small');
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  console.log('sweep-copy-ok');
+  console.log('sweep-ok');
+}
+
+async function blockStream() {
+  let received = 0;
+  let reported = -1;
+  await new Promise((resolve, reject) => {
+    fs.createReadStream(multi, { highWaterMark: 65536 })
+      .on('data', (c) => {
+        received += c.length;
+        const block = Math.floor((received - 1) / BLOCK);
+        while (reported < block) {
+          reported++;
+          console.log(`reached-block-${reported}`);
+        }
+      })
+      .on('error', reject)
+      .on('end', resolve);
+  });
+  assert(received === MULTI_SIZE, 'stream length');
+  console.log('stream-ok');
+}
+
+async function rangeBlock0() {
+  const got = await streamAll(multi, { start: 0, end: 1024 * 1024 - 1 });
+  assert(got.equals(expectedRange(0, 1024 * 1024)), 'range content');
+  const fd = fs.openSync(multi, 'r');
+  const buf = Buffer.alloc(100);
+  assert(fs.readSync(fd, buf, 0, 100, 500) === 100 && buf.equals(expectedRange(500, 600)), 'positional block 0');
+  fs.closeSync(fd);
+  console.log('range-block0-ok');
+}
+
+async function tamperAfterRead() {
+  // Reader A validates block 0 and keeps it.
+  const a = fs.openSync(multi, 'r');
+  const first = Buffer.alloc(100);
+  assert(fs.readSync(a, first, 0, 100, 0) === 100 && first.equals(expectedRange(0, 100)), 'A first read');
+
+  // Now corrupt block 0 of the entry in place on disk (same inode).
+  const raw = originalFs.readFileSync(archive);
+  const at = raw.indexOf(Buffer.from(MARKER(0)));
+  assert(at !== -1, 'marker present');
+  const rawFd = originalFs.openSync(archive, 'r+');
+  originalFs.writeSync(rawFd, Buffer.from('TAMPERED0MAGIC!!'), 0, 16, at);
+  originalFs.closeSync(rawFd);
+
+  // A serves from its already-validated block; nothing has been re-read.
+  assert(fs.readSync(a, first, 0, 100, 0) === 100 && first.equals(expectedRange(0, 100)), 'A cached read');
+  console.log('tamper-after-read-A-ok');
+
+  // A fresh reader must re-validate block 0 and die.
+  const b = fs.openSync(multi, 'r');
+  fs.readSync(b, Buffer.alloc(100), 0, 100, 0);
+  console.log('tamper-after-read-B-unexpectedly-ok');
+}
+
+async function readFileWhole() {
+  const got = fs.readFileSync(multi);
+  assert(got.equals(expectedRange(0, MULTI_SIZE)), 'readFileSync content');
+  console.log('readfile-ok');
+}
+
+const modes = {
+  sweep,
+  'block-stream': blockStream,
+  'range-block0': rangeBlock0,
+  'tamper-after-read': tamperAfterRead,
+  readfile: readFileWhole
+};
+
+// app.exit() (which process.exit() maps to in the main process) is only
+// reliable once the app is ready; exiting during startup can be lost.
+const exitWhenReady = (code) => app.whenReady().then(() => process.exit(code));
+
+modes[mode]().then(
+  () => exitWhenReady(0),
+  (error) => {
+    console.log(`${mode}-failed: ${error && error.stack}`);
+    return exitWhenReady(4);
+  }
+);

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -96,11 +96,11 @@ declare namespace NodeJS {
     realpath(path: string): string | false;
     copyFileOut(path: string): string | false;
     getFdAndValidateIntegrityLater(): number | -1;
-    dupFd(): number | -1;
   }
 
   interface AsarBinding {
     Archive: { new (path: string): AsarArchive };
+    createSentinelFd(): number | -1;
     splitPath(path: string):
       | {
           isAsar: false;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -73,9 +73,12 @@ declare namespace NodeJS {
     size: number;
     unpacked: boolean;
     offset: number;
+    executable: boolean;
     integrity?: {
       algorithm: 'SHA256';
       hash: string;
+      blockSize: number;
+      blocks: string[];
     };
   };
 
@@ -92,6 +95,7 @@ declare namespace NodeJS {
     realpath(path: string): string | false;
     copyFileOut(path: string): string | false;
     getFdAndValidateIntegrityLater(): number | -1;
+    dupFd(): number | -1;
   }
 
   interface AsarBinding {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -86,6 +86,7 @@ declare namespace NodeJS {
     size: number;
     offset: number;
     type: number;
+    executable: boolean;
   };
 
   interface AsarArchive {


### PR DESCRIPTION
#### Description of Change

Removes the temp-file extraction (`Archive::CopyFileOut`) from every fs path except `process.dlopen` and `child_process.execFile*`, which need a real path.

- `fs.open`/`openSync`/`promises.open` on a packed entry return a descriptor `dup`'d from the archive's retained handle (CLOEXEC / non-inheritable). The fs binding (`read`, `readBuffers`, `fstat`, `close`, `readFileUtf8`) is hooked so every fd-based API — `read*`, `readv*`, `fstat*`, `readFile(fd)`, `createReadStream`, `FileHandle` — reads straight out of the archive; positions are translated and clamped to the entry. Non-integrity reads are passed to native with the caller's own request (no extra hop).
- With ASAR integrity enabled, bytes are only handed out from a block whose hash was just verified (per-reader last-block cache, no shared "validated" bitmap, so in-place tampering after a first read is still caught). A violation now terminates synchronously (`process.reallyExit`); previously the graceful `app.exit()` let tampered bytes reach `require()` first.
- Opening a packed entry with write flags → `EACCES` (was: silently wrote to the cached temp copy, poisoning later reads); `fchmod`/`fchown`/`futimes` on such fds → `EACCES`; `writeFileSync` fast path routed through the same check.
- `copyFile`/`copyFileSync`/`promises.copyFile` stream archive→destination (mode flags validated like Node, `COPYFILE_EXCL` honored, `FICLONE_FORCE` → `ENOTSUP`, executable bit preserved). `fs.cp`/`promises.cp` now work for directories via Node's own implementation; `cpSync` natives get archive-aware equivalents.
- New: `fs.opendir*` and `fs.readlink*` for archives (readlink returns the link-relative target). `fs.stat` follows archive symlinks (so `cp({ dereference })` works); `bigint` stats supported; stats built via `getStatsFromBinding` (drops the DEP0180 `fs.Stats` constructor warning); directories/symlinks report 0755/0777 so copies stay traversable.
- `original-fs` is generated from the same sources and shared the binding object; it now gets a pristine snapshot (`script/node/generate_original_fs.py`) and is covered by a spec.
- Remaining temp copies (dlopen/execFile) are made read-only.
- Fixes from the audit: `fs.exists` on an invalid archive returned an `Error` (truthy) instead of `false`; `readFile` validated integrity before checking the read error and ignored short reads; `readFileSync` returned `''` for empty files when given an options object.

Breaking (semantic narrowing, documented in `breaking-changes.md`): the descriptor is only meaningful through `fs`; handing it to a native addon / `child_process` stdio / `net.Socket({fd})` is not supported.

#### Benchmarks

Median of 3 runs on an M-series Mac, `testing` build, 376 MB archive; "cold" = first access of a distinct entry (the old temp copy was cached per entry after that).

| Benchmark | before | after |
|---|---:|---:|
| cold `openSync` + read 64 KB + close, 16 MB entry | 5.3 ms | 0.04 ms |
| cold `createReadStream` first 64 KB, 16 MB | 5.6 ms | 0.12 ms |
| cold `promises.open` + read 64 KB, 16 MB | 6.0 ms | 0.13 ms |
| cold `openSync` + read 64 KB, 1 MB | 0.45 ms | 0.05 ms |
| cold `copyFileSync` 16 MB | 12.6 ms | 3.2 ms |
| cold `createReadStream` whole 16 MB | 13.5 ms | 27 ms (¹) |
| `copyFileSync` 64 MB | 28.5 ms | 8.1 ms |
| `promises.copyFile` 64 MB | 20.9 ms | 12.2 ms |
| `createReadStream` 64 MB | 252 ms | 107 ms |
| `createReadStream` 4 MB | 5.8 ms | 2.5 ms |
| `promises.cp` directory (100 × 4 KB) | ENOENT | 36 ms |
| temp files left in tmpdir by the run | 65 | 0 |

¹ the one regression: a first-ever whole-file stream of a cold entry now issues 64 KB preads against the cold region instead of one sequential copy followed by a hot-cache stream. Small-file steady-state numbers are within noise of each other.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes (`spec/asar-spec.ts` 258, `spec/asar-integrity-spec.ts` 20 incl. new fuse-backed multi-block tests)
- [x] tests are changed or added
- [x] relevant documentation is changed or added
- [x] PR title follows semantic commit guidelines

#### Release Notes

Notes: `fs.open`, `fs.createReadStream`, `fs.copyFile`, `fs.cp` and friends now read files inside ASAR archives directly from the archive instead of extracting a temporary copy; `fs.opendir` and `fs.readlink` work on archives; opening a packed file for writing fails with `EACCES`.