### PR TITLE
build: trim the non-link overhead of macOS release builds

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -57,6 +57,17 @@ runs:
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
+    # CI builds start from a fresh out dir, so the ThinLTO cache
+    # (-Wl,-cache_path_lto) is written (~100 GB across a release build's
+    # links) and never read; on the 5-core / 14 GB macOS runners that IO
+    # competes with links that are already swapping. Local builds keep the
+    # default so incremental relinks stay fast.
+    - name: Set GN_EXTRA_ARGS for MacOS Release Builds
+      shell: bash
+      if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'macos' }}
+      run: |
+        GN_APPENDED_ARGS="$GN_EXTRA_ARGS thin_lto_enable_cache=false"
+        echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Set GN_EXTRA_ARGS for Windows
       shell: bash
       if: ${{ inputs.target-platform == 'win' }}

--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -51,11 +51,20 @@ runs:
           echo "Can only publish release builds"
           exit 1
         fi
+    # The shipped mksnapshot.zip must contain an x64 mksnapshot for x64
+    # releases, so the snapshot tools are built in an x64 toolchain (and run
+    # under Rosetta on the arm64 build hosts). Release builds use Electron's
+    # non-LTO variant of it (see //electron/build/toolchain/mac).
     - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
       shell: bash
       if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
       run: |
-        GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
+        if [ "${{ inputs.is-release }}" = "true" ]; then
+          SNAPSHOT_TOOLCHAIN="//electron/build/toolchain/mac:clang_x64_snapshot"
+        else
+          SNAPSHOT_TOOLCHAIN="//build/toolchain/mac:clang_x64"
+        fi
+        GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"$SNAPSHOT_TOOLCHAIN\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     # CI builds start from a fresh out dir, so the ThinLTO cache
     # (-Wl,-cache_path_lto) is written (~100 GB across a release build's
@@ -67,6 +76,15 @@ runs:
       if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'macos' }}
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS thin_lto_enable_cache=false"
+        # Build mksnapshot, node_mksnapshot, v8_context_snapshot_generator
+        # and the natives code-cache generator without ThinLTO/PGO/dsyms
+        # (see //electron/build/toolchain/mac); with the default toolchain
+        # they are four serialized ThinLTO links of V8/Blink/Node (~40 min
+        # of link-pool time) whose outputs are optimization-independent
+        # data. x64 is handled in the x64 step above.
+        if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+          GN_APPENDED_ARGS="$GN_APPENDED_ARGS v8_snapshot_toolchain=\"//electron/build/toolchain/mac:clang_arm64_snapshot\""
+        fi
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Set GN_EXTRA_ARGS for Windows
       shell: bash

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1a105fe49c59e173d91925b4a1e6760bcff73cf9
+      export BUILD_TOOLS_SHA=458c9bf2a51da7015351686f077d77e404149511
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -96,12 +96,6 @@ env:
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
   RUNNER_LABEL: ${{ inputs.build-runs-on }}
-  # The macOS runners have 5 cores and 14 GB, so a remote step that siso gives
-  # up on (its 2 minute client-side deadline covers RBE queueing, upload and
-  # execution) and re-runs locally costs 5-10 minutes per LTO compile and
-  # lands on the critical path. no-fallback makes siso retry remotely (with a
-  # 4x longer deadline) instead of ever compiling locally.
-  SISO_EXPERIMENTS: ${{ inputs.target-platform == 'macos' && 'no-fallback' || '' }}
 
 jobs:
   build:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -96,6 +96,12 @@ env:
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
   RUNNER_LABEL: ${{ inputs.build-runs-on }}
+  # The macOS runners have 5 cores and 14 GB, so a remote step that siso gives
+  # up on (its 2 minute client-side deadline covers RBE queueing, upload and
+  # execution) and re-runs locally costs 5-10 minutes per LTO compile and
+  # lands on the critical path. no-fallback makes siso retry remotely (with a
+  # 4x longer deadline) instead of ever compiling locally.
+  SISO_EXPERIMENTS: ${{ inputs.target-platform == 'macos' && 'no-fallback' || '' }}
 
 jobs:
   build:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1887,6 +1887,14 @@ group("electron_mksnapshot") {
 
 dist_zip("electron_mksnapshot_zip") {
   data_deps = mksnapshot_deps
+
+  # When the snapshot tools are built in a secondary toolchain (see
+  # //electron/build/toolchain/mac) their runtime deps live under
+  # $root_out_dir/<toolchain>/; flatten so mksnapshot.zip keeps the layout
+  # consumers (@electron/mksnapshot) expect on macOS: everything at the root.
+  if (is_mac && v8_snapshot_toolchain != default_toolchain) {
+    flatten = true
+  }
   if (is_linux && is_official_build) {
     data_deps += [
       ":strip_libffmpeg_shlib",

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Anthropic, PBC.
+# Use of this source code is governed by the MIT license that can be
+# found in the LICENSE file.
+
+import("//build/config/mac/mac_sdk.gni")
+import("//build/toolchain/apple/toolchain.gni")
+
+# Toolchains for the build-time V8/Node tools: mksnapshot, node_mksnapshot,
+# v8_context_snapshot_generator and electron_natives_codecache. Their outputs
+# (snapshot blobs, code cache) are data that do not depend on how optimized
+# the tool binary itself is, but by default `v8_snapshot_toolchain` is the
+# target toolchain, so in official builds each of them is a full ThinLTO+PGO
+# link of V8 (and Blink, and Node) that runs serially through the link pool
+# on the macOS CI runners: 12 + 6 + 20 + 2 minutes of a release build before
+# the Electron Framework link can even start, at 5-9 GB RSS each on a 14 GB
+# machine.
+#
+# These toolchains are the target toolchain with ThinLTO and PGO turned off
+# and no debug info, so those tools become plain native links (seconds) at
+# the cost of compiling V8/Blink/Node a second time in this toolchain (remote
+# and cacheable; symbol_level=0 keeps those ~28k extra objects small).
+#
+# `enable_dsyms` is deliberately not overridden: the apple toolchain template
+# reads it from the default toolchain's scope when it defines the link tools,
+# so a per-toolchain override has no effect - but with symbol_level=0 there is
+# no DWARF for dsymutil to link, so the dsym step is near-free anyway.
+template("electron_snapshot_toolchain") {
+  apple_toolchain(target_name) {
+    bin_path = mac_bin_path
+    toolchain_args = {
+      forward_variables_from(invoker.toolchain_args, "*")
+      current_os = "mac"
+      use_thin_lto = false
+      chrome_pgo_phase = 0
+      symbol_level = 0
+    }
+  }
+}
+
+electron_snapshot_toolchain("clang_arm64_snapshot") {
+  toolchain_args = {
+    current_cpu = "arm64"
+  }
+}
+
+electron_snapshot_toolchain("clang_x64_snapshot") {
+  toolchain_args = {
+    current_cpu = "x64"
+  }
+}
+
+# arm64 host tools that generate x64 snapshots (arm64 -> x64 cross builds).
+electron_snapshot_toolchain("clang_arm64_v8_x64_snapshot") {
+  toolchain_args = {
+    current_cpu = "arm64"
+    v8_current_cpu = "x64"
+  }
+}

--- a/build/zip.py
+++ b/build/zip.py
@@ -61,13 +61,21 @@ def skip_path(dep, dist_zip, target_cpu):
   # and arm 64 binaries of mksnapshot since they are built on x64 hardware.
   # Consumers of arm and arm64 mksnapshot can generate snapshot_blob.bin
   # themselves by running mksnapshot.
+  #
+  # Outputs of a secondary toolchain live under $root_out_dir/<toolchain>/
+  # (e.g. clang_x64_v8_arm64/gen/...), so match PATHS_TO_SKIP against the
+  # path relative to that toolchain dir too.
+  candidates = [dep]
+  if dep.startswith('clang_') and '/' in dep:
+    toolchain_relative_dep = dep.split('/', 1)[1]
+    candidates += [toolchain_relative_dep, './' + toolchain_relative_dep]
   should_skip = (
-    any(dep.startswith(path) for path in PATHS_TO_SKIP) or
+    any(c.startswith(path) for c in candidates for path in PATHS_TO_SKIP) or
     any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP) or
     (
       "arm" in target_cpu
       and dist_zip == "mksnapshot.zip"
-      and dep == "snapshot_blob.bin"
+      and "snapshot_blob.bin" in candidates
     )
   )
   if should_skip and os.environ.get('ELECTRON_DEBUG_ZIP_SKIP') == '1':
@@ -102,6 +110,7 @@ def main(argv):
     with zipfile.ZipFile(
       dist_zip, 'w', zipfile.ZIP_DEFLATED, allowZip64=True
     ) as z:
+      written = set()
       for dep in dist_files:
         if os.path.isdir(dep):
           for root, _, files in os.walk(dep):
@@ -127,6 +136,11 @@ def main(argv):
                 name_to_write = os.path.basename(arcname)
             else:
               name_to_write = os.path.basename(arcname)
+          # Flattening can map several deps onto one name (e.g. the same
+          # file built by two toolchains); keep the first.
+          if name_to_write in written:
+            continue
+          written.add(name_to_write)
           z.write(
             dep,
             name_to_write,

--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -110,6 +110,20 @@ async function uploadObjectChangeStats(stats) {
   await uploadSeriesToDatadog(series);
 }
 
+// Returns the last `maxBytes` of `filename` as a string.
+async function readTail(filename, maxBytes) {
+  const handle = await fs.open(filename, 'r');
+  try {
+    const { size } = await handle.stat();
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, size - length);
+    return buffer.toString('utf-8');
+  } finally {
+    await handle.close();
+  }
+}
+
 // Lists the .o/.obj files under `outDir`, relative to it. Objects only live
 // under `obj/` and `<secondary-toolchain>/obj/`, so only those trees are
 // walked: a recursive readdir of the whole out dir touches ~800k entries
@@ -221,10 +235,11 @@ async function main() {
     throw new Error('--out-dir only makes sense with --input-object-checksums or --output-object-checksums');
   }
 
-  const log = await fs.readFile(filename, 'utf-8');
-
   // We expect to find a line which looks like stats=build.Stats{..., CacheHit:39008, Local:4778, Remote:0, LocalFallback:0, ...}
-  const match = log.match(/stats=build\.Stats{(.*)}/);
+  // near the end of the log. siso.INFO can exceed V8's maximum string length
+  // (it grows with the step count; a release build's is several hundred MB),
+  // so read the tail of the file rather than the whole thing.
+  const match = (await readTail(filename, 16 * 1024 * 1024)).match(/stats=build\.Stats{(.*)}/);
 
   if (!match) {
     throw new Error('could not find stats=build.Stats in log');

--- a/script/build-stats.mjs
+++ b/script/build-stats.mjs
@@ -1,8 +1,10 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
+import { availableParallelism } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
 
 import { getChromiumVersionFromDEPS } from './lib/utils.js';
 
@@ -108,6 +110,77 @@ async function uploadObjectChangeStats(stats) {
   await uploadSeriesToDatadog(series);
 }
 
+// Lists the .o/.obj files under `outDir`, relative to it. Objects only live
+// under `obj/` and `<secondary-toolchain>/obj/`, so only those trees are
+// walked: a recursive readdir of the whole out dir touches ~800k entries
+// (gen/, bundles, dSYMs) and dominated this step's runtime.
+async function listObjectFiles(outDir) {
+  const objectFiles = [];
+  const isObject = (name) => name.endsWith('.o') || name.endsWith('.obj');
+  const walk = async (rel) => {
+    const entries = await fs.readdir(resolve(outDir, rel), { withFileTypes: true });
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryRel = rel ? `${rel}/${entry.name}` : entry.name;
+        if (entry.isDirectory()) {
+          await walk(entryRel);
+        } else if (entry.isFile() && isObject(entry.name)) {
+          objectFiles.push(entryRel);
+        }
+      })
+    );
+  };
+  const top = await fs.readdir(outDir, { withFileTypes: true });
+  for (const entry of top) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'obj') {
+      await walk('obj');
+      continue;
+    }
+    const objDir = `${entry.name}/obj`;
+    const st = await fs.stat(resolve(outDir, objDir)).catch(() => null);
+    if (st && st.isDirectory()) await walk(objDir);
+  }
+  return objectFiles.sort();
+}
+
+// Hashes `files` (relative to `dir`) on a pool of worker threads. A release
+// build has ~6 GB of objects; hashing them serially on the main thread took
+// 2-3 minutes on the 5-core macOS runners.
+async function checksumFiles(dir, files) {
+  const workers = Math.max(1, Math.min(availableParallelism(), files.length));
+  const shard = Math.ceil(files.length / workers);
+  const results = await Promise.all(
+    Array.from({ length: workers }, (_, i) => {
+      const chunk = files.slice(i * shard, (i + 1) * shard);
+      return new Promise((resolve, reject) => {
+        const worker = new Worker(new URL(import.meta.url), {
+          workerData: { dir, files: chunk }
+        });
+        worker.once('message', resolve);
+        worker.once('error', reject);
+        worker.once('exit', (code) => {
+          if (code !== 0) reject(new Error(`checksum worker exited with code ${code}`));
+        });
+      });
+    })
+  );
+  return Object.assign({}, ...results);
+}
+
+if (!isMainThread) {
+  const { dir, files } = workerData;
+  const checksums = {};
+  for (const file of files) {
+    const content = await fs.readFile(resolve(dir, file));
+    checksums[file] = {
+      size: content.byteLength,
+      checksum: createHash('sha256').update(content).digest('hex')
+    };
+  }
+  parentPort.postMessage(checksums);
+}
+
 async function main() {
   const {
     positionals: [filename],
@@ -176,16 +249,8 @@ async function main() {
     const currentVersion = getChromiumVersionFromDEPS(depsContent);
 
     // Calculate the SHA256 for each object file under `outDir`
-    const files = await fs.readdir(outDir, { encoding: 'utf8', recursive: true });
-    const objectFiles = files.filter((file) => file.endsWith('.o') || file.endsWith('.obj'));
-    const checksums = {};
-    for (const file of objectFiles) {
-      const content = await fs.readFile(resolve(outDir, file));
-      checksums[file] = {
-        size: content.byteLength,
-        checksum: createHash('sha256').update(content).digest('hex')
-      };
-    }
+    const objectFiles = await listObjectFiles(outDir);
+    const checksums = await checksumFiles(outDir, objectFiles);
 
     if (outputObjectChecksums) {
       const outputData = {
@@ -259,7 +324,7 @@ async function main() {
   }
 }
 
-if ((await fs.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
+if (isMainThread && (await fs.realpath(process.argv[1])) === fileURLToPath(import.meta.url)) {
   main()
     .then(() => {
       process.exit(0);

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -91,6 +91,12 @@ def make_zip(zip_file_path, files, dirs):
       zip_file.close()
 
 
+# xz preset for dsym.tar.xz. The default preset (-6) is ~5x slower than -3
+# for ~12% smaller output on DWARF; on the 5-core macOS CI runners that is
+# the difference between a ~6 minute and a ~30 minute "Zip Symbols" step.
+XZ_PRESET = '-3'
+
+
 def make_tar_xz(tar_file_path, files, dirs):
   safe_unlink(tar_file_path)
   allfiles = files + dirs
@@ -98,17 +104,38 @@ def make_tar_xz(tar_file_path, files, dirs):
   # dSYMs this is used for. Multi-threaded xz splits the input into
   # independently compressed blocks (~1% larger, still a standard .xz stream
   # that any xz decoder can read) and scales ~linearly with core count.
+  #
+  # Prefer piping an uncompressed tar stream through the xz binary: it is the
+  # only path that reliably multi-threads. macOS's bsdtar accepts
+  # --options xz:threads=0 but its liblzma still emits a single block (i.e.
+  # one thread), and GNU tar only threads via XZ_OPT.
+  xz = shutil.which('xz')
+  if xz:
+    with open(tar_file_path, 'wb') as out:
+      tar = subprocess.Popen(['tar', '-cf', '-'] + allfiles,
+                             stdout=subprocess.PIPE)
+      xz_proc = subprocess.Popen([xz, '-T0', XZ_PRESET, '-c'],
+                                 stdin=tar.stdout, stdout=out)
+      tar.stdout.close()
+      xz_rc = xz_proc.wait()
+      tar_rc = tar.wait()
+    if tar_rc != 0 or xz_rc != 0:
+      raise RuntimeError(
+          f'tar | xz failed (tar={tar_rc}, xz={xz_rc}) for {tar_file_path}')
+    return
   tar_version = subprocess.run(['tar', '--version'], capture_output=True,
                                text=True, check=False).stdout
   if 'bsdtar' in tar_version:
-    # macOS ships bsdtar, whose xz filter is configured via --options; a
-    # thread count of 0 means "one per CPU".
-    args = ['tar', '--options', 'xz:threads=0', '-cJf', tar_file_path]
+    # bsdtar's xz filter is configured via --options; a thread count of 0
+    # means "one per CPU" (where liblzma supports it).
+    args = ['tar', '--options',
+            f'xz:threads=0,xz:compression-level={XZ_PRESET[1:]}',
+            '-cJf', tar_file_path]
     env = None
   else:
     # GNU tar shells out to the xz binary, which reads XZ_OPT.
     args = ['tar', '-cJf', tar_file_path]
-    env = dict(os.environ, XZ_OPT='-T0')
+    env = dict(os.environ, XZ_OPT=f'-T0 {XZ_PRESET}')
   execute(args + allfiles, env=env)
 
 

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -111,11 +111,11 @@ def make_tar_xz(tar_file_path, files, dirs):
   # one thread), and GNU tar only threads via XZ_OPT.
   xz = shutil.which('xz')
   if xz:
-    with open(tar_file_path, 'wb') as out:
-      tar = subprocess.Popen(['tar', '-cf', '-'] + allfiles,
-                             stdout=subprocess.PIPE)
-      xz_proc = subprocess.Popen([xz, '-T0', XZ_PRESET, '-c'],
-                                 stdin=tar.stdout, stdout=out)
+    with open(tar_file_path, 'wb') as out, \
+         subprocess.Popen(['tar', '-cf', '-'] + allfiles,
+                          stdout=subprocess.PIPE) as tar, \
+         subprocess.Popen([xz, '-T0', XZ_PRESET, '-c'],
+                          stdin=tar.stdout, stdout=out) as xz_proc:
       tar.stdout.close()
       xz_rc = xz_proc.wait()
       tar_rc = tar.wait()


### PR DESCRIPTION
Four independent, low-risk changes for the macOS release job, which today spends over an hour outside the ThinLTO links themselves. Numbers from the siso reports of the 2026-08-14 arm64 nightly (98% cache hit, 3h18m).

* **Zip Symbols (31 min → ~6 min):** `tar --options xz:threads=0` does not actually multi-thread on macOS (Apple's liblzma emits a single block), so ~7 GB of dSYMs were compressed by one core at preset -6. Pipe the tar stream through the `xz` binary with `-T0` (fallback to the tar options if xz is missing) and use preset -3 (~5x faster than -6 for ~12% larger output). Same `.tar.xz` format.
* **siso `no-fallback` on macOS:** a remote compile that exceeds siso's 2-minute client-side deadline (RBE queueing, an upload stall) is re-run locally; on the 5-core / 14 GB runners a local ThinLTO compile takes 5-10 min and lands on the critical path (75 such fallbacks in that build, 570 in a testing build). `no-fallback` retries remotely with a 4x longer deadline instead.
* **`thin_lto_enable_cache=false` for macOS release builds:** CI starts from a fresh out dir, so the ThinLTO cache is written (~100 GB across a release build's links) and never read, competing for IO with links that are already swapping. Local builds keep the default.
* **build-stats (~2.5 min → seconds):** hash objects on worker threads and only walk `obj/` and `<toolchain>/obj/` instead of a recursive readdir of the whole out dir (~800k entries). Telemetry only; the change-rate metric compares files present in both snapshots so the (slightly smaller) file set doesn't affect it.

Measurement runs (macOS only, no publish) are in flight on `release-build.yml` for a baseline vs this branch; I'll post the before/after here.

Notes: none