### PR TITLE
docs: document the corsEnabled custom scheme privilege

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -124,6 +124,32 @@ The `<video>` and `<audio>` HTML elements expect protocols to buffer their
 responses by default. The `stream` flag configures those elements to correctly
 expect streaming responses.
 
+Without `corsEnabled`, requests to the scheme that use the CORS protocol, such as
+`fetch()` and `XMLHttpRequest` from a page on a different origin, are rejected
+before the protocol handler runs. Requests that do not use the CORS protocol,
+such as an `<img>` load, are unaffected.
+
+Setting `corsEnabled: true` allows those cross-origin requests through. Electron
+does not validate `Access-Control-Allow-Origin` on responses to custom schemes,
+so the response body is readable by the requesting origin whether or not the
+handler sets that header:
+
+```js
+const { protocol } = require('electron')
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'app', privileges: { standard: true, secure: true, supportFetchAPI: true } },
+  { scheme: 'open', privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true } }
+])
+
+// A page on https://example.com can read `open://` responses, but not `app://` ones.
+```
+
+> [!IMPORTANT]
+> `corsEnabled` grants cross-origin access; it does not enforce the CORS
+> protocol. Do not set it on a scheme that serves data other origins should not
+> be able to read.
+
 ### `protocol.handle(scheme, handler)`
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is

--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -7,7 +7,13 @@
   * `bypassCSP` boolean (optional) - Default false.
   * `allowServiceWorkers` boolean (optional) - Default false.
   * `supportFetchAPI` boolean (optional) - Default false.
-  * `corsEnabled` boolean (optional) - Default false.
+  * `corsEnabled` boolean (optional) - Whether other origins are allowed to
+    request this scheme. When `true`, a page from any other origin may
+    `fetch()` or `XMLHttpRequest` this scheme and read the response. Electron
+    does not validate `Access-Control-Allow-Origin` on responses to custom
+    schemes, so this privilege grants cross-origin access rather than enforcing
+    the CORS protocol. Leave it `false` for schemes that serve data other
+    origins should not be able to read. Default false.
   * `stream` boolean (optional) - Default false.
   * `codeCache` boolean (optional) - Enable V8 code cache for the scheme, only
     works when `standard` is also set to true. Default false.


### PR DESCRIPTION
`corsEnabled` was the only privilege in the CustomScheme structure listed without a description, and its name reads as though it makes Electron enforce CORS for the scheme. It does the opposite: registering a scheme with `url::AddCorsEnabledScheme` lets cross-origin requests through, and because requests to registered protocols are served by ElectronURLLoaderFactory rather than the network service's CorsURLLoaderFactory, no `Access-Control-Allow-Origin` validation is performed on the response.

That is what the suite asserts today: `does not affect cross-origin fetch to a corsEnabled scheme` reads the body of a response that sets no ACAO header, while `blocks cross-origin fetch on a standard supportFetchAPI-only scheme` expects the same fetch to fail without the privilege.

Document the privilege accordingly, and describe the behaviour in `registerSchemesAsPrivileged` so it is clear that leaving `corsEnabled` unset is what keeps a scheme unreadable cross-origin.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have built and tested this change
- [ ] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
