### PR TITLE
fix: don't crash on non-UTF8 serviceName in app.setLoginItemSettings

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -75,6 +75,10 @@ SMAppService* GetServiceForType(const std::string& type,
                                 const std::string& name)
     API_AVAILABLE(macosx(13.0)) {
   NSString* service_name = [NSString stringWithUTF8String:name.c_str()];
+  if (!service_name) {
+    LOG(ERROR) << "Login item service name is not valid UTF-8";
+    return nullptr;
+  }
   if (type == "mainAppService") {
     return [SMAppService mainAppService];
   } else if (type == "agentService") {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -913,6 +913,16 @@ describe('app module', () => {
         }).to.throw(/'name' is required when type is not mainAppService/);
       });
 
+      ifit(isVenturaOrHigher)('does not crash when the service name is not valid UTF-8', () => {
+        expect(() => {
+          app.setLoginItemSettings({
+            openAtLogin: false,
+            type: 'daemonService',
+            serviceName: '\uD800'
+          });
+        }).to.not.throw();
+      });
+
       ifit(isVenturaOrHigher)('can unset a login item', () => {
         app.setLoginItemSettings({
           openAtLogin: true,


### PR DESCRIPTION
Backport of #52773

See that PR for details.

Manual backport notes: the new spec is guarded with `ifit(isVenturaOrHigher)` to match the neighbouring SMAppService tests on this branch; the `platform_util_mac.mm` hunk is identical to `main`.

Notes: Fixed a crash with `app.setLoginItemSettings` if a non-UTF8 service name is used
