### PR TITLE
fix: tear down Node's per-process state before the process exits

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -329,6 +329,11 @@ int NodeMain() {
 
   v8::V8::Dispose();
 
+  // Matches node::InitializeOncePerProcess() above. In particular this joins
+  // the off-thread CA certificate loader that `require('tls')` starts, which
+  // would otherwise race the static destructors run by exit() and abort().
+  node::TearDownOncePerProcess();
+
   return exit_code;
 }
 

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -23,6 +23,7 @@
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/node_bindings.h"
 #include "shell/common/thread_restrictions.h"
 
 namespace electron {
@@ -131,7 +132,11 @@ void Browser::Exit(gin::Arguments* args) {
 
 void Browser::ExitWithCode(int code) {
   if (!ElectronBrowserMainParts::Get()->SetExitCode(code)) {
-    // Message loop is not ready, quit directly.
+    // Message loop is not ready, quit directly. Nothing below us gets torn
+    // down on this path, so at least undo Node's per-process initialization
+    // before exit() starts running static destructors underneath any threads
+    // Node has started.
+    NodeBindings::TearDownOncePerProcess();
     exit(code);
   } else {
     // Prepare to quit when all windows have been closed.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -548,6 +548,17 @@ NodeBindings::~NodeBindings() {
   // Clean up worker loop
   if (in_worker_loop())
     stop_and_close_uv_loop(uv_loop_);
+
+  if (initialized_node_per_process_)
+    TearDownOncePerProcess();
+}
+
+// static
+void NodeBindings::TearDownOncePerProcess() {
+  if (!g_is_initialized)
+    return;
+  g_is_initialized = false;
+  node::TearDownOncePerProcess();
 }
 
 void NodeBindings::StopPolling() {
@@ -754,6 +765,7 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
   }
 
   g_is_initialized = true;
+  initialized_node_per_process_ = true;
 }
 
 std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -122,6 +122,14 @@ class NodeBindings {
   static void RegisterBuiltinBindings();
   static bool IsInitialized();
 
+  // Undo node::InitializeOncePerProcess() for this process. Must run before
+  // the process exits whenever Node was initialized: among other things it
+  // joins the thread Node uses to load CA certificates off the main thread
+  // (started the first time `tls` is loaded), which otherwise races exit-time
+  // static destruction and abort()s. Safe to call more than once and when Node
+  // was never initialized.
+  static void TearDownOncePerProcess();
+
   virtual ~NodeBindings();
 
   // Setup V8, libuv.
@@ -230,6 +238,10 @@ class NodeBindings {
 
   // Indicates whether polling thread has been created.
   bool initialized_ = false;
+
+  // Whether this instance ran node::InitializeOncePerProcess() and so owns the
+  // matching TearDownOncePerProcess() in its destructor.
+  bool initialized_node_per_process_ = false;
 
   // Whether PrepareEmbedThread has initialized the semaphore and async handle.
   // Unlike |initialized_|, this is never reset — the handles live until the

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -235,7 +235,9 @@ describe('app module', () => {
       expect(code).to.equal(123, 'exit code should be 123, if you see this please tag @MarshallOfSound');
     });
 
-    it('exits cleanly when called before ready right after loading tls', async () => {
+    // Exiting before 'ready' leaves browser start-up state unfreed by design,
+    // which LeakSanitizer reports and turns into exit code 1.
+    ifit(!process.env.IS_ASAN)('exits cleanly when called before ready right after loading tls', async () => {
       const appPath = path.join(fixturesPath, 'api', 'exit-before-ready-after-tls');
       // This guards against a shutdown race that was lost roughly one run in
       // five, so go a few rounds.

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -235,6 +235,25 @@ describe('app module', () => {
       expect(code).to.equal(123, 'exit code should be 123, if you see this please tag @MarshallOfSound');
     });
 
+    it('exits cleanly when called before ready right after loading tls', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'exit-before-ready-after-tls');
+      // This guards against a shutdown race that was lost roughly one run in
+      // five, so go a few rounds.
+      for (let i = 0; i < 15; i++) {
+        appProcess = cp.spawn(process.execPath, [appPath]);
+        let stderr = '';
+        appProcess.stderr!.on('data', (data) => {
+          stderr += data;
+        });
+        const [code, signal] = await once(appProcess, 'exit');
+        appProcess = null;
+        const message = `run ${i}: code=${code} signal=${signal}\n${stderr}`;
+        expect(signal).to.equal(null, message);
+        expect(code).to.equal(123, message);
+        expect(stderr).to.not.match(/Received signal \d+|Ignoring extra certs/, message);
+      }
+    });
+
     ifit(['darwin', 'linux'].includes(process.platform))('exits gracefully', async function () {
       const electronPath = process.execPath;
       const appPath = path.join(fixturesPath, 'api', 'singleton');

--- a/spec/fixtures/api/exit-before-ready-after-tls/main.js
+++ b/spec/fixtures/api/exit-before-ready-after-tls/main.js
@@ -1,0 +1,8 @@
+// Loading tls starts Node's off-main-thread CA certificate loader. Exiting
+// straight away, before 'ready', used to race that thread against exit-time
+// static destruction and abort().
+require('node:tls');
+
+const { app } = require('electron');
+
+app.exit(123);

--- a/spec/fixtures/api/exit-before-ready-after-tls/package.json
+++ b/spec/fixtures/api/exit-before-ready-after-tls/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-exit-before-ready-after-tls",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

Since Node 24.9 (nodejs/node#59856), loading `tls` starts a background thread that parses the CA certificates. Upstream joins it in `node::TearDownOncePerProcess()`, but Electron never called that on any exit path, so a process that loads `tls`/`https` and exits soon after can have `exit()` destroy Node's static `per_process::cli_options_mutex` underneath that thread → `uv_mutex_lock` → `abort()`. Silent SIGABRT, no output. This is what has been picking off random `test-tls-*` / `test-https-*` tests in the `nn-test` job (3 of the last 34 runs). Fixes #52860.

- `NodeMain` (`ELECTRON_RUN_AS_NODE`): call `node::TearDownOncePerProcess()` after `V8::Dispose()`, matching `node::Start()`.
- `NodeBindings`: the instance that ran `InitializeOncePerProcess()` now runs `TearDownOncePerProcess()` in its destructor — covers normal browser quit and the utility process.
- `Browser::ExitWithCode`: the pre-ready `app.exit()` path calls `exit()` directly with nothing torn down, so tear Node down first there too.
- spec: `require('node:tls'); app.exit(123)` before ready, 15×, asserting a clean exit.

Linux x64 testing build, this branch vs `main`:

| scenario | before | after |
|---|---|---|
| `require('node:tls'); app.exit()` before ready (browser process) | 20/100 SIGABRT, 37/100 read destroyed statics | 0/700 |
| `ELECTRON_RUN_AS_NODE=1 electron -e "require('tls')"` | 3/2,000 SIGABRT | 0/20,000 |
| Node `parallel/test-tls-*` at `-j128` | 3/96,000 (`exitcode: -6`, all three cores in `LoadCACertificates → uv_mutex_lock → abort`) | 0/48,000 |

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a possible crash (SIGABRT) during process exit when the process had loaded `tls`/`https` shortly before exiting, affecting `app.exit()` before `ready` and short-lived `ELECTRON_RUN_AS_NODE` / `child_process.fork()` scripts.
