### PR TITLE
fix: transparent windows can be resized on Linux

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -27,8 +27,13 @@
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
-#include "shell/browser/ui/views/frameless_view.h"
 #include "ui/views/view_utils.h"
+#endif
+
+#if BUILDFLAG(IS_WIN)
+#include "shell/browser/ui/views/frameless_view.h"
+#elif BUILDFLAG(IS_LINUX)
+#include "shell/browser/ui/views/electron_frame_view_linux.h"
 #endif
 
 #if defined(USE_OZONE)
@@ -649,9 +654,16 @@ int NativeWindow::NonClientHitTest(const gfx::Point& point) {
 #if !BUILDFLAG(IS_MAC)
   // We need to ensure we account for resizing borders on Windows and Linux.
   if ((!has_frame() || has_client_frame()) && IsResizable()) {
-    auto* frame = views::AsViewClass<FramelessView>(
-        widget()->non_client_view()->frame_view());
-    if (frame) {
+    // TODO(mitchchn): bring back a cross-platform interface for
+    // frame operations. (Both Windows and Linux used to inherit
+    // from FramelessView.)
+#if BUILDFLAG(IS_WIN)
+    using ResizableFrameView = FramelessView;
+#else
+    using ResizableFrameView = ElectronFrameViewLinux;
+#endif
+    auto* frame_view = widget()->non_client_view()->frame_view();
+    if (auto* frame = views::AsViewClass<ResizableFrameView>(frame_view)) {
       int border_hit = frame->ResizingBorderHitTest(point);
       if (border_hit != HTNOWHERE)
         return border_hit;

--- a/shell/browser/ui/views/electron_frame_view_linux.cc
+++ b/shell/browser/ui/views/electron_frame_view_linux.cc
@@ -13,12 +13,21 @@
 #include "ui/base/hit_test.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
+#include "ui/gfx/geometry/insets.h"
 #include "ui/views/background.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/frame_background.h"
 #include "ui/views/window/frame_caption_button.h"
 
 namespace electron {
+
+namespace {
+
+// Values used for internal resizing when there are no insets.
+const int kResizeAreaCornerSize = 16;
+const int kResizeInsideBoundsSize = 5;
+
+}  // namespace
 
 ElectronFrameViewLinux::ElectronFrameViewLinux(NativeWindowViews* window,
                                                views::Widget* widget)
@@ -119,6 +128,21 @@ int ElectronFrameViewLinux::NonClientHitTest(const gfx::Point& point) {
     return contents_hit_test;
 
   return HTCLIENT;
+}
+
+int ElectronFrameViewLinux::ResizingBorderHitTest(const gfx::Point& point) {
+  // Fall back to an internal resize band only when there are no frame insets
+  // but the window is still supposed to be resizable. The main use case is
+  // transparent windows. Matches the behavior of
+  // WinFrameView::ResizingBorderHitTest.
+  if (!window_->IsResizable() ||
+      !efv_layout()->GetRestoredFrameBorderInsets().IsEmpty() ||
+      GetWidget()->IsMaximized() || GetWidget()->IsFullscreen())
+    return HTNOWHERE;
+
+  return GetHTComponentForFrame(point, gfx::Insets(kResizeInsideBoundsSize),
+                                kResizeAreaCornerSize, kResizeAreaCornerSize,
+                                /*can_resize=*/true);
 }
 
 void ElectronFrameViewLinux::Layout(PassKey) {

--- a/shell/browser/ui/views/electron_frame_view_linux.h
+++ b/shell/browser/ui/views/electron_frame_view_linux.h
@@ -29,6 +29,10 @@ class ElectronFrameViewLinux : public views::FrameViewLinux {
   bool WantsFrame() const;
   void SetWantsFrame(bool wants_frame);
 
+  // Hit test for the internal resize band used when the frame has no
+  // external frame insets (e.g., translucent windows).
+  int ResizingBorderHitTest(const gfx::Point& point);
+
   // views::FrameViewLinux:
   bool HasWindowTitle() const override;
   int NonClientHitTest(const gfx::Point& point) override;


### PR DESCRIPTION
Backport of #52740

See that PR for details.

Manual backport notes: the only conflict was positional in `electron_frame_view_linux.cc` (the new anonymous-namespace constants sit above a constructor whose signature differs on `main`); `ResizingBorderHitTest()` and the `native_window.cc` / header hunks are identical to `main`.

Notes: Fixed a regression preventing from transparent frameless windows from being resized on Linux.
