### PR TITLE
docs: document the corsEnabled custom scheme privilege

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -124,6 +124,32 @@ The `<video>` and `<audio>` HTML elements expect protocols to buffer their
 responses by default. The `stream` flag configures those elements to correctly
 expect streaming responses.
 
+Without `corsEnabled`, requests to the scheme that use the CORS protocol, such as
+`fetch()` and `XMLHttpRequest` from a page on a different origin, are rejected
+before the protocol handler runs. Requests that do not use the CORS protocol,
+such as an `<img>` load, are unaffected.
+
+Setting `corsEnabled: true` allows those cross-origin requests through. Electron
+does not validate `Access-Control-Allow-Origin` on responses to custom schemes,
+so the response body is readable by the requesting origin whether or not the
+handler sets that header:
+
+```js
+const { protocol } = require('electron')
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'app', privileges: { standard: true, secure: true, supportFetchAPI: true } },
+  { scheme: 'open', privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true } }
+])
+
+// A page on https://example.com can read `open://` responses, but not `app://` ones.
+```
+
+> [!IMPORTANT]
+> `corsEnabled` grants cross-origin access; it does not enforce the CORS
+> protocol. Do not set it on a scheme that serves data other origins should not
+> be able to read.
+
 ### `protocol.handle(scheme, handler)`
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is

--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -7,7 +7,13 @@
   * `bypassCSP` boolean (optional) - Default false.
   * `allowServiceWorkers` boolean (optional) - Default false.
   * `supportFetchAPI` boolean (optional) - Default false.
-  * `corsEnabled` boolean (optional) - Default false.
+  * `corsEnabled` boolean (optional) - Whether other origins are allowed to
+    request this scheme. When `true`, a page from any other origin may
+    `fetch()` or `XMLHttpRequest` this scheme and read the response. Electron
+    does not validate `Access-Control-Allow-Origin` on responses to custom
+    schemes, so this privilege grants cross-origin access rather than enforcing
+    the CORS protocol. Leave it `false` for schemes that serve data other
+    origins should not be able to read. Default false.
   * `stream` boolean (optional) - Default false.
   * `codeCache` boolean (optional) - Enable V8 code cache for the scheme, only
     works when `standard` is also set to true. Default false.


### PR DESCRIPTION
#### Description of Change

Addresses item 1 of #52498.

`corsEnabled` is the only privilege in the [`CustomScheme`](https://github.com/electron/electron/blob/main/docs/api/structures/custom-scheme.md) structure listed with no description, and the name reads as though it makes Electron *enforce* CORS for the scheme. It does close to the opposite:

* `registerSchemesAsPrivileged` calls `url::AddCorsEnabledScheme` for the scheme ([`electron_api_protocol.cc`](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_protocol.cc#L150)).
* `ElectronURLLoaderFactory::CreateLoaderAndStart` replicates the `kCorsDisabledScheme` gate from `CorsURLLoader::StartRequest` and rejects a cross-origin CORS-mode request when the scheme is *not* in `url::GetCorsEnabledSchemes()` ([`electron_url_loader_factory.cc`](https://github.com/electron/electron/blob/main/shell/browser/net/electron_url_loader_factory.cc#L508)).
* Requests to registered protocols are served by that factory rather than by the network service's `CorsURLLoaderFactory`, so nothing validates `Access-Control-Allow-Origin` on the response.

So the privilege permits cross-origin reads instead of policing them, which is what the suite asserts today:

* `does not affect cross-origin fetch to a corsEnabled scheme` reads the body of a `Response` that sets no ACAO header.
* `blocks cross-origin fetch on a standard supportFetchAPI-only scheme` expects that same fetch to fail without the privilege.

This PR documents the privilege in the structure, and describes the behaviour in the `registerSchemesAsPrivileged` prose so it is clear that *leaving `corsEnabled` unset* is what keeps a scheme unreadable cross-origin.

Item 2 of the issue (the `GHSA-v3j7-r9gq-3gjw` workaround text) is not touched here, since amending a published advisory is maintainer-only. The issue author also offered to open a docs PR for item 1 — happy to close this in favour of theirs if they have one in flight.

> [!NOTE]
> Drafted with Claude Code (Claude Opus 5) and disclosed per the [AI tool policy](https://github.com/electron/governance/blob/main/policy/ai.md); the commit carries a `Co-Authored-By` trailer. The wording follows the behaviour in the two source files linked above and the two specs named above, and no behaviour is changed by this PR.

Verified with the docs tooling rather than a build, since this is documentation only:

* `npm run lint:markdown` — 0 errors
* `npm run lint:js-in-markdown` — 0 errors
* `npm run lint:docs-relative-links` — 0 errors
* `npm run lint:api-history` — 0 errors (1 pre-existing warning in `crash-reporter.md`, present on a clean tree too)
* `npm run create-api-json` — parses (the first draft used a `####` heading here, which `@electron/docs-parser` rejects as a method block; the text is plain prose instead)

#### Checklist

- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented that the `corsEnabled` custom scheme privilege permits cross-origin requests to the scheme rather than enforcing the CORS protocol.
