### PR TITLE
fix: avoid resize jitter in opaque frameless X11 windows

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -35,8 +35,13 @@
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
-#include "shell/browser/ui/views/frameless_view.h"
 #include "ui/views/view_utils.h"
+#endif
+
+#if BUILDFLAG(IS_WIN)
+#include "shell/browser/ui/views/frameless_view.h"
+#elif BUILDFLAG(IS_LINUX)
+#include "shell/browser/ui/views/electron_frame_view_linux.h"
 #endif
 
 #if defined(USE_OZONE)
@@ -737,9 +742,16 @@ int NativeWindow::NonClientHitTest(const gfx::Point& point) {
 #if !BUILDFLAG(IS_MAC)
   // We need to ensure we account for resizing borders on Windows and Linux.
   if ((!has_frame() || has_client_frame()) && IsResizable()) {
-    auto* frame = views::AsViewClass<FramelessView>(
-        widget()->non_client_view()->frame_view());
-    if (frame) {
+    // TODO(mitchchn): bring back a cross-platform interface for
+    // frame operations. (Both Windows and Linux used to inherit
+    // from FramelessView.)
+#if BUILDFLAG(IS_WIN)
+    using ResizableFrameView = FramelessView;
+#else
+    using ResizableFrameView = ElectronFrameViewLinux;
+#endif
+    auto* frame_view = widget()->non_client_view()->frame_view();
+    if (auto* frame = views::AsViewClass<ResizableFrameView>(frame_view)) {
       int border_hit = frame->ResizingBorderHitTest(point);
       if (border_hit != HTNOWHERE)
         return border_hit;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -298,8 +298,10 @@ NativeWindowViews::NativeWindowViews(const int32_t base_window_id,
   if (transparent() || has_client_frame())
     params.opacity = InitParams::WindowOpacity::kTranslucent;
 #if BUILDFLAG(IS_LINUX)
-  // Resize handles and shadows on frameless windows need translucent insets.
-  if (!has_frame())
+  // Wayland CSD resize handles and shadows need translucent insets. Keep
+  // opaque X11 frameless windows on the system visual: ARGB windows visibly
+  // lag behind their native bounds during interactive GPU-composited resizes.
+  if (!has_frame() && !x11_util::IsX11())
     params.opacity = InitParams::WindowOpacity::kTranslucent;
 #endif
 

--- a/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
+++ b/shell/browser/ui/electron_desktop_window_tree_host_linux.cc
@@ -40,7 +40,13 @@ ElectronDesktopWindowTreeHostLinux::~ElectronDesktopWindowTreeHostLinux() =
     default;
 
 bool ElectronDesktopWindowTreeHostLinux::SupportsClientFrameShadow() const {
-  return platform_window()->CanSetDecorationInsets() &&
+  // Opaque X11 frameless windows use the internal resize band instead of
+  // translucent CSD shadow insets. This matches Electron's pre-43 behavior and
+  // keeps those windows on the system visual during interactive resizes.
+  const bool uses_internal_x11_frameless_resize =
+      x11_util::IsX11() && !native_window_view_->has_frame();
+  return !uses_internal_x11_frameless_resize &&
+         platform_window()->CanSetDecorationInsets() &&
          views::Widget::IsWindowCompositingSupported();
 }
 

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -18,12 +18,21 @@
 #include "ui/base/hit_test.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/frame_background.h"
 #include "ui/views/window/frame_caption_button.h"
 
 namespace electron {
+
+namespace {
+
+// Values used for internal resizing when there are no insets.
+const int kResizeAreaCornerSize = 16;
+const int kResizeInsideBoundsSize = 5;
+
+}  // namespace
 
 ElectronFrameViewLinux::ElectronFrameViewLinux(
     NativeWindowViews* window,
@@ -148,6 +157,21 @@ int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
     return contents_hit_test;
 
   return HTCLIENT;
+}
+
+int ElectronFrameViewLinux::ResizingBorderHitTest(const gfx::Point& point) {
+  // Fall back to an internal resize band only when there are no frame insets
+  // but the window is still supposed to be resizable. The main use case is
+  // transparent windows. Matches the behavior of
+  // WinFrameView::ResizingBorderHitTest.
+  if (!window_->IsResizable() ||
+      !efv_layout()->GetRestoredFrameBorderInsets().IsEmpty() ||
+      GetWidget()->IsMaximized() || GetWidget()->IsFullscreen())
+    return HTNOWHERE;
+
+  return GetHTComponentForFrame(point, gfx::Insets(kResizeInsideBoundsSize),
+                                kResizeAreaCornerSize, kResizeAreaCornerSize,
+                                /*can_resize=*/true);
 }
 
 void ElectronFrameViewLinux::Layout(PassKey) {

--- a/shell/browser/ui/views/electron_frame_view_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_linux.h
@@ -44,6 +44,10 @@ class ElectronFrameViewLinux : public views::NativeFrameViewLinux {
   bool WantsFrame() const;
   void SetWantsFrame(bool wants_frame);
 
+  // Hit test for the internal resize band used when the frame has no
+  // external frame insets (e.g., translucent windows).
+  int ResizingBorderHitTest(const gfx::Point& point);
+
   // views::FrameViewLinux:
   bool HasWindowTitle() const override;
   int NonClientHitTest(const gfx::Point& point) override;


### PR DESCRIPTION
#### Description of Change

Opaque frameless X11 windows became translucent native widgets when `OpaqueFrameView` was replaced by `ElectronFrameViewLinux`. On GNOME/X11, these ARGB GPU-composited windows can visibly lag behind their native bounds during fast interactive resizing.

This change keeps opaque frameless X11 windows on the system visual, matching Electron's pre-43 behavior. It disables client-frame shadow insets for that path and relies on the internal resize band introduced by #52740. Genuine `transparent: true` windows and Wayland CSD windows remain translucent.

#### Relationships and dependencies

- Fixes #52866, the dedicated Linux/X11 interactive-resize jitter report.
- Related to #52452, which reports the missing resize handles, white borders, and top-edge resize failures introduced by the same frame-view refactor, but not this compositor jitter.
- The regression was introduced by #51161 (`b36120f48` on `main`; `accc847eb` on `43-x-y`), which replaced `OpaqueFrameView` with `ElectronFrameViewLinux` and made every Linux frameless widget translucent.
- Depends on #52740 for its internal frameless resize hit-test band. Without that dependency, removing translucent CSD insets from opaque X11 windows would also remove their native edge and corner resize target.

This is therefore stacked on #52740. It should be rebased onto `main` after that dependency lands.

Standalone reproduction: https://gist.github.com/otanim/12c2cece789b68d04c271b96bfc41b68

Validation performed on Ubuntu 22.04.5, GNOME Shell 42.9, X11, Intel Meteor Lake-P / Intel Arc Graphics, Mesa 23.2.1:

- Bisected the first bad release to 43.0.0-alpha.4; alpha.3 is repeatedly smooth.
- Confirmed current `main` plus #52740 still jitters before this change.
- Confirmed the proposed policy preview resizes smoothly during repeated fast vertical and diagonal resizing, with native edge and corner resize working.
- Verified the opaque path changes from depth-32 ARGB to depth-24 with a full opaque region.
- Verified `transparent: true` remains depth-32 ARGB.
- Verified source formatting with `git diff --check`.

The compositor presentation behavior is not practical to assert in Electron's existing automated/headless tests. A standalone reproduction and the complete version/isolation matrix are attached to the linked issue.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

The unchecked build/test items remain intentional and accurate. The exact source policy was validated in a binary-level preview, but a full Electron source build and suite have not yet been run.

#### Release Notes

Notes: Fixed visual jitter while interactively resizing opaque frameless windows on Linux/X11.
