### PR TITLE
fix: show DevTools popup menus for setDevToolsWebContents() frontends

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -78,6 +78,7 @@
 #include "content/public/common/page_visibility_state.h"
 #include "content/public/common/referrer_type_converters.h"
 #include "content/public/common/result_codes.h"
+#include "content/public/common/url_constants.h"
 #include "content/public/common/webplugininfo.h"
 #include "electron/buildflags/buildflags.h"
 #include "electron/mas.h"
@@ -118,6 +119,7 @@
 #include "shell/browser/preload_script.h"
 #include "shell/browser/renderer_startup_data.h"
 #include "shell/browser/session_preferences.h"
+#include "shell/browser/ui/devtools_context_menu.h"
 #include "shell/browser/ui/drag_util.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
@@ -172,8 +174,10 @@
 #include "third_party/blink/public/mojom/renderer_preferences.mojom.h"
 #include "ui/base/cursor/cursor.h"
 #include "ui/base/cursor/mojom/cursor_type.mojom-shared.h"
+#include "ui/base/mojom/menu_source_type.mojom.h"
 #include "ui/display/screen.h"
 #include "ui/events/base_event_utils.h"
+#include "ui/views/widget/widget.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "ui/base/cocoa/defaults_utils.h"
@@ -1738,6 +1742,28 @@ void WebContents::RendererResponsive(
 
 bool WebContents::HandleContextMenu(content::RenderFrameHost& render_frame_host,
                                     const content::ContextMenuParams& params) {
+  // A WebContents hosting a DevTools frontend directly (e.g. one passed to
+  // webContents.setDevToolsWebContents()) keeps its own delegate, so menu
+  // requests from InspectorFrontendHost.showContextMenuAtPoint() arrive here
+  // instead of at InspectableWebContents. Such requests are recognizable by
+  // carrying menu items in |params.custom_items| or by the kNone source type
+  // (the request is programmatic, not a user gesture). Show them as a native
+  // menu anchored to whichever widget hosts this WebContents; emitting
+  // 'context-menu' would drop the items and leave the frontend waiting for a
+  // selection forever. Ordinary right-clicks in the frontend still emit
+  // 'context-menu' below.
+  if (render_frame_host.GetMainFrame()->GetLastCommittedURL().SchemeIs(
+          content::kChromeDevToolsScheme) &&
+      (!params.custom_items.empty() ||
+       params.source_type == ui::mojom::MenuSourceType::kNone)) {
+    devtools_context_menu_ =
+        std::make_unique<DevToolsContextMenu>(web_contents(), params);
+    devtools_context_menu_->RunMenuAt(
+        views::Widget::GetTopLevelWidgetForNativeView(
+            web_contents()->GetNativeView()));
+    return true;
+  }
+
   ui::Clipboard::GetForCurrentThread()->ReadAvailableTypes(
       ui::ClipboardBuffer::kCopyPaste, std::nullopt,
       base::BindOnce(&WebContents::OnReadAvailableTypes, GetWeakPtr(), params,

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -99,6 +99,7 @@ class SkRegion;
 
 namespace electron {
 
+class DevToolsContextMenu;
 class ElectronBrowserContext;
 class InspectableWebContents;
 class WebContentsZoomController;
@@ -872,6 +873,10 @@ class WebContents final : public ExclusiveAccessContext,
   // dialog_manager_, so we can make sure inspectable_web_contents_ is
   // destroyed before dialog_manager_, otherwise a crash would happen.
   std::unique_ptr<InspectableWebContents> inspectable_web_contents_;
+
+  // Menu for context menu requests coming from a DevTools frontend hosted
+  // directly in this WebContents (e.g. via setDevToolsWebContents()).
+  std::unique_ptr<DevToolsContextMenu> devtools_context_menu_;
 
   std::optional<GURL> pending_unload_url_ = std::nullopt;
 

--- a/shell/browser/ui/devtools_context_menu.cc
+++ b/shell/browser/ui/devtools_context_menu.cc
@@ -32,7 +32,7 @@ constexpr size_t kMaxCustomMenuTotalItems = 1000;
 DevToolsContextMenu::DevToolsContextMenu(
     content::WebContents* devtools_web_contents,
     const content::ContextMenuParams& params)
-    : web_contents_(devtools_web_contents), params_(params) {
+    : content::WebContentsObserver(devtools_web_contents), params_(params) {
   if (!params_.custom_items.empty()) {
     size_t total_items = 0;
     AppendCustomItems(params_.custom_items, &menu_model_, 0, &total_items);
@@ -49,17 +49,21 @@ DevToolsContextMenu::~DevToolsContextMenu() {
 }
 
 void DevToolsContextMenu::RunMenuAt(views::Widget* parent_widget) {
-  if (menu_model_.GetItemCount() == 0) {
-    // Nothing to show; let the frontend clean up its pending menu state.
-    web_contents_->NotifyContextMenuClosed(params_.link_followed,
-                                           params_.impression);
+  if (!web_contents())
+    return;
+
+  if (!parent_widget || menu_model_.GetItemCount() == 0) {
+    // No widget to anchor to (e.g. offscreen rendering) or nothing to show;
+    // let the frontend clean up its pending menu state.
+    web_contents()->NotifyContextMenuClosed(params_.link_followed,
+                                            params_.impression);
     return;
   }
 
   // Block further context menu requests and renderer mouse-move handling
   // while the menu is showing, like Chrome's RenderViewContextMenuBase does.
   menu_open_ = true;
-  web_contents_->SetShowingContextMenu(true);
+  web_contents()->SetShowingContextMenu(true);
 
   menu_runner_ = std::make_unique<views::MenuRunner>(
       &menu_model_,
@@ -71,12 +75,19 @@ void DevToolsContextMenu::RunMenuAt(views::Widget* parent_widget) {
   // them to screen coordinates for the menu runner.
   gfx::Point screen_point{params_.x, params_.y};
   if (content::RenderWidgetHostView* view =
-          web_contents_->GetRenderWidgetHostView())
+          web_contents()->GetRenderWidgetHostView())
     screen_point += view->GetViewBounds().OffsetFromOrigin();
 
   menu_runner_->RunMenuAt(
       parent_widget, nullptr, gfx::Rect{screen_point, gfx::Size{}},
       views::MenuAnchorPosition::kTopLeft, params_.source_type);
+
+  // RunMenuAt can return without showing anything (e.g. during shutdown), in
+  // which case the closed callback never fires. On macOS it blocks until the
+  // menu closes, and WebContentsDestroyed() may have reset |menu_runner_|
+  // while the menu was open.
+  if (!menu_runner_ || !menu_runner_->IsRunning())
+    OnMenuClosed();
 }
 
 void DevToolsContextMenu::AppendCustomItems(
@@ -160,9 +171,16 @@ void DevToolsContextMenu::OnMenuClosed() {
   if (!menu_open_)
     return;
   menu_open_ = false;
-  web_contents_->SetShowingContextMenu(false);
-  web_contents_->NotifyContextMenuClosed(params_.link_followed,
-                                         params_.impression);
+  if (!web_contents())
+    return;
+  web_contents()->SetShowingContextMenu(false);
+  web_contents()->NotifyContextMenuClosed(params_.link_followed,
+                                          params_.impression);
+}
+
+void DevToolsContextMenu::WebContentsDestroyed() {
+  menu_open_ = false;
+  menu_runner_.reset();
 }
 
 bool DevToolsContextMenu::IsCommandIdChecked(int command_id) const {
@@ -180,36 +198,39 @@ bool DevToolsContextMenu::IsCommandIdEnabled(int command_id) const {
 }
 
 void DevToolsContextMenu::ExecuteCommand(int command_id, int event_flags) {
+  if (!web_contents())
+    return;
+
   switch (command_id) {
     case kEditCommandUndo:
-      web_contents_->Undo();
+      web_contents()->Undo();
       return;
     case kEditCommandRedo:
-      web_contents_->Redo();
+      web_contents()->Redo();
       return;
     case kEditCommandCut:
-      web_contents_->Cut();
+      web_contents()->Cut();
       return;
     case kEditCommandCopy:
-      web_contents_->Copy();
+      web_contents()->Copy();
       return;
     case kEditCommandPaste:
-      web_contents_->Paste();
+      web_contents()->Paste();
       return;
     case kEditCommandPasteAndMatchStyle:
-      web_contents_->PasteAndMatchStyle();
+      web_contents()->PasteAndMatchStyle();
       return;
     case kEditCommandDelete:
-      web_contents_->Delete();
+      web_contents()->Delete();
       return;
     case kEditCommandSelectAll:
-      web_contents_->SelectAll();
+      web_contents()->SelectAll();
       return;
     default:
       // A custom DevTools item: the frontend receives the action as
       // DevToolsAPI.contextMenuItemSelected(action).
-      web_contents_->ExecuteCustomContextMenuCommand(command_id,
-                                                     params_.link_followed);
+      web_contents()->ExecuteCustomContextMenuCommand(command_id,
+                                                      params_.link_followed);
       return;
   }
 }

--- a/shell/browser/ui/devtools_context_menu.h
+++ b/shell/browser/ui/devtools_context_menu.h
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
-#include "base/memory/raw_ptr.h"
 #include "content/public/browser/context_menu_params.h"
+#include "content/public/browser/web_contents_observer.h"
 #include "third_party/blink/public/mojom/context_menu/context_menu.mojom-forward.h"
 #include "ui/menus/simple_menu_model.h"
 
@@ -30,7 +30,10 @@ namespace electron {
 // from the Blink-provided items in |params.custom_items| and selections are
 // reported back to the frontend through the standard custom context menu
 // plumbing (DevToolsAPI.contextMenuItemSelected / contextMenuCleared).
-class DevToolsContextMenu : private ui::SimpleMenuModel::Delegate {
+// Observes the DevTools WebContents so the menu closes, without touching the
+// dying WebContents, if it is destroyed while the menu is open.
+class DevToolsContextMenu : private content::WebContentsObserver,
+                            private ui::SimpleMenuModel::Delegate {
  public:
   DevToolsContextMenu(content::WebContents* devtools_web_contents,
                       const content::ContextMenuParams& params);
@@ -69,6 +72,8 @@ class DevToolsContextMenu : private ui::SimpleMenuModel::Delegate {
 
   void OnMenuClosed();
 
+  void WebContentsDestroyed() override;
+
   // ui::SimpleMenuModel::Delegate:
   bool IsCommandIdChecked(int command_id) const override;
   bool IsCommandIdEnabled(int command_id) const override;
@@ -79,7 +84,6 @@ class DevToolsContextMenu : private ui::SimpleMenuModel::Delegate {
     bool checked = false;
   };
 
-  raw_ptr<content::WebContents> web_contents_;
   content::ContextMenuParams params_;
 
   bool menu_open_ = false;

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -279,8 +279,6 @@ void InspectableWebContentsView::ShowDevToolsContextMenu(
   // that opening it doesn't shift focus to the inspected page's window.
   views::Widget* widget =
       devtools_window_ ? devtools_window_.get() : GetWidget();
-  if (!widget)
-    return;
 
   context_menu_ =
       std::make_unique<DevToolsContextMenu>(devtools_web_contents, params);

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1513,16 +1513,38 @@ describe('webContents module', () => {
       await waitUntil(() => w.webContents.devToolsWebContents!.executeJavaScript('typeof DevToolsAPI !== "undefined"'));
     }
 
+    // The DevTools frontend should route context menus through the native
+    // DevToolsHost binding rather than a JS override injected by Electron.
+    function usesNativeShowContextMenu(devtoolsContents: Electron.WebContents): Promise<boolean> {
+      return devtoolsContents.executeJavaScript(
+        'typeof DevToolsHost !== "undefined" && InspectorFrontendHost.showContextMenuAtPoint.toString().includes("DevToolsHost")'
+      );
+    }
+
+    // Triggers InspectorFrontendHost.showContextMenuAtPoint with an empty
+    // item list at a non-editable point. No menu UI is shown, but a correctly
+    // routed request still round-trips through the browser, which reports
+    // the menu closed back to the frontend as DevToolsAPI.contextMenuCleared.
+    // A request swallowed by the generic context-menu path never resolves.
+    function devToolsMenuRequestRoundTrips(devtoolsContents: Electron.WebContents): Promise<boolean> {
+      return devtoolsContents.executeJavaScript(`new Promise(resolve => {
+        const timeout = setTimeout(() => resolve(false), 5000);
+        const original = DevToolsAPI.contextMenuCleared.bind(DevToolsAPI);
+        DevToolsAPI.contextMenuCleared = () => {
+          clearTimeout(timeout);
+          DevToolsAPI.contextMenuCleared = original;
+          resolve(true);
+          original();
+        };
+        InspectorFrontendHost.showContextMenuAtPoint(10, 10, [], document);
+      })`);
+    }
+
     it('uses the native showContextMenuAtPoint implementation', async () => {
       const w = new BrowserWindow({ show: false });
       await openDevTools(w);
 
-      // The DevTools frontend should route context menus through the native
-      // DevToolsHost binding rather than a JS override injected by Electron.
-      const usesNativeContextMenu = await w.webContents.devToolsWebContents!.executeJavaScript(
-        'typeof DevToolsHost !== "undefined" && InspectorFrontendHost.showContextMenuAtPoint.toString().includes("DevToolsHost")'
-      );
-      expect(usesNativeContextMenu).to.be.true();
+      expect(await usesNativeShowContextMenu(w.webContents.devToolsWebContents!)).to.be.true();
     });
 
     it('uses the native window.confirm implementation', async () => {
@@ -1535,6 +1557,58 @@ describe('webContents module', () => {
         'window.confirm.toString().includes("[native code]")'
       );
       expect(confirmIsNative).to.be.true();
+    });
+
+    // Baseline for the setDevToolsWebContents() regression test below: the
+    // managed (built-in) DevTools route via InspectableWebContents.
+    it('routes context menu requests through the native menu path', async () => {
+      const w = new BrowserWindow({ show: false });
+      await openDevTools(w);
+
+      const roundTripped = await devToolsMenuRequestRoundTrips(w.webContents.devToolsWebContents!);
+      expect(roundTripped).to.be.true();
+    });
+
+    describe('with setDevToolsWebContents()', () => {
+      async function openCustomDevTools(w: BrowserWindow, devtools: BrowserWindow) {
+        await w.loadURL('about:blank');
+        w.webContents.setDevToolsWebContents(devtools.webContents);
+        const devtoolsReady = once(devtools.webContents, 'dom-ready');
+        w.webContents.openDevTools();
+        await devtoolsReady;
+        await waitUntil(() => devtools.webContents.executeJavaScript('typeof DevToolsAPI !== "undefined"'));
+        // The browser only delivers context-menu-closed notifications to a
+        // focused frame; focus the frontend like a user interacting with it.
+        devtools.webContents.focus();
+        await waitUntil(() => devtools.webContents.executeJavaScript('document.hasFocus()'));
+      }
+
+      it('uses the native showContextMenuAtPoint implementation', async () => {
+        const w = new BrowserWindow({ show: false });
+        const devtools = new BrowserWindow({ show: false });
+        await openCustomDevTools(w, devtools);
+
+        expect(await usesNativeShowContextMenu(devtools.webContents)).to.be.true();
+      });
+
+      // Regression test for https://github.com/electron/electron/issues/51962:
+      // a DevTools frontend hosted in a user-provided WebContents must show
+      // its popup menus via the native DevTools menu path rather than having
+      // the request swallowed by the generic 'context-menu' event plumbing.
+      it('routes context menu requests through the native menu path', async () => {
+        const w = new BrowserWindow({ show: false });
+        const devtools = new BrowserWindow({ show: false });
+        await openCustomDevTools(w, devtools);
+
+        let emittedContextMenu = false;
+        devtools.webContents.once('context-menu', () => {
+          emittedContextMenu = true;
+        });
+
+        const roundTripped = await devToolsMenuRequestRoundTrips(devtools.webContents);
+        expect(roundTripped).to.be.true();
+        expect(emittedContextMenu).to.be.false();
+      });
     });
   });
 


### PR DESCRIPTION
Backport of #52205

See that PR for details.

Manual backport notes: `content::WebContents::NotifyContextMenuClosed()` still takes `(link_followed, impression)` on this branch's Chromium, so the two call sites keep the two-argument form; otherwise identical to `main`.

Notes: Fixed DevTools popup and context menus not appearing when DevTools is hosted in a custom window via `webContents.setDevToolsWebContents()`.
