### PR TITLE
ci: log Datadog upload failure instead of failing job

### DIFF
--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -99,7 +99,7 @@ jobs:
         echo "cross-instance-cache: free before=${CROSS_FREE_BEFORE_GB}GB, after=${CROSS_FREE_AFTER_GB}GB, freed=${CROSS_FREED_GB}GB, total=${CROSS_TOTAL_GB}GB"
         echo "win-cache: free before=${WIN_FREE_BEFORE_GB}GB, after=${WIN_FREE_AFTER_GB}GB, freed=${WIN_FREED_GB}GB, total=${WIN_TOTAL_GB}GB"
 
-        curl -s -X POST "https://api.datadoghq.com/api/v2/series" \
+        if curl -sS -X POST "https://api.datadoghq.com/api/v2/series" \
           -H "Content-Type: application/json" \
           -H "DD-API-KEY: ${DD_API_KEY}" \
           -d @- << EOF
@@ -164,5 +164,8 @@ jobs:
           ]
         }
         EOF
-
-        echo "Disk space metrics logged to Datadog"
+        then
+          echo "Disk space metrics logged to Datadog"
+        else
+          echo "::warning::Datadog metrics upload failed"
+        fi

--- a/.github/workflows/macos-disk-cleanup.yml
+++ b/.github/workflows/macos-disk-cleanup.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Free space after: ${FREE_AFTER_GB}GB"
           echo "Space freed: ${SPACE_FREED_GB}GB"
 
-          curl -s -X POST "https://api.datadoghq.com/api/v2/series" \
+          if curl -sS -X POST "https://api.datadoghq.com/api/v2/series" \
             -H "Content-Type: application/json" \
             -H "DD-API-KEY: ${DD_API_KEY}" \
             -d @- << EOF
@@ -101,5 +101,8 @@ jobs:
             ]
           }
           EOF
-
-          echo "Disk space metrics logged to Datadog"
+          then
+            echo "Disk space metrics logged to Datadog"
+          else
+            echo "::warning::Datadog metrics upload failed"
+          fi


### PR DESCRIPTION
Backport of #52352

See that PR for details.

Manual backport notes: the `build-electron/action.yml` hunk is dropped because the "Log Disk Space to Datadog" step it modifies comes from #51843, which is `no-backport`; the `clean-src-cache.yml` and `macos-disk-cleanup.yml` hunks are identical to `main`.

Notes: none
