### PR TITLE
perf: stop rebuilding the whole path per component in asar::GetAsarArchivePath

### DIFF
--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -81,24 +82,62 @@ bool GetAsarArchivePath(const base::FilePath& full_path,
                         base::FilePath* asar_path,
                         base::FilePath* relative_path,
                         bool allow_root) {
-  base::FilePath iter = full_path;
+  using StringType = base::FilePath::StringType;
+  constexpr auto is_separator = &base::FilePath::IsSeparator;
+  const StringType& value = full_path.value();
+
+  // Walk the components from the deepest one up, the way repeated DirName()
+  // calls would, but on offsets into |value| instead of freshly built paths.
+  size_t end = value.size();
+  while (end > 0 && is_separator(value[end - 1]))
+    --end;
+  size_t component_end = end;
+  bool leaf = true;
   while (true) {
-    base::FilePath dirname = iter.DirName();
-    if (iter.MatchesExtension(kAsarExtension) && !IsDirectoryCached(iter))
-      break;
-    else if (iter == dirname)
+    size_t start = component_end;
+    while (start > 0 && !is_separator(value[start - 1]))
+      --start;
+    const auto component = base::FilePath::StringViewType{value}.substr(
+        start, component_end - start);
+    // ".asar" is five characters; MatchesExtension() decides the rest (case
+    // folding, dotfiles) exactly as it does for a whole path.
+    if (component.size() >= 5 &&
+        component[component.size() - 5] ==
+            base::FilePath::kExtensionSeparator &&
+        base::FilePath(component).MatchesExtension(kAsarExtension)) {
+      base::FilePath candidate =
+          leaf ? full_path : base::FilePath(value.substr(0, component_end));
+      if (!IsDirectoryCached(candidate)) {
+        if (leaf && !allow_root)
+          return false;
+        base::FilePath tail;
+        size_t pos = component_end;
+        while (pos < end) {
+          while (pos < end && is_separator(value[pos]))
+            ++pos;
+          size_t next = pos;
+          while (next < end && !is_separator(value[next]))
+            ++next;
+          if (next > pos) {
+            tail = tail.Append(
+                base::FilePath::StringViewType{value}.substr(pos, next - pos));
+          }
+          pos = next;
+        }
+        *asar_path = std::move(candidate);
+        *relative_path = std::move(tail);
+        return true;
+      }
+    }
+    if (start == 0)
       return false;
-    iter = dirname;
+    leaf = false;
+    component_end = start;
+    while (component_end > 0 && is_separator(value[component_end - 1]))
+      --component_end;
+    if (component_end == 0)
+      return false;
   }
-
-  base::FilePath tail;
-  if (!((allow_root && iter == full_path) ||
-        iter.AppendRelativePath(full_path, &tail)))
-    return false;
-
-  *asar_path = iter;
-  *relative_path = tail;
-  return true;
 }
 
 bool ReadFileToString(const base::FilePath& path, std::string* contents) {

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1733,6 +1733,34 @@ describe('asar package', function () {
       });
     });
 
+    describe('splitPath', function () {
+      itremote('splits at the deepest .asar file component and normalizes the relative part', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        const archive = path.join(asarDir, 'a.asar');
+        expect(splitPath(path.join(archive, 'dir1', 'file1'))).to.deep.equal({ isAsar: true, asarPath: archive, filePath: ['dir1', 'file1'].join(path.sep) });
+        expect(splitPath(archive + path.sep + path.sep + 'dir1' + path.sep + path.sep + 'file1' + path.sep)).to.deep.equal({ isAsar: true, asarPath: archive, filePath: ['dir1', 'file1'].join(path.sep) });
+        expect(splitPath(path.join(archive, 'nested.asar', 'x'))).to.deep.equal({ isAsar: true, asarPath: path.join(archive, 'nested.asar'), filePath: 'x' });
+        expect(splitPath(archive)).to.deep.equal({ isAsar: true, asarPath: archive, filePath: '' });
+      });
+
+      itremote('does not treat a real directory named like an archive as an archive', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        expect(splitPath(path.join(asarDir, 'file'))).to.deep.equal({ isAsar: false });
+        expect(splitPath(asarDir)).to.deep.equal({ isAsar: false });
+        expect(splitPath(path.join(fixtures, 'module', 'noop.js'))).to.deep.equal({ isAsar: false });
+      });
+
+      itremote('matches the archive extension the same way base::FilePath does', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        const dir = path.join(fixtures, 'module');
+        expect(splitPath(path.join(dir, 'X.ASAR', 'y')).isAsar).to.equal(true);
+        expect(splitPath(path.join(dir, '.asar', 'y')).isAsar).to.equal(true);
+        expect(splitPath(path.join(dir, 'x.asar.gz', 'y')).isAsar).to.equal(false);
+        expect(splitPath(path.join(dir, 'x.asarx', 'y')).isAsar).to.equal(false);
+        expect(splitPath(path.join(dir, 'asar', 'y')).isAsar).to.equal(false);
+      });
+    });
+
     describe('process.noAsar', function () {
       const errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
 


### PR DESCRIPTION
#### Description of Change

**Every `fs` lookup on a path inside an `.asar` gets ~4x cheaper in native (`asar.splitPath()` 5.3 -> 1.3 us); for a test app requiring ~1000 modules from `app.asar` that alone is launch to `ready` 393 -> 347 ms.**

| Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| `asar.splitPath()` on a path inside an archive / on a plain path (30) | 5.3 / 1.7 us | 1.3 / 0.6 us |
| `internalModuleStat()` / `fs.statSync()` / `fs.readFileSync()` inside an archive (30) | 7.8 / 14.2 / 13.2 us | 3.7 / 6.0 / 9.2 us |
| require a 1040-module tree from `app.asar` (30) | 252 ms | 206 ms |
| same tree from a plain directory (control) | 166 ms | 166 ms |
| packaged app requiring that tree: launch to `ready` (30, three sessions) | 393 ms | 347 ms |

Why: `asar::GetAsarArchivePath()`, behind every `fs` call on a path that mentions `.asar`, found the archive by calling `DirName()` once per component and `MatchesExtension()` on every intermediate path, then split the result with `AppendRelativePath()`, which runs `GetComponents()` over both paths - dozens of short-lived string allocations per lookup, ~10 lookups per `require()` of a module in an archive.

What changes: it walks component boundaries as offsets into the existing string, hands only the candidate component to `MatchesExtension()`, and builds the relative part with `Append()` from the components after the match. Outputs are byte-identical to before, corner cases included (an on-disk directory named `*.asar` stays a directory, the deepest matching component wins, doubled separators and a leading `.` collapse the way `Append()` collapses them, a trailing separator on the archive path is kept).

Testing: three new asar-spec cases pin that behavior; `splitPath`/`statSync`/`readdirSync` output diffed identical for 45 crafted paths between old and new binaries; asar/modules/node specs and an ASAN pass clean. Shared C++ for all platforms; the extension match still goes through `base::FilePath` so the per-platform case folding is unchanged.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved the performance of file lookups inside ASAR archives.
