### PR TITLE
fix: inherit sandbox flags in windows opened by a sandboxed top-level frame

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1483,7 +1483,7 @@ content::WebContents* WebContents::OpenURLFromTab(
     auto* initiator = static_cast<content::RenderFrameHostImpl*>(
         content::RenderFrameHost::FromID(params.source_render_process_id,
                                          params.source_render_frame_id));
-    if (initiator && initiator->GetParent()) {
+    if (initiator) {
       // Use the initiating document's active sandboxing flag set (its policy
       // container flags), which is what
       // content::WebContentsImpl::CreateWithOpener consults when deciding
@@ -1495,7 +1495,7 @@ content::WebContents* WebContents::OpenURLFromTab(
       if (!allow(SandboxFlags::kPopups)) {
         initiator->AddMessageToConsole(
             blink::mojom::ConsoleMessageLevel::kError,
-            "Blocked opening a new window because the iframe is sandboxed "
+            "Blocked opening a new window because the opener is sandboxed "
             "and the 'allow-popups' keyword is not set.");
         return nullptr;
       }

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -5140,6 +5140,9 @@ describe('iframe sandbox popups', () => {
         res.end(makeChildHtml('https://example.com/sandbox-bypassed'));
       } else if (req.url === '/child-local-popup') {
         res.end(makeChildHtml('/popup'));
+      } else if (req.url === '/csp-sandbox-top') {
+        res.setHeader('Content-Security-Policy', 'sandbox allow-scripts allow-popups');
+        res.end(makeChildHtml('/popup'));
       } else if (req.url === '/popup') {
         res.end('<title>popup</title>');
       } else {
@@ -5226,5 +5229,28 @@ describe('iframe sandbox popups', () => {
     expect(result.origin).to.equal(new URL(serverUrl).origin);
     expect(result.localStorage).to.equal('allowed');
     expect(result.cookie).to.equal('allowed');
+  });
+
+  it('popups opened by a sandboxed top-level frame inherit the sandbox', async () => {
+    // A document made sandboxed by a CSP header is a sandboxed main frame (no
+    // parent); a window it opens must stay sandboxed just like an iframe's does.
+    const didCreateWindow = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow]>;
+    await w.loadURL(`${serverUrl}/csp-sandbox-top`);
+    const [popup] = await didCreateWindow;
+    if (popup.webContents.isLoading()) {
+      await once(popup.webContents, 'did-finish-load');
+    }
+    const result = await popup.webContents.executeJavaScript(
+      `(() => {
+      const result = { origin: String(self.origin) };
+      try { localStorage.setItem('k', 'v'); result.localStorage = 'allowed'; } catch (e) { result.localStorage = e.name; }
+      try { document.cookie = 'k=v'; result.cookie = 'allowed'; } catch (e) { result.cookie = e.name; }
+      return result;
+    })()`,
+      true
+    );
+    expect(result.origin).to.equal('null');
+    expect(result.localStorage).to.equal('SecurityError');
+    expect(result.cookie).to.equal('SecurityError');
   });
 });


### PR DESCRIPTION
`WebContents::OpenURLFromTab` only propagated the initiating frame's sandbox flags to the window it opened when that frame had a parent, so windows opened by a sandboxed top-level frame were created without them.

- Resolve and apply the initiator's active sandbox flags regardless of its position in the frame tree — a top-level frame can be sandboxed too (a sandboxed iframe's popup, or a `Content-Security-Policy: sandbox` header).
- Add a regression test for a window opened by a CSP-sandboxed top-level document.

Notes: Fixed windows opened by a sandboxed top-level frame not inheriting the opener's sandbox restrictions.
