### PR TITLE
ci: bump build-tools SHA (`4b75f1f`)

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=67979ae1cadad053d2f13e2fb5d1559b923484c7
+      export BUILD_TOOLS_SHA=4b75f1f7bd42fa15a91abc71694d1e35ac4361c6
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools


### PR DESCRIPTION
Backport of #52059

See that PR for details.

Manual backport notes: 43-x-y moves `BUILD_TOOLS_SHA` from `67979ae` to `4b75f1f`. That range includes electron/build-tools#861 (fallback to `CHROMIUM_BUILDTOOLS_PATH` when e/e still exports it), which 43-x-y CI relies on since #51558 is not on this branch.

Notes: none
