### PR TITLE
docs: document the standardized window-drag CSS property

### DIFF
--- a/docs/tutorial/custom-window-interactions.md
+++ b/docs/tutorial/custom-window-interactions.md
@@ -34,6 +34,30 @@ button {
 If you're only setting a custom title bar as draggable, you also need to make all
 buttons in title bar non-draggable.
 
+### The standardized `window-drag` property
+
+`app-region` predates standardization. The CSS Working Group has since
+standardized [`window-drag`][window-drag-spec], which Chromium implements as of
+Electron 44. Chromium keeps `app-region` as a surrogate for `window-drag`, so
+both properties write the same underlying value and either may be used.
+
+The keywords are not the same, though:
+
+| `app-region`          | `window-drag`         |
+| --------------------- | --------------------- |
+| `app-region: drag`    | `window-drag: move`   |
+| `app-region: no-drag` | no equivalent         |
+
+`window-drag: none` is not a replacement for `app-region: no-drag`. `no-drag`
+excludes its area from an ancestor's draggable region, while `none` only means
+that the element does not define a draggable region of its own, so an element
+with `window-drag: none` inside a `window-drag: move` region stays draggable.
+Keep using `app-region: no-drag` to re-enable pointer events on buttons and
+other controls.
+
+Because `app-region` works on every supported version of Electron and covers
+both cases, the examples on this page use it.
+
 ### Tip: disable text selection
 
 When creating a draggable region, the dragging behavior may conflict with text selection.
@@ -107,3 +131,4 @@ This makes the web page click-through when over the `#clickThroughElement` eleme
 and returns to normal outside it.
 
 [ignore-mouse-events]: ../api/browser-window.md#winsetignoremouseeventsignore-options
+[window-drag-spec]: https://drafts.csswg.org/css-ui-4/#window-drag


### PR DESCRIPTION
#### Description of Change

Closes #52325.

> [!NOTE]
> Opened as a draft only because this repository allows contributors without write access one non-draft PR at a time, and I have one open ([#52908](https://github.com/electron/electron/pull/52908)). Happy to mark it ready whenever a maintainer wants to look at it — the change itself is finished.

The issue asks whether Electron supports Chromium's standardized `window-drag`, and if so whether [Custom Window Interactions](https://www.electronjs.org/docs/latest/tutorial/custom-window-interactions) should stop showing `app-region`. It does support it — but it is not a rename, so this documents the difference instead of swapping the examples over.

What the Chromium in `DEPS` (153.0.8001.0) actually does:

* `css_properties.json5` registers `app-region` with `surrogate_for: "window-drag"`, and `-webkit-app-region` as an alias for `app-region`. All three write the same computed value.
* `window-drag` parses only `none` and `move`. `app-region` also parses `no-drag` (`CSSParserFastPaths::IsValidKeywordPropertyAndValue`: `kWindowDrag` accepts `kNone`/`kMove`; `kAppRegion` accepts `kDrag`–`kNoDrag` plus `kNone`).
* `LayoutObject::AddDraggableRegions` returns early for `EDraggableRegionMode::kNone` and contributes no region, whereas `kNoDrag` contributes a region with `draggable = false`. Electron then unions the draggable regions and *subtracts* the non-draggable ones (`DraggableRegionsToSkRegion` in `shell/browser/ui/drag_util.cc`).

So `window-drag: move` is equivalent to `app-region: drag`, but **`window-drag: none` is not equivalent to `app-region: no-drag`** — an element with `window-drag: none` inside a `window-drag: move` region contributes nothing and stays covered by the ancestor's union, i.e. it stays draggable. There is currently no `window-drag` keyword for the `no-drag` carve-out that the page tells people to use for buttons, which is why the examples still use `app-region`.

Availability, from `runtime_enabled_features.json5`:

| Chromium | Electron | `CSSWindowDrag` |
| -------- | -------- | --------------- |
| 150 | 43 | flag absent |
| 152 | 44 | `status: "stable"` |
| 153 | main | `status: "stable"` |

> [!NOTE]
> Drafted with Claude Code (Claude Opus 5) and disclosed per the [AI tool policy](https://github.com/electron/governance/blob/main/policy/ai.md); the commit carries a `Co-Authored-By` trailer. Every claim above was read out of the Chromium revision pinned in `DEPS` and out of `drag_util.cc`; I have not run a build, so the `window-drag: none` behaviour is derived from `AddDraggableRegions` rather than observed at runtime. Worth a maintainer eye on that one point, and on whether you would rather wait for a `no-drag` equivalent before mentioning the property at all.

`npm run lint:markdown` — 0 errors. Documentation only; no code changes.

#### Checklist

- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented the standardized `window-drag` CSS property alongside `app-region`, including that `window-drag: none` does not replace `app-region: no-drag`.