### PR TITLE
perf: split paths under the last-used archive without calling into native

### DIFF
--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -28,9 +28,9 @@ const binding = internalBinding('fs');
 const cachedArchives = new Map<string, NodeJS.AsarArchive>();
 
 const getOrCreateArchive = (archivePath: string) => {
-  const isCached = cachedArchives.has(archivePath);
-  if (isCached) {
-    return cachedArchives.get(archivePath)!;
+  const cached = cachedArchives.get(archivePath);
+  if (cached !== undefined) {
+    return cached;
   }
 
   try {
@@ -60,6 +60,13 @@ const { validateBoolean, validateFunction } = __non_webpack_require__(
 // the global URL instance.  We need to do instanceof checks against the internal URL impl
 const { URL: NodeURL } = __non_webpack_require__('internal/url') as typeof import('@node/lib/internal/url');
 
+// Consecutive lookups nearly always hit the same archive, so paths under the
+// archive native returned last are split here. Tails native could split again
+// (".asar" under ASCII, macOS or Windows case folding, hence \u017f) or would
+// truncate (NUL) still go through it.
+let lastArchivePath = '';
+const nestedArchiveRe = /\.a[s\u017f]ar/i;
+
 // Separate asar package's path from full path.
 const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
   // Shortcut for disabled asar.
@@ -76,7 +83,22 @@ const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
   if (typeof archivePath !== 'string') return { isAsar: <const>false };
   if (!asarRe.test(archivePath)) return { isAsar: <const>false };
 
-  return asar.splitPath(path.normalize(archivePath));
+  archivePath = path.normalize(archivePath);
+  if (lastArchivePath !== '' && archivePath.startsWith(lastArchivePath)) {
+    if (archivePath.length === lastArchivePath.length) {
+      return { isAsar: <const>true, asarPath: lastArchivePath, filePath: '' };
+    }
+    if (archivePath[lastArchivePath.length] === path.sep) {
+      let filePath = archivePath.slice(lastArchivePath.length + 1);
+      if (filePath.endsWith(path.sep)) filePath = filePath.slice(0, -1);
+      if (filePath !== '' && !filePath.includes('\0') && !nestedArchiveRe.test(filePath)) {
+        return { isAsar: <const>true, asarPath: lastArchivePath, filePath };
+      }
+    }
+  }
+  const result = asar.splitPath(archivePath);
+  if (result.isAsar && result.filePath !== '') lastArchivePath = result.asarPath;
+  return result;
 };
 
 // Convert asar archive's Stats object to fs's Stats object.
@@ -116,8 +138,10 @@ const fileTypeToMode = new Map<AsarFileType, number>([
   [AsarFileType.kLink, constants.S_IFLNK]
 ]);
 
+let Stats: any;
+
 const asarStatsToFsStats = function (stats: NodeJS.AsarFileStat) {
-  const { Stats } = require('fs');
+  Stats ??= require('fs').Stats;
 
   const mode =
     constants.S_IROTH | constants.S_IRGRP | constants.S_IRUSR | constants.S_IWUSR | fileTypeToMode.get(stats.type)!;
@@ -306,12 +330,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     return true;
   };
 
-  const { lstatSync } = fs;
-  fs.lstatSync = (pathArgument: string, options: any) => {
-    const pathInfo = splitPath(pathArgument);
-    if (!pathInfo.isAsar) return lstatSync(pathArgument, options);
-    const { asarPath, filePath } = pathInfo;
-
+  const asarLstatSync = ({ asarPath, filePath }: { asarPath: string; filePath: string }, options: any) => {
     const archive = getOrCreateArchive(asarPath);
     if (!archive) {
       if (shouldThrowStatError(options)) {
@@ -331,16 +350,14 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     return asarStatsToFsStats(stats);
   };
 
-  const { lstat } = fs;
-  fs.lstat = (pathArgument: string, options: any, callback: any) => {
+  const { lstatSync } = fs;
+  fs.lstatSync = (pathArgument: string, options: any) => {
     const pathInfo = splitPath(pathArgument);
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    if (!pathInfo.isAsar) return lstat(pathArgument, options, callback);
-    const { asarPath, filePath } = pathInfo;
+    if (!pathInfo.isAsar) return lstatSync(pathArgument, options);
+    return asarLstatSync(pathInfo, options);
+  };
 
+  const asarLstat = ({ asarPath, filePath }: { asarPath: string; filePath: string }, callback: any) => {
     const archive = getOrCreateArchive(asarPath);
     if (!archive) {
       const error = createError(AsarError.INVALID_ARCHIVE, { asarPath });
@@ -359,28 +376,36 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     nextTick(callback, [null, fsStats]);
   };
 
-  fs.promises.lstat = util.promisify(fs.lstat);
-
-  const { statSync } = fs;
-  fs.statSync = (pathArgument: string, options: any) => {
-    const { isAsar } = splitPath(pathArgument);
-    if (!isAsar) return statSync(pathArgument, options);
-
-    // Do not distinguish links for now.
-    return fs.lstatSync(pathArgument, options);
-  };
-
-  const { stat } = fs;
-  fs.stat = (pathArgument: string, options: any, callback: any) => {
-    const { isAsar } = splitPath(pathArgument);
+  const { lstat } = fs;
+  fs.lstat = (pathArgument: string, options: any, callback: any) => {
+    const pathInfo = splitPath(pathArgument);
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
-    if (!isAsar) return stat(pathArgument, options, callback);
+    if (!pathInfo.isAsar) return lstat(pathArgument, options, callback);
+    asarLstat(pathInfo, callback);
+  };
 
-    // Do not distinguish links for now.
-    process.nextTick(() => fs.lstat(pathArgument, options, callback));
+  fs.promises.lstat = util.promisify(fs.lstat);
+
+  // Links are not distinguished for now, so stat inside an archive is lstat.
+  const { statSync } = fs;
+  fs.statSync = (pathArgument: string, options: any) => {
+    const pathInfo = splitPath(pathArgument);
+    if (!pathInfo.isAsar) return statSync(pathArgument, options);
+    return asarLstatSync(pathInfo, options);
+  };
+
+  const { stat } = fs;
+  fs.stat = (pathArgument: string, options: any, callback: any) => {
+    const pathInfo = splitPath(pathArgument);
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    if (!pathInfo.isAsar) return stat(pathArgument, options, callback);
+    asarLstat(pathInfo, callback);
   };
 
   fs.promises.stat = util.promisify(fs.stat);

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -60,12 +60,14 @@ const { validateBoolean, validateFunction } = __non_webpack_require__(
 // the global URL instance.  We need to do instanceof checks against the internal URL impl
 const { URL: NodeURL } = __non_webpack_require__('internal/url') as typeof import('@node/lib/internal/url');
 
-// Consecutive lookups nearly always hit the same archive, so paths under the
-// archive native returned last are split here. Tails native could split again
-// (".asar" under ASCII, macOS or Windows case folding, hence \u017f) or would
-// truncate (NUL) still go through it.
+// Paths under the archive native returned last are split in JS; tails native
+// could split again (".asar" under any platform's case folding) or truncate
+// at a NUL still go through it.
 let lastArchivePath = '';
 const nestedArchiveRe = /\.a[s\u017f]ar/i;
+// What path.normalize() would rewrite in a tail: "."/".." components, doubled
+// or trailing separators, and on Windows any forward slash.
+const needsNormalizeRe = process.platform === 'win32' ? /(?:^|[\\/])\.\.?(?:[\\/]|$)|[\\/][\\/]|\/|\\$/ : /(?:^|\/)\.\.?(?:\/|$)|\/\/|\/$/;
 
 // Separate asar package's path from full path.
 const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
@@ -83,19 +85,14 @@ const splitPath = (archivePathOrBuffer: string | Buffer | URL) => {
   if (typeof archivePath !== 'string') return { isAsar: <const>false };
   if (!asarRe.test(archivePath)) return { isAsar: <const>false };
 
-  archivePath = path.normalize(archivePath);
-  if (lastArchivePath !== '' && archivePath.startsWith(lastArchivePath)) {
-    if (archivePath.length === lastArchivePath.length) {
-      return { isAsar: <const>true, asarPath: lastArchivePath, filePath: '' };
-    }
-    if (archivePath[lastArchivePath.length] === path.sep) {
-      let filePath = archivePath.slice(lastArchivePath.length + 1);
-      if (filePath.endsWith(path.sep)) filePath = filePath.slice(0, -1);
-      if (filePath !== '' && !filePath.includes('\0') && !nestedArchiveRe.test(filePath)) {
-        return { isAsar: <const>true, asarPath: lastArchivePath, filePath };
-      }
+  if (lastArchivePath !== '' && archivePath.length > lastArchivePath.length + 1 &&
+      archivePath[lastArchivePath.length] === path.sep && archivePath.startsWith(lastArchivePath)) {
+    const filePath = archivePath.slice(lastArchivePath.length + 1);
+    if (!needsNormalizeRe.test(filePath) && !filePath.includes('\0') && !nestedArchiveRe.test(filePath)) {
+      return { isAsar: <const>true, asarPath: lastArchivePath, filePath };
     }
   }
+  archivePath = path.normalize(archivePath);
   const result = asar.splitPath(archivePath);
   if (result.isAsar && result.filePath !== '') lastArchivePath = result.asarPath;
   return result;

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1733,6 +1733,21 @@ describe('asar package', function () {
       });
     });
 
+    describe('consecutive lookups', function () {
+      itremote('do not let a nested archive name or an odd tail change how later paths split', function () {
+        const archive = path.join(asarDir, 'a.asar');
+        expect(fs.readFileSync(path.join(archive, 'file1'), 'utf8').trim()).to.equal('file1');
+        expect(fs.existsSync(path.join(archive, 'dir1', 'nope.asar', 'x'))).to.equal(false);
+        expect(() => fs.readFileSync(path.join(archive, 'dir1', 'nope.asar', 'x'))).to.throw(/Invalid package/);
+        expect(fs.existsSync(archive + path.sep + path.sep + 'file1')).to.equal(true);
+        expect(fs.existsSync(path.join(archive, 'file1') + path.sep)).to.equal(true);
+        expect(fs.existsSync(path.join(archive, 'file1\0nope'))).to.equal(false);
+        expect(fs.readdirSync(archive)).to.include('file1');
+        expect(fs.existsSync(path.join(asarDir, 'echo.asar', 'file1'))).to.equal(false);
+        expect(fs.readFileSync(path.join(archive, 'dir1', 'file1'), 'utf8').trim()).to.equal('file1');
+      });
+    });
+
     describe('process.noAsar', function () {
       const errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
 


### PR DESCRIPTION
#### Description of Change

**Apps that load their code from `app.asar` start faster: launch to `ready` 395 -> 317 ms (-20%) and first contentful paint -74 ms for a test app requiring ~1000 modules, because every `fs` call on a path inside the archive gets 3-5x cheaper.**

| Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| `fs.statSync()` on a file inside an archive (20) | 14.6 us | 2.9 us |
| `internalModuleStat()` / `existsSync()` (20) | 8.0 / 7.9 us | 2.2 / 2.6 us |
| `readFileSync()` / `readdirSync()` (20) | 13.4 / 9.5 us | 7.4 / 4.5 us |
| require a 1040-module tree from `app.asar`, `ELECTRON_RUN_AS_NODE` (30) | 249 ms | 175 ms |
| same tree from a plain directory (control) | 166 ms | 165 ms |
| packaged app requiring that tree at startup: launch to `ready` / to first contentful paint (30, two sessions) | 395 / 619 ms | 317 / 545 ms |

Why: the asar `fs` wrapper decides whether a path is inside an archive by handing every path that mentions `.asar` to the native splitter, on every wrapped call. Module resolution alone issues thousands of `internalModuleStat`/`realpath`/`readFileSync` calls back to back, nearly all for the same archive, and each paid a JS -> native round trip plus a result object.

What changes: the wrapper remembers the archive path the native splitter returned last and answers paths under it in JS - only when the answer cannot differ from native's: the path starts with that archive path plus a separator, and the remainder has no NUL (native truncates there) and nothing the native matcher could read as a further archive component (`/\\.a[s\\u017f]ar/i`, covering the ASCII, CFString and `CharUpper` case folding `base::FilePath::MatchesExtension` applies per platform). First sight of an archive, other archives, nested archive names and a trailing separator on the archive path still go native; the remainder is only `path.normalize()`d when it contains something normalize would change. Alongside: `stat`/`statSync` inside an archive stop splitting the path twice, the archive map is read once per call, and `fs.Stats` is resolved once.

Testing: outputs of the sync and async `stat`/`lstat`/`exists`/`readdir`/`readFile`/`realpath`/`access`/`internalModuleStat` wrappers diffed identical between old and new builds over paths built to trip the cache (nested `.asar` names, `X.ASAR`, `U+017F`, embedded NUL, doubled and trailing separators, `Buffer` and `URL` arguments); a new asar-spec case keeps the interesting ones. JS only.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved the performance of `fs` operations and `require()` on paths inside ASAR archives.
