### PR TITLE
docs: avoid exposing ipcRenderer in navigation history fiddle

### DIFF
--- a/docs/fiddles/features/navigation-history/preload.js
+++ b/docs/fiddles/features/navigation-history/preload.js
@@ -8,5 +8,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   loadURL: (url) => ipcRenderer.invoke('nav:loadURL', url),
   getCurrentURL: () => ipcRenderer.invoke('nav:getCurrentURL'),
   getHistory: () => ipcRenderer.invoke('nav:getHistory'),
-  onNavigationUpdate: (callback) => ipcRenderer.on('nav:updated', callback)
+  onNavigationUpdate: (callback) => ipcRenderer.on('nav:updated', () => callback())
 })


### PR DESCRIPTION
#### Description of Change

The navigation history fiddle's preload passed a renderer callback directly to `ipcRenderer.on('nav:updated', callback)`. That is the pattern called out as unsafe in [security guideline 20](https://www.electronjs.org/docs/latest/tutorial/security#20-do-not-expose-electron-apis-to-untrusted-web-content): the listener's first argument is an `IpcRendererEvent` whose `sender` is `ipcRenderer`.

This wraps the callback the same way as the IPC tutorial and other fiddles (for example `docs/fiddles/ipc/pattern-3/preload.js` and `docs/fiddles/windows/manage-windows/window-events/preload.js`), so the event object never crosses the context bridge. The renderer already ignores event arguments, so this is behavior-preserving.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none