### PR TITLE
perf: serialize ipc values straight into the buffer they are sent in

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -663,6 +663,8 @@ filenames = {
     "shell/common/gin_converters/osr_converter.cc",
     "shell/common/gin_converters/osr_converter.h",
     "shell/common/gin_converters/serial_port_info_converter.h",
+    "shell/common/gin_converters/serialized_value_converter.cc",
+    "shell/common/gin_converters/serialized_value_converter.h",
     "shell/common/gin_converters/service_worker_converter.cc",
     "shell/common/gin_converters/service_worker_converter.h",
     "shell/common/gin_converters/std_converter.h",

--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -22,6 +22,7 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -133,7 +134,7 @@ void ServiceWorkerMain::Send(v8::Isolate* isolate,
                              bool internal,
                              const std::string& channel,
                              v8::Local<v8::Value> args) {
-  blink::CloneableMessage message;
+  electron::SerializedValue message;
   if (!gin::ConvertFromV8(isolate, args, &message)) {
     isolate->ThrowException(v8::Exception::Error(
         gin::StringToV8(isolate, "Failed to serialize arguments")));

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -28,6 +28,7 @@
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -333,7 +334,7 @@ void WebFrameMain::Send(v8::Isolate* isolate,
                         bool internal,
                         const std::string& channel,
                         v8::Local<v8::Value> args) {
-  blink::CloneableMessage message;
+  electron::SerializedValue message;
   if (!gin::ConvertFromV8(isolate, args, &message)) {
     isolate->ThrowException(v8::Exception::Error(
         gin::StringToV8(isolate, "Failed to serialize arguments")));

--- a/shell/browser/api/ipc_dispatcher.h
+++ b/shell/browser/api/ipc_dispatcher.h
@@ -11,7 +11,7 @@
 #include "shell/browser/api/message_port.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/api/api.mojom.h"
-#include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/handle.h"
@@ -30,14 +30,14 @@ class IpcDispatcher {
  public:
   void Message(v8::Local<v8::Object> event,
                const std::string& channel,
-               blink::CloneableMessage args) {
+               electron::SerializedValue args) {
     TRACE_EVENT1("electron", "IpcDispatcher::Message", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message", event, channel, args);
   }
 
   void Invoke(v8::Local<v8::Object> event,
               const std::string& channel,
-              blink::CloneableMessage arguments) {
+              electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::Invoke", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-invoke", event, channel,
                                 std::move(arguments));
@@ -60,7 +60,7 @@ class IpcDispatcher {
 
   void MessageSync(v8::Local<v8::Object> event,
                    const std::string& channel,
-                   blink::CloneableMessage arguments) {
+                   electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageSync", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message-sync", event, channel,
                                 std::move(arguments));
@@ -68,7 +68,7 @@ class IpcDispatcher {
 
   void MessageHost(v8::Local<v8::Object> event,
                    const std::string& channel,
-                   blink::CloneableMessage arguments) {
+                   electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageHost", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message-host", event, channel,
                                 std::move(arguments));

--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -43,7 +43,7 @@ void ElectronApiIPCHandlerImpl::OnConnectionError() {
 
 void ElectronApiIPCHandlerImpl::Message(bool internal,
                                         const std::string& channel,
-                                        blink::CloneableMessage arguments) {
+                                        electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -58,7 +58,7 @@ void ElectronApiIPCHandlerImpl::Message(bool internal,
 }
 void ElectronApiIPCHandlerImpl::Invoke(bool internal,
                                        const std::string& channel,
-                                       blink::CloneableMessage arguments,
+                                       electron::SerializedValue arguments,
                                        InvokeCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -93,7 +93,7 @@ void ElectronApiIPCHandlerImpl::ReceivePostMessage(
 
 void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
                                             const std::string& channel,
-                                            blink::CloneableMessage arguments,
+                                            electron::SerializedValue arguments,
                                             MessageSyncCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -109,8 +109,9 @@ void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
   }
 }
 
-void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
-                                            blink::CloneableMessage arguments) {
+void ElectronApiIPCHandlerImpl::MessageHost(
+    const std::string& channel,
+    electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();

--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -43,19 +43,19 @@ class ElectronApiIPCHandlerImpl : public mojom::ElectronApiIPC,
   // mojom::ElectronApiIPC:
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void Invoke(bool internal,
               const std::string& channel,
-              blink::CloneableMessage arguments,
+              electron::SerializedValue arguments,
               InvokeCallback callback) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   blink::CloneableMessage arguments,
+                   electron::SerializedValue arguments,
                    MessageSyncCallback callback) override;
   void MessageHost(const std::string& channel,
-                   blink::CloneableMessage arguments) override;
+                   electron::SerializedValue arguments) override;
 
   base::WeakPtr<ElectronApiIPCHandlerImpl> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/shell/browser/electron_api_sw_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.cc
@@ -71,7 +71,7 @@ void ElectronApiSWIPCHandlerImpl::RemoteDisconnected() {
 
 void ElectronApiSWIPCHandlerImpl::Message(bool internal,
                                           const std::string& channel,
-                                          blink::CloneableMessage arguments) {
+                                          electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -87,7 +87,7 @@ void ElectronApiSWIPCHandlerImpl::Message(bool internal,
 
 void ElectronApiSWIPCHandlerImpl::Invoke(bool internal,
                                          const std::string& channel,
-                                         blink::CloneableMessage arguments,
+                                         electron::SerializedValue arguments,
                                          InvokeCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -120,10 +120,11 @@ void ElectronApiSWIPCHandlerImpl::ReceivePostMessage(
   }
 }
 
-void ElectronApiSWIPCHandlerImpl::MessageSync(bool internal,
-                                              const std::string& channel,
-                                              blink::CloneableMessage arguments,
-                                              MessageSyncCallback callback) {
+void ElectronApiSWIPCHandlerImpl::MessageSync(
+    bool internal,
+    const std::string& channel,
+    electron::SerializedValue arguments,
+    MessageSyncCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -140,7 +141,7 @@ void ElectronApiSWIPCHandlerImpl::MessageSync(bool internal,
 
 void ElectronApiSWIPCHandlerImpl::MessageHost(
     const std::string& channel,
-    blink::CloneableMessage arguments) {
+    electron::SerializedValue arguments) {
   NOTIMPLEMENTED();  // Service workers have no <webview>
 }
 

--- a/shell/browser/electron_api_sw_ipc_handler_impl.h
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.h
@@ -52,19 +52,19 @@ class ElectronApiSWIPCHandlerImpl : public mojom::ElectronApiIPC,
   // mojom::ElectronApiIPC:
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void Invoke(bool internal,
               const std::string& channel,
-              blink::CloneableMessage arguments,
+              electron::SerializedValue arguments,
               InvokeCallback callback) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   blink::CloneableMessage arguments,
+                   electron::SerializedValue arguments,
                    MessageSyncCallback callback) override;
   void MessageHost(const std::string& channel,
-                   blink::CloneableMessage arguments) override;
+                   electron::SerializedValue arguments) override;
 
   base::WeakPtr<ElectronApiSWIPCHandlerImpl> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -1,7 +1,39 @@
 import("//mojo/public/tools/bindings/mojom.gni")
 
+source_set("serialized_value") {
+  sources = [
+    "serialized_value.cc",
+    "serialized_value.h",
+  ]
+  include_dirs = [ "//electron" ]
+  public_deps = [
+    "//base",
+    "//mojo/public/cpp/base",
+  ]
+}
+
 mojom("mojo") {
   sources = [ "api/api.mojom" ]
+
+  cpp_typemaps = [
+    {
+      types = [
+        {
+          mojom = "electron.mojom.SerializedValue"
+          cpp = "::electron::SerializedValue"
+          move_only = true
+        },
+      ]
+      traits_headers =
+          [ "//electron/shell/common/serialized_value_mojom_traits.h" ]
+      traits_sources =
+          [ "//electron/shell/common/serialized_value_mojom_traits.cc" ]
+      traits_public_deps = [
+        ":serialized_value",
+        "//mojo/public/cpp/base:shared_typemap_traits",
+      ]
+    },
+  ]
 
   public_deps = [
     "//mojo/public/mojom/base",

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -1,8 +1,8 @@
 module electron.mojom;
 
+import "mojo/public/mojom/base/big_buffer.mojom";
 import "mojo/public/mojom/base/string16.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
-import "third_party/blink/public/mojom/messaging/cloneable_message.mojom";
 import "third_party/blink/public/mojom/messaging/transferable_message.mojom";
 
 // A preload script and its contents, pushed to the renderer ahead of the
@@ -32,6 +32,13 @@ struct RendererStartupData {
   string helper_exec_path;
 };
 
+// A value serialized with electron::SerializeV8Value(), in the buffer it is
+// sent in. |buffer| may be larger than the |size| bytes that were written.
+struct SerializedValue {
+  mojo_base.mojom.BigBuffer buffer;
+  uint64 size;
+};
+
 // Per-frame associated interface ordered against content.mojom.Frame, so
 // SetStartupData() arrives before the CommitNavigation that follows it.
 interface ElectronFrameStartup {
@@ -42,7 +49,7 @@ interface ElectronRenderer {
   Message(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments);
+      SerializedValue arguments);
 
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
 
@@ -64,14 +71,14 @@ interface ElectronApiIPC {
   Message(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments);
+      SerializedValue arguments);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and returns the response.
   Invoke(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments) => (blink.mojom.CloneableMessage result);
+      SerializedValue arguments) => (SerializedValue result);
 
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
 
@@ -81,9 +88,9 @@ interface ElectronApiIPC {
   MessageSync(
     bool internal,
     string channel,
-    blink.mojom.CloneableMessage arguments) => (blink.mojom.CloneableMessage result);
+    SerializedValue arguments) => (SerializedValue result);
 
   MessageHost(
     string channel,
-    blink.mojom.CloneableMessage arguments);
+    SerializedValue arguments);
 };

--- a/shell/common/gin_converters/serialized_value_converter.cc
+++ b/shell/common/gin_converters/serialized_value_converter.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/gin_converters/serialized_value_converter.h"
+
+#include "shell/common/v8_util.h"
+
+namespace gin {
+
+v8::Local<v8::Value> Converter<electron::SerializedValue>::ToV8(
+    v8::Isolate* isolate,
+    const electron::SerializedValue& in) {
+  return electron::DeserializeV8Value(isolate, in);
+}
+
+bool Converter<electron::SerializedValue>::FromV8(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> val,
+    electron::SerializedValue* out) {
+  return electron::SerializeV8Value(isolate, val, out);
+}
+
+}  // namespace gin

--- a/shell/common/gin_converters/serialized_value_converter.h
+++ b/shell/common/gin_converters/serialized_value_converter.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_
+#define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_
+
+#include "gin/converter.h"
+#include "shell/common/serialized_value.h"
+
+namespace gin {
+
+template <>
+struct Converter<electron::SerializedValue> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const electron::SerializedValue& in);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::SerializedValue* out);
+};
+
+}  // namespace gin
+
+#endif  // ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_

--- a/shell/common/gin_helper/reply_channel.cc
+++ b/shell/common/gin_helper/reply_channel.cc
@@ -7,7 +7,7 @@
 #include "gin/data_object_builder.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/javascript_environment.h"
-#include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "v8/include/cppgc/allocation.h"
 #include "v8/include/v8-cppgc.h"
@@ -46,7 +46,7 @@ bool ReplyChannel::SendReplyImpl(v8::Isolate* isolate,
   if (!callback)
     return false;
 
-  blink::CloneableMessage msg;
+  electron::SerializedValue msg;
   if (!gin::ConvertFromV8(isolate, arg, &msg))
     return false;
 

--- a/shell/common/serialized_value.cc
+++ b/shell/common/serialized_value.cc
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/serialized_value.h"
+
+#include <utility>
+
+#include "base/check_op.h"
+
+namespace electron {
+
+SerializedValue::SerializedValue() = default;
+
+SerializedValue::SerializedValue(mojo_base::BigBuffer buffer, size_t size)
+    : buffer_(std::move(buffer)), size_(size) {
+  CHECK_LE(size_, buffer_.size());
+}
+
+SerializedValue::SerializedValue(SerializedValue&& other)
+    : buffer_(std::move(other.buffer_)), size_(std::exchange(other.size_, 0)) {}
+
+SerializedValue& SerializedValue::operator=(SerializedValue&& other) {
+  buffer_ = std::move(other.buffer_);
+  size_ = std::exchange(other.size_, 0);
+  return *this;
+}
+
+SerializedValue::~SerializedValue() = default;
+
+}  // namespace electron

--- a/shell/common/serialized_value.h
+++ b/shell/common/serialized_value.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_
+#define ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "base/containers/span.h"
+#include "mojo/public/cpp/base/big_buffer.h"
+
+namespace electron {
+
+// A V8-serialized value held in the buffer it crosses the process boundary in:
+// inline bytes for small values, a shared memory region above
+// mojo_base::BigBuffer::kMaxInlineBytes. The region may be larger than the
+// payload; only the first size() bytes are meaningful.
+class SerializedValue {
+ public:
+  SerializedValue();
+  SerializedValue(mojo_base::BigBuffer buffer, size_t size);
+  SerializedValue(SerializedValue&&);
+  SerializedValue& operator=(SerializedValue&&);
+  SerializedValue(const SerializedValue&) = delete;
+  SerializedValue& operator=(const SerializedValue&) = delete;
+  ~SerializedValue();
+
+  base::span<const uint8_t> bytes() const {
+    return base::span(buffer_).first(size_);
+  }
+  size_t size() const { return size_; }
+  bool is_shared_memory() const {
+    return buffer_.storage_type() ==
+           mojo_base::BigBuffer::StorageType::kSharedMemory;
+  }
+
+  mojo_base::BigBuffer& buffer() { return buffer_; }
+
+ private:
+  mojo_base::BigBuffer buffer_;
+  size_t size_ = 0;
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_

--- a/shell/common/serialized_value_mojom_traits.cc
+++ b/shell/common/serialized_value_mojom_traits.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "electron/shell/common/serialized_value_mojom_traits.h"
+
+#include <utility>
+
+namespace mojo {
+
+// static
+bool StructTraits<electron::mojom::SerializedValueDataView,
+                  electron::SerializedValue>::
+    Read(electron::mojom::SerializedValueDataView data,
+         electron::SerializedValue* out) {
+  mojo_base::BigBuffer buffer;
+  if (!data.ReadBuffer(&buffer) || data.size() > buffer.size())
+    return false;
+  *out = electron::SerializedValue(std::move(buffer), data.size());
+  return true;
+}
+
+}  // namespace mojo

--- a/shell/common/serialized_value_mojom_traits.h
+++ b/shell/common/serialized_value_mojom_traits.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_
+#define ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_
+
+#include <stdint.h>
+
+#include "electron/shell/common/api/api.mojom-shared.h"
+#include "electron/shell/common/serialized_value.h"
+#include "mojo/public/cpp/base/big_buffer.h"
+#include "mojo/public/cpp/base/big_buffer_mojom_traits.h"
+#include "mojo/public/cpp/bindings/struct_traits.h"
+
+namespace mojo {
+
+template <>
+struct StructTraits<electron::mojom::SerializedValueDataView,
+                    electron::SerializedValue> {
+  static mojo_base::BigBuffer& buffer(electron::SerializedValue& value) {
+    return value.buffer();
+  }
+  static uint64_t size(const electron::SerializedValue& value) {
+    return value.size();
+  }
+  static bool Read(electron::mojom::SerializedValueDataView data,
+                   electron::SerializedValue* out);
+};
+
+}  // namespace mojo
+
+#endif  // ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_

--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -9,9 +9,13 @@
 #include <vector>
 
 #include "base/base_switches.h"
+#include "base/containers/heap_array.h"
 #include "base/memory/raw_ptr.h"
 #include "gin/converter.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "shell/common/api/electron_api_native_image.h"
+#include "shell/common/process_util.h"
+#include "shell/common/serialized_value.h"
 #include "skia/public/mojom/bitmap.mojom.h"
 #include "third_party/blink/public/common/messaging/cloneable_message.h"
 #include "third_party/blink/public/common/messaging/web_message_port.h"
@@ -45,30 +49,34 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   ~V8Serializer() override = default;
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
-    v8::MicrotasksScope microtasks_scope(
-        isolate_->GetCurrentContext(),
-        v8::MicrotasksScope::kDoNotRunMicrotasks);
-    WriteBlinkEnvelope(19);
-
-    serializer_.WriteHeader();
-    bool wrote_value;
-    if (!serializer_.WriteValue(isolate_->GetCurrentContext(), value)
-             .To(&wrote_value)) {
-      isolate_->ThrowException(v8::Exception::Error(
-          gin::StringToV8(isolate_, "An object could not be cloned.")));
+    size_t length;
+    if (!Write(value, &length))
       return false;
-    }
-    DCHECK(wrote_value);
-
-    const auto [data_bytes, data_len] = serializer_.Release();
-    DCHECK_EQ(std::data(data_), data_bytes);
-    DCHECK_GE(std::size(data_), data_len);
-    data_.resize(data_len);
-    out->owned_encoded_message = std::move(data_);
+    heap_.resize(length);
+    out->owned_encoded_message = std::move(heap_);
     out->encoded_message = out->owned_encoded_message;
     out->sender_agent_cluster_id =
         blink::WebMessagePort::GetEmbedderAgentClusterID();
+    return true;
+  }
 
+  // Large values continue in the shared memory region they will be sent in.
+  // Only such a region may travel larger than the payload (its spare bytes are
+  // kernel-zeroed or this value's own); heap-backed results are trimmed.
+  bool Serialize(v8::Local<v8::Value> value, SerializedValue* out) {
+    use_transport_buffer_ = true;
+    size_t length;
+    if (!Write(value, &length))
+      return false;
+    if (transport_.storage_type() !=
+            mojo_base::BigBuffer::StorageType::kSharedMemory ||
+        length <= mojo_base::BigBuffer::kMaxInlineBytes) {
+      base::span<const uint8_t> written =
+          transport_.size() ? base::span(transport_) : base::span(heap_);
+      mojo_base::BigBuffer exact(written.first(length));
+      transport_ = std::move(exact);
+    }
+    *out = SerializedValue(std::move(transport_), length);
     return true;
   }
 
@@ -76,15 +84,27 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   void* ReallocateBufferMemory(void* old_buffer,
                                size_t size,
                                size_t* actual_size) override {
-    DCHECK_EQ(old_buffer, data_.data());
-    data_.resize(size);
-    *actual_size = data_.capacity();
-    return data_.data();
+    if (use_transport_buffer_ && size > mojo_base::BigBuffer::kMaxInlineBytes) {
+      mojo_base::BigBuffer bigger(size);
+      base::span<uint8_t> written =
+          transport_.size() ? base::span(transport_) : base::span(heap_);
+      base::span(bigger).first(capacity_).copy_from(written.first(capacity_));
+      transport_ = std::move(bigger);
+      heap_ = {};
+      capacity_ = transport_.size();
+    } else {
+      DCHECK_EQ(transport_.size(), 0u);
+      heap_.resize(size);
+      capacity_ = heap_.size();
+    }
+    *actual_size = capacity_;
+    return transport_.size() ? transport_.data() : heap_.data();
   }
 
   void FreeBufferMemory(void* buffer) override {
-    DCHECK_EQ(buffer, data_.data());
-    data_ = {};
+    heap_ = {};
+    transport_ = {};
+    capacity_ = 0;
   }
 
   v8::Maybe<bool> WriteHostObject(v8::Isolate* isolate,
@@ -115,6 +135,29 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   }
 
  private:
+  bool Write(v8::Local<v8::Value> value, size_t* length) {
+    v8::MicrotasksScope microtasks_scope(
+        isolate_->GetCurrentContext(),
+        v8::MicrotasksScope::kDoNotRunMicrotasks);
+    WriteBlinkEnvelope(19);
+
+    serializer_.WriteHeader();
+    bool wrote_value;
+    if (!serializer_.WriteValue(isolate_->GetCurrentContext(), value)
+             .To(&wrote_value)) {
+      isolate_->ThrowException(v8::Exception::Error(
+          gin::StringToV8(isolate_, "An object could not be cloned.")));
+      return false;
+    }
+    DCHECK(wrote_value);
+
+    const auto [data_bytes, data_len] = serializer_.Release();
+    DCHECK_EQ(data_bytes, transport_.size() ? transport_.data() : heap_.data());
+    DCHECK_LE(data_len, capacity_);
+    *length = data_len;
+    return true;
+  }
+
   void WriteTag(const uint8_t tag) { serializer_.WriteRawBytes(&tag, 1U); }
 
   void WriteBlinkEnvelope(uint32_t blink_version) {
@@ -125,7 +168,10 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   }
 
   raw_ptr<v8::Isolate> isolate_;
-  std::vector<uint8_t> data_;
+  std::vector<uint8_t> heap_;
+  mojo_base::BigBuffer transport_;
+  size_t capacity_ = 0;
+  bool use_transport_buffer_ = false;
   v8::ValueSerializer serializer_;
 };
 
@@ -241,9 +287,26 @@ bool SerializeV8Value(v8::Isolate* isolate,
   return V8Serializer(isolate).Serialize(value, out);
 }
 
+bool SerializeV8Value(v8::Isolate* isolate,
+                      v8::Local<v8::Value> value,
+                      SerializedValue* out) {
+  return V8Serializer(isolate).Serialize(value, out);
+}
+
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         const blink::CloneableMessage& in) {
   return V8Deserializer(isolate, in).Deserialize();
+}
+
+v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
+                                        const SerializedValue& in) {
+  // The process that sent a shared-memory payload can still write to it while
+  // it is parsed here; only renderers parse in place, everyone else a copy.
+  if (in.is_shared_memory() && !IsRendererProcess()) {
+    auto copy = base::HeapArray<uint8_t>::CopiedFrom(in.bytes());
+    return V8Deserializer(isolate, copy.as_span()).Deserialize();
+  }
+  return V8Deserializer(isolate, in.bytes()).Deserialize();
 }
 
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,

--- a/shell/common/v8_util.h
+++ b/shell/common/v8_util.h
@@ -21,11 +21,20 @@ struct CloneableMessage;
 
 namespace electron {
 
+class SerializedValue;
+
+// The CloneableMessage forms are for values that stay in this process or ride
+// inside a blink message; SerializedValue is what Electron's own IPC sends.
 bool SerializeV8Value(v8::Isolate* isolate,
                       v8::Local<v8::Value> value,
                       blink::CloneableMessage* out);
+bool SerializeV8Value(v8::Isolate* isolate,
+                      v8::Local<v8::Value> value,
+                      SerializedValue* out);
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         const blink::CloneableMessage& in);
+v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
+                                        const SerializedValue& in);
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         base::span<const uint8_t> data);
 

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -14,12 +14,14 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gc_plugin.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/function_template_extensions.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/serialized_value.h"
 #include "shell/common/v8_util.h"
 #include "shell/renderer/preload_realm_context.h"
 #include "shell/renderer/service_worker_data.h"
@@ -75,7 +77,7 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return;
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
@@ -91,18 +93,18 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return {};
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return {};
     }
-    gin_helper::Promise<blink::CloneableMessage> p(isolate);
+    gin_helper::Promise<electron::SerializedValue> p(isolate);
     auto handle = p.GetHandle();
 
     electron_ipc_remote_->Invoke(
         internal, channel, std::move(message),
         base::BindOnce(
-            [](gin_helper::Promise<blink::CloneableMessage> p,
-               blink::CloneableMessage result) { p.Resolve(result); },
+            [](gin_helper::Promise<electron::SerializedValue> p,
+               electron::SerializedValue result) { p.Resolve(result); },
             std::move(p)));
 
     return handle;
@@ -157,7 +159,7 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return;
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
@@ -173,12 +175,12 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return {};
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return {};
     }
 
-    blink::CloneableMessage result;
+    electron::SerializedValue result;
     electron_ipc_remote_->MessageSync(internal, channel, std::move(message),
                                       &result);
     return electron::DeserializeV8Value(isolate, result);

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -10,6 +10,7 @@
 #include "gin/converter.h"
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/heap_snapshot.h"
 #include "shell/common/thread_restrictions.h"
 #include "shell/common/v8_util.h"
@@ -127,7 +128,7 @@ void ElectronApiServiceImpl::OnConnectionError() {
 
 void ElectronApiServiceImpl::Message(bool internal,
                                      const std::string& channel,
-                                     blink::CloneableMessage arguments) {
+                                     electron::SerializedValue arguments) {
   blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
   if (!frame)
     return;

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -46,7 +46,7 @@ class ElectronApiServiceImpl
   // mojom::ElectronRenderer
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,

--- a/shell/renderer/service_worker_data.cc
+++ b/shell/renderer/service_worker_data.cc
@@ -6,6 +6,7 @@
 
 #include "base/notimplemented.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/renderer/electron_ipc_native.h"
 #include "shell/renderer/preload_realm_context.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
@@ -36,7 +37,7 @@ void ServiceWorkerData::OnElectronRendererRequest(
 
 void ServiceWorkerData::Message(bool internal,
                                 const std::string& channel,
-                                blink::CloneableMessage arguments) {
+                                electron::SerializedValue arguments) {
   v8::Isolate* isolate = isolate_.get();
   v8::HandleScope handle_scope(isolate);
 

--- a/shell/renderer/service_worker_data.h
+++ b/shell/renderer/service_worker_data.h
@@ -53,7 +53,7 @@ class ServiceWorkerData : public mojom::ElectronRenderer {
   // mojom::ElectronRenderer
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -144,6 +144,57 @@ describe('ipc module', () => {
     });
   });
 
+  describe('payloads across the shared-memory threshold', () => {
+    let w: BrowserWindow;
+    const sizes = [0, 1, 65535, 65536, 65537, 256 * 1024 + 3, 3 * 1024 * 1024 + 1];
+
+    before(async () => {
+      w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+      await w.loadURL('about:blank');
+      ipcMain.handle('echo-large', (_e, arg) => arg);
+      ipcMain.on('echo-large-sync', (e, arg) => { e.returnValue = arg; });
+      ipcMain.on('echo-large-send', (e, arg) => { e.sender.send('echo-large-reply', arg); });
+    });
+    after(async () => {
+      w.destroy();
+      ipcMain.removeHandler('echo-large');
+      ipcMain.removeAllListeners('echo-large-sync');
+      ipcMain.removeAllListeners('echo-large-send');
+    });
+
+    function digest (value: any): any {
+      if (typeof value === 'string') return { string: value.length, ends: value.slice(0, 4) + value.slice(-4) };
+      if (value instanceof Uint8Array) return { u8: value.length, sum: value.reduce((a: number, b: number) => (a + b) % 65521, 0) };
+      return { text: digest(value.text), bytes: digest(value.bytes), meta: value.meta };
+    }
+
+    function samples (n: number) {
+      const text = `<${'x'.repeat(n)}>`;
+      const bytes = new Uint8Array(n).map((_, i) => (i * 7) & 255);
+      return [text, bytes, { text, bytes, meta: { n, list: [1, 'two', { three: true }] } }];
+    }
+
+    it('round trips strings, typed arrays and nested objects of each size through invoke, sendSync and send', async () => {
+      const result = await w.webContents.executeJavaScript(`(${async (sizes: number[], samples: (n: number) => any[], digest: (v: any) => any) => {
+        const { ipcRenderer } = require('electron');
+        const out: any[] = [];
+        for (const n of sizes) {
+          for (const value of samples(n)) {
+            out.push(digest(await ipcRenderer.invoke('echo-large', value)));
+            out.push(digest(ipcRenderer.sendSync('echo-large-sync', value)));
+            out.push(digest(await new Promise((resolve) => {
+              ipcRenderer.once('echo-large-reply', (_e: any, v: any) => resolve(v));
+              ipcRenderer.send('echo-large-send', value);
+            })));
+          }
+        }
+        return out;
+      }})(${JSON.stringify(sizes)}, ${samples}, ${digest})`, true);
+      const expected = sizes.flatMap((n) => samples(n).flatMap((value) => Array(3).fill(digest(value))));
+      expect(result).to.deep.equal(expected);
+    });
+  });
+
   describe('ordering', () => {
     let w: BrowserWindow;
 


### PR DESCRIPTION
#### Description of Change

**Large values through `ipcRenderer.invoke`/`send`/`sendSync`/`sendToHost`, `webContents.send` and `webFrameMain.send` cost about a third less main-thread time on both sides; small messages are unchanged.**

| sandboxed page doing raw `ipcRenderer.invoke` round trips; Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| 1 MB string echoed both ways / `Uint8Array` (20, two sessions) | 4.2 / 4.7 ms | 2.8 / 3.3 ms |
| 4 MB echoed both ways | 14.2 ms | 9.2 ms |
| main -> renderer only, 1 MB / 4 MB | 2.7 / 8.4 ms | 1.6 / 5.5 ms |
| renderer -> main only, 1 MB / 4 MB | 2.1 / 6.9 ms | 1.7 / 5.5 ms |
| 64 KB / 256 KB round trips | 0.45 / 0.85 ms | 0.40 / 0.76 ms |
| 1 KB messages, `contextBridge` calls, `MessagePort` traffic, app startup (controls) | unchanged | |

Why: these values travel as `blink.mojom.CloneableMessage`. Above mojo's 64 KB inline limit that means three freshly allocated buffers per hop: the V8 serializer grows a zero-filled `std::vector`, mojo copies it into a newly created shared memory region (`BigBuffer`), and the receiving traits copy the region back out into another vector before V8 reads a byte. Profiling 1-4 MB messages, both main threads spent 30-40% of their time in page faults for those buffers.

What changes: Electron owns both ends of these interfaces, so they get their own payload type. `electron.mojom.SerializedValue` is a `mojo_base.mojom.BigBuffer` plus the number of bytes written. `V8Serializer` keeps small values on the heap as before; once V8 asks for more than the inline limit it continues in the shared memory region that will be sent, so the sender never holds a second copy. On the receiving side a renderer parses the region in place. The browser (and any non-renderer process) still parses a private copy, because the process that sent a shared memory region keeps write access to it while it is read - the same reason the blink traits copy today. A region only travels larger than its payload when it is kernel-zeroed shared memory written solely with that value; heap-backed results are trimmed to the exact length. `MessagePort`/`postMessage` keep `TransferableMessage`, and the `CloneableMessage` overloads stay for in-process users (`contextBridge`, `app` second-instance data). Same wire format, channels and validation as before.

Testing: a new `api-ipc-spec` case round-trips strings, `Uint8Array`s and nested objects of 0, 1, 65535, 65536, 65537, 256K+3 and 3M+1 bytes through `invoke`, `sendSync` and `send`; ipc/webview/context-bridge/utility-process specs and an ASAN pass clean. C++ shared by all platforms; `BigBuffer` picks the platform's shared memory primitive.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Reduced the main-thread cost of sending large values through `ipcRenderer`, `ipcMain` handlers and `webContents.send`.
