### PR TITLE
docs: clarify which resolveHost sources use DNS-over-HTTPS

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1217,7 +1217,9 @@ indicates success while any other value indicates failure according to Chromium 
     resolver is used in preference to getaddrinfo. When enabled, the built-in
     resolver will attempt to use the system's DNS settings to do DNS lookups
     itself. Enabled by default on macOS, disabled by default on Windows and
-    Linux.
+    Linux. This only applies to insecure lookups: DoH is controlled by
+    `secureDnsMode` and `secureDnsServers`, and remains in use when this is
+    `false`.
   * `enableHappyEyeballs` boolean (optional) - Whether the
     [Happy Eyeballs V3][happy-eyeballs-v3] algorithm should be used in creating
     network connections. When enabled, hostnames resolving to multiple IP

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -799,8 +799,10 @@ pooled sockets using previous proxy from being reused by future requests.
     * `any` (default) - Resolver will pick an appropriate source. Results could
       come from DNS, MulticastDNS, HOSTS file, etc
     * `system` - Results will only be retrieved from the system or OS, e.g. via
-      the `getaddrinfo()` system call
-    * `dns` - Results will only come from DNS queries
+      the `getaddrinfo()` system call. This does not go through the built-in
+      resolver, so DNS-over-HTTPS is not used
+    * `dns` - Results will only come from DNS queries, made by the built-in
+      resolver, so DNS-over-HTTPS is used when it is configured
     * `mdns` - Results will only come from Multicast DNS queries
     * `localOnly` - No external sources will be used. Results will only come
       from fast local sources that are available no matter the source setting,
@@ -817,6 +819,12 @@ pooled sockets using previous proxy from being reused by future requests.
     * `disable`
 
 Returns [`Promise<ResolvedHost>`](structures/resolved-host.md) - Resolves with the resolved IP addresses for the `host`.
+
+To resolve a host through the DNS-over-HTTPS servers configured with
+[`app.configureHostResolver`](app.md#appconfigurehostresolveroptions), leave
+`source` unset or set it to `dns`, and leave `secureDnsPolicy` at its default.
+Setting `source` to `system` hands the lookup to the OS resolver, which knows
+nothing about that configuration.
 
 #### `ses.resolveProxy(url)`
 


### PR DESCRIPTION
#### Description of Change

Closes #49055.

> [!NOTE]
> Opened as a draft only because this repository allows contributors without write access one non-draft PR at a time, and I have one open ([#52908](https://github.com/electron/electron/pull/52908)). Happy to mark it ready whenever a maintainer wants to look at it — the change itself is finished.

The issue asks which `source` value in `ses.resolveHost()` reaches the DNS-over-HTTPS servers set up with `app.configureHostResolver()`. Neither page says how the two interact, so there is no way to work it out from the docs.

`HostResolverManager::CreateTaskSequence` (`net/dns/host_resolver_manager.cc`) is where it is decided:

| `source` | tasks pushed | DoH |
| --- | --- | --- |
| `system` | `TaskType::SYSTEM` only | no — the OS resolver knows nothing about the DoH config |
| `dns` | `PushDnsTasks(...)` via `dns_client_`, `system_task_allowed = false` | yes |
| `any` | `PushDnsTasks(...)` when the client has an effective config; system fallback is disabled when the secure mode is `secure` | yes, when configured |
| `mdns` / `localOnly` | mDNS only / nothing external | no |

The reporter's snippet also sets `enableBuiltInResolver: false`, which is a separate axis and worth spelling out. `App::ConfigureHostResolver` maps it to `net::InsecureDnsMode` (`kEnabledBuiltIn` or `kDisabled`), and:

```cpp
bool CanUseSecureDnsTransactions() const override {
  const DnsConfig* config = GetEffectiveConfig();
  return config && !config->doh_config.servers().empty();
}

bool CanUseInsecureDnsTransactions() const override {
  const DnsConfig* config = GetEffectiveConfig();
  return config && config->nameservers.size() > 0 &&
         insecure_dns_mode_ != InsecureDnsMode::kDisabled && ...;
}
```

So only the insecure path consults `insecure_dns_mode_`; DoH keeps working with `enableBuiltInResolver: false`. The current wording — "used in preference to getaddrinfo" — reads as though turning it off would turn off the built-in resolver entirely, DoH included.

The change adds that to the `source` bullets, notes the `enableBuiltInResolver` scope, and states the combination to use for a DoH lookup.

> [!NOTE]
> Drafted with Claude Code (Claude Opus 5) and disclosed per the [AI tool policy](https://github.com/electron/governance/blob/main/policy/ai.md); the commit carries a `Co-Authored-By` trailer. Everything above was read out of the Chromium revision pinned in `DEPS` (153.0.8001.0) and out of `shell/browser/api/electron_api_app.cc`; documentation only, no behaviour change, and no build was run.

* `npm run lint:markdown` — 0 errors
* `npm run lint:js-in-markdown` — 0 errors
* `npm run lint:docs-relative-links` — 0 errors
* `npm run create-api-json` — parses

#### Checklist

- [x] I have filled out the PR description
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Documented which `session.resolveHost()` `source` values use DNS-over-HTTPS configured with `app.configureHostResolver()`, and that `enableBuiltInResolver` only affects insecure lookups.
