### PR TITLE
feat: allow panels to be key windows and update focus/blur events

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1425,6 +1425,29 @@ On macOS it does not remove the focus from the window.
 
 Returns `boolean` - Whether the window can be focused.
 
+#### `win.setActivable(activable)` _macOS_
+
+* `activable` boolean
+
+Sets whether a `panel` window can become the main window. This behavior can also
+be set at creation with the `activable` option, whose default is `true` for panel
+windows. When `activable` is `false`, a panel can still become the key window if
+`focusable` is `true`.
+
+When `activable` is `false`, the panel does not emit the `focus` and `blur`
+events in the main process. To listen for focus changes in the renderer process,
+use the DOM `window` events:
+
+```js
+window.addEventListener('focus', () => {})
+window.addEventListener('blur', () => {})
+```
+
+This method has no effect on non-panel window types.
+
+The `activable` setting is independent of `focusable`. When `focusable` is
+`false`, the panel cannot become either the key or main window.
+
 #### `win.setParentWindow(parent)`
 
 * `parent` BaseWindow | null

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1641,6 +1641,29 @@ On macOS it does not remove the focus from the window.
 
 Returns `boolean` - Whether the window can be focused.
 
+#### `win.setActivable(activable)` _macOS_
+
+* `activable` boolean
+
+Sets whether a `panel` window can become the main window. This behavior can also
+be set at creation with the `activable` option, whose default is `true` for panel
+windows. When `activable` is `false`, a panel can still become the key window if
+`focusable` is `true`.
+
+When `activable` is `false`, the panel does not emit the `focus` and `blur`
+events in the main process. To listen for focus changes in the renderer process,
+use the DOM `window` events:
+
+```js
+window.addEventListener('focus', () => {})
+window.addEventListener('blur', () => {})
+```
+
+This method has no effect on non-panel window types.
+
+The `activable` setting is independent of `focusable`. When `focusable` is
+`false`, the panel cannot become either the key or main window.
+
 #### `win.setParentWindow(parent)`
 
 * `parent` BrowserWindow | null

--- a/docs/api/structures/base-window-options.md
+++ b/docs/api/structures/base-window-options.md
@@ -28,6 +28,9 @@
   `skipTaskbar: true`. On Linux setting `focusable: false` makes the window
   stop interacting with wm, so the window will always stay on top in all
   workspaces.
+* `activable` boolean (optional) _macOS_ - Whether a `panel` window can become
+  the main window. Default is `true` for panel windows. This option has no
+  effect on other window types.
 * `alwaysOnTop` boolean (optional) - Whether the window should always stay on top of
   other windows. Default is `false`. Not supported on Wayland (Linux).
 * `fullscreen` boolean (optional) - Whether the window should show in fullscreen. When

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -883,6 +883,10 @@ bool BaseWindow::IsHiddenInMissionControl() {
 void BaseWindow::SetHiddenInMissionControl(bool hidden) {
   window_->SetHiddenInMissionControl(hidden);
 }
+
+void BaseWindow::SetActivable(bool activable) {
+  window_->SetActivable(activable);
+}
 #endif
 
 void BaseWindow::SetTouchBar(
@@ -1270,6 +1274,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                  &BaseWindow::IsHiddenInMissionControl)
       .SetMethod("setHiddenInMissionControl",
                  &BaseWindow::SetHiddenInMissionControl)
+      .SetMethod("setActivable", &BaseWindow::SetActivable)
 #endif
       .SetMethod("_setTouchBarItems", &BaseWindow::SetTouchBar)
       .SetMethod("_refreshTouchBarItem", &BaseWindow::RefreshTouchBarItem)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -211,6 +211,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 
   bool IsHiddenInMissionControl();
   void SetHiddenInMissionControl(bool hidden);
+  void SetActivable(bool activable);
 #endif
 
   void SetTouchBar(std::vector<gin_helper::PersistentDictionary> items);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -244,10 +244,13 @@ class NativeWindow : public views::WidgetDelegate {
   virtual void UpdateFrame() = 0;
 #endif
 
-// whether windows should be ignored by mission control
 #if BUILDFLAG(IS_MAC)
+  // whether windows should be ignored by mission control
   virtual bool IsHiddenInMissionControl() const = 0;
   virtual void SetHiddenInMissionControl(bool hidden) = 0;
+
+  // Whether a panel window can become the main window.
+  virtual void SetActivable(bool activable) = 0;
 #endif
 
   // Touchbar API

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -113,6 +113,7 @@ class NativeWindowMac : public NativeWindow,
   void SetContentProtection(bool enable) override;
   bool IsContentProtected() const override;
   void SetFocusable(bool focusable) override;
+  void SetActivable(bool activable) override;
   bool IsFocusable() const override;
   void SetParentWindow(NativeWindow* parent) override;
   content::DesktopMediaID GetDesktopMediaID() const override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -283,6 +283,9 @@ NativeWindowMac::NativeWindowMac(const int32_t base_window_id,
 
   if (windowType == "panel") {
     [window_ setLevel:NSFloatingWindowLevel];
+    bool activable = true;
+    options.Get(options::kActivable, &activable);
+    SetActivable(activable);
   }
 
   if (bool val; options.Get(options::kFocusable, &val) && !val)
@@ -1242,6 +1245,12 @@ void NativeWindowMac::SetFocusable(bool focusable) {
 
 bool NativeWindowMac::IsFocusable() const {
   return ![window_ disableKeyOrMainWindow];
+}
+
+void NativeWindowMac::SetActivable(bool activable) {
+  if (![window_ isKindOfClass:[ElectronNSPanel class]])
+    return;
+  [static_cast<ElectronNSPanel*>(window_) setCanActivate:activable];
 }
 
 void NativeWindowMac::SetParentWindow(NativeWindow* parent) {

--- a/shell/browser/ui/cocoa/electron_ns_panel.h
+++ b/shell/browser/ui/cocoa/electron_ns_panel.h
@@ -10,6 +10,8 @@
 @interface ElectronNSPanel : ElectronNSWindow
 @property NSWindowStyleMask styleMask;
 @property NSWindowStyleMask originalStyleMask;
+// Whether this panel can become the main window.
+@property BOOL canActivate;
 - (id)initWithShell:(electron::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask;
 @end

--- a/shell/browser/ui/cocoa/electron_ns_panel.mm
+++ b/shell/browser/ui/cocoa/electron_ns_panel.mm
@@ -7,11 +7,13 @@
 @implementation ElectronNSPanel
 
 @synthesize originalStyleMask;
+@synthesize canActivate;
 
 - (id)initWithShell:(electron::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask {
   if (self = [super initWithShell:shell styleMask:styleMask]) {
     originalStyleMask = styleMask;
+    canActivate = NO;
   }
   return self;
 }
@@ -34,6 +36,10 @@
       (NSWindowCollectionBehaviorCanJoinAllSpaces |
        NSWindowCollectionBehaviorFullScreenAuxiliary);
   [super setCollectionBehavior:collectionBehavior | panelBehavior];
+}
+
+- (BOOL)canBecomeMainWindow {
+  return self.canActivate && [super canBecomeMainWindow];
 }
 
 @end

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -103,6 +103,8 @@ inline constexpr std::string_view kOpacity = "opacity";
 
 // Whether the window can be activated.
 inline constexpr std::string_view kFocusable = "focusable";
+// Whether a panel window can become the main window.
+inline constexpr std::string_view kActivable = "activable";
 
 // The WebPreferences.
 inline constexpr std::string_view kWebPreferences = "webPreferences";

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1523,6 +1523,43 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    ifdescribe(process.platform === 'darwin')('"activable" option', () => {
+      afterEach(closeAllWindows);
+
+      it('defaults to true and emits focus when shown', async () => {
+        const w = new BrowserWindow({ show: false, type: 'panel' });
+        const focused = once(w, 'focus');
+        w.show();
+        await focused;
+      });
+
+      it('does not emit focus in the main process when false', async () => {
+        const w = new BrowserWindow({
+          show: false,
+          type: 'panel',
+          activable: false,
+          webPreferences: { nodeIntegration: true, contextIsolation: false }
+        });
+        await w.loadURL('about:blank');
+
+        let mainProcessFocusEmitted = false;
+        w.once('focus', () => {
+          mainProcessFocusEmitted = true;
+        });
+
+        const domFocused = once(ipcMain, 'activable-test-dom-focus');
+        await w.webContents.executeJavaScript(
+          "window.addEventListener('focus', () => require('electron').ipcRenderer.send('activable-test-dom-focus'))"
+        );
+
+        w.show();
+        w.webContents.focus();
+        await domFocused;
+
+        expect(mainProcessFocusEmitted).to.equal(false);
+      });
+    });
+
     // TODO(RaisinTen): Make this work on Windows too.
     // Refs: https://github.com/electron/electron/issues/20464.
     ifdescribe(process.platform !== 'win32')('BrowserWindow.blur()', () => {


### PR DESCRIPTION
#### Description of Change

This PR improves macOS panel window activation semantics and focus event delivery.

Panel windows can now remain key windows without becoming main windows. A new macOS-only activable option and win.setActivable(activable) API control whether a panel can become the main window. Panels default to activable: false; when focusable is true, they can still receive keyboard input as key windows. focusable: false continues to take precedence and prevents a panel from becoming either the key or main window.

The macOS native window delegate now dispatches focus and blur from key-window notifications rather than main-window notifications. This lets non-activable panels emit the same focus lifecycle events when they gain or lose keyboard focus.

The change also documents the constructor option and runtime API for both BaseWindow and BrowserWindow, and adds macOS regression coverage for panel focus/blur behavior and the setActivable API binding.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `activable` BrowserWindow option on macOS to create NSPanel windows that receive keyboard input without stealing main-window activation.
