### PR TITLE
build: generate the Node startup snapshot on cross-arch builds too (42-x-y)

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -305,9 +305,18 @@ index 856878c33681a73d41016729dabe48b0a6a80589..91a11852d206b65485fe90fd037a0bd1
      if sys.platform == 'win32':
        files = [ x.replace('\\', '/') for x in files ]
 diff --git a/unofficial.gni b/unofficial.gni
-index aa78f9ce60c0439536eaf6e23880e30ebef0e1a9..df0ae804a5338d8f2ec4d331a1e2ed053c3c3955 100644
+index aa78f9ce60c0439536eaf6e23880e30ebef0e1a9..7265e09bf7601afe76463f528ffb385db796e093 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
+@@ -94,7 +94,7 @@ template("node_gn_build") {
+       "-Wno-unused-function",
+     ]
+ 
+-    if (current_cpu == "x86") {
++    if (target_cpu == "x86") {
+       node_arch = "ia32"
+     } else {
+       node_arch = target_cpu
 @@ -147,32 +147,42 @@ template("node_gn_build") {
      public_configs = [
        ":node_external_config",

--- a/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
+++ b/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
@@ -14,7 +14,7 @@ We don't need to do this for zlib, as the existing gn workflow uses the same
 Upstreamed at https://github.com/nodejs/node/pull/55903
 
 diff --git a/unofficial.gni b/unofficial.gni
-index eeffbafa4023ed68f56410c858e459f569ed6344..d7c717d5c2799692c7ea4537d7faea234faefaa2 100644
+index dce99416375f18e9d5ce9f4d992023990f44878d..d278835be141d28c1514e404e63c33096cbcaa6b 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -203,7 +203,17 @@ template("node_gn_build") {

--- a/patches/node/build_enable_perfetto.patch
+++ b/patches/node/build_enable_perfetto.patch
@@ -799,7 +799,7 @@ index 0bc9df81d87562243817a6618641a49b602654e3..b6dd8b9a9c21051f3d385d5ecea9c50c
  namespace tracing {
  
 diff --git a/unofficial.gni b/unofficial.gni
-index df0ae804a5338d8f2ec4d331a1e2ed053c3c3955..eeffbafa4023ed68f56410c858e459f569ed6344 100644
+index 7265e09bf7601afe76463f528ffb385db796e093..dce99416375f18e9d5ce9f4d992023990f44878d 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -143,7 +143,10 @@ template("node_gn_build") {

--- a/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
+++ b/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
@@ -20,7 +20,7 @@ index ab7dc27de3e304f6d912d5834da47e3b4eb25495..b6c0fd4ceee989dac55c7d54e52fef18
    }
  }
 diff --git a/unofficial.gni b/unofficial.gni
-index d7c717d5c2799692c7ea4537d7faea234faefaa2..bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a 100644
+index d278835be141d28c1514e404e63c33096cbcaa6b..6326abf521d0e5c8e86e9dfa8562f0a648a56a19 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -146,6 +146,7 @@ template("node_gn_build") {

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -3,32 +3,49 @@ From: Samuel Attard <sattard@anthropic.com>
 Date: Tue, 19 May 2026 10:37:56 +0100
 Subject: electron: enable node startup snapshot generation in Chromium's V8
 
-Re-enable node_use_node_snapshot for native builds so node_mksnapshot
-generates an embedded Node startup snapshot the Electron browser process
-can be created from, eliminating the Node bootstrap recompile.
+Re-enable node_use_node_snapshot so node_mksnapshot generates an embedded
+Node startup snapshot the Electron browser process can be created from,
+eliminating the Node bootstrap recompile.
 
-- node.gni: gate to native builds (cross-compile stays off).
+- node.gni: enable the snapshot (and the builtins' code cache that
+  complements it) wherever the v8_snapshot_toolchain node_mksnapshot is
+  built in can execute the code its V8 generates -- native builds, x64
+  hosts targeting arm64 (V8's arm64 simulator), and mac arm64 hosts
+  targeting x64 when v8_snapshot_toolchain is the Rosetta-run
+  //build/toolchain/mac:clang_x64 (Electron CI's setting) -- i.e.
+  host_os == target_os except V8's default mac clang_arm64_v8_x64
+  toolchain, which emits x64 code from an arm64 binary with no simulator.
+  Neither the snapshot nor the code cache contains machine code, so what a
+  cross node_mksnapshot produces is valid on the target.
 - unofficial.gni: node_mksnapshot host tool (no_chromium_code,
   zstd:compress, NODE_USE_V8_PLATFORM=1 in v8_snapshot_toolchain,
   external_startup_data config, --electron-v8-snapshot-blob arg);
-  source_set("node_snapshot") provides the strong
-  GetEmbeddedSnapshotData over a now-weak node_snapshot_stub.cc so the
-  shipped framework links the real snapshot without a GN cycle.
+  GetEmbeddedSnapshotData() moves out of libnode into two source_sets,
+  ":node_snapshot" (the generated snapshot, linked by the shipped
+  framework and the snapshot code-cache tool) and ":node_snapshot_stub"
+  (the nullptr fallback, linked by node_mksnapshot, the node CLI and the
+  other host tools), so every target links exactly one strong definition
+  -- no weak override, which lld-link cannot fold -- and there is no GN
+  cycle through run_node_mksnapshot. Both depend on
+  //base:debugging_buildflags for the generated header node_builtins.h
+  pulls in through base/dcheck_is_on.h.
 - node_snapshot_builder.h / node_snapshotable.cc / embed_helpers.cc:
   Set/GetBaseSnapshotForCreation so the SnapshotCreator EXTENDS the V8
   startup snapshot (params.snapshot_blob) rather than building the heap
   from scratch -- Chromium's V8 only links the deserialize-only
   setup-isolate delegate; the full one is private to V8's own mksnapshot.
-- util.cc: NewFunctionTemplate / SetFastMethod drop the fast-API
-  c_function while building a snapshot. V8 stores c_function_overloads
-  as Managed<CFunctionWithSignature> -- a Foreign holding a heap-allocated
-  ManagedPtrDestructor* -- which V8's snapshot serializer cannot encode
-  as an external reference. Slow-callback fallback after deserialize.
+- node_external_reference.h: Register(const v8::CFunction&) also
+  registers the address of the CFunction object itself. Since V8 stores
+  the v8::CFunction directly in FunctionTemplateInfo (wrapped in a
+  Foreign), the snapshot serializer encodes that address and needs it in
+  the external reference table. Upstream has the same change
+  (nodejs/node@0401a2d, 2026-06-02); drop this hunk once Electron's Node
+  includes it.
 - node_builtins.cc: RefreshCodeCache merges instead of replacing so the
   build-time js2c cache for electron/js2c/* can be fed alongside the
   snapshot's per-builtin cache.
-- node_mksnapshot.cc: read --electron-v8-snapshot-blob, set the c_function
-  drop env var, plumb the base blob to the SnapshotCreator.
+- node_mksnapshot.cc: read --electron-v8-snapshot-blob and plumb the base
+  blob to the SnapshotCreator.
 - node_wasi.cc: make the per-instantiation CFunction in
   WasiFunction::SetFunction static. Since the V8 change to store the
   v8::CFunction pointer directly in FunctionTemplateInfo (wrapped in a
@@ -42,22 +59,50 @@ can be created from, eliminating the Node bootstrap recompile.
   below.
 
 diff --git a/node.gni b/node.gni
-index 156fee33b3813fe4d94a1c9585f217a99dbfbd5f..fb7462cc0c7c2e267847c54e7e1ff4db1559b338 100644
+index 156fee33b3813fe4d94a1c9585f217a99dbfbd5f..a443ff52ca1dda5cb2cfdfe5241076836a33b8fc 100644
 --- a/node.gni
 +++ b/node.gni
-@@ -64,11 +64,10 @@ declare_args() {
-   # Use code cache to speed up startup. Disabled for cross compilation.
-   node_use_node_code_cache = host_os == target_os && host_cpu == target_cpu
+@@ -31,6 +31,13 @@ declare_args() {
+   ]
+ }
  
++import("$node_v8_path/gni/snapshot_toolchain.gni")
++
++# See node_use_node_snapshot below.
++node_snapshot_toolchain_runs_target_code =
++    host_os == target_os &&
++    v8_snapshot_toolchain != "//build/toolchain/mac:clang_arm64_v8_x64"
++
+ # Equivalent of gyp file's configurations.
+ declare_args() {
+   # Enable the V8 inspector protocol for use with node.
+@@ -61,14 +68,21 @@ declare_args() {
+   # default to https://nodejs.org/download/release/').
+   node_release_urlbase = ""
+ 
+-  # Use code cache to speed up startup. Disabled for cross compilation.
+-  node_use_node_code_cache = host_os == target_os && host_cpu == target_cpu
+-
 -  # Use snapshot to speed up startup.
 -  # TODO(zcbenz): There are few broken things for now:
 -  #   1. cross-os compilation is not supported.
 -  #   2. node_mksnapshot crashes when cross-compiling for x64 from arm64.
 -  node_use_node_snapshot = false
-+  # Use snapshot to speed up startup. Known breakage is cross-compile only
-+  # (cross-os unsupported; node_mksnapshot crashes cross-compiling x64 from
-+  # arm64), so gate to native builds like node_use_node_code_cache above.
-+  node_use_node_snapshot = host_os == target_os && host_cpu == target_cpu
++  # Embed a startup snapshot of the bootstrapped Node.js environment, and the
++  # V8 code cache for the builtins that complements it, to speed up startup.
++  # Neither contains machine code, so cross-arch builds can generate them, but
++  # node_mksnapshot runs the Node.js bootstrap -- it executes target-CPU code --
++  # so the v8_snapshot_toolchain it is built in must be able to run what its V8
++  # generates: natively; under V8's simulator (x64 hosts targeting arm64, e.g.
++  # //build/toolchain/linux:clang_x64_v8_arm64, or the win host toolchain with
++  # v8_target_cpu = "arm64"); or as an x64 binary under Rosetta (mac arm64
++  # hosts targeting x64 with v8_snapshot_toolchain =
++  # "//build/toolchain/mac:clang_x64", which is how Electron's CI builds mac
++  # x64). V8's default toolchain for mac arm64 -> x64, clang_arm64_v8_x64, is
++  # an arm64 binary emitting x64 code with no simulator and cannot; neither can
++  # a cross-OS host tool.
++  node_use_node_snapshot = node_snapshot_toolchain_runs_target_code
++  node_use_node_code_cache = node_snapshot_toolchain_runs_target_code
  
    # Build with Amaro (TypeScript utils).
    node_use_amaro = true
@@ -260,7 +305,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index 1285f83662e4f252faa1730df04cafc588cd7556..fe2c6786a10f94fc0a15d4b6a0d3bfffb79f2e33 100644
+index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca4943627825ff98 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {
@@ -378,7 +423,7 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..fe2c6786a10f94fc0a15d4b6a0d3bfff
        script = "$node_v8_path/tools/run.py"
        sources = []
        data = []
-@@ -344,10 +373,89 @@ template("node_gn_build") {
+@@ -344,10 +373,91 @@ template("node_gn_build") {
        args = [
          "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
          rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
@@ -412,6 +457,7 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..fe2c6786a10f94fc0a15d4b6a0d3bfff
 +    }
 +    public_configs = [ ":zstd_include_config" ]
 +    deps = [
++      "//base:debugging_buildflags",
 +      "deps/ada",
 +      "deps/simdjson",
 +      "deps/uv",
@@ -440,6 +486,7 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..fe2c6786a10f94fc0a15d4b6a0d3bfff
 +    }
 +    public_configs = [ ":zstd_include_config" ]
 +    deps = [
++      "//base:debugging_buildflags",
 +      "deps/uv",
 +      "deps/ada",
 +      "deps/simdjson",

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -28,7 +28,13 @@ eliminating the Node bootstrap recompile.
   -- no weak override, which lld-link cannot fold -- and there is no GN
   cycle through run_node_mksnapshot. Both depend on
   //base:debugging_buildflags for the generated header node_builtins.h
-  pulls in through base/dcheck_is_on.h.
+  pulls in through base/dcheck_is_on.h. run_node_mksnapshot exists only in
+  the default toolchain and every toolchain's ":node_snapshot" compiles its
+  one output: on cross builds the snapshot code-cache tool is built in
+  v8_snapshot_toolchain, and a second node_mksnapshot run there is not
+  guaranteed to produce a byte-identical snapshot (it does not on Windows),
+  which left the tool's cache keyed to a read-only-heap checksum the
+  shipped framework's snapshot did not have.
 - node_snapshot_builder.h / node_snapshotable.cc / embed_helpers.cc:
   Set/GetBaseSnapshotForCreation so the SnapshotCreator EXTENDS the V8
   startup snapshot (params.snapshot_blob) rather than building the heap
@@ -305,7 +311,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca4943627825ff98 100644
+index 1285f83662e4f252faa1730df04cafc588cd7556..b129d19879fa9421b04ff67b55a7b55b4ae9d5ae 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {
@@ -401,7 +407,7 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca494362
        }
  
        # This config disables a link time optimization "ICF", which may merge
-@@ -325,14 +349,19 @@ template("node_gn_build") {
+@@ -325,26 +349,121 @@ template("node_gn_build") {
            ldflags = [ "/OPT:NOICF" ]  # link.exe, but also lld-link.exe.
          } else if (is_apple && !use_lld) {
            ldflags = [ "-Wl,-no_deduplicate" ]  # ld64.
@@ -412,32 +418,54 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca494362
        }
      }
  
-     action("run_node_mksnapshot") {
+-    action("run_node_mksnapshot") {
 -      deps = [ ":node_mksnapshot($v8_snapshot_toolchain)" ]
-+      deps = [
-+        ":node_mksnapshot($v8_snapshot_toolchain)",
-+
-+        # The V8 startup snapshot node_mksnapshot extends.
-+        "$node_v8_path:run_mksnapshot_default",
-+      ]
-       script = "$node_v8_path/tools/run.py"
-       sources = []
-       data = []
-@@ -344,10 +373,91 @@ template("node_gn_build") {
-       args = [
-         "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
-         rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
-+
-+        # Electron's V8 has external startup data, so node_mksnapshot must
-+        # load the V8 startup snapshot and extend it rather than build the
-+        # heap from scratch (node_mksnapshot.cc parses this flag before
-+        # InitializeOncePerProcess).
-+        "--electron-v8-snapshot-blob=" +
-+            rebase_path("$root_out_dir/snapshot_blob.bin", root_build_dir),
-       ]
-     }
-   }
+-      script = "$node_v8_path/tools/run.py"
+-      sources = []
+-      data = []
++    # One run per build: every toolchain's ":node_snapshot" compiles this file,
++    # so the browser js2c code-cache tool (v8_snapshot_toolchain) is keyed to
++    # the exact snapshot the framework ships (two runs need not be identical).
++    if (current_toolchain == default_toolchain) {
++      action("run_node_mksnapshot") {
++        deps = [
++          ":node_mksnapshot($v8_snapshot_toolchain)",
  
+-      mksnapshot_dir = get_label_info(":node_mksnapshot($v8_snapshot_toolchain)",
+-                                      "root_out_dir")
++          # The V8 startup snapshot node_mksnapshot extends.
++          "$node_v8_path:run_mksnapshot_default",
++        ]
++        script = "$node_v8_path/tools/run.py"
++        sources = []
++        data = []
++
++        mksnapshot_dir =
++            get_label_info(":node_mksnapshot($v8_snapshot_toolchain)",
++                           "root_out_dir")
++
++        outputs = [ "$target_gen_dir/node_snapshot.cc" ]
++        args = [
++          "./" +
++              rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
++          rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
++
++          # Electron's V8 has external startup data, so node_mksnapshot must
++          # load the V8 startup snapshot and extend it rather than build the
++          # heap from scratch (node_mksnapshot.cc parses this flag before
++          # InitializeOncePerProcess).
++          "--electron-v8-snapshot-blob=" +
++              rebase_path("$root_out_dir/snapshot_blob.bin", root_build_dir),
++        ]
++      }
++    }
++  }
+ 
+-      outputs = [ "$target_gen_dir/node_snapshot.cc" ]
+-      args = [
+-        "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
+-        rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
+-      ]
 +  # The no-snapshot fallback GetEmbeddedSnapshotData(), as its own source_set so
 +  # libnode doesn't carry it. Linked by libnode consumers that do NOT link
 +  # ":node_snapshot" and don't already compile the stub themselves:
@@ -495,8 +523,10 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca494362
 +      "$node_v8_path:v8_libplatform",
 +    ]
 +    if (node_use_node_snapshot) {
-+      sources = [ "$target_gen_dir/node_snapshot.cc" ]
-+      deps += [ ":run_node_mksnapshot" ]
++      _run_node_mksnapshot = ":run_node_mksnapshot($default_toolchain)"
++      sources = [ get_label_info(_run_node_mksnapshot, "target_gen_dir") +
++                  "/node_snapshot.cc" ]
++      deps += [ _run_node_mksnapshot ]
 +      if (is_clang || !is_win) {
 +        # The generated node_snapshot.cc is huge auto-generated C++.
 +        cflags_cc += [
@@ -509,9 +539,6 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..a4cfd560a4a0a37d23eab3b2ca494362
 +      # ":node_snapshot_stub" so consumers of ":node_snapshot" still get one
 +      # definition of GetEmbeddedSnapshotData().
 +      sources = [ "src/node_snapshot_stub.cc" ]
-+    }
-+  }
-+
-   action("generate_config_gypi") {
-     deps = [ "$node_v8_path:v8_generate_features_json" ]
-     script = "tools/generate_config_gypi.py"
+     }
+   }
+ 

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -311,7 +311,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index 1285f83662e4f252faa1730df04cafc588cd7556..b129d19879fa9421b04ff67b55a7b55b4ae9d5ae 100644
+index 59bb1eddde665a4cd2086c632109d0112daf33a3..fd43b9d077b6e2f476c26327a83933bcff1102d0 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {

--- a/patches/node/fix_redefined_macos_sdk_header_symbols.patch
+++ b/patches/node/fix_redefined_macos_sdk_header_symbols.patch
@@ -10,7 +10,7 @@ change, it seems to introduce an incompatibility when compiling
 using clang modules. Disabling them resolves the issue.
 
 diff --git a/unofficial.gni b/unofficial.gni
-index bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a..1285f83662e4f252faa1730df04cafc588cd7556 100644
+index 6326abf521d0e5c8e86e9dfa8562f0a648a56a19..59bb1eddde665a4cd2086c632109d0112daf33a3 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -199,6 +199,10 @@ template("node_gn_build") {


### PR DESCRIPTION
Backport of #52874
Backport of #52902
Backport of #52959

See those PRs for details. Rebased onto the current 42-x-y head (the earlier failing `mksnapshot` check was this branch predating the 42-x-y backport of #52872); the node patch series was re-applied against v24.18.1 and re-exported for this branch.

#52902 fixes the cross-arch snapshot #52874 introduces: without it a second `node_mksnapshot` run in `v8_snapshot_toolchain` keyed the browser js2c code cache to a snapshot the framework never shipped, so it was rejected at startup on Windows. #52959 fixes `process.arch` reading `ia32` in the main process on linux-arm once it boots from the cross-generated snapshot (the arm test failures on the earlier runs here).

Notes: Linux arm64, Windows arm64 and macOS x64 builds now start the main process from the embedded Node.js startup snapshot like the other platforms, improving startup time.
