### PR TITLE
perf: allocate Buffer.allocUnsafe backing stores through the isolate's allocator

### DIFF
--- a/patches/node/support_v8_sandboxed_pointers.patch
+++ b/patches/node/support_v8_sandboxed_pointers.patch
@@ -117,7 +117,7 @@ index cb1ad6bcfa7ea421642d097d6a9a8a5e04d5cf7c..6b7e4211a8969351168fc982fe3466a2
    auto backing = ArrayBuffer::NewBackingStore(
        mem->data,
 diff --git a/src/node_buffer.cc b/src/node_buffer.cc
-index 46a9b925d276f8fe597c2a757b691aeeb3f9efc1..c3e4ea6e7cb7782561e9a2f1283bffd6c1be2637 100644
+index 46a9b925d276f8fe597c2a757b691aeeb3f9efc1..b3d0d2c236c1d8c161f007e01f193070194b2ba8 100644
 --- a/src/node_buffer.cc
 +++ b/src/node_buffer.cc
 @@ -1489,7 +1489,7 @@ inline size_t CheckNumberToSize(Local<Value> number) {
@@ -129,41 +129,6 @@ index 46a9b925d276f8fe597c2a757b691aeeb3f9efc1..c3e4ea6e7cb7782561e9a2f1283bffd6
  #endif
    return size;
  }
-@@ -1512,6 +1512,26 @@ void CreateUnsafeArrayBuffer(const FunctionCallbackInfo<Value>& args) {
-       env->isolate_data()->is_building_snapshot()) {
-     buf = ArrayBuffer::New(isolate, size);
-   } else {
-+#if defined(V8_ENABLE_SANDBOX)
-+    // When the V8 sandbox is enabled, all array buffers must be allocated
-+    // within the V8 memory cage via the V8 allocator.
-+    std::unique_ptr<ArrayBuffer::Allocator> allocator(
-+        ArrayBuffer::Allocator::NewDefaultAllocator());
-+    void* data = allocator->AllocateUninitialized(size);
-+    if (!data) [[unlikely]] {
-+      THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
-+      return;
-+    }
-+    std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-+        data,
-+        size,
-+        [](void* data, size_t length, void*) {
-+          std::unique_ptr<ArrayBuffer::Allocator> allocator(
-+              ArrayBuffer::Allocator::NewDefaultAllocator());
-+          allocator->Free(data, length);
-+        },
-+        nullptr);
-+#else
-     std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-         isolate,
-         size,
-@@ -1522,6 +1542,7 @@ void CreateUnsafeArrayBuffer(const FunctionCallbackInfo<Value>& args) {
-       THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
-       return;
-     }
-+#endif
- 
-     buf = ArrayBuffer::New(isolate, std::move(store));
-   }
 diff --git a/src/node_i18n.cc b/src/node_i18n.cc
 index 3c4f419aa29470b3280174b58680b9421b0340b5..3b24ad2a2316f89d98b067e2c13988f87a9a00d2 100644
 --- a/src/node_i18n.cc


### PR DESCRIPTION
#### Description of Change

**`Buffer.allocUnsafe()` gets 6-80x cheaper (1 MB: 420 -> 29 us) and reading MB-sized files in the main process roughly halves (`fs.promises.readFile` 1 MB: 1.45 -> 0.63 ms), by dropping an Electron-specific allocation path that zero-filled through a page-granular allocator.**

| main process, Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| `Buffer.allocUnsafe` 8 KB / 64 KB / 512 KB / 1 MB / 4 MB (15) | 3.3 / 29 / 224 / 420 / 2171 us | 0.6 / 5.5 / 7 / 29 / 26 us |
| `fs.promises.readFile` 1 MB / `fs.readFile` 1 MB / `fs.readFileSync` 1 MB (15-20, two sessions) | 1446 / 912 / 609 us | 630 / 639 / 460 us |
| packaged app reading attachment-sized files: `fs.promises.readFile` 256 KB / 1 MB, `readFileSync` 4 MB (30) | 0.43 / 1.26 / 1.81 ms | 0.28 / 1.12 / 1.54 ms |
| 64-byte stdio round trip to a child (20) | 33.5 us | 28.6 us |
| `Buffer.concat` of two 1 MB inputs (15) | 838 us | 909 us |

Why: the sandboxed-pointers patch made Node's `createUnsafeArrayBuffer()` (behind `Buffer.allocUnsafe()`, `allocUnsafeSlow()` and the pool refill) construct a fresh V8 default array-buffer allocator per allocation and again per free. Under the sandbox that allocator hands out page-granular memory from the sandbox's address space, so every unpooled Buffer paid a map/unmap round trip and came back zero-filled.

What changes: upstream Node has since moved this function to `ArrayBuffer::NewBackingStore(isolate, size, kUninitialized)`, which allocates through the isolate's registered allocator - exactly what the sandbox needs, since Electron registers gin's PartitionAlloc-backed allocator inside the cage. So the Electron-specific branch is dropped and upstream's code kept; the other call sites in the patch wrap externally allocated memory and keep their copy-into-cage handling.

One give-back, stated plainly: page zeroing moves from the allocator to first touch, so a Buffer that is immediately written end to end pays the same faults later instead - `Buffer.concat` of MB-sized inputs measures +8%. That is upstream Node's allocation behavior; the zero-fill was the anomaly. Node C++ shared by all platforms; buffer/fs/child_process specs and an ASAN pass clean.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved the performance of `Buffer.allocUnsafe()` and of large file reads in the main process.
