### PR TITLE
fix: dangling rawptr `NativeWindow::primary_web_contents_view_`

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -70,7 +70,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
       WebContentsView::Create(isolate, web_preferences);
   DCHECK(web_contents_view.get());
   window()->AddDraggableRegionProvider(web_contents_view.get());
-  window()->set_primary_web_contents_view(
+  window()->InitPrimaryWebContentsView(
       static_cast<InspectableWebContentsView*>(web_contents_view->view()));
   web_contents_view_.Reset(isolate, web_contents_view.ToV8());
 
@@ -102,8 +102,6 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 }
 
 BrowserWindow::~BrowserWindow() {
-  window()->set_primary_web_contents_view(nullptr);
-
   if (api_web_contents_) {
     // Cleanup the observers if user destroyed this instance directly instead of
     // gracefully closing content::WebContents.
@@ -117,7 +115,6 @@ void BrowserWindow::BeforeUnloadDialogCancelled() {
 }
 
 void BrowserWindow::WebContentsDestroyed() {
-  window()->set_primary_web_contents_view(nullptr);
   api_web_contents_ = nullptr;
   CloseImmediately();
 }

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -17,6 +17,7 @@
 #include "shell/browser/browser.h"
 #include "shell/browser/draggable_region_provider.h"
 #include "shell/browser/ui/drag_util.h"
+#include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -97,6 +98,18 @@ NativeWindow::NativeWindow(const int32_t base_window_id,
   }
 
   WindowList::AddWindow(this);
+}
+
+InspectableWebContentsView* NativeWindow::primary_web_contents_view() {
+  return static_cast<InspectableWebContentsView*>(
+      primary_web_contents_view_.view());
+}
+
+void NativeWindow::InitPrimaryWebContentsView(
+    InspectableWebContentsView* view) {
+  CHECK(view);
+  CHECK(!primary_web_contents_view_);
+  primary_web_contents_view_.SetView(view);
 }
 
 NativeWindow::~NativeWindow() {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -22,6 +22,7 @@
 #include "extensions/browser/app_window/size_constraints.h"
 #include "shell/browser/native_window_observer.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
+#include "ui/views/view_tracker.h"
 #include "ui/views/widget/widget_delegate.h"
 
 class SkRegion;
@@ -408,12 +409,8 @@ class NativeWindow : public views::WidgetDelegate {
 
   [[nodiscard]] constexpr int32_t window_id() const { return window_id_; }
 
-  InspectableWebContentsView* primary_web_contents_view() const {
-    return primary_web_contents_view_;
-  }
-  void set_primary_web_contents_view(InspectableWebContentsView* view) {
-    primary_web_contents_view_ = view;
-  }
+  InspectableWebContentsView* primary_web_contents_view();
+  void InitPrimaryWebContentsView(InspectableWebContentsView* view);
 
   void add_child_window(NativeWindow* child) {
     child_windows_.push_back(child);
@@ -564,7 +561,7 @@ class NativeWindow : public views::WidgetDelegate {
 
   gfx::Rect overlay_rect_;
 
-  raw_ptr<InspectableWebContentsView> primary_web_contents_view_ = nullptr;
+  views::ViewTracker primary_web_contents_view_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
 };


### PR DESCRIPTION
Backport of #52546

See that PR for details.

Manual backport notes: the only conflict was in `native_window.h`, where `main` has the #51510 window-state members adjacent to `primary_web_contents_view_`; resolved to just the `views::ViewTracker` change so this stays independent of the #51510 backport (whichever lands second needs a trivial rebase).

Notes: none.
