### PR TITLE
chore: cherry-pick 3a02de271fd3 and 726eafecc145 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -133,6 +133,8 @@ allow_electron_to_depend_on_components_os_crypt_sync.patch
 expose_referrerscriptinfo_hostdefinedoptionsindex.patch
 chore_disable_protocol_handler_dcheck.patch
 fix_check_for_file_existence_before_setting_mtime.patch
+cherry-pick-3a02de271fd3.patch
+cherry-pick-726eafecc145.patch
 fix_linux_tray_id.patch
 expose_gtk_ui_platform_field.patch
 patch_osr_control_screen_info.patch

--- a/patches/chromium/cherry-pick-3a02de271fd3.patch
+++ b/patches/chromium/cherry-pick-3a02de271fd3.patch
@@ -1,0 +1,244 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 5 Aug 2026 21:13:26 -0700
+Subject: Support org.freedesktop.StatusNotifierItem for Linux status icons
+
+crrev.com/1658383 updated status icons to use well-known service
+names formatted as org.freedesktop.StatusNotifierItem-PID-ID.
+However, status_icon_linux_dbus.cc exported methods and checked property
+queries only against org.kde.StatusNotifierItem.
+
+Desktop environments such as XFCE request property GetAll with interface
+org.freedesktop.StatusNotifierItem, which caused Chromium's property
+handler to return a D-Bus error and led to status icons missing in XFCE.
+
+This change exports methods, handles property requests, and emits
+signals on both org.kde.StatusNotifierItem and
+org.freedesktop.StatusNotifierItem interfaces for StatusIconLinuxDbus.
+
+Fixed: 542402912
+Change-Id: Ifff3013c4b49c39a29431a18439277e269b6383c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8189930
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1674712}
+
+Electron backport note: the upstream unittest and BUILD.gn test-target
+changes are omitted here since Electron does not build Chromium unit
+tests; only the production status_icon_linux_dbus.{cc,h} changes are
+carried. This patch can be removed once this branch is on a Chromium
+revision that includes crrev.com/c/8189930 (>= 153.0.7994.0).
+
+diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+index 951ee684c6b02ddc4cae65b2997722457c1ec9dd..384c92b90429961a1bc8a116477b254457c631ce 100644
+--- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
++++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+@@ -63,9 +63,9 @@ namespace {
+ const char kServiceStatusNotifierWatcher[] = "org.kde.StatusNotifierWatcher";
+ 
+ // Interfaces.
+-// If/when the StatusNotifierItem spec gets accepted AND widely used, replace
+-// "kde" with "freedesktop".
+ const char kInterfaceStatusNotifierItem[] = "org.kde.StatusNotifierItem";
++const char kInterfaceStatusNotifierItemFreedesktop[] =
++    "org.freedesktop.StatusNotifierItem";
+ const char kInterfaceStatusNotifierWatcher[] = "org.kde.StatusNotifierWatcher";
+ 
+ // Object paths.
+@@ -270,24 +270,29 @@ class StatusIconLinuxDbus::Multiplexer {
+ 
+  private:
+   friend class base::NoDestructor<Multiplexer>;
++  friend class StatusIconLinuxDbus;
+   Multiplexer() = default;
+   ~Multiplexer() = default;
+ 
+   void ExportMethods(dbus::Bus* bus) {
+     item_ = bus->GetExportedObject(dbus::ObjectPath(kPathStatusNotifierItem));
+ 
+-    item_->ExportMethod(kInterfaceStatusNotifierItem, kMethodActivate,
+-                        base::BindRepeating(&Multiplexer::OnActivate),
+-                        base::DoNothing());
+-    item_->ExportMethod(kInterfaceStatusNotifierItem, kMethodContextMenu,
+-                        base::BindRepeating(&Multiplexer::OnContextMenu),
+-                        base::DoNothing());
+-    item_->ExportMethod(kInterfaceStatusNotifierItem, kMethodScroll,
+-                        base::BindRepeating(&Multiplexer::OnScroll),
+-                        base::DoNothing());
+-    item_->ExportMethod(kInterfaceStatusNotifierItem, kMethodSecondaryActivate,
+-                        base::BindRepeating(&Multiplexer::OnSecondaryActivate),
+-                        base::DoNothing());
++    for (const char* interface : {kInterfaceStatusNotifierItem,
++                                  kInterfaceStatusNotifierItemFreedesktop}) {
++      item_->ExportMethod(interface, kMethodActivate,
++                          base::BindRepeating(&Multiplexer::OnActivate),
++                          base::DoNothing());
++      item_->ExportMethod(interface, kMethodContextMenu,
++                          base::BindRepeating(&Multiplexer::OnContextMenu),
++                          base::DoNothing());
++      item_->ExportMethod(interface, kMethodScroll,
++                          base::BindRepeating(&Multiplexer::OnScroll),
++                          base::DoNothing());
++      item_->ExportMethod(
++          interface, kMethodSecondaryActivate,
++          base::BindRepeating(&Multiplexer::OnSecondaryActivate),
++          base::DoNothing());
++    }
+     item_->ExportMethod(DBUS_INTERFACE_PROPERTIES, "Get",
+                         base::BindRepeating(&Multiplexer::OnGetProperty),
+                         base::DoNothing());
+@@ -383,7 +388,8 @@ class StatusIconLinuxDbus::Multiplexer {
+       return;
+     }
+ 
+-    if (interface != kInterfaceStatusNotifierItem) {
++    if (interface != kInterfaceStatusNotifierItem &&
++        interface != kInterfaceStatusNotifierItemFreedesktop) {
+       std::move(response_sender).Run(nullptr);
+       return;
+     }
+@@ -418,7 +424,11 @@ class StatusIconLinuxDbus::Multiplexer {
+       return;
+     }
+ 
+-    if (interface != kInterfaceStatusNotifierItem) {
++    // The D-Bus specification allows an empty interface_name in GetAll to
++    // request properties across all interfaces.
++    if (interface != kInterfaceStatusNotifierItem &&
++        interface != kInterfaceStatusNotifierItemFreedesktop &&
++        !interface.empty()) {
+       std::move(response_sender).Run(nullptr);
+       return;
+     }
+@@ -436,6 +446,16 @@ class StatusIconLinuxDbus::Multiplexer {
+   scoped_refptr<dbus::ExportedObject> item_;
+ };
+ 
++// static
++void StatusIconLinuxDbus::ExportMultiplexerMethodsForTesting(dbus::Bus* bus) {
++  Multiplexer::Get()->ExportMethods(bus);
++}
++
++// static
++void StatusIconLinuxDbus::UnexportMultiplexerMethodsForTesting(dbus::Bus* bus) {
++  Multiplexer::Get()->UnexportMethods(bus);
++}
++
+ StatusIconLinuxDbus::StatusIconLinuxDbus()
+     : bus_(dbus_thread_linux::GetSharedSessionBus()),
+       should_write_icon_to_file_(ShouldWriteIconToFile()),
+@@ -489,8 +509,11 @@ void StatusIconLinuxDbus::SetToolTip(const std::u16string& tool_tip) {
+       kPropertyToolTip,
+       MakeDbusToolTip(base::UTF16ToUTF8(delegate_->GetToolTip())));
+   if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
+-    dbus::Signal signal(kInterfaceStatusNotifierItem, kSignalNewToolTip);
+-    multiplexer_item->SendSignal(&signal);
++    for (const char* interface : {kInterfaceStatusNotifierItem,
++                                  kInterfaceStatusNotifierItemFreedesktop}) {
++      dbus::Signal signal(interface, kSignalNewToolTip);
++      multiplexer_item->SendSignal(&signal);
++    }
+   }
+ }
+ 
+@@ -765,8 +788,12 @@ void StatusIconLinuxDbus::SetImageImpl(const gfx::ImageSkia& image,
+                            send_signals);
+     if (send_signals) {
+       if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
+-        dbus::Signal signal(kInterfaceStatusNotifierItem, kSignalNewIcon);
+-        multiplexer_item->SendSignal(&signal);
++        for (const char* interface :
++             {kInterfaceStatusNotifierItem,
++              kInterfaceStatusNotifierItemFreedesktop}) {
++          dbus::Signal signal(interface, kSignalNewIcon);
++          multiplexer_item->SendSignal(&signal);
++        }
+       }
+     }
+   }
+@@ -785,13 +812,16 @@ void StatusIconLinuxDbus::OnIconFileWritten(const base::FilePath& icon_file) {
+                    icon_file_.BaseName().RemoveExtension().value(), false);
+ 
+   if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
+-    dbus::Signal new_icon_theme_path_signal(kInterfaceStatusNotifierItem,
+-                                            kSignalNewIconThemePath);
+-    dbus::MessageWriter writer(&new_icon_theme_path_signal);
+-    writer.AppendString(icon_file_.DirName().value());
+-    multiplexer_item->SendSignal(&new_icon_theme_path_signal);
+-    dbus::Signal new_icon_signal(kInterfaceStatusNotifierItem, kSignalNewIcon);
+-    multiplexer_item->SendSignal(&new_icon_signal);
++    for (const char* interface : {kInterfaceStatusNotifierItem,
++                                  kInterfaceStatusNotifierItemFreedesktop}) {
++      dbus::Signal new_icon_theme_path_signal(interface,
++                                              kSignalNewIconThemePath);
++      dbus::MessageWriter writer(&new_icon_theme_path_signal);
++      writer.AppendString(icon_file_.DirName().value());
++      multiplexer_item->SendSignal(&new_icon_theme_path_signal);
++      dbus::Signal new_icon_signal(interface, kSignalNewIcon);
++      multiplexer_item->SendSignal(&new_icon_signal);
++    }
+   }
+ }
+ 
+@@ -805,24 +835,30 @@ void StatusIconLinuxDbus::CleanupIconFile() {
+ }
+ 
+ void StatusIconLinuxDbus::PropertyUpdated(const std::string& property_name) {
+-  dbus::Signal signal(DBUS_INTERFACE_PROPERTIES, "PropertiesChanged");
+-  dbus::MessageWriter writer(&signal);
+-  writer.AppendString(kInterfaceStatusNotifierItem);
+-
+-  // Changed properties.
+-  dbus::MessageWriter array_writer(nullptr);
+-  writer.OpenArray("{sv}", &array_writer);
+-  dbus::MessageWriter dict_entry_writer(nullptr);
+-  array_writer.OpenDictEntry(&dict_entry_writer);
+-  dict_entry_writer.AppendString(property_name);
+-  properties_[property_name].Write(dict_entry_writer);
+-  array_writer.CloseContainer(&dict_entry_writer);
+-  writer.CloseContainer(&array_writer);
+-
+-  // Invalidated properties.
+-  writer.AppendArrayOfStrings({});
++  auto* multiplexer_item = Multiplexer::GetMultiplexerItem();
++  if (!multiplexer_item) {
++    return;
++  }
++
++  for (const char* interface : {kInterfaceStatusNotifierItem,
++                                kInterfaceStatusNotifierItemFreedesktop}) {
++    dbus::Signal signal(DBUS_INTERFACE_PROPERTIES, "PropertiesChanged");
++    dbus::MessageWriter writer(&signal);
++    writer.AppendString(interface);
++
++    // Changed properties.
++    dbus::MessageWriter array_writer(nullptr);
++    writer.OpenArray("{sv}", &array_writer);
++    dbus::MessageWriter dict_entry_writer(nullptr);
++    array_writer.OpenDictEntry(&dict_entry_writer);
++    dict_entry_writer.AppendString(property_name);
++    properties_[property_name].Write(dict_entry_writer);
++    array_writer.CloseContainer(&dict_entry_writer);
++    writer.CloseContainer(&array_writer);
++
++    // Invalidated properties.
++    writer.AppendArrayOfStrings({});
+ 
+-  if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
+     multiplexer_item->SendSignal(&signal);
+   }
+ }
+diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
+index b692109cb926c1ac9de533587436b57897fbb533..36adc9ff0926fc136355e34f3c95261f4b8ac4cc 100644
+--- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
++++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
+@@ -53,6 +53,9 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+   // ui::SimpleMenuModel::Delegate:
+   void ExecuteCommand(int command_id, int event_flags) override;
+ 
++  static void ExportMultiplexerMethodsForTesting(dbus::Bus* bus);
++  static void UnexportMultiplexerMethodsForTesting(dbus::Bus* bus);
++
+  private:
+   friend class base::RefCounted<StatusIconLinuxDbus>;
+ 

--- a/patches/chromium/cherry-pick-726eafecc145.patch
+++ b/patches/chromium/cherry-pick-726eafecc145.patch
@@ -1,0 +1,593 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 12 Aug 2026 18:11:20 -0700
+Subject: Reland "Fix D-Bus unique name destination resolution for status
+ icons"
+
+This is a reland of commit a814681acc9b0ac3e1ece9bb923d01fbe6656c35
+
+The reland removes usage of testing::Invoke.
+
+Original change's description:
+> Fix D-Bus unique name destination resolution for status icons
+>
+> Tray hosts using GDBusProxy (e.g. Cinnamon, XFCE, GNOME extensions)
+> resolve the owner of the well-known status icon service name
+> (org.freedesktop.StatusNotifierItem-PID-ID) and then address subsequent
+> method calls and property queries directly to the unique connection name
+> (:1.x).
+>
+> Previously, StatusIconLinuxDbus::Multiplexer::GetIcon only looked up
+> destinations in its map of well-known service names. When addressed via
+> a unique connection name, the lookup failed and returned a D-Bus error,
+> leaving status icons unresponsive and without images.
+>
+> This CL fixes the issue by updating Multiplexer::GetIcon to fall back to
+> the first registered status icon when destination lookup fails and
+> icons_ is non-empty.
+>
+> Fixed: 543471702
+> Change-Id: Id2c828498b1b94ceacf9bc9e0699a4f78c494144
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8236711
+> Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Commit-Queue: Lei Zhang <thestig@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1677795}
+
+Change-Id: Ifc22af2e1fe29668fde2daa7c5c54c20b26c2abf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8250459
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1678472}
+
+Electron backport note: the upstream unittest changes are omitted here
+since Electron does not build Chromium unit tests. This patch can be
+removed once this branch is on a Chromium revision that includes
+crrev.com/c/8250459 (>= 153.0.8006.0).
+
+diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+index 384c92b90429961a1bc8a116477b254457c631ce..ddc7877f7891fcda71ddfc84db55ab0072078ad5 100644
+--- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
++++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+@@ -23,11 +23,11 @@
+ #include "base/process/process.h"
+ #include "base/strings/strcat.h"
+ #include "base/strings/string_number_conversions.h"
++#include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/task/thread_pool.h"
+ #include "components/dbus/menu/menu.h"
+ #include "components/dbus/properties/dbus_properties.h"
+-#include "components/dbus/properties/success_barrier_callback.h"
+ #include "components/dbus/thread_linux/dbus_thread_linux.h"
+ #include "components/dbus/utils/bind_weak_ptr_for_export_method.h"
+ #include "components/dbus/utils/call_method.h"
+@@ -232,238 +232,19 @@ base::FilePath WriteIconFile(size_t icon_file_id,
+ 
+ }  // namespace
+ 
+-class StatusIconLinuxDbus::Multiplexer {
+- public:
+-  static Multiplexer* Get() {
+-    static base::NoDestructor<Multiplexer> instance;
+-    return instance.get();
+-  }
+-
+-  static dbus::ExportedObject* GetMultiplexerItem() {
+-    return Get()->item_.get();
+-  }
+-
+-  void Register(const std::string& service_name,
+-                StatusIconLinuxDbus* icon,
+-                dbus::Bus* bus) {
+-    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+-    if (icons_.empty()) {
+-      ExportMethods(bus);
+-    }
+-    icons_[service_name] = icon;
+-  }
+-
+-  void Unregister(const std::string& service_name, dbus::Bus* bus) {
+-    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+-    // Unregister may be called for a service name that was never registered
+-    // if initialization failed before registration.
+-    icons_.erase(service_name);
+-    if (icons_.empty()) {
+-      UnexportMethods(bus);
+-    }
+-  }
+-
+-  StatusIconLinuxDbus* GetIcon(const std::string& service_name) {
+-    auto it = icons_.find(service_name);
+-    return it != icons_.end() ? it->second : nullptr;
+-  }
+-
+- private:
+-  friend class base::NoDestructor<Multiplexer>;
+-  friend class StatusIconLinuxDbus;
+-  Multiplexer() = default;
+-  ~Multiplexer() = default;
+-
+-  void ExportMethods(dbus::Bus* bus) {
+-    item_ = bus->GetExportedObject(dbus::ObjectPath(kPathStatusNotifierItem));
+-
+-    for (const char* interface : {kInterfaceStatusNotifierItem,
+-                                  kInterfaceStatusNotifierItemFreedesktop}) {
+-      item_->ExportMethod(interface, kMethodActivate,
+-                          base::BindRepeating(&Multiplexer::OnActivate),
+-                          base::DoNothing());
+-      item_->ExportMethod(interface, kMethodContextMenu,
+-                          base::BindRepeating(&Multiplexer::OnContextMenu),
+-                          base::DoNothing());
+-      item_->ExportMethod(interface, kMethodScroll,
+-                          base::BindRepeating(&Multiplexer::OnScroll),
+-                          base::DoNothing());
+-      item_->ExportMethod(
+-          interface, kMethodSecondaryActivate,
+-          base::BindRepeating(&Multiplexer::OnSecondaryActivate),
+-          base::DoNothing());
+-    }
+-    item_->ExportMethod(DBUS_INTERFACE_PROPERTIES, "Get",
+-                        base::BindRepeating(&Multiplexer::OnGetProperty),
+-                        base::DoNothing());
+-    item_->ExportMethod(DBUS_INTERFACE_PROPERTIES, "GetAll",
+-                        base::BindRepeating(&Multiplexer::OnGetAllProperties),
+-                        base::DoNothing());
+-  }
+-
+-  void UnexportMethods(dbus::Bus* bus) {
+-    if (item_ && bus) {
+-      bus->UnregisterExportedObject(dbus::ObjectPath(kPathStatusNotifierItem));
+-      item_ = nullptr;
+-    }
+-  }
+-
+-  static void OnActivate(dbus::MethodCall* method_call,
+-                         dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (icon) {
+-      dbus::MessageReader reader(method_call);
+-      int32_t x = 0;
+-      int32_t y = 0;
+-      if (reader.PopInt32(&x) && reader.PopInt32(&y)) {
+-        (void)icon->OnActivate(x, y);
+-      }
+-    }
+-    std::move(response_sender).Run(dbus::Response::FromMethodCall(method_call));
+-  }
+-
+-  static void OnContextMenu(
+-      dbus::MethodCall* method_call,
+-      dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (icon) {
+-      dbus::MessageReader reader(method_call);
+-      int32_t x = 0;
+-      int32_t y = 0;
+-      if (reader.PopInt32(&x) && reader.PopInt32(&y)) {
+-        (void)icon->OnContextMenu(x, y);
+-      }
+-    }
+-    std::move(response_sender).Run(dbus::Response::FromMethodCall(method_call));
+-  }
+-
+-  static void OnScroll(dbus::MethodCall* method_call,
+-                       dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (icon) {
+-      dbus::MessageReader reader(method_call);
+-      int32_t delta = 0;
+-      std::string orientation;
+-      if (reader.PopInt32(&delta) && reader.PopString(&orientation)) {
+-        (void)icon->OnScroll(delta, orientation);
+-      }
+-    }
+-    std::move(response_sender).Run(dbus::Response::FromMethodCall(method_call));
+-  }
+-
+-  static void OnSecondaryActivate(
+-      dbus::MethodCall* method_call,
+-      dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (icon) {
+-      dbus::MessageReader reader(method_call);
+-      int32_t x = 0;
+-      int32_t y = 0;
+-      if (reader.PopInt32(&x) && reader.PopInt32(&y)) {
+-        (void)icon->OnSecondaryActivate(x, y);
+-      }
+-    }
+-    std::move(response_sender).Run(dbus::Response::FromMethodCall(method_call));
+-  }
+-
+-  static void OnGetProperty(
+-      dbus::MethodCall* method_call,
+-      dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (!icon) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    dbus::MessageReader reader(method_call);
+-    std::string interface;
+-    std::string property_name;
+-    if (!reader.PopString(&interface) || !reader.PopString(&property_name)) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    if (interface != kInterfaceStatusNotifierItem &&
+-        interface != kInterfaceStatusNotifierItemFreedesktop) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    std::unique_ptr<dbus::Response> response =
+-        dbus::Response::FromMethodCall(method_call);
+-    dbus::MessageWriter writer(response.get());
+-
+-    auto prop_it = icon->properties_.find(property_name);
+-    if (prop_it != icon->properties_.end()) {
+-      prop_it->second.Write(writer);
+-      std::move(response_sender).Run(std::move(response));
+-    } else {
+-      std::move(response_sender).Run(nullptr);
+-    }
+-  }
+-
+-  static void OnGetAllProperties(
+-      dbus::MethodCall* method_call,
+-      dbus::ExportedObject::ResponseSender response_sender) {
+-    std::string destination = method_call->GetDestination();
+-    auto* icon = Get()->GetIcon(destination);
+-    if (!icon) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    dbus::MessageReader reader(method_call);
+-    std::string interface;
+-    if (!reader.PopString(&interface)) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    // The D-Bus specification allows an empty interface_name in GetAll to
+-    // request properties across all interfaces.
+-    if (interface != kInterfaceStatusNotifierItem &&
+-        interface != kInterfaceStatusNotifierItemFreedesktop &&
+-        !interface.empty()) {
+-      std::move(response_sender).Run(nullptr);
+-      return;
+-    }
+-
+-    std::unique_ptr<dbus::Response> response =
+-        dbus::Response::FromMethodCall(method_call);
+-    dbus::MessageWriter writer(response.get());
+-
+-    dbus_utils::WriteValue(writer, icon->properties_);
+-    std::move(response_sender).Run(std::move(response));
+-  }
+-
+-  // A map of registered status icons, keyed by their unique D-Bus service name.
+-  std::map<std::string, StatusIconLinuxDbus*> icons_;
+-  scoped_refptr<dbus::ExportedObject> item_;
+-};
+-
+-// static
+-void StatusIconLinuxDbus::ExportMultiplexerMethodsForTesting(dbus::Bus* bus) {
+-  Multiplexer::Get()->ExportMethods(bus);
+-}
+-
+-// static
+-void StatusIconLinuxDbus::UnexportMultiplexerMethodsForTesting(dbus::Bus* bus) {
+-  Multiplexer::Get()->UnexportMethods(bus);
+-}
+-
+ StatusIconLinuxDbus::StatusIconLinuxDbus()
+-    : bus_(dbus_thread_linux::GetSharedSessionBus()),
++    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus()) {}
++
++StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus)
++    : bus_(std::move(bus)),
+       should_write_icon_to_file_(ShouldWriteIconToFile()),
+       icon_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
+           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+-  CheckStatusNotifierWatcherHasOwner();
++  if (bus_) {
++    CheckStatusNotifierWatcherHasOwner();
++  }
+ }
+ 
+ void StatusIconLinuxDbus::SetImage(const gfx::ImageSkia& image) {
+@@ -508,11 +289,11 @@ void StatusIconLinuxDbus::SetToolTip(const std::u16string& tool_tip) {
+   SetProperty<"(sa(iiay)ss)">(
+       kPropertyToolTip,
+       MakeDbusToolTip(base::UTF16ToUTF8(delegate_->GetToolTip())));
+-  if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
++  if (item_) {
+     for (const char* interface : {kInterfaceStatusNotifierItem,
+                                   kInterfaceStatusNotifierItemFreedesktop}) {
+       dbus::Signal signal(interface, kSignalNewToolTip);
+-      multiplexer_item->SendSignal(&signal);
++      item_->SendSignal(&signal);
+     }
+   }
+ }
+@@ -541,7 +322,6 @@ StatusIconLinuxDbus::~StatusIconLinuxDbus() {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+   CleanupIconFile();
+ 
+-  Multiplexer::Get()->Unregister(service_name_, bus_.get());
+   if (!service_name_.empty()) {
+     bus_->GetDBusTaskRunner()->PostTask(
+         FROM_HERE,
+@@ -552,6 +332,12 @@ StatusIconLinuxDbus::~StatusIconLinuxDbus() {
+             bus_, service_name_));
+   }
+ 
++  if (item_) {
++    bus_->UnregisterExportedObject(
++        ObjectPathFromId(kPathStatusNotifierItem, service_id_));
++    item_ = nullptr;
++  }
++
+   if (menu_) {
+     menu_.reset();
+     bus_->UnregisterExportedObject(
+@@ -609,14 +395,48 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+                     base::NumberToString(base::Process::Current().Pid()), "-",
+                     base::NumberToString(service_id_)});
+ 
+-  // The barrier only requires 1 call (for `menu_` initialization).
+-  barrier_ = SuccessBarrierCallback(
+-      1, base::BindOnce(&StatusIconLinuxDbus::OnInitialized,
+-                        weak_factory_.GetWeakPtr()));
++  item_ = bus_->GetExportedObject(
++      ObjectPathFromId(kPathStatusNotifierItem, service_id_));
++
++  for (const char* interface : {kInterfaceStatusNotifierItem,
++                                kInterfaceStatusNotifierItemFreedesktop}) {
++    dbus_utils::ExportMethod<"ii", "">(
++        item_, interface, kMethodActivate,
++        dbus_utils::BindWeakPtrForExportMethod(&StatusIconLinuxDbus::OnActivate,
++                                               weak_factory_.GetWeakPtr()),
++        base::DoNothing());
++    dbus_utils::ExportMethod<"ii", "">(
++        item_, interface, kMethodContextMenu,
++        dbus_utils::BindWeakPtrForExportMethod(
++            &StatusIconLinuxDbus::OnContextMenu, weak_factory_.GetWeakPtr()),
++        base::DoNothing());
++    dbus_utils::ExportMethod<"is", "">(
++        item_, interface, kMethodScroll,
++        dbus_utils::BindWeakPtrForExportMethod(&StatusIconLinuxDbus::OnScroll,
++                                               weak_factory_.GetWeakPtr()),
++        base::DoNothing());
++    dbus_utils::ExportMethod<"ii", "">(
++        item_, interface, kMethodSecondaryActivate,
++        dbus_utils::BindWeakPtrForExportMethod(
++            &StatusIconLinuxDbus::OnSecondaryActivate,
++            weak_factory_.GetWeakPtr()),
++        base::DoNothing());
++  }
++
++  item_->ExportMethod(DBUS_INTERFACE_PROPERTIES, "Get",
++                      base::BindRepeating(&StatusIconLinuxDbus::OnGetProperty,
++                                          weak_factory_.GetWeakPtr()),
++                      base::DoNothing());
++  item_->ExportMethod(
++      DBUS_INTERFACE_PROPERTIES, "GetAll",
++      base::BindRepeating(&StatusIconLinuxDbus::OnGetAllProperties,
++                          weak_factory_.GetWeakPtr()),
++      base::DoNothing());
+ 
+   menu_ = std::make_unique<DbusMenu>(
+       bus_->GetExportedObject(ObjectPathFromId(kPathDbusMenu, service_id_)),
+-      barrier_);
++      base::BindOnce(&StatusIconLinuxDbus::OnInitialized,
++                     weak_factory_.GetWeakPtr()));
+   UpdateMenuImpl(delegate_->GetMenuModel(), false);
+ 
+   // Initialize properties map.
+@@ -655,8 +475,6 @@ void StatusIconLinuxDbus::OnInitialized(bool success) {
+       base::BindRepeating(&StatusIconLinuxDbus::OnNameOwnerChangedReceived,
+                           weak_factory_.GetWeakPtr()));
+ 
+-  Multiplexer::Get()->Register(service_name_, this, bus_.get());
+-
+   bus_->RequestOwnership(
+       service_name_, dbus::Bus::REQUIRE_PRIMARY,
+       base::BindOnce(&StatusIconLinuxDbus::OnOwnershipAcquired,
+@@ -680,7 +498,9 @@ void StatusIconLinuxDbus::RegisterStatusNotifierItem() {
+       kMethodRegisterStatusNotifierItem,
+       base::BindOnce(&StatusIconLinuxDbus::OnRegistered,
+                      weak_factory_.GetWeakPtr()),
+-      service_name_);
++      base::StrCat(
++          {service_name_,
++           ObjectPathFromId(kPathStatusNotifierItem, service_id_).value()}));
+ }
+ 
+ void StatusIconLinuxDbus::OnRegistered(
+@@ -769,6 +589,65 @@ void StatusIconLinuxDbus::UpdateMenuImpl(ui::MenuModel* model,
+   menu_runner_.reset();
+ }
+ 
++void StatusIconLinuxDbus::OnGetProperty(
++    dbus::MethodCall* method_call,
++    dbus::ExportedObject::ResponseSender response_sender) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  dbus::MessageReader reader(method_call);
++  std::string interface;
++  std::string property_name;
++  if (!reader.PopString(&interface) || !reader.PopString(&property_name)) {
++    std::move(response_sender).Run(nullptr);
++    return;
++  }
++
++  if (interface != kInterfaceStatusNotifierItem &&
++      interface != kInterfaceStatusNotifierItemFreedesktop) {
++    std::move(response_sender).Run(nullptr);
++    return;
++  }
++
++  auto prop_it = properties_.find(property_name);
++  if (prop_it == properties_.end()) {
++    std::move(response_sender).Run(nullptr);
++    return;
++  }
++
++  std::unique_ptr<dbus::Response> response =
++      dbus::Response::FromMethodCall(method_call);
++  dbus::MessageWriter writer(response.get());
++  prop_it->second.Write(writer);
++  std::move(response_sender).Run(std::move(response));
++}
++
++void StatusIconLinuxDbus::OnGetAllProperties(
++    dbus::MethodCall* method_call,
++    dbus::ExportedObject::ResponseSender response_sender) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  dbus::MessageReader reader(method_call);
++  std::string interface;
++  if (!reader.PopString(&interface)) {
++    std::move(response_sender).Run(nullptr);
++    return;
++  }
++
++  // The D-Bus specification allows an empty interface_name in GetAll to
++  // request properties across all interfaces.
++  if (interface != kInterfaceStatusNotifierItem &&
++      interface != kInterfaceStatusNotifierItemFreedesktop &&
++      !interface.empty()) {
++    std::move(response_sender).Run(nullptr);
++    return;
++  }
++
++  std::unique_ptr<dbus::Response> response =
++      dbus::Response::FromMethodCall(method_call);
++  dbus::MessageWriter writer(response.get());
++
++  dbus_utils::WriteValue(writer, properties_);
++  std::move(response_sender).Run(std::move(response));
++}
++
+ void StatusIconLinuxDbus::SetImageImpl(const gfx::ImageSkia& image,
+                                        bool send_signals) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+@@ -786,14 +665,11 @@ void StatusIconLinuxDbus::SetImageImpl(const gfx::ImageSkia& image,
+   } else {
+     SetProperty<"a(iiay)">(kPropertyIconPixmap, MakeDbusImage(image),
+                            send_signals);
+-    if (send_signals) {
+-      if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
+-        for (const char* interface :
+-             {kInterfaceStatusNotifierItem,
+-              kInterfaceStatusNotifierItemFreedesktop}) {
+-          dbus::Signal signal(interface, kSignalNewIcon);
+-          multiplexer_item->SendSignal(&signal);
+-        }
++    if (send_signals && item_) {
++      for (const char* interface : {kInterfaceStatusNotifierItem,
++                                    kInterfaceStatusNotifierItemFreedesktop}) {
++        dbus::Signal signal(interface, kSignalNewIcon);
++        item_->SendSignal(&signal);
+       }
+     }
+   }
+@@ -811,16 +687,16 @@ void StatusIconLinuxDbus::OnIconFileWritten(const base::FilePath& icon_file) {
+   SetProperty<"s">(kPropertyIconName,
+                    icon_file_.BaseName().RemoveExtension().value(), false);
+ 
+-  if (auto* multiplexer_item = Multiplexer::GetMultiplexerItem()) {
++  if (item_) {
+     for (const char* interface : {kInterfaceStatusNotifierItem,
+                                   kInterfaceStatusNotifierItemFreedesktop}) {
+       dbus::Signal new_icon_theme_path_signal(interface,
+                                               kSignalNewIconThemePath);
+       dbus::MessageWriter writer(&new_icon_theme_path_signal);
+       writer.AppendString(icon_file_.DirName().value());
+-      multiplexer_item->SendSignal(&new_icon_theme_path_signal);
++      item_->SendSignal(&new_icon_theme_path_signal);
+       dbus::Signal new_icon_signal(interface, kSignalNewIcon);
+-      multiplexer_item->SendSignal(&new_icon_signal);
++      item_->SendSignal(&new_icon_signal);
+     }
+   }
+ }
+@@ -835,8 +711,7 @@ void StatusIconLinuxDbus::CleanupIconFile() {
+ }
+ 
+ void StatusIconLinuxDbus::PropertyUpdated(const std::string& property_name) {
+-  auto* multiplexer_item = Multiplexer::GetMultiplexerItem();
+-  if (!multiplexer_item) {
++  if (!item_) {
+     return;
+   }
+ 
+@@ -859,6 +734,6 @@ void StatusIconLinuxDbus::PropertyUpdated(const std::string& property_name) {
+     // Invalidated properties.
+     writer.AppendArrayOfStrings({});
+ 
+-    multiplexer_item->SendSignal(&signal);
++    item_->SendSignal(&signal);
+   }
+ }
+diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
+index 36adc9ff0926fc136355e34f3c95261f4b8ac4cc..5f7e20bc0b56b5621cfb04d96712b2f1db91cf0e 100644
+--- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
++++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
+@@ -39,6 +39,7 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+                             public base::RefCounted<StatusIconLinuxDbus> {
+  public:
+   StatusIconLinuxDbus();
++  explicit StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus);
+ 
+   StatusIconLinuxDbus(const StatusIconLinuxDbus&) = delete;
+   StatusIconLinuxDbus& operator=(const StatusIconLinuxDbus&) = delete;
+@@ -53,15 +54,9 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+   // ui::SimpleMenuModel::Delegate:
+   void ExecuteCommand(int command_id, int event_flags) override;
+ 
+-  static void ExportMultiplexerMethodsForTesting(dbus::Bus* bus);
+-  static void UnexportMultiplexerMethodsForTesting(dbus::Bus* bus);
+-
+  private:
+   friend class base::RefCounted<StatusIconLinuxDbus>;
+ 
+-  class Multiplexer;
+-  friend class Multiplexer;
+-
+   ~StatusIconLinuxDbus() override;
+ 
+   // Step 0: send the request to verify that the StatusNotifierWatcher service
+@@ -99,6 +94,11 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+                                             std::string orientation);
+   dbus_utils::ExportMethodResult<> OnSecondaryActivate(int32_t x, int32_t y);
+ 
++  void OnGetProperty(dbus::MethodCall* method_call,
++                     dbus::ExportedObject::ResponseSender response_sender);
++  void OnGetAllProperties(dbus::MethodCall* method_call,
++                          dbus::ExportedObject::ResponseSender response_sender);
++
+   void UpdateMenuImpl(ui::MenuModel* model, bool send_signal);
+ 
+   void SetImageImpl(const gfx::ImageSkia& image, bool send_signals);
+@@ -135,8 +135,6 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+   raw_ptr<dbus::ObjectProxy, DanglingUntriaged> watcher_ = nullptr;
+   raw_ptr<dbus::ExportedObject, DanglingUntriaged> item_ = nullptr;
+ 
+-  base::RepeatingCallback<void(bool)> barrier_;
+-
+   // A map of property names (e.g. "Category", "Id") to their values.
+   std::map<std::string, dbus_utils::Variant> properties_;
+ 

--- a/patches/chromium/fix_linux_tray_id.patch
+++ b/patches/chromium/fix_linux_tray_id.patch
@@ -13,7 +13,7 @@ https://github.com/electron/electron/pull/48675#issuecomment-3452781711
 for more info.
 
 diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
-index 951ee684c6b02ddc4cae65b2997722457c1ec9dd..b1adb3bb230d64533b0e9d5cedd18bf6efa4c077 100644
+index ddc7877f7891fcda71ddfc84db55ab0072078ad5..35b992eacd9ca393561a79ccc2243953c0c91be9 100644
 --- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
 +++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
 @@ -136,8 +136,9 @@ int NextServiceId() {
@@ -28,13 +28,20 @@ index 951ee684c6b02ddc4cae65b2997722457c1ec9dd..b1adb3bb230d64533b0e9d5cedd18bf6
  }
  
  dbus::ObjectPath ObjectPathFromId(const std::string& path, int service_id) {
-@@ -436,12 +437,13 @@ class StatusIconLinuxDbus::Multiplexer {
-   scoped_refptr<dbus::ExportedObject> item_;
- };
+@@ -232,15 +233,18 @@ base::FilePath WriteIconFile(size_t icon_file_id,
+ 
+ }  // namespace
  
 -StatusIconLinuxDbus::StatusIconLinuxDbus()
+-    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus()) {}
 +StatusIconLinuxDbus::StatusIconLinuxDbus(const std::string_view app_name)
-     : bus_(dbus_thread_linux::GetSharedSessionBus()),
++    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus(),
++                          app_name) {}
+ 
+-StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus)
++StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus,
++                                         const std::string_view app_name)
+     : bus_(std::move(bus)),
        should_write_icon_to_file_(ShouldWriteIconToFile()),
        icon_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
            {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
@@ -42,9 +49,9 @@ index 951ee684c6b02ddc4cae65b2997722457c1ec9dd..b1adb3bb230d64533b0e9d5cedd18bf6
 +           base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
 +      app_name_(app_name) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-   CheckStatusNotifierWatcherHasOwner();
- }
-@@ -604,7 +606,8 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+   if (bus_) {
+     CheckStatusNotifierWatcherHasOwner();
+@@ -447,7 +451,8 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
    SetProperty<"s">(kPropertyAttentionIconName, "", false);
    SetProperty<"s">(kPropertyAttentionMovieName, "", false);
    SetProperty<"s">(kPropertyCategory, kPropertyValueCategory, false);
@@ -55,19 +62,22 @@ index 951ee684c6b02ddc4cae65b2997722457c1ec9dd..b1adb3bb230d64533b0e9d5cedd18bf6
    SetProperty<"s">(kPropertyStatus, kPropertyValueStatus, false);
    SetProperty<"s">(kPropertyTitle, "", false);
 diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
-index b692109cb926c1ac9de533587436b57897fbb533..9c60fc96bed04f3d40bb2837904d08af0e36f32a 100644
+index 5f7e20bc0b56b5621cfb04d96712b2f1db91cf0e..9668ee5a48e180d0ace989c6cb6d9364a162c5ce 100644
 --- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
 +++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h
-@@ -38,7 +38,7 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+@@ -38,8 +38,9 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
                              public ui::SimpleMenuModel::Delegate,
                              public base::RefCounted<StatusIconLinuxDbus> {
   public:
 -  StatusIconLinuxDbus();
+-  explicit StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus);
 +  StatusIconLinuxDbus(const std::string_view app_name = "chrome");
++  explicit StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus,
++                               const std::string_view app_name = "chrome");
  
    StatusIconLinuxDbus(const StatusIconLinuxDbus&) = delete;
    StatusIconLinuxDbus& operator=(const StatusIconLinuxDbus&) = delete;
-@@ -160,6 +160,8 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
+@@ -161,6 +162,8 @@ class StatusIconLinuxDbus : public ui::StatusIconLinux,
    size_t icon_file_id_ = 0;
    base::FilePath icon_file_;
  


### PR DESCRIPTION
#### Description of Change

Fixes #52674.

Cherry-picks two upstream Linux status-icon fixes into `patches/chromium`:

* [crrev.com/c/8189930](https://chromium-review.googlesource.com/c/chromium/src/+/8189930) — *Support org.freedesktop.StatusNotifierItem for Linux status icons* (`cherry-pick-3a02de271fd3.patch`, in Chromium ≥ 153.0.7994.0)
* [crrev.com/c/8250459](https://chromium-review.googlesource.com/c/chromium/src/+/8250459) — *Reland "Fix D-Bus unique name destination resolution for status icons"* (`cherry-pick-726eafecc145.patch`, in Chromium ≥ 153.0.8006.0)

The StatusNotifierItem multiplexer that landed in this branch's Chromium (M152 / the M150 `.181` merge) only routed requests addressed to the icon's well-known bus name on the `org.kde` interface. Tray hosts built on `GDBusProxy` (GNOME's AppIndicator extension, Cinnamon, xApp) resolve the well-known name to the unique connection name and talk to that, and XFCE queries the `org.freedesktop.StatusNotifierItem` interface — both got D-Bus errors back, so the icon never appeared (three-dot placeholder, no menu). The second CL removes the multiplexer and gives each icon its own exported object path again; it is written on top of the first, so both are picked. Only the production `status_icon_linux_dbus.{cc,h}` hunks are carried (upstream unittest / BUILD.gn test-target hunks are omitted since we don't build Chromium unit tests) — this is noted in each patch description along with the Chromium version at which it can be dropped.

`fix_linux_tray_id.patch` touched the same constructor, so it is rebased onto the new delegating-constructor shape (threading `app_name` through both constructors) and the two cherry-picks are ordered immediately before it in `.patches`. The resulting `status_icon_linux_dbus.{cc,h}` before the tray-id patch is byte-identical to upstream at 726eafecc145.

`main` does not need this: both CLs arrive with the pending Chromium roll (#52800 → 153.0.8009.0), which will need the same `fix_linux_tray_id.patch` rebase. 42-x-y (M148) predates the multiplexer and is unaffected. The 43-x-y equivalent is #52952.

Unrelated but adjacent: #52819 (snap `org.kde` bus-name prefix) touches the same file and will need a trivial rebase on top of this if it lands.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `Tray` icons not appearing (and their menus not opening) on Linux desktops that address the StatusNotifierItem by its unique D-Bus name or via the `org.freedesktop.StatusNotifierItem` interface, such as GNOME with the AppIndicator extension, Cinnamon and XFCE.
