### PR TITLE
docs: note the Document-Policy needed for collectJavaScriptCallStack

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -175,6 +175,35 @@ app.on('web-contents-created', (_, webContents) => {
 })
 ```
 
+Enabling the feature is not sufficient on its own: the document loaded in the
+frame must also opt in, by being served with the
+`include-js-call-stacks-in-crash-reports` [Document Policy][document-policy].
+Without it, the promise resolves with `Website owner has not opted in for JS
+call stacks in crash reports.` instead of a call stack.
+
+Document Policy is only delivered by an HTTP response header, so a document
+loaded from a `file://` URL cannot opt in. Serve the page over HTTP or from a
+custom protocol and set the header on the response:
+
+```js
+const { app, protocol } = require('electron')
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'app', privileges: { standard: true, secure: true } }
+])
+
+app.whenReady().then(() => {
+  protocol.handle('app', () => {
+    return new Response('<script>/* ... */</script>', {
+      headers: {
+        'content-type': 'text/html',
+        'document-policy': 'include-js-call-stacks-in-crash-reports'
+      }
+    })
+  })
+})
+```
+
 #### `frame.copyVideoFrameAt(x, y)`
 
 * `x` Integer
@@ -348,3 +377,4 @@ newly navigated page replaced it in the frame tree.
 [`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 [`MessagePortMain`]: message-port-main.md
 [unload]: https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event
+[document-policy]: https://wicg.github.io/document-policy/


### PR DESCRIPTION
#### Description of Change

Closes #45356.

> [!NOTE]
> Opened as a draft only because this repository allows contributors without write access one non-draft PR at a time, and I have one open ([#52908](https://github.com/electron/electron/pull/52908)). Happy to mark it ready whenever a maintainer wants to look at it — the change itself is finished.

The documented example for `frame.collectJavaScriptCallStack()` only enables the `DocumentPolicyIncludeJSCallStacksInCrashReports` feature. That is necessary but not sufficient — the document itself has to opt in — and the issue reporter found this out by experiment.

`JavaScriptCallStackCollector` (`third_party/blink/renderer/controller/javascript_call_stack_collector.cc`) checks the document policy separately from the runtime feature:

```cpp
if (!execution_context->IsFeatureEnabled(
        mojom::blink::DocumentPolicyFeature::
            kIncludeJSCallStacksInCrashReports)) {
  builder.Append(kWebsiteOwnerNotOptedInMessage);
} else {
  ...
  CollectFilteredCallStack(isolate, builder);
}
```

`include-js-call-stacks-in-crash-reports` has `default_value: "false"` in `document_policy_features.json5`, and `kWebsiteOwnerNotOptedInMessage` is `"Website owner has not opted in for JS call stacks in crash reports."` (`javascript_call_stack_collector.h`). So without the header the promise resolves with that sentence rather than a call stack — which looks like the documented "unable to be collected" case, with nothing pointing at the missing header.

The change:

* States that the frame's document must be served with the `include-js-call-stacks-in-crash-reports` Document Policy.
* Quotes the string that comes back when it is not, so it is searchable.
* Notes that Document Policy is delivered only by an HTTP response header, so a `file://` document cannot opt in, and shows setting the header from a `protocol.handle` response — which is how most apps serving their own content would do it.

> [!NOTE]
> Drafted with Claude Code (Claude Opus 5) and disclosed per the [AI tool policy](https://github.com/electron/governance/blob/main/policy/ai.md); the commit carries a `Co-Authored-By` trailer. Every claim was read out of the Chromium revision pinned in `DEPS` (153.0.8001.0) and out of `shell/browser/api/electron_api_web_frame_main.cc`. I have not run a build, so the exact wording of the resolved string is taken from the constant rather than observed at runtime.

Verified with the docs tooling, since this is documentation only:

* `npm run lint:markdown` — 0 errors
* `npm run lint:js-in-markdown` — 0 errors
* `npm run lint:ts-check-js-in-markdown` — 0 errors (the added `protocol.handle` snippet typechecks against the generated `electron.d.ts`)
* `npm run lint:docs-relative-links` — 0 errors

#### Checklist

- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented that `webFrameMain.collectJavaScriptCallStack()` also requires the frame's document to be served with the `include-js-call-stacks-in-crash-reports` Document Policy.
