### PR TITLE
chore: cherry-pick 3 changes from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -257,3 +257,4 @@ cherry-pick-322d045537fd.patch
 cherry-pick-7009092548dd.patch
 cherry-pick-adbdd928eb27.patch
 cherry-pick-278468608392.patch
+cherry-pick-e09d67f7844c.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -255,3 +255,4 @@ cherry-pick-526fd4a0352b.patch
 cherry-pick-ece2fa50a313.patch
 cherry-pick-322d045537fd.patch
 cherry-pick-7009092548dd.patch
+cherry-pick-adbdd928eb27.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -256,3 +256,4 @@ cherry-pick-ece2fa50a313.patch
 cherry-pick-322d045537fd.patch
 cherry-pick-7009092548dd.patch
 cherry-pick-adbdd928eb27.patch
+cherry-pick-278468608392.patch

--- a/patches/chromium/cherry-pick-278468608392.patch
+++ b/patches/chromium/cherry-pick-278468608392.patch
@@ -24,7 +24,6 @@ Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
 Reviewed-by: Greg Thompson <grt@chromium.org>
 Reviewed-by: Charlie Reis <creis@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#1678427}
----
 
 diff --git a/chrome/app/main_dll_loader_win.cc b/chrome/app/main_dll_loader_win.cc
 index 721c7cb973f808ce48318c3f8616379054295ce6..54472e64b4ad060e12a42173f2180c1bc60db06f 100644

--- a/patches/chromium/cherry-pick-278468608392.patch
+++ b/patches/chromium/cherry-pick-278468608392.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 12 Aug 2026 17:33:15 -0700
+Subject: [content] Lower child process shutdown priority on Windows
+
+At logoff and shutdown csrss ends processes in descending shutdown-level
+order and, within a level, in no particular order. chrome.exe lowers
+every non-browser process to 0x280 - 1 in its DLL loader so the browser
+(default 0x280) goes first and never sees its children killed. That
+lives in chrome/app, so no other content embedder gets it: their
+browser process shares a level with its own GPU, network and renderer
+processes, watches them die mid-session-teardown, and reacts as if
+they had crashed (relaunches that fail DLL initialization, sad tabs,
+and the GPU fallback ladder ending in an intentional browser crash).
+
+Do it in content's CommonSubprocessInit() for every non-browser
+process instead, still before any sandbox lockdown, and drop the two
+now-duplicate calls from Chrome's loader.
+
+Bug: 542224257
+Change-Id: I6ee480982dc99f5a330afb4606655c8a4d9322ee
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8223224
+Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
+Reviewed-by: Greg Thompson <grt@chromium.org>
+Reviewed-by: Charlie Reis <creis@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1678427}
+---
+
+diff --git a/chrome/app/main_dll_loader_win.cc b/chrome/app/main_dll_loader_win.cc
+index 721c7cb973f808ce48318c3f8616379054295ce6..54472e64b4ad060e12a42173f2180c1bc60db06f 100644
+--- a/chrome/app/main_dll_loader_win.cc
++++ b/chrome/app/main_dll_loader_win.cc
+@@ -151,8 +151,6 @@ MainDllLoader::MainDllLoader() : dll_(nullptr) {}
+ 
+ MainDllLoader::~MainDllLoader() = default;
+ 
+-const int kNonBrowserShutdownPriority = 0x280;
+-
+ // Launching is a matter of loading the right dll and calling the entry point.
+ // Derived classes can add custom code in the OnBeforeLaunch callback.
+ int MainDllLoader::Launch(HINSTANCE instance,
+@@ -188,16 +186,6 @@ int MainDllLoader::Launch(HINSTANCE instance,
+   if (!dll_)
+     return CHROME_RESULT_CODE_MISSING_DATA;
+ 
+-  if (!is_browser) {
+-    // Set non-browser processes up to be killed by the system after the
+-    // browser goes away. The browser uses the default shutdown order, which
+-    // is 0x280. Note that lower numbers here denote "kill later" and higher
+-    // numbers mean "kill sooner". This gets rid of most of those unsightly
+-    // sad tabs on logout and shutdown.
+-    ::SetProcessShutdownParameters(kNonBrowserShutdownPriority - 1,
+-                                   SHUTDOWN_NORETRY);
+-  }
+-
+   OnBeforeLaunch(process_type_, file);
+   DLL_MAIN chrome_main =
+       reinterpret_cast<DLL_MAIN>(::GetProcAddress(dll_, "ChromeMain"));
+@@ -237,14 +225,6 @@ void ChromeDllLoader::OnBeforeLaunch(const std::string& process_type,
+     if constexpr (kShouldRecordActiveUse) {
+       RecordDidRun(dll_path);
+     }
+-  } else {
+-    // Set non-browser processes up to be killed by the system after the browser
+-    // goes away. The browser uses the default shutdown order, which is 0x280.
+-    // Note that lower numbers here denote "kill later" and higher numbers mean
+-    // "kill sooner".
+-    // This gets rid of most of those unsightly sad tabs on logout and shutdown.
+-    ::SetProcessShutdownParameters(kNonBrowserShutdownPriority - 1,
+-                                   SHUTDOWN_NORETRY);
+   }
+ }
+ 
+diff --git a/content/app/content_main.cc b/content/app/content_main.cc
+index f2b1cdff827eae3726febe590f2f30b5f6d89046..f945cc4368276ede338843d6f6c92425b3514a66 100644
+--- a/content/app/content_main.cc
++++ b/content/app/content_main.cc
+@@ -124,6 +124,12 @@ bool IsSubprocess() {
+ 
+ void CommonSubprocessInit() {
+ #if BUILDFLAG(IS_WIN)
++  // Lower non-browser processes to 0x27F so `csrss` notifies/terminates the
++  // browser process (0x280) first during OS shutdown. The browser's teardown
++  // or job handle cleanup then takes care of child processes before it can
++  // observe them dying unexpectedly.
++  ::SetProcessShutdownParameters(0x280 - 1, SHUTDOWN_NORETRY);
++
+   // HACK: Let Windows know that we have started.  This is needed to suppress
+   // the IDC_APPSTARTING cursor from being displayed for a prolonged period
+   // while a subprocess is starting.

--- a/patches/chromium/cherry-pick-278468608392.patch
+++ b/patches/chromium/cherry-pick-278468608392.patch
@@ -71,7 +71,7 @@ index 721c7cb973f808ce48318c3f8616379054295ce6..54472e64b4ad060e12a42173f2180c1b
  }
  
 diff --git a/content/app/content_main.cc b/content/app/content_main.cc
-index f2b1cdff827eae3726febe590f2f30b5f6d89046..f945cc4368276ede338843d6f6c92425b3514a66 100644
+index dcce405488dd4c61c218a6b6c356d5932de99fb2..a67db088f014a747726152f7dc59a8b63a189e6b 100644
 --- a/content/app/content_main.cc
 +++ b/content/app/content_main.cc
 @@ -124,6 +124,12 @@ bool IsSubprocess() {

--- a/patches/chromium/cherry-pick-adbdd928eb27.patch
+++ b/patches/chromium/cherry-pick-adbdd928eb27.patch
@@ -35,13 +35,12 @@ Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
 Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
 Reviewed-by: Rafael Cintron <rafael.cintron@microsoft.com>
 Cr-Commit-Position: refs/heads/main@{#1678281}
----
 
 diff --git a/content/browser/gpu/gpu_process_host.cc b/content/browser/gpu/gpu_process_host.cc
-index b52430a0..ab3f702 100644
+index bc3fa4b1bb0bb31b1620b5962d93111e4e0328a6..df888345341a9559e4031d164696faff040211db 100644
 --- a/content/browser/gpu/gpu_process_host.cc
 +++ b/content/browser/gpu/gpu_process_host.cc
-@@ -107,6 +107,8 @@
+@@ -106,6 +106,8 @@
  #endif
  
  #if BUILDFLAG(IS_WIN)
@@ -50,7 +49,7 @@ index b52430a0..ab3f702 100644
  #include "base/win/access_token.h"
  #include "base/win/security_descriptor.h"
  #include "base/win/win_util.h"
-@@ -567,6 +569,17 @@
+@@ -557,6 +559,17 @@ void InitGpuPersistentCacheFileFactoryOnce() {
    }
  }
  
@@ -68,7 +67,7 @@ index b52430a0..ab3f702 100644
  }  // anonymous namespace
  
  // static
-@@ -614,6 +627,12 @@
+@@ -604,6 +617,12 @@ GpuProcessHost* GpuProcessHost::Get(GpuProcessKind kind, bool force_create) {
      return nullptr;
    }
  
@@ -81,7 +80,7 @@ index b52430a0..ab3f702 100644
    if (kind != GPU_PROCESS_KIND_INFO_COLLECTION) {
      InitGpuPersistentCacheFileFactoryOnce();
    }
-@@ -1474,6 +1493,14 @@
+@@ -1435,6 +1454,14 @@ void GpuProcessHost::RecordProcessCrash() {
    if (!process_launched_ || kind_ != GPU_PROCESS_KIND_SANDBOXED)
      return;
  

--- a/patches/chromium/cherry-pick-adbdd928eb27.patch
+++ b/patches/chromium/cherry-pick-adbdd928eb27.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 12 Aug 2026 13:34:48 -0700
+Subject: [gpu] Don't count Windows session teardown as GPU crashes
+
+When a Windows session ends (logoff, shutdown, restart) the OS kills a
+browser's child processes and refuses to initialize new ones: GPU
+children exit with STATUS_DLL_INIT_FAILED_LOGOFF (0xC000026B) or are
+terminated with DBG_TERMINATE_PROCESS (0x40010004). GpuProcessHost
+counts each of these as a GPU crash, so a browser process that is still
+alive at that moment drains the whole fallback ladder within about a
+second and dies in IntentionallyCrashBrowserForUnusableGpuProcess() - a
+crash report that has nothing to do with the GPU.
+
+Chrome rarely sees this because of ordering, not because its GPU
+process is treated specially: chrome.exe lowers the shutdown priority
+of every non-browser process (SetProcessShutdownParameters in
+chrome/app/main_dll_loader_win.cc), so the OS ends the browser first,
+and the browser terminates itself in chrome::SessionEnding() before its
+children are killed. Content embedders that do neither still have a
+live browser process while their GPU process is torn down, and this is
+their top browser-process crash on Windows.
+
+Exit codes are reported on behalf of the child, so ask the OS instead:
+RecordProcessCrash() returns early while
+GetSystemMetrics(SM_SHUTTINGDOWN) is nonzero, and GpuProcessHost::Get()
+does not launch a new GPU process in that window. Relaunch,
+GpuDataManagerImpl::ProcessCrashed() and fallback for real crashes are
+unchanged.
+
+Bug: 542224257
+Change-Id: I4f843921043127ced6685c93b5f4a46364ef21f8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8186617
+Reviewed-by: Kyle Charbonneau <kylechar@chromium.org>
+Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
+Reviewed-by: Rafael Cintron <rafael.cintron@microsoft.com>
+Cr-Commit-Position: refs/heads/main@{#1678281}
+---
+
+diff --git a/content/browser/gpu/gpu_process_host.cc b/content/browser/gpu/gpu_process_host.cc
+index b52430a0..ab3f702 100644
+--- a/content/browser/gpu/gpu_process_host.cc
++++ b/content/browser/gpu/gpu_process_host.cc
+@@ -107,6 +107,8 @@
+ #endif
+ 
+ #if BUILDFLAG(IS_WIN)
++#include <windows.h>
++
+ #include "base/win/access_token.h"
+ #include "base/win/security_descriptor.h"
+ #include "base/win/win_util.h"
+@@ -567,6 +569,17 @@
+   }
+ }
+ 
++// True while the OS is ending the user session (Windows logoff, shutdown,
++// restart): it is killing this browser's child processes and refuses to start
++// new ones, which says nothing about the GPU.
++bool IsSessionEnding() {
++#if BUILDFLAG(IS_WIN)
++  return ::GetSystemMetrics(SM_SHUTTINGDOWN) != 0;
++#else
++  return false;
++#endif
++}
++
+ }  // anonymous namespace
+ 
+ // static
+@@ -614,6 +627,12 @@
+     return nullptr;
+   }
+ 
++  // Nor while the OS ends the session: the launch would fail and nothing is
++  // left to use the process.
++  if (IsSessionEnding()) {
++    return nullptr;
++  }
++
+   if (kind != GPU_PROCESS_KIND_INFO_COLLECTION) {
+     InitGpuPersistentCacheFileFactoryOnce();
+   }
+@@ -1474,6 +1493,14 @@
+   if (!process_launched_ || kind_ != GPU_PROCESS_KIND_SANDBOXED)
+     return;
+ 
++  // The OS is ending the session: it kills child processes, refuses to start
++  // new ones, and ends the browser next. Whether this exit was that or a real
++  // crash just before no longer matters - Get() won't launch another GPU
++  // process - so don't spend the fallback budget on it.
++  if (IsSessionEnding()) {
++    return;
++  }
++
+   // Keep track of the total number of GPU crashes.
+   base::subtle::NoBarrier_AtomicIncrement(&gpu_crash_count_, 1);
+   LOG(WARNING) << "The GPU process has crashed " << GetGpuCrashCount()

--- a/patches/chromium/cherry-pick-e09d67f7844c.patch
+++ b/patches/chromium/cherry-pick-e09d67f7844c.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 12 Aug 2026 13:31:16 -0700
+Subject: mac: resolve the Cocoa locale override to a locale with a pak
+
+l10n_util::OverrideLocaleWithCocoaLocale() stores [OuterBundle()
+preferredLocalizations][0] verbatim, but the outer bundle can advertise
+localizations the framework has no locale.pak for (an embedder shipping
+de-DE.lproj when the framework only has de.lproj). The override then
+resolves to an empty pak path, LoadLocaleResources() loads nothing, and
+every localized string is empty for the rest of the session. Non-Apple
+platforms already run the requested locale through
+CheckAndResolveLocale(); do the same here at the one point the Cocoa
+value enters, falling back to en-US the way the non-Apple path does.
+
+No behavior change for Chrome: its outer bundle only advertises
+pak-backed localizations, so CheckAndResolveLocale() returns the input
+unchanged.
+
+Bug: 542025190
+Change-Id: Id933ff4a8c5e2ca598907f052e6e7bf9343300b2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8175050
+Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
+Reviewed-by: Danilo Tedeschi <danft@google.com>
+Reviewed-by: David Sanders <dsanders11@ucsbalum.com>
+Cr-Commit-Position: refs/heads/main@{#1678275}
+---
+
+diff --git a/ui/base/l10n/l10n_util_mac.mm b/ui/base/l10n/l10n_util_mac.mm
+index cad5022..efc4bf2 100644
+--- a/ui/base/l10n/l10n_util_mac.mm
++++ b/ui/base/l10n/l10n_util_mac.mm
+@@ -62,6 +62,12 @@
+   if (locale_value == "en")
+     locale_value = "en-US";
+ 
++  // The outer bundle can advertise a localization the framework has no
++  // locale.pak for (e.g. de-DE.lproj beside de.lproj); resolve to one that
++  // does, falling back to en-US like GetApplicationLocaleInternalNonMac().
++  locale_value =
++      l10n_util::CheckAndResolveLocale(locale_value).value_or("en-US");
++
+   g_overridden_locale.Get() = locale_value;
+ }
+ 

--- a/patches/chromium/cherry-pick-e09d67f7844c.patch
+++ b/patches/chromium/cherry-pick-e09d67f7844c.patch
@@ -24,13 +24,12 @@ Commit-Queue: Shelley Vohr <shelley.vohr@gmail.com>
 Reviewed-by: Danilo Tedeschi <danft@google.com>
 Reviewed-by: David Sanders <dsanders11@ucsbalum.com>
 Cr-Commit-Position: refs/heads/main@{#1678275}
----
 
 diff --git a/ui/base/l10n/l10n_util_mac.mm b/ui/base/l10n/l10n_util_mac.mm
-index cad5022..efc4bf2 100644
+index cad5022d82a9b4987dd07ecc38c4eddddfa07512..efc4bf25fdd46635f1f763ca8e3afef9ed40c4d9 100644
 --- a/ui/base/l10n/l10n_util_mac.mm
 +++ b/ui/base/l10n/l10n_util_mac.mm
-@@ -62,6 +62,12 @@
+@@ -62,6 +62,12 @@ void OverrideLocaleWithCocoaLocale() {
    if (locale_value == "en")
      locale_value = "en-US";
  


### PR DESCRIPTION
Backports the following changes:

* adbdd928eb27 from chromium - [gpu] Don't count Windows session teardown as GPU crashes (542224257)
* 278468608392 from chromium - [content] Lower child process shutdown priority on Windows (542224257)
* e09d67f7844c from chromium - mac: resolve the Cocoa locale override to a locale with a pak (542025190)

The first two stop the browser process from crashing itself with "GPU process isn't usable. Goodbye." while Windows ends the session: child deaths during `SM_SHUTTINGDOWN` no longer count toward the GPU fallback budget, and every non-browser process gets Chrome's lower shutdown priority so csrss ends the browser first. The third makes an `AppleLanguages` override that has no matching .pak (for example `de-DE`) resolve to a locale that does, instead of loading zero locale strings. All three landed on Chromium main after M150 branched; the `chrome/app/main_dll_loader_win.cc` hunk of 278468608392 is rebased onto this branch's Chromium, the other two apply as landed.

Notes: Backported fixes for 542224257, 542025190.
