### PR TITLE
fix: keep remote api::WebContents alive while their content::WebContents lives

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -816,6 +816,18 @@ WebContents::WebContents(v8::Isolate* isolate,
   script_executor_ = std::make_unique<extensions::ScriptExecutor>(web_contents);
 #endif
 
+  // Nothing owns a remote api::WebContents on the JS side, so its wrapper is
+  // only kept alive by whoever happens to hold a reference to it. Some callers
+  // create it and only pick it back up later (e.g. the DevTools WebContents is
+  // created in InspectableWebContents::ShowDevTools and next looked up in
+  // DevToolsOpened once the frontend has loaded); if a GC runs in between the
+  // wrapper is collected while the C++ object is still reachable via
+  // From(), and FromOrCreate() then hands back an empty handle. Pin the
+  // wrapper for as long as the underlying content::WebContents is alive, see
+  // WebContentsDestroyed().
+  if (type_ == Type::kRemote)
+    Pin(isolate);
+
   // TODO: This works for main frames, but does not work for child frames.
   // See: https://github.com/electron/electron/issues/49256
   web_contents->SetSupportsDraggableRegions(true);
@@ -2606,6 +2618,9 @@ content::WebContents* WebContents::GetDevToolsWebContents() const {
 }
 
 void WebContents::WebContentsDestroyed() {
+  // The underlying content::WebContents is gone, let the wrapper be collected.
+  Unpin();
+
   // Clear the pointer stored in wrapper.
   if (GetAllWebContents().Lookup(id_))
     GetAllWebContents().Remove(id_);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1321,7 +1321,9 @@ describe('webContents module', () => {
       await w.loadURL('about:blank');
 
       const created: number[] = [];
-      const onCreated = (_: any, wc: WebContents) => { created.push(wc.id); };
+      const onCreated = (_: any, wc: WebContents) => {
+        created.push(wc.id);
+      };
       app.on('web-contents-created', onCreated);
       try {
         const devtoolsOpened = once(w.webContents, 'devtools-opened');

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1308,6 +1308,38 @@ describe('webContents module', () => {
       expect(w.webContents.isDevToolsOpened()).to.be.true();
     });
 
+    // Regression test for https://github.com/electron/electron/issues/52158.
+    // The api::WebContents wrapping the DevTools WebContents is created as soon
+    // as openDevTools() is called but only referenced again once the frontend
+    // has finished loading. A GC in between used to collect its wrapper, after
+    // which `devtools-opened` would either crash the main process (if the
+    // collected object had not been freed yet) or create a second
+    // api::WebContents for the same DevTools WebContents.
+    it('keeps the DevTools WebContents alive across a garbage collection while the frontend is loading', async () => {
+      const gc = require('node:vm').runInNewContext('gc');
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      const created: number[] = [];
+      const onCreated = (_: any, wc: WebContents) => { created.push(wc.id); };
+      app.on('web-contents-created', onCreated);
+      try {
+        const devtoolsOpened = once(w.webContents, 'devtools-opened');
+        w.webContents.openDevTools({ mode: 'detach', activate: false });
+        gc({ type: 'major', execution: 'sync' });
+        await devtoolsOpened;
+      } finally {
+        app.removeListener('web-contents-created', onCreated);
+      }
+
+      const devtools = w.webContents.devToolsWebContents;
+      expect(devtools).to.not.be.null();
+      expect(devtools!.isDestroyed()).to.be.false();
+      // Exactly one WebContents (the DevTools one) was created, and it is the
+      // one we ended up with.
+      expect(created).to.deep.equal([devtools!.id]);
+    });
+
     it('updates and restores the inspected page viewport for right-docked DevTools', async () => {
       const w = new BrowserWindow({ show: false, width: 800, height: 600 });
       await w.loadURL('about:blank');


### PR DESCRIPTION
#### Description of Change

Fixes #52158, the recurring `SIGSEGV` in `WebContents::DevToolsOpened()` on the macOS CI shards (same bug as #29890 / #34042 / #47187).

The api::WebContents for the DevTools `content::WebContents` is created up front in `InspectableWebContents::ShowDevTools` and the handle is dropped. It's a `kRemote` WebContents so nothing pins it, and nothing references its wrapper again until the frontend has loaded and `DevToolsOpened()` stashes it in `devtools_web_contents_`. If a GC lands in between, the wrapper is collected but the C++ object is still findable via `From()` until the deferred delete runs, and `FromOrCreate()` hands `DevToolsOpened()` an empty handle.

```
openDevTools()                                                devtools frontend "loadCompleted"
  |                                                                          |
  ShowDevTools: FromOrCreate(devtools wc)  ->  api::WebContents #2           LoadCompleted -> DevToolsOpened
  |             (handle dropped, wrapper only weakly held)                    |  FromOrCreate(devtools wc)
  |                                                                          |
  |            GC: wrapper of #2 collected                                    |
  |            FirstWeakCallback: dead_ = true, wrapper_.Reset()              |
  |            (delete is posted, From() still finds #2)                     |
  |                  |                                                        |
  |                  +--- delete task runs before loadCompleted  ------------>|  From() finds nothing, creates #3
  |                  |                                                        |  (web-contents-created fires twice,
  |                  |                                                        |   devToolsWebContents.id != #2)
  |                  |                                                        |
  |                  +--- loadCompleted arrives before the delete  ---------->|  From() returns zombie #2
                                                                             |  GetWrapper() empty -> handle.get() == nullptr
                                                                             |  handle->owner_window() => SEGV_ACCERR
                                                                             |  (0x1e0 on main, 0x1d0 on 42-x-y = offsetof(owner_window_))
```

- Fix: `Pin()` remote api::WebContents in the constructor and `Unpin()` in `WebContentsDestroyed()`, so a remote api::WebContents lives exactly as long as its `content::WebContents`. Same `Pinnable` mechanism background pages already use, no new `v8::Global`.
- Regression spec forces a major GC between `openDevTools()` and `devtools-opened` and asserts exactly one DevTools api::WebContents was created and it's the one on `devToolsWebContents`. Fails on the pre-fix build (`expected [ 2, 3 ] to deeply equal [ 3 ]`), passes with the fix.
- #52166 wasn't the fix for this, it protects the *inspected* api::WebContents. Here that one is alive and the *DevTools* one is the zombie; the crash reproduced on 42-x-y with #52511 present.

<details>
<summary>History of api::WebContents lifetime management (for the curious)</summary>

- Pre gin (mate::TrackableObject): weak wrapper + a per class weak map. Owned WebContents were kept alive by their window / webview, everything else was collectable whenever JS dropped it.
- #24651 (2020) ginified WebContents, added the `UserDataLink` WeakPtr so `From()` can find the api object from a `content::WebContents`. Still nothing strong for remotes.
- #23128 (2021-04) removed the `RenderProcessReady` backstop and started eagerly creating api::WebContents for DevTools / extension hosts / mime guests. This is where "created early, referenced late" starts, #29890 shows up two months later.
- #30030 (2021-07, `ccb16e2921`) pinned background page api::WebContents in `InitWithExtensionView` for exactly this reason ("live until the underlying content::WebContents is destroyed"). `kRemote` returns early right above that Pin, so it was left out. That's the only Pin WebContents ever had, and there was never an `Unpin()`.
- #46389 (2025) blamed a dangling `owner_window_` WeakPtr, closed. #47243 added the `DCHECK`s in `DevToolsOpened` (the `DCHECK_EQ(handle->owner_window(), nullptr)` is now the line we crash on in CI builds). #49406 / #51420 / #52166 all guard the *inspected* WebContents being freed, which is a different bug.
- Why it's timing dependent: V8 only runs second pass phantom callbacks synchronously for forced GCs, for a natural GC they're a posted task, so the zombie window has been at least one task since 2021. #50688 (2026-04) added `DeleteSoon` on top and widened it by another task, which lines up with #52158 showing up in June.

</details>

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] `npm test` passes (`webContents module`, `chrome extensions`, `session module`, `webFrameMain module`, `BrowserWindow module devtools`, `MenuItems`: 558 ok / 0 failing locally)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed a rare crash in the main process when DevTools were opened and a garbage collection ran before the DevTools frontend finished loading.
