### PR TITLE
build: link the macOS snapshot tools without ThinLTO in release builds

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -51,11 +51,20 @@ runs:
           echo "Can only publish release builds"
           exit 1
         fi
+    # The shipped mksnapshot.zip must contain an x64 mksnapshot for x64
+    # releases, so the snapshot tools are built in an x64 toolchain (and run
+    # under Rosetta on the arm64 build hosts). Release builds use Electron's
+    # non-LTO variant of it (see //electron/build/toolchain/mac).
     - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
       shell: bash
       if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
       run: |
-        GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"//build/toolchain/mac:clang_x64\""
+        if [ "${{ inputs.is-release }}" = "true" ]; then
+          SNAPSHOT_TOOLCHAIN="//electron/build/toolchain/mac:clang_x64_snapshot"
+        else
+          SNAPSHOT_TOOLCHAIN="//build/toolchain/mac:clang_x64"
+        fi
+        GN_APPENDED_ARGS="$GN_EXTRA_ARGS target_cpu=\"x64\" v8_snapshot_toolchain=\"$SNAPSHOT_TOOLCHAIN\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     # CI builds start from a fresh out dir, so the ThinLTO cache
     # (-Wl,-cache_path_lto) is written (~100 GB across a release build's
@@ -67,6 +76,15 @@ runs:
       if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'macos' }}
       run: |
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS thin_lto_enable_cache=false"
+        # Build mksnapshot, node_mksnapshot, v8_context_snapshot_generator
+        # and the natives code-cache generator without ThinLTO/PGO/dsyms
+        # (see //electron/build/toolchain/mac); with the default toolchain
+        # they are four serialized ThinLTO links of V8/Blink/Node (~40 min
+        # of link-pool time) whose outputs are optimization-independent
+        # data. x64 is handled in the x64 step above.
+        if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+          GN_APPENDED_ARGS="$GN_APPENDED_ARGS v8_snapshot_toolchain=\"//electron/build/toolchain/mac:clang_arm64_snapshot\""
+        fi
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Set GN_EXTRA_ARGS for Windows
       shell: bash

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1a105fe49c59e173d91925b4a1e6760bcff73cf9
+      export BUILD_TOOLS_SHA=458c9bf2a51da7015351686f077d77e404149511
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1887,6 +1887,14 @@ group("electron_mksnapshot") {
 
 dist_zip("electron_mksnapshot_zip") {
   data_deps = mksnapshot_deps
+
+  # When the snapshot tools are built in a secondary toolchain (see
+  # //electron/build/toolchain/mac) their runtime deps live under
+  # $root_out_dir/<toolchain>/; flatten so mksnapshot.zip keeps the layout
+  # consumers (@electron/mksnapshot) expect on macOS: everything at the root.
+  if (is_mac && v8_snapshot_toolchain != default_toolchain) {
+    flatten = true
+  }
   if (is_linux && is_official_build) {
     data_deps += [
       ":strip_libffmpeg_shlib",

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Anthropic, PBC.
+# Use of this source code is governed by the MIT license that can be
+# found in the LICENSE file.
+
+import("//build/config/mac/mac_sdk.gni")
+import("//build/toolchain/apple/toolchain.gni")
+
+# Toolchains for the build-time V8/Node tools: mksnapshot, node_mksnapshot,
+# v8_context_snapshot_generator and electron_natives_codecache. Their outputs
+# (snapshot blobs, code cache) are data that do not depend on how optimized
+# the tool binary itself is, but by default `v8_snapshot_toolchain` is the
+# target toolchain, so in official builds each of them is a full ThinLTO+PGO
+# link of V8 (and Blink, and Node) that runs serially through the link pool
+# on the macOS CI runners: 12 + 6 + 20 + 2 minutes of a release build before
+# the Electron Framework link can even start, at 5-9 GB RSS each on a 14 GB
+# machine.
+#
+# These toolchains are the target toolchain with ThinLTO and PGO turned off
+# and no debug info, so those tools become plain native links (seconds) at
+# the cost of compiling V8/Blink/Node a second time in this toolchain (remote
+# and cacheable; symbol_level=0 keeps those ~28k extra objects small).
+#
+# `enable_dsyms` is deliberately not overridden: the apple toolchain template
+# reads it from the default toolchain's scope when it defines the link tools,
+# so a per-toolchain override has no effect - but with symbol_level=0 there is
+# no DWARF for dsymutil to link, so the dsym step is near-free anyway.
+template("electron_snapshot_toolchain") {
+  apple_toolchain(target_name) {
+    bin_path = mac_bin_path
+    toolchain_args = {
+      forward_variables_from(invoker.toolchain_args, "*")
+      current_os = "mac"
+      use_thin_lto = false
+      chrome_pgo_phase = 0
+      symbol_level = 0
+    }
+  }
+}
+
+electron_snapshot_toolchain("clang_arm64_snapshot") {
+  toolchain_args = {
+    current_cpu = "arm64"
+  }
+}
+
+electron_snapshot_toolchain("clang_x64_snapshot") {
+  toolchain_args = {
+    current_cpu = "x64"
+  }
+}
+
+# arm64 host tools that generate x64 snapshots (arm64 -> x64 cross builds).
+electron_snapshot_toolchain("clang_arm64_v8_x64_snapshot") {
+  toolchain_args = {
+    current_cpu = "arm64"
+    v8_current_cpu = "x64"
+  }
+}

--- a/build/zip.py
+++ b/build/zip.py
@@ -61,13 +61,21 @@ def skip_path(dep, dist_zip, target_cpu):
   # and arm 64 binaries of mksnapshot since they are built on x64 hardware.
   # Consumers of arm and arm64 mksnapshot can generate snapshot_blob.bin
   # themselves by running mksnapshot.
+  #
+  # Outputs of a secondary toolchain live under $root_out_dir/<toolchain>/
+  # (e.g. clang_x64_v8_arm64/gen/...), so match PATHS_TO_SKIP against the
+  # path relative to that toolchain dir too.
+  candidates = [dep]
+  if dep.startswith('clang_') and '/' in dep:
+    toolchain_relative_dep = dep.split('/', 1)[1]
+    candidates += [toolchain_relative_dep, './' + toolchain_relative_dep]
   should_skip = (
-    any(dep.startswith(path) for path in PATHS_TO_SKIP) or
+    any(c.startswith(path) for c in candidates for path in PATHS_TO_SKIP) or
     any(dep.endswith(ext) for ext in EXTENSIONS_TO_SKIP) or
     (
       "arm" in target_cpu
       and dist_zip == "mksnapshot.zip"
-      and dep == "snapshot_blob.bin"
+      and "snapshot_blob.bin" in candidates
     )
   )
   if should_skip and os.environ.get('ELECTRON_DEBUG_ZIP_SKIP') == '1':
@@ -102,6 +110,7 @@ def main(argv):
     with zipfile.ZipFile(
       dist_zip, 'w', zipfile.ZIP_DEFLATED, allowZip64=True
     ) as z:
+      written = set()
       for dep in dist_files:
         if os.path.isdir(dep):
           for root, _, files in os.walk(dep):
@@ -127,6 +136,11 @@ def main(argv):
                 name_to_write = os.path.basename(arcname)
             else:
               name_to_write = os.path.basename(arcname)
+          # Flattening can map several deps onto one name (e.g. the same
+          # file built by two toolchains); keep the first.
+          if name_to_write in written:
+            continue
+          written.add(name_to_write)
           z.write(
             dep,
             name_to_write,


### PR DESCRIPTION
Prototype, stacked on #52883.

In official builds `v8_snapshot_toolchain` is the target toolchain, so mksnapshot, node_mksnapshot, v8_context_snapshot_generator and the natives code-cache generator are each a full ThinLTO+PGO link of V8/Blink/Node with dsymutil. On the 5-core / 14 GB macOS runners those four links take 12 + 6 + 20 + 2 min (21 + 46 min on x64, under Rosetta), run serially through a link pool of depth 1 at 5-9 GB RSS each, all before the Electron Framework link can start — and their outputs are data that does not depend on how optimized the tool binary is.

* Add `//electron/build/toolchain/mac` with mac toolchain variants that turn off ThinLTO, PGO and debug info (`symbol_level=0`, so the extra objects are small and dsymutil is near-free), and point macOS release builds at them: `clang_arm64_snapshot` (arm64) / `clang_x64_snapshot` (x64 stays x64 so `mksnapshot.zip` still ships an x64 mksnapshot). V8/Blink/Node compile a second time in that toolchain (~28k objects, remote + cacheable).
* Flatten `mksnapshot.zip` on macOS when the tools live under `<toolchain>/`, and teach `build/zip.py` to apply `PATHS_TO_SKIP` toolchain-relative and to drop duplicates when flattening. Verified the resulting file set is identical to today's.
* Testing builds unaffected (no LTO there).

Trade-off to measure: the extra ~28k cache-hit fetches cost fetch-phase time on the 5-core runner against ~40 min of serialized link time. Measurement runs (macOS only, no publish) are in flight alongside a baseline and #52883.

Notes: none