### PR TITLE
perf: preallocate the file descriptor table before threads start on linux

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -22,6 +22,8 @@ filenames = {
   ]
 
   lib_sources_linux = [
+    "shell/app/preallocate_fd_table_linux.cc",
+    "shell/app/preallocate_fd_table_linux.h",
     "shell/browser/browser_linux.cc",
     "shell/browser/lib/power_observer_linux.cc",
     "shell/browser/lib/power_observer_linux.h",

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -65,6 +65,7 @@
 
 #if BUILDFLAG(IS_LINUX)
 #include "base/nix/xdg_util.h"
+#include "shell/app/preallocate_fd_table_linux.h"
 #include "ui/linux/display_server_utils.h"
 #include "v8/include/v8-wasm-trap-handler-posix.h"
 #include "v8/include/v8.h"
@@ -460,6 +461,9 @@ bool ElectronMainDelegate::ShouldLockSchemeRegistry() {
 
 #if BUILDFLAG(IS_LINUX)
 void ElectronMainDelegate::ZygoteForked() {
+  // fork() sized this process's descriptor table to the zygote's open files.
+  PreallocateFileDescriptorTable();
+
   // Needs to be called after we have DIR_USER_DATA.  BrowserMain sets
   // this up for the browser process in a different manner.
   ElectronCrashReporterClient::Create();

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -13,6 +13,7 @@
 #include "electron/fuses.h"
 #include "shell/app/electron_main_delegate.h"  // NOLINT
 #include "shell/app/node_main.h"
+#include "shell/app/preallocate_fd_table_linux.h"
 #include "shell/app/uv_stdio_fix.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_constants.h"
@@ -29,6 +30,7 @@ namespace {
 
 int main(int argc, char* argv[]) {
   FixStdioStreams();
+  electron::PreallocateFileDescriptorTable();
 
   // Chromium expects the original argv in its original memory location
   // to update /proc/<pid>/cmdline.

--- a/shell/app/preallocate_fd_table_linux.cc
+++ b/shell/app/preallocate_fd_table_linux.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/app/preallocate_fd_table_linux.h"
+
+#include <fcntl.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+#include <algorithm>
+
+#include "base/files/scoped_file.h"
+#include "base/posix/eintr_wrapper.h"
+
+namespace electron {
+
+namespace {
+
+// Enough for launch and ordinary use; 8 KB of kernel memory per process.
+constexpr int kPreallocatedFileDescriptors = 1024;
+
+}  // namespace
+
+void PreallocateFileDescriptorTable() {
+  struct rlimit limit;
+  if (getrlimit(RLIMIT_NOFILE, &limit) != 0)
+    return;
+  const int highest_fd =
+      std::min<rlim_t>(kPreallocatedFileDescriptors, limit.rlim_cur) - 1;
+  base::ScopedFD null_fd(HANDLE_EINTR(open("/dev/null", O_RDONLY | O_CLOEXEC)));
+  if (!null_fd.is_valid() || highest_fd <= null_fd.get())
+    return;
+  // Duplicating onto a high descriptor number is what sizes the table.
+  if (HANDLE_EINTR(dup3(null_fd.get(), highest_fd, O_CLOEXEC)) == highest_fd)
+    close(highest_fd);
+}
+
+}  // namespace electron

--- a/shell/app/preallocate_fd_table_linux.h
+++ b/shell/app/preallocate_fd_table_linux.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_APP_PREALLOCATE_FD_TABLE_LINUX_H_
+#define ELECTRON_SHELL_APP_PREALLOCATE_FD_TABLE_LINUX_H_
+
+namespace electron {
+
+// The kernel grows a process's file descriptor table on demand and, once the
+// table is shared by threads, waits for an RCU grace period before freeing the
+// old one (fs/file.c, expand_fdtable), which stalls whichever open()/socket()
+// call happened to cross the boundary for 10-100 ms. Call this while the
+// process is still single-threaded so the table is grown once, for free.
+void PreallocateFileDescriptorTable();
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_APP_PREALLOCATE_FD_TABLE_LINUX_H_


### PR DESCRIPTION
#### Description of Change

**The first `new BrowserWindow()` on Linux stops sleeping in the kernel for tens of milliseconds: 100 -> 18 ms on the test host, launch to first contentful paint 610 -> 525 ms, and launch-time variance drops with it.**

| packaged app: ~1000 modules, one window with a sandboxed preload, local page; Linux x64 release build, medians of interleaved fresh-process runs (n per side in parentheses), all p < 0.01. | before | after |
|---|---|---|
| `new BrowserWindow()` (`show: false`), median / standard deviation (30, two sessions) | 95-102 ms / 21 ms | 18 ms / 0.8 ms |
| launch to the renderer starting the preload | 565 ms | 486 ms |
| launch to first contentful paint | 610-613 ms | 525-529 ms |
| module loading, `ready`, steady-state IPC and child-process metrics (controls) | unchanged | |

The test host has 64 vCPUs and long RCU grace periods; expect a fraction of this on a workstation kernel (grace periods of 10-30 ms are typical) but the same shape.

Why: sampling the browser main thread's scheduler state showed the constructor at ~15 ms on-CPU and 55-116 ms in uninterruptible sleep, inside the `openat()` that returns descriptor 64, wait channel `__wait_rcu_gp`. Linux sizes a process's descriptor table lazily (64 entries, then powers of two) and `expand_fdtable()` waits for a full RCU grace period before freeing the old table whenever the `files_struct` is shared, which it is in any process that has started threads. The browser reliably crosses 64 descriptors while setting up the first renderer, so the first window pays a grace period; later crossings land wherever they land, in every process type.

What changes: growing the table while the process is still single-threaded needs no grace period, so `PreallocateFileDescriptorTable()` does it once up front: it duplicates `/dev/null` onto descriptor `min(1024, RLIMIT_NOFILE) - 1` and closes it again, leaving a 1024-entry table (8 KB) and nothing else behind. It runs first thing in `main()` (browser, GPU/utility children, `ELECTRON_RUN_AS_NODE`) and in `ZygoteForked()`, because `fork()` hands zygote children a table shrunk back to the zygote's open descriptors. Linux only; the macOS and Windows kernels have no equivalent wait.

Testing: full main-process suite and an ASAN pass clean; the on-CPU part of window creation is unchanged, the difference is entirely the `D`-state wait disappearing.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a stall of tens of milliseconds while creating the first `BrowserWindow` on Linux.
