### PR TITLE
build: update build-tools for remote generators and longer remote compile deadlines

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1a105fe49c59e173d91925b4a1e6760bcff73cf9
+      export BUILD_TOOLS_SHA=458c9bf2a51da7015351686f077d77e404149511
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
Stacked on #52884 (which is stacked on #52883). Bumps `BUILD_TOOLS_SHA` to pick up electron/build-tools#889 and #890:

* siso runs the mojom parser/generator/type-mappings, Blink bindings generator, grit strings and TypeScript/WebUI generators on RBE workers (all hosts) instead of locally, and they become cache hits across builds. On the 5-core macOS release runners these steps are ~1 CPU-hour of local python/node per build (1,148 mojom generator steps; the Blink bindings generator step alone ~4 min), contending with siso's include scanning during the fetch phase. Each rule was validated against our RBE from a macOS host: remote execution, byte-identical outputs, cache hit on rerun.
* remote `clang/*` steps on macOS hosts get a 10-minute client-side deadline instead of 2 minutes, so ordinary RBE queueing no longer triggers the 5-10 minute local ThinLTO fallback compiles (75 in one release build, 570 in a testing build). This replaces the `no-fallback` experiment from #52883, which failed builds outright under RBE queue pressure.

Measurement (macOS only, no publish) with the whole stack is in flight; numbers to follow here.

Notes: none