### PR TITLE
perf: size protocol and asar response pipes to the body

### DIFF
--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/numerics/safe_conversions.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/file_url_loader.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -22,6 +23,7 @@
 #include "net/base/mime_util.h"
 #include "net/http/http_byte_range.h"
 #include "net/http/http_util.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/net/asar/asar_file_validator.h"
 #include "shell/common/asar/archive.h"
@@ -48,12 +50,16 @@ net::Error ConvertMojoResultToNetError(MojoResult result) {
   }
 }
 
-constexpr size_t kDefaultFileUrlPipeSize = 65536;
-
-// Because this makes things simpler.
-static_assert(kDefaultFileUrlPipeSize >= net::kMaxBytesToSniff,
-              "Default file data pipe size must be at least as large as a MIME-"
-              "type sniffing buffer.");
+// A pipe as large as the body up to what FileURLLoader uses for file://, so
+// small files do not pay for a 2 MB shared buffer and large ones are not fed
+// through in 64 KB slices. Never smaller than the MIME sniffing buffer, which
+// is written in one go.
+uint32_t ResponsePipeSize(uint64_t body_size) {
+  return base::saturated_cast<uint32_t>(std::clamp<uint64_t>(
+      body_size, net::kMaxBytesToSniff,
+      network::GetDataPipeDefaultAllocationSize(
+          network::DataPipeAllocationSize::kLargerSizeIfPossible)));
+}
 
 // Modified from the |FileURLLoader| in |file_url_loader_factory.cc|, to serve
 // asar files instead of normal files.
@@ -139,7 +145,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
 
     mojo::ScopedDataPipeProducerHandle producer_handle;
     mojo::ScopedDataPipeConsumerHandle consumer_handle;
-    if (mojo::CreateDataPipe(kDefaultFileUrlPipeSize, producer_handle,
+    if (mojo::CreateDataPipe(ResponsePipeSize(info.size), producer_handle,
                              consumer_handle) != MOJO_RESULT_OK) {
       OnClientComplete(net::ERR_FAILED);
       return;
@@ -225,8 +231,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
 
     if (first_byte_to_send < read_result.bytes_read) {
       // Write any data we read for MIME sniffing, constraining by range where
-      // applicable. This will always fit in the pipe (see assertion near
-      // |kDefaultFileUrlPipeSize| definition).
+      // applicable. This will always fit in the pipe (see ResponsePipeSize()).
       const size_t write_size = std::min(
           (read_result.bytes_read - first_byte_to_send), total_bytes_to_send);
       base::span<const uint8_t> bytes =

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -12,6 +12,7 @@
 
 #include "base/containers/fixed_flat_map.h"
 #include "base/memory/self_deleting.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
@@ -30,6 +31,7 @@
 #include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/cors/cors.h"
 #include "services/network/public/cpp/cors/cors_error_status.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
@@ -263,9 +265,15 @@ class URLPipeLoader : public network::mojom::URLLoader,
 
   void OnResponseStarted(const GURL& final_url,
                          const network::mojom::URLResponseHead& response_head) {
+    const uint32_t pipe_size =
+        response_head.content_length > 0
+            ? base::saturated_cast<uint32_t>(std::min<int64_t>(
+                  response_head.content_length,
+                  network::GetDataPipeDefaultAllocationSize()))
+            : 0;
     mojo::ScopedDataPipeProducerHandle producer;
     mojo::ScopedDataPipeConsumerHandle consumer;
-    MojoResult rv = mojo::CreateDataPipe(nullptr, producer, consumer);
+    MojoResult rv = mojo::CreateDataPipe(pipe_size, producer, consumer);
     if (rv != MOJO_RESULT_OK) {
       NotifyComplete(net::ERR_INSUFFICIENT_RESOURCES);
       return;
@@ -892,10 +900,13 @@ void ElectronURLLoaderFactory::SendContents(
   // Add header to ignore CORS.
   head->headers->AddHeader("Access-Control-Allow-Origin", "*");
 
-  // Code below follows the pattern of data_url_loader_factory.cc.
+  // Code below follows the pattern of data_url_loader_factory.cc, with the
+  // pipe sized to the body (up to the network service's default).
   mojo::ScopedDataPipeProducerHandle producer;
   mojo::ScopedDataPipeConsumerHandle consumer;
-  if (mojo::CreateDataPipe(nullptr, producer, consumer) != MOJO_RESULT_OK) {
+  const uint32_t pipe_size = base::saturated_cast<uint32_t>(std::clamp<size_t>(
+      data.size(), 1u, network::GetDataPipeDefaultAllocationSize()));
+  if (mojo::CreateDataPipe(pipe_size, producer, consumer) != MOJO_RESULT_OK) {
     client_remote->OnComplete(
         network::URLLoaderCompletionStatus(net::ERR_INSUFFICIENT_RESOURCES));
     return;

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -4,10 +4,13 @@
 
 #include "shell/browser/net/node_stream_loader.h"
 
+#include <algorithm>
 #include <string_view>
 #include <utility>
 
+#include "base/numerics/safe_conversions.h"
 #include "mojo/public/cpp/system/string_data_source.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/node_includes.h"
 
@@ -50,9 +53,17 @@ NodeStreamLoader::~NodeStreamLoader() {
 }
 
 void NodeStreamLoader::Start(network::mojom::URLResponseHeadPtr head) {
+  // A declared Content-Length sizes the pipe (up to the network service's
+  // default); streams of unknown length keep mojo's default (0).
+  const uint32_t pipe_size =
+      head->content_length > 0
+          ? base::saturated_cast<uint32_t>(
+                std::min<int64_t>(head->content_length,
+                                  network::GetDataPipeDefaultAllocationSize()))
+          : 0;
   mojo::ScopedDataPipeProducerHandle producer;
   mojo::ScopedDataPipeConsumerHandle consumer;
-  MojoResult rv = mojo::CreateDataPipe(nullptr, producer, consumer);
+  MojoResult rv = mojo::CreateDataPipe(pipe_size, producer, consumer);
   if (rv != MOJO_RESULT_OK) {
     NotifyComplete(net::ERR_INSUFFICIENT_RESOURCES);
     return;


### PR DESCRIPTION
#### Description of Change

**Large files served to the renderer from an `.asar` arrive as fast as plain `file://` (16 MB: 35 -> 22 ms) and large `protocol.handle` responses with a known length ~20% faster; small responses keep exactly the pipe they had.**

| sandboxed page `fetch()`ing local resources into an `ArrayBuffer`; Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| 16 MB file from inside an `.asar` (`file://`, `AsarURLLoader`) (15, two sessions) | 35.0 ms | 22.2 ms |
| same file as plain `file://` (`FileURLLoader`, reference) | 21.7 ms | 21.5 ms |
| 1 MB / 64 KB from the `.asar` | 2.74 / 0.34 ms | 2.60 / 0.34 ms |
| 16 MB / 1 MB `protocol.handle` response with a `Content-Length` (15) | 49.3 / 3.36 ms | 39.8 / 3.10 ms |
| responses without a declared length, 64 KB responses, app startup with small asar assets (controls) | unchanged | |

Why: Electron's URL loaders created the data pipe for their response bodies with mojo's 64 KB default - `NodeStreamLoader` (every `protocol.handle` body), `SendContents` (string/buffer responses), `URLPipeLoader`, and `AsarURLLoader`, which still carried a hard-coded `65536` from the `FileURLLoader` it was modeled on. A response larger than that reaches the renderer in 64 KB slices, each a producer wakeup on the browser main thread and a consumer wakeup in the renderer: 256 round trips for 16 MB. Upstream sized these up a while ago (`network::GetDataPipeDefaultAllocationSize()`: 512 KB, or 2 MB for `file://`), but a data pipe is a shared memory buffer base preallocates in full, so a uniformly larger pipe makes every small response measurably slower (~0.4 ms per response for a 2 MB pipe) - `file://` itself shows that today.

What changes: the pipe is sized to the body wherever the length is known before the pipe is created, with upstream's caps: archive entries up to the 2 MB `file://` size (the loader knows the entry size), string/buffer responses and any `protocol.handle` response that declares a `Content-Length` up to the 512 KB default. Streams of unknown length keep mojo's default; a handler that knows its body size opts in by setting the header. The old `>= net::kMaxBytesToSniff` `static_assert` becomes the clamp's lower bound.

Testing: protocol/asar/session/web-request specs and an ASAN pass clean. Shared C++; the helper returns 512 KB for both caps on 32-bit and ChromeOS as upstream decided.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Improved throughput of large responses served from ASAR archives and through `protocol.handle` when the response has a known length.
