### PR TITLE
chore: use base::SysNSStringToUTF8 in more places

### DIFF
--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/path_service.h"
+#include "base/strings/sys_string_conversions.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/process_util.h"
 #include "shell/common/thread_restrictions.h"
@@ -23,7 +24,7 @@ base::FilePath App::GetDefaultAppLogPath() {
       [NSString stringWithFormat:@"Library/Logs/%@", bundle_name];
   NSString* library_path =
       [NSHomeDirectory() stringByAppendingPathComponent:logs_path];
-  return base::FilePath{[library_path UTF8String]};
+  return base::FilePath{base::SysNSStringToUTF8(library_path)};
 }
 
 void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -452,8 +452,8 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
                       reply:^(BOOL success, NSError* error) {
                         // NOLINTBEGIN(bugprone-use-after-move)
                         if (!success) {
-                          std::string err_msg = std::string(
-                              [error.localizedDescription UTF8String]);
+                          std::string err_msg = base::SysNSStringToUTF8(
+                              error.localizedDescription);
                           runner->PostTask(
                               FROM_HERE,
                               base::BindOnce(

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -8,6 +8,7 @@
 
 #include "base/apple/bundle_locations.h"
 #include "base/apple/foundation_util.h"
+#include "base/strings/sys_string_conversions.h"
 #include "services/device/public/cpp/geolocation/geolocation_system_permission_manager.h"
 #include "services/device/public/cpp/geolocation/system_geolocation_source_apple.h"
 #include "shell/browser/browser_process_impl.h"
@@ -92,11 +93,9 @@ std::string ElectronBrowserMainParts::GetCurrentSystemLocale() {
       [[NSLocale currentLocale] localeIdentifier];
 
   // Mac OS X uses "_" instead of "-", so swap to get a real locale value.
-  std::string locale_value = [[systemLocaleIdentifier
+  return base::SysNSStringToUTF8([systemLocaleIdentifier
       stringByReplacingOccurrencesOfString:@"_"
-                                withString:@"-"] UTF8String];
-
-  return locale_value;
+                                withString:@"-"]);
 }
 
 }  // namespace electron

--- a/shell/browser/mac/in_app_purchase.mm
+++ b/shell/browser/mac/in_app_purchase.mm
@@ -179,7 +179,7 @@ void FinishTransactionByDate(const std::string& date) {
 std::string GetReceiptURL() {
   NSURL* receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
   if (receiptURL != nil) {
-    return std::string([[receiptURL path] UTF8String]);
+    return base::SysNSStringToUTF8(receiptURL.path);
   } else {
     return "";
   }

--- a/shell/browser/mac/in_app_purchase_observer.mm
+++ b/shell/browser/mac/in_app_purchase_observer.mm
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/strings/sys_string_conversions.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 
@@ -100,11 +101,14 @@ using InAppTransactionCallback = base::RepeatingCallback<void(
     (SKPaymentDiscount*)paymentDiscount {
   in_app_purchase::PaymentDiscount paymentDiscountStruct;
 
-  paymentDiscountStruct.identifier = [paymentDiscount.identifier UTF8String];
+  paymentDiscountStruct.identifier =
+      base::SysNSStringToUTF8(paymentDiscount.identifier);
   paymentDiscountStruct.keyIdentifier =
-      [paymentDiscount.keyIdentifier UTF8String];
-  paymentDiscountStruct.nonce = [[paymentDiscount.nonce UUIDString] UTF8String];
-  paymentDiscountStruct.signature = [paymentDiscount.signature UTF8String];
+      base::SysNSStringToUTF8(paymentDiscount.keyIdentifier);
+  paymentDiscountStruct.nonce =
+      base::SysNSStringToUTF8(paymentDiscount.nonce.UUIDString);
+  paymentDiscountStruct.signature =
+      base::SysNSStringToUTF8(paymentDiscount.signature);
   paymentDiscountStruct.timestamp = [paymentDiscount.timestamp intValue];
 
   return paymentDiscountStruct;
@@ -119,7 +123,8 @@ using InAppTransactionCallback = base::RepeatingCallback<void(
   in_app_purchase::Payment paymentStruct;
 
   if (payment.productIdentifier != nil) {
-    paymentStruct.productIdentifier = [payment.productIdentifier UTF8String];
+    paymentStruct.productIdentifier =
+        base::SysNSStringToUTF8(payment.productIdentifier);
   }
 
   if (payment.quantity >= 1) {
@@ -128,7 +133,7 @@ using InAppTransactionCallback = base::RepeatingCallback<void(
 
   if (payment.applicationUsername != nil) {
     paymentStruct.applicationUsername =
-        [payment.applicationUsername UTF8String];
+        base::SysNSStringToUTF8(payment.applicationUsername);
   }
 
   if (payment.paymentDiscount != nil) {
@@ -150,29 +155,29 @@ using InAppTransactionCallback = base::RepeatingCallback<void(
 
   if (transaction.transactionIdentifier != nil) {
     transactionStruct.transactionIdentifier =
-        [transaction.transactionIdentifier UTF8String];
+        base::SysNSStringToUTF8(transaction.transactionIdentifier);
   }
 
   if (transaction.transactionDate != nil) {
-    transactionStruct.transactionDate =
-        [[self dateToISOString:transaction.transactionDate] UTF8String];
+    transactionStruct.transactionDate = base::SysNSStringToUTF8(
+        [self dateToISOString:transaction.transactionDate]);
   }
 
   if (transaction.originalTransaction != nil) {
-    transactionStruct.originalTransactionIdentifier =
-        [transaction.originalTransaction.transactionIdentifier UTF8String];
+    transactionStruct.originalTransactionIdentifier = base::SysNSStringToUTF8(
+        transaction.originalTransaction.transactionIdentifier);
   }
 
   if (transaction.error != nil) {
     transactionStruct.errorCode = (int)transaction.error.code;
     transactionStruct.errorMessage =
-        [[transaction.error localizedDescription] UTF8String];
+        base::SysNSStringToUTF8(transaction.error.localizedDescription);
   }
 
   if (transaction.transactionState < 5) {
-    transactionStruct.transactionState =
-        [[@[ @"purchasing", @"purchased", @"failed", @"restored", @"deferred" ]
-            objectAtIndex:transaction.transactionState] UTF8String];
+    transactionStruct.transactionState = base::SysNSStringToUTF8(
+        [@[ @"purchasing", @"purchased", @"failed", @"restored", @"deferred" ]
+            objectAtIndex:transaction.transactionState]);
   }
 
   if (transaction.payment != nil) {

--- a/shell/browser/mac/in_app_purchase_product.mm
+++ b/shell/browser/mac/in_app_purchase_product.mm
@@ -154,8 +154,8 @@
 
   if (productDiscount.priceLocale != nil) {
     productDiscountStruct.priceLocale =
-        [[self formatPrice:productDiscount.price
-                 withLocal:productDiscount.priceLocale] UTF8String];
+        base::SysNSStringToUTF8([self formatPrice:productDiscount.price
+                                        withLocal:productDiscount.priceLocale]);
   }
 
   if (productDiscount.subscriptionPeriod != nil) {
@@ -164,9 +164,8 @@
   }
 
   productDiscountStruct.type = (int)productDiscount.type;
-  if (productDiscount.identifier != nil) {
-    productDiscountStruct.identifier = [productDiscount.identifier UTF8String];
-  }
+  productDiscountStruct.identifier =
+      base::SysNSStringToUTF8(productDiscount.identifier);
   productDiscountStruct.price = [productDiscount.price doubleValue];
 
   return productDiscountStruct;
@@ -181,18 +180,14 @@
   in_app_purchase::Product productStruct;
 
   // Product Identifier
-  if (product.productIdentifier != nil) {
-    productStruct.productIdentifier = [product.productIdentifier UTF8String];
-  }
+  productStruct.productIdentifier =
+      base::SysNSStringToUTF8(product.productIdentifier);
 
   // Product Attributes
-  if (product.localizedDescription != nil) {
-    productStruct.localizedDescription =
-        [product.localizedDescription UTF8String];
-  }
-  if (product.localizedTitle != nil) {
-    productStruct.localizedTitle = [product.localizedTitle UTF8String];
-  }
+  productStruct.localizedDescription =
+      base::SysNSStringToUTF8(product.localizedDescription);
+  productStruct.localizedTitle =
+      base::SysNSStringToUTF8(product.localizedTitle);
 
   // Pricing Information
   if (product.price != nil) {
@@ -200,14 +195,12 @@
 
     if (product.priceLocale != nil) {
       productStruct.formattedPrice =
-          [[self formatPrice:product.price
-                   withLocal:product.priceLocale] UTF8String];
+          base::SysNSStringToUTF8([self formatPrice:product.price
+                                          withLocal:product.priceLocale]);
 
       // Currency Information
-      if (product.priceLocale.currencyCode != nil) {
-        productStruct.currencyCode =
-            [product.priceLocale.currencyCode UTF8String];
-      }
+      productStruct.currencyCode =
+          base::SysNSStringToUTF8(product.priceLocale.currencyCode);
     }
   }
 
@@ -220,10 +213,8 @@
         [self skProductSubscriptionPeriodToStruct:product.subscriptionPeriod];
   }
 
-  if (product.subscriptionGroupIdentifier != nil) {
-    productStruct.subscriptionGroupIdentifier =
-        [product.subscriptionGroupIdentifier UTF8String];
-  }
+  productStruct.subscriptionGroupIdentifier =
+      base::SysNSStringToUTF8(product.subscriptionGroupIdentifier);
 
   if (product.discounts != nil) {
     productStruct.discounts.reserve([product.discounts count]);
@@ -237,10 +228,8 @@
   // Downloadable Content Information
   productStruct.isDownloadable = [product isDownloadable];
 
-  if (product.downloadContentVersion != nil) {
-    productStruct.downloadContentVersion =
-        [product.downloadContentVersion UTF8String];
-  }
+  productStruct.downloadContentVersion =
+      base::SysNSStringToUTF8(product.downloadContentVersion);
 
   if (product.downloadContentLengths != nil) {
     productStruct.downloadContentLengths.reserve(

--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -207,7 +207,7 @@ void CocoaNotification::ScheduleNotification(
                        << [error.localizedDescription UTF8String];
            }
            std::string error_description =
-               [error.localizedDescription UTF8String];
+               base::SysNSStringToUTF8(error.localizedDescription);
            task_runner->PostTask(
                FROM_HERE, base::BindOnce(
                               [](base::WeakPtr<Notification> weak_self,

--- a/shell/browser/notifications/mac/notification_center_delegate.mm
+++ b/shell/browser/notifications/mac/notification_center_delegate.mm
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/strings/sys_string_conversions.h"
 #include "electron/mas.h"
 #include "shell/browser/notifications/mac/cocoa_notification.h"
 #include "shell/browser/notifications/mac/notification_presenter_mac.h"
@@ -60,7 +61,7 @@
         if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
           NSString* userText =
               [(UNTextInputNotificationResponse*)response userText];
-          notification->NotificationReplied([userText UTF8String]);
+          notification->NotificationReplied(base::SysNSStringToUTF8(userText));
         }
       } else if ([actionIdentifier hasPrefix:@"ACTION_"]) {
         NSString* actionIndexString =

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -244,7 +244,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 - (void)buttonAction:(id)sender {
   NSString* item_id =
       [NSString stringWithFormat:@"%ld", ((NSButton*)sender).tag];
-  window_->NotifyTouchBarItemInteraction([item_id UTF8String], {});
+  window_->NotifyTouchBarItemInteraction(base::SysNSStringToUTF8(item_id), {});
 }
 
 - (void)colorPickerAction:(id)sender {
@@ -256,7 +256,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
       electron::ToRGBHex(skia::NSDeviceColorToSkColor(color));
   base::DictValue details;
   details.Set("color", hex_color);
-  window_->NotifyTouchBarItemInteraction([item_id UTF8String],
+  window_->NotifyTouchBarItemInteraction(base::SysNSStringToUTF8(item_id),
                                          std::move(details));
 }
 
@@ -266,7 +266,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
                                   withPrefix:SliderIdentifier];
   base::DictValue details;
   details.Set("value", [((NSSliderTouchBarItem*)sender).slider intValue]);
-  window_->NotifyTouchBarItemInteraction([item_id UTF8String],
+  window_->NotifyTouchBarItemInteraction(base::SysNSStringToUTF8(item_id),
                                          std::move(details));
 }
 
@@ -285,7 +285,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
       "isSelected",
       [((NSSegmentedControl*)sender)
           isSelectedForSegment:((NSSegmentedControl*)sender).selectedSegment]);
-  window_->NotifyTouchBarItemInteraction([item_id UTF8String],
+  window_->NotifyTouchBarItemInteraction(base::SysNSStringToUTF8(item_id),
                                          std::move(details));
 }
 
@@ -294,8 +294,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   base::DictValue details;
   details.Set("selectedIndex", static_cast<int>(selectedIndex));
   details.Set("type", "select");
-  window_->NotifyTouchBarItemInteraction([scrubber.identifier UTF8String],
-                                         std::move(details));
+  window_->NotifyTouchBarItemInteraction(
+      base::SysNSStringToUTF8(scrubber.identifier), std::move(details));
 }
 
 - (void)scrubber:(NSScrubber*)scrubber
@@ -303,8 +303,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   base::DictValue details;
   details.Set("highlightedIndex", static_cast<int>(highlightedIndex));
   details.Set("type", "highlight");
-  window_->NotifyTouchBarItemInteraction([scrubber.identifier UTF8String],
-                                         std::move(details));
+  window_->NotifyTouchBarItemInteraction(
+      base::SysNSStringToUTF8(scrubber.identifier), std::move(details));
 }
 
 - (NSTouchBarItemIdentifier)identifierFromID:(const std::string&)item_id
@@ -344,7 +344,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeButtonForID:(NSString*)id
                     withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -404,7 +404,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeLabelForID:(NSString*)id
                    withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -441,7 +441,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeColorPickerForID:(NSString*)id
                          withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -478,7 +478,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeSliderForID:(NSString*)id
                     withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -507,7 +507,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makePopoverForID:(NSString*)id
                      withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -547,7 +547,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeGroupForID:(NSString*)id
                    withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -597,7 +597,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeSegmentedControlForID:(NSString*)id
                               withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -682,7 +682,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSTouchBarItem*)makeScrubberForID:(NSString*)id
                       withIdentifier:(NSString*)identifier {
-  std::string s_id([id UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(id);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -760,7 +760,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSInteger)numberOfItemsForScrubber:(NSScrubber*)scrubber {
-  std::string s_id([[scrubber identifier] UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(scrubber.identifier);
   if (![self hasItemWithID:s_id])
     return 0;
 
@@ -775,7 +775,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
 - (NSScrubberItemView*)scrubber:(NSScrubber*)scrubber
              viewForItemAtIndex:(NSInteger)index {
-  std::string s_id([[scrubber identifier] UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(scrubber.identifier);
   if (![self hasItemWithID:s_id])
     return nil;
 
@@ -822,7 +822,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   NSInteger margin = 15;
   NSSize defaultSize = NSMakeSize(width, height);
 
-  std::string s_id([[scrubber identifier] UTF8String]);
+  std::string s_id = base::SysNSStringToUTF8(scrubber.identifier);
   if (![self hasItemWithID:s_id])
     return defaultSize;
 

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -49,7 +49,7 @@ void ReceivedThumbnailResult(CGSize size,
                              QLThumbnailRepresentation* thumbnail,
                              NSError* error) {
   if (error || !thumbnail) {
-    std::string err_msg([error.localizedDescription UTF8String]);
+    std::string err_msg = base::SysNSStringToUTF8(error.localizedDescription);
     p.RejectWithErrorMessage("unable to retrieve thumbnail preview "
                              "image for the given path: " +
                              err_msg);


### PR DESCRIPTION
Backport of #52710

See that PR for details.

Manual backport notes: include-order conflict only (`in_app_purchase_observer.mm`); hunks are otherwise identical to `main`.

Notes: none
