### PR TITLE
fix: don't let pending shell operations block app exit on Windows

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -22,6 +22,7 @@
 #include "base/logging.h"
 #include "base/strings/escape.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/scoped_blocking_call.h"
 #include "base/win/atl.h"
@@ -328,34 +329,47 @@ std::string OpenPathOnThread(const base::FilePath& full_path) {
 
 namespace platform_util {
 
+namespace {
+
+// Shell operations are handed to a COM STA thread-pool thread. They are
+// USER_BLOCKING because they are the direct result of a user action, and
+// CONTINUE_ON_SHUTDOWN because ShellExecuteEx() and friends can block for an
+// unbounded amount of time inside the OS -- e.g. while Windows shows its
+// "you'll need a new app to open this link" / "How do you want to open this
+// file?" UI for a scheme or file type with no registered handler. With the
+// default SKIP_ON_SHUTDOWN behaviour a task that is already running blocks
+// ThreadPoolInstance::Shutdown(), so app.quit() would never finish until the
+// user dismissed that system dialog. Nothing these tasks touch depends on
+// browser state that is torn down at shutdown.
+scoped_refptr<base::SingleThreadTaskRunner> CreateShellOperationTaskRunner() {
+  return base::ThreadPool::CreateCOMSTATaskRunner(
+      {base::MayBlock(), base::TaskPriority::USER_BLOCKING,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN});
+}
+
+}  // namespace
+
 void ShowItemInFolder(const base::FilePath& full_path) {
-  base::ThreadPool::CreateCOMSTATaskRunner(
-      {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
-      ->PostTask(FROM_HERE,
-                 base::BindOnce(&ShowItemInFolderOnWorkerThread,
+  CreateShellOperationTaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce(&ShowItemInFolderOnWorkerThread,
                                 full_path.NormalizePathSeparators()));
 }
 
 void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  base::ThreadPool::CreateCOMSTATaskRunner(
-      {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
-      ->PostTaskAndReplyWithResult(
-          FROM_HERE,
-          base::BindOnce(&OpenPathOnThread,
-                         full_path.NormalizePathSeparators()),
-          std::move(callback));
+  CreateShellOperationTaskRunner()->PostTaskAndReplyWithResult(
+      FROM_HERE,
+      base::BindOnce(&OpenPathOnThread, full_path.NormalizePathSeparators()),
+      std::move(callback));
 }
 
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
                   OpenCallback callback) {
-  base::ThreadPool::CreateCOMSTATaskRunner(
-      {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
-      ->PostTaskAndReplyWithResult(
-          FROM_HERE, base::BindOnce(&OpenExternalOnWorkerThread, url, options),
-          std::move(callback));
+  CreateShellOperationTaskRunner()->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce(&OpenExternalOnWorkerThread, url, options),
+      std::move(callback));
 }
 
 bool MoveItemToTrashWithError(const base::FilePath& path,


### PR DESCRIPTION
#### Description of Change

Fixes #52141 (the `crash cases > "promise-destroy-crash"` flake on Windows), which turned out to be a real quit hang rather than a test problem.

- `shell.openExternal()` / `shell.openPath()` / `shell.showItemInFolder()` post their `ShellExecuteEx()` work to a COM STA thread-pool task with the default `SKIP_ON_SHUTDOWN` behaviour. A `SKIP_ON_SHUTDOWN` task that has already started blocks `ThreadPoolInstance::Shutdown()`, and `ShellExecuteEx()` can block inside the OS for as long as Windows is showing UI for the request — e.g. the "you'll need a new app to open this link" dialog for a scheme with no registered handler (its helper thread sits in a synchronous cross-process COM release into `OpenWith.exe` until the dialog is dismissed). Net effect: `app.quit()` fires `will-quit`/`quit`, then the browser main thread parks in `TaskTracker::CompleteShutdown()` and the process never exits until the user clicks OK.
- Post these tasks with `CONTINUE_ON_SHUTDOWN` instead. This matches Chrome's `platform_util::OpenItem`, which uses that trait for exactly this reason ("can hang shutdown without this trait as it may result in an interactive dialog"). The tasks only touch their bound arguments and OS APIs, so letting shutdown proceed while one is still blocked in the shell is safe.

Verified on Windows CI by looping the `promise-destroy-crash` fixture with native stack capture on hang: current behaviour hung 132/243 runs (main thread in `TaskTracker::CompleteShutdown`, worker in `ShellExecuteExW → CShellExecute::_RunThreadMaybeWait`, shell helper thread in `combase!RemoteReleaseRifRef`); with this change 0/243.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Windows where the app process could fail to exit after `app.quit()` while a `shell.openExternal()` or `shell.openPath()` call was still waiting on a system "Open with" dialog.
