### PR TITLE
feat: re-add app.setBadgeCount and win.setProgressBar for Linux

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1404,11 +1404,13 @@ Returns `boolean` - Whether the call succeeded.
 Sets the counter badge for current app. Setting the count to `0` will hide the
 badge.
 
-On macOS, it shows on the dock icon. On Linux, it only works for Unity launcher.
+On macOS, it shows on the Dock icon. On Linux, it shows on docks and taskbars that support the LauncherEntry D-Bus API,
 
 > [!NOTE]
-> Unity launcher requires a `.desktop` file to work. For more information,
-> please read the [Unity integration documentation][unity-requirement].
+> On Linux, the badge is associated with the app's `.desktop` file, so
+> [`app.setDesktopName`](#appsetdesktopnamename-linux) (or the `desktopName`
+> field in `package.json`) must match the name of the app's actual `.desktop`
+> file.
 
 > [!NOTE]
 > On macOS, you need to ensure that your application has the permission
@@ -1786,13 +1788,7 @@ Users can pass a [Menu](menu.md) to set this property.
 
 ### `app.badgeCount` _Linux_ _macOS_
 
-An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge.
-
-On macOS, setting this with any nonzero integer shows on the dock icon. On Linux, this property only works for Unity launcher.
-
-> [!NOTE]
-> Unity launcher requires a `.desktop` file to work. For more information,
-> please read the [Unity integration documentation][unity-requirement].
+An `Integer` property that returns the badge count for current app. Setting the count to `0` will hide the badge. Setting this with any nonzero integer shows the count on the Dock icon on macOS, or on the launcher on Linux.
 
 > [!NOTE]
 > On macOS, you need to ensure that your application has the permission
@@ -1825,7 +1821,6 @@ A `string` property that returns the app's [Toast Activator CLSID][toast-activat
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/documentation/coreservices/1441725-lscopydefaulthandlerforurlscheme?language=objc
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
-[unity-requirement]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
 [mas-builds]: ../tutorial/mac-app-store-submission-guide.md
 [Squirrel-Windows]: https://github.com/Squirrel/Squirrel.Windows
 [JumpListBeginListMSDN]: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-icustomdestinationlist-beginlist

--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -1152,6 +1152,11 @@ On Windows, a mode can be passed. Accepted values are `none`, `normal`,
 `indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
 mode set (but with a value within the valid range), `normal` will be assumed.
 
+On Linux, the progress bar shows on docks and taskbars that support the
+LauncherEntry D-Bus API. It is associated with the app's `.desktop` file, so
+[`app.setDesktopName`](app.md#appsetdesktopnamename-linux) must match the name
+of the app's actual `.desktop` file. Indeterminate mode is not supported.
+
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 
 * `overlay` [NativeImage](native-image.md) | null - the icon to display on the bottom

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1358,6 +1358,11 @@ On Windows, a mode can be passed. Accepted values are `none`, `normal`,
 `indeterminate`, `error`, and `paused`. If you call `setProgressBar` without a
 mode set (but with a value within the valid range), `normal` will be assumed.
 
+On Linux, the progress bar shows on docks and taskbars that support the
+LauncherEntry D-Bus API. It is associated with the app's `.desktop` file, so
+[`app.setDesktopName`](app.md#appsetdesktopnamename-linux) must match the name
+of the app's actual `.desktop` file. Indeterminate mode is not supported.
+
 #### `win.setOverlayIcon(overlay, description)` _Windows_
 
 * `overlay` [NativeImage](native-image.md) | null - the icon to display on the bottom

--- a/filenames.gni
+++ b/filenames.gni
@@ -25,6 +25,8 @@ filenames = {
     "shell/browser/browser_linux.cc",
     "shell/browser/lib/power_observer_linux.cc",
     "shell/browser/lib/power_observer_linux.h",
+    "shell/browser/linux/launcher_entry.cc",
+    "shell/browser/linux/launcher_entry.h",
     "shell/browser/linux/unity_service.cc",
     "shell/browser/linux/unity_service.h",
     "shell/browser/notifications/linux/libnotify_notification.cc",

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -21,6 +21,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "electron/electron_version.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/browser/linux/launcher_entry.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
@@ -257,13 +258,12 @@ v8::Local<v8::Promise> Browser::GetApplicationInfoForProtocol(
 }
 
 bool Browser::SetBadgeCount(std::optional<int> count) {
-  if (IsUnityRunning() && count.has_value()) {
-    unity::SetDownloadCount(count.value());
-    badge_count_ = count.value();
-    return true;
-  } else {
+  if (!count.has_value())
     return false;
-  }
+  if (!launcher_entry::SetBadgeCount(count.value()))
+    return false;
+  badge_count_ = count.value();
+  return true;
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {}

--- a/shell/browser/linux/launcher_entry.cc
+++ b/shell/browser/linux/launcher_entry.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/linux/launcher_entry.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/task/sequenced_task_runner.h"
+#include "components/dbus/thread_linux/dbus_thread_linux.h"
+#include "components/dbus/utils/variant.h"
+#include "components/dbus/utils/write_value.h"
+#include "dbus/bus.h"
+#include "dbus/message.h"
+#include "dbus/object_path.h"
+#include "shell/common/platform_util.h"
+
+namespace electron::launcher_entry {
+
+namespace {
+
+constexpr char kLauncherEntryInterface[] = "com.canonical.Unity.LauncherEntry";
+constexpr char kLauncherEntryPath[] = "/com/canonical/unity/launcherentry";
+
+using Properties = std::map<std::string, dbus_utils::Variant>;
+
+std::optional<std::string> GetAppUri() {
+  std::optional<std::string> desktop_id = platform_util::GetDesktopName();
+  if (!desktop_id || desktop_id->empty())
+    return std::nullopt;
+  return "application://" + *desktop_id;
+}
+
+void ConnectAndSend(scoped_refptr<dbus::Bus> bus,
+                    std::unique_ptr<dbus::Signal> signal) {
+  if (!bus->Connect())
+    return;
+  uint32_t serial = 0;
+  bus->Send(signal->raw_message(), &serial);
+}
+
+bool EmitUpdate(const Properties& properties) {
+  std::optional<std::string> app_uri = GetAppUri();
+  if (!app_uri)
+    return false;
+
+  auto signal =
+      std::make_unique<dbus::Signal>(kLauncherEntryInterface, "Update");
+  CHECK(signal->SetPath(dbus::ObjectPath(kLauncherEntryPath)));
+  dbus::MessageWriter writer(signal.get());
+  writer.AppendString(*app_uri);
+  dbus_utils::WriteValue(writer, properties);
+
+  scoped_refptr<dbus::Bus> bus = dbus_thread_linux::GetSharedSessionBus();
+  bus->GetDBusTaskRunner()->PostTask(
+      FROM_HERE, base::BindOnce(&ConnectAndSend, bus, std::move(signal)));
+  return true;
+}
+
+}  // namespace
+
+bool SetBadgeCount(int64_t count) {
+  Properties props;
+  props.emplace("count", dbus_utils::Variant::Wrap<"x">(count));
+  props.emplace("count-visible", dbus_utils::Variant::Wrap<"b">(count != 0));
+  return EmitUpdate(props);
+}
+
+bool SetProgress(double progress) {
+  Properties props;
+  props.emplace("progress", dbus_utils::Variant::Wrap<"d">(progress));
+  props.emplace("progress-visible", dbus_utils::Variant::Wrap<"b">(
+                                        progress > 0.0 && progress < 1.0));
+  return EmitUpdate(props);
+}
+
+}  // namespace electron::launcher_entry

--- a/shell/browser/linux/launcher_entry.h
+++ b/shell/browser/linux/launcher_entry.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Mitchell Cohen.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_
+#define ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_
+
+#include <cstdint>
+
+// Emits com.canonical.Unity.LauncherEntry Update signals on the session bus.
+// Despite the name, this D-Bus API is the de facto protocol for taskbar badge
+// counts and progress bars on Linux.
+namespace electron::launcher_entry {
+
+// Sets the badge count on the app's launcher entry. A count of zero hides
+// the badge. Returns false when the app's desktop name is not known.
+// Otherwise the signal is emitted best-effort and whether anything renders
+// it depends on the desktop environment.
+bool SetBadgeCount(int64_t count);
+
+// Sets the progress bar on the app's launcher entry. Values outside (0, 1)
+// hide the progress bar. Returns false under the same conditions as
+// SetBadgeCount().
+bool SetProgress(double progress);
+
+}  // namespace electron::launcher_entry
+
+#endif  // ELECTRON_SHELL_BROWSER_LINUX_LAUNCHER_ENTRY_H_

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -60,7 +60,7 @@
 #if BUILDFLAG(IS_LINUX)
 #include "base/notimplemented.h"
 #include "shell/browser/browser.h"
-#include "shell/browser/linux/unity_service.h"
+#include "shell/browser/linux/launcher_entry.h"
 #include "shell/browser/linux/x11_util.h"
 #include "shell/browser/ui/electron_desktop_window_tree_host_linux.h"
 #include "shell/browser/ui/views/electron_frame_view_linux.h"
@@ -1592,9 +1592,7 @@ void NativeWindowViews::SetProgressBar(double progress,
 #if BUILDFLAG(IS_WIN)
   taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, state);
 #elif BUILDFLAG(IS_LINUX)
-  if (unity::IsRunning()) {
-    unity::SetProgressFraction(progress);
-  }
+  launcher_entry::SetProgress(progress);
 #endif
 }
 

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -682,8 +682,7 @@ describe('app module', () => {
   });
 
   describe('app.badgeCount', () => {
-    const platformIsNotSupported =
-      process.platform === 'win32' || (process.platform === 'linux' && !app.isUnityRunning());
+    const platformIsSupported = process.platform === 'darwin' || process.platform === 'linux';
 
     const expectedBadgeCount = 42;
 
@@ -691,7 +690,7 @@ describe('app module', () => {
       app.badgeCount = 0;
     });
 
-    ifdescribe(!platformIsNotSupported)('on supported platform', () => {
+    ifdescribe(platformIsSupported)('on supported platform', () => {
       describe('with properties', () => {
         it('sets a badge count', function () {
           app.badgeCount = expectedBadgeCount;
@@ -704,25 +703,11 @@ describe('app module', () => {
           app.setBadgeCount(expectedBadgeCount);
           expect(app.getBadgeCount()).to.equal(expectedBadgeCount);
         });
-        it('sets an non numeric (dot) badge count', function () {
+        // A badge count is required on Linux; only macOS displays a plain
+        // dot when no count is provided.
+        ifit(process.platform === 'darwin')('sets an non numeric (dot) badge count', function () {
           app.setBadgeCount();
           // Badge count should be zero when non numeric (dot) is requested
-          expect(app.getBadgeCount()).to.equal(0);
-        });
-      });
-    });
-
-    ifdescribe(process.platform !== 'win32' && platformIsNotSupported)('on unsupported platform', () => {
-      describe('with properties', () => {
-        it('does not set a badge count', function () {
-          app.badgeCount = 9999;
-          expect(app.badgeCount).to.equal(0);
-        });
-      });
-
-      describe('with functions', () => {
-        it('does not set a badge count)', function () {
-          app.setBadgeCount(9999);
           expect(app.getBadgeCount()).to.equal(0);
         });
       });


### PR DESCRIPTION
Backport of #52739

See that PR for details.

Manual backport notes: 43-x-y still has the libunity implementation and the public `app.isUnityRunning()` API (the removal in #51649 is `main`-only). This backport switches `app.setBadgeCount` / `win.setProgressBar` on Linux to the new LauncherEntry D-Bus implementation exactly as on `main`, while keeping `unity_service.cc/h` in the build solely for `app.isUnityRunning()`. Docs take the new wording (and drop the now-unreferenced `[unity-requirement]` link definition); the spec changes match `main`.

Notes: Restored `app.setBadgeCount` and `win.setProgressBar` for Linux. These APIs now support any dock or taskbar which implements the LauncherEntry D-Bus API, and they no longer require `libunity`.
