### PR TITLE
build: generate the Node startup snapshot once per build

### DIFF
--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -28,7 +28,13 @@ eliminating the Node bootstrap recompile.
   -- no weak override, which lld-link cannot fold -- and there is no GN
   cycle through run_node_mksnapshot. Both depend on
   //base:debugging_buildflags for the generated header node_builtins.h
-  pulls in through base/dcheck_is_on.h.
+  pulls in through base/dcheck_is_on.h. run_node_mksnapshot exists only in
+  the default toolchain and every toolchain's ":node_snapshot" compiles its
+  one output: on cross builds the snapshot code-cache tool is built in
+  v8_snapshot_toolchain, and a second node_mksnapshot run there is not
+  guaranteed to produce a byte-identical snapshot (it does not on Windows),
+  which left the tool's cache keyed to a read-only-heap checksum the
+  shipped framework's snapshot did not have.
 - node_snapshot_builder.h / node_snapshotable.cc / embed_helpers.cc:
   Set/GetBaseSnapshotForCreation so the SnapshotCreator EXTENDS the V8
   startup snapshot (params.snapshot_blob) rather than building the heap
@@ -283,7 +289,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index 1285f83662e4f252faa1730df04cafc588cd7556..06aeced9d41519efd801603631418e6ec46a8a42 100644
+index 1285f83662e4f252faa1730df04cafc588cd7556..94f7ac684107ed1693fdc1f6663cfb4729bd8a0d 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {
@@ -379,7 +385,7 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..06aeced9d41519efd801603631418e6e
        }
  
        # This config disables a link time optimization "ICF", which may merge
-@@ -325,14 +349,19 @@ template("node_gn_build") {
+@@ -325,26 +349,121 @@ template("node_gn_build") {
            ldflags = [ "/OPT:NOICF" ]  # link.exe, but also lld-link.exe.
          } else if (is_apple && !use_lld) {
            ldflags = [ "-Wl,-no_deduplicate" ]  # ld64.
@@ -390,32 +396,54 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..06aeced9d41519efd801603631418e6e
        }
      }
  
-     action("run_node_mksnapshot") {
+-    action("run_node_mksnapshot") {
 -      deps = [ ":node_mksnapshot($v8_snapshot_toolchain)" ]
-+      deps = [
-+        ":node_mksnapshot($v8_snapshot_toolchain)",
-+
-+        # The V8 startup snapshot node_mksnapshot extends.
-+        "$node_v8_path:run_mksnapshot_default",
-+      ]
-       script = "$node_v8_path/tools/run.py"
-       sources = []
-       data = []
-@@ -344,10 +373,91 @@ template("node_gn_build") {
-       args = [
-         "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
-         rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
-+
-+        # Electron's V8 has external startup data, so node_mksnapshot must
-+        # load the V8 startup snapshot and extend it rather than build the
-+        # heap from scratch (node_mksnapshot.cc parses this flag before
-+        # InitializeOncePerProcess).
-+        "--electron-v8-snapshot-blob=" +
-+            rebase_path("$root_out_dir/snapshot_blob.bin", root_build_dir),
-       ]
-     }
-   }
+-      script = "$node_v8_path/tools/run.py"
+-      sources = []
+-      data = []
++    # One run per build: every toolchain's ":node_snapshot" compiles this file,
++    # so the browser js2c code-cache tool (v8_snapshot_toolchain) is keyed to
++    # the exact snapshot the framework ships (two runs need not be identical).
++    if (current_toolchain == default_toolchain) {
++      action("run_node_mksnapshot") {
++        deps = [
++          ":node_mksnapshot($v8_snapshot_toolchain)",
  
+-      mksnapshot_dir = get_label_info(":node_mksnapshot($v8_snapshot_toolchain)",
+-                                      "root_out_dir")
++          # The V8 startup snapshot node_mksnapshot extends.
++          "$node_v8_path:run_mksnapshot_default",
++        ]
++        script = "$node_v8_path/tools/run.py"
++        sources = []
++        data = []
++
++        mksnapshot_dir =
++            get_label_info(":node_mksnapshot($v8_snapshot_toolchain)",
++                           "root_out_dir")
++
++        outputs = [ "$target_gen_dir/node_snapshot.cc" ]
++        args = [
++          "./" +
++              rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
++          rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
++
++          # Electron's V8 has external startup data, so node_mksnapshot must
++          # load the V8 startup snapshot and extend it rather than build the
++          # heap from scratch (node_mksnapshot.cc parses this flag before
++          # InitializeOncePerProcess).
++          "--electron-v8-snapshot-blob=" +
++              rebase_path("$root_out_dir/snapshot_blob.bin", root_build_dir),
++        ]
++      }
++    }
++  }
+ 
+-      outputs = [ "$target_gen_dir/node_snapshot.cc" ]
+-      args = [
+-        "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
+-        rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),
+-      ]
 +  # The no-snapshot fallback GetEmbeddedSnapshotData(), as its own source_set so
 +  # libnode doesn't carry it. Linked by libnode consumers that do NOT link
 +  # ":node_snapshot" and don't already compile the stub themselves:
@@ -473,8 +501,10 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..06aeced9d41519efd801603631418e6e
 +      "$node_v8_path:v8_libplatform",
 +    ]
 +    if (node_use_node_snapshot) {
-+      sources = [ "$target_gen_dir/node_snapshot.cc" ]
-+      deps += [ ":run_node_mksnapshot" ]
++      _run_node_mksnapshot = ":run_node_mksnapshot($default_toolchain)"
++      sources = [ get_label_info(_run_node_mksnapshot, "target_gen_dir") +
++                  "/node_snapshot.cc" ]
++      deps += [ _run_node_mksnapshot ]
 +      if (is_clang || !is_win) {
 +        # The generated node_snapshot.cc is huge auto-generated C++.
 +        cflags_cc += [
@@ -487,9 +517,6 @@ index 1285f83662e4f252faa1730df04cafc588cd7556..06aeced9d41519efd801603631418e6e
 +      # ":node_snapshot_stub" so consumers of ":node_snapshot" still get one
 +      # definition of GetEmbeddedSnapshotData().
 +      sources = [ "src/node_snapshot_stub.cc" ]
-+    }
-+  }
-+
-   action("generate_config_gypi") {
-     deps = [ "$node_v8_path:v8_generate_features_json" ]
-     script = "tools/generate_config_gypi.py"
+     }
+   }
+ 

--- a/patches/node/fix_use_a_dedicated_cppheappointertag_for_cppgc_wrappables.patch
+++ b/patches/node/fix_use_a_dedicated_cppheappointertag_for_cppgc_wrappables.patch
@@ -77,7 +77,7 @@ index c1fa104fa25bd5919e405a3df94f3701d0e234a2..17fb7dcbbf5838b7448ea29a82c2dcba
  
  void IsolateData::MemoryInfo(MemoryTracker* tracker) const {
 diff --git a/unofficial.gni b/unofficial.gni
-index 06aeced9d41519efd801603631418e6ec46a8a42..bfa2be389e9c2455a1e7ec00addb3187188eeaf6 100644
+index 94f7ac684107ed1693fdc1f6663cfb4729bd8a0d..98fc33d8ccd92bd0c2b972757f4f7b5ff09fbf02 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -63,6 +63,12 @@ template("node_gn_build") {


### PR DESCRIPTION
#### Description of Change

`run_node_mksnapshot` was defined in every toolchain that pulled in `:node_snapshot`, so a cross build ran it twice: once in the default toolchain for the shipped framework and once in `v8_snapshot_toolchain` for the host tool that generates the browser process's js2c code cache. Two runs aren't guaranteed to produce the same snapshot, and on Windows they don't, so the tool built its cache against a read-only heap the framework never embedded. V8 then rejected every entry at startup with a read-only snapshot checksum mismatch and the browser process compiled `browser_init`, `utility_init` and `node_init` from source instead - which is what the `js2c build-time code cache` specs caught on windows-arm64 (https://github.com/electron/electron/actions/runs/32001222846/job/95314127255).

This defines the action only in the default toolchain and has each toolchain's `:node_snapshot` compile that one output, so the snapshot the cache is keyed to is the snapshot the framework ships.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)
- [x] PR release notes describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#release-notes).

#### Release Notes

Notes: none
