### PR TITLE
build: name node's arch after the target cpu in every toolchain

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -309,9 +309,18 @@ index 856878c33681a73d41016729dabe48b0a6a80589..91a11852d206b65485fe90fd037a0bd1
      if sys.platform == 'win32':
        files = [ x.replace('\\', '/') for x in files ]
 diff --git a/unofficial.gni b/unofficial.gni
-index aa78f9ce60c0439536eaf6e23880e30ebef0e1a9..df0ae804a5338d8f2ec4d331a1e2ed053c3c3955 100644
+index aa78f9ce60c0439536eaf6e23880e30ebef0e1a9..7265e09bf7601afe76463f528ffb385db796e093 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
+@@ -94,7 +94,7 @@ template("node_gn_build") {
+       "-Wno-unused-function",
+     ]
+ 
+-    if (current_cpu == "x86") {
++    if (target_cpu == "x86") {
+       node_arch = "ia32"
+     } else {
+       node_arch = target_cpu
 @@ -147,32 +147,42 @@ template("node_gn_build") {
      public_configs = [
        ":node_external_config",

--- a/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
+++ b/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
@@ -14,7 +14,7 @@ We don't need to do this for zlib, as the existing gn workflow uses the same
 Upstreamed at https://github.com/nodejs/node/pull/55903
 
 diff --git a/unofficial.gni b/unofficial.gni
-index eeffbafa4023ed68f56410c858e459f569ed6344..d7c717d5c2799692c7ea4537d7faea234faefaa2 100644
+index dce99416375f18e9d5ce9f4d992023990f44878d..d278835be141d28c1514e404e63c33096cbcaa6b 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -203,7 +203,17 @@ template("node_gn_build") {

--- a/patches/node/build_enable_perfetto.patch
+++ b/patches/node/build_enable_perfetto.patch
@@ -799,7 +799,7 @@ index 0bc9df81d87562243817a6618641a49b602654e3..b6dd8b9a9c21051f3d385d5ecea9c50c
  namespace tracing {
  
 diff --git a/unofficial.gni b/unofficial.gni
-index df0ae804a5338d8f2ec4d331a1e2ed053c3c3955..eeffbafa4023ed68f56410c858e459f569ed6344 100644
+index 7265e09bf7601afe76463f528ffb385db796e093..dce99416375f18e9d5ce9f4d992023990f44878d 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -143,7 +143,10 @@ template("node_gn_build") {

--- a/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
+++ b/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
@@ -20,7 +20,7 @@ index ab7dc27de3e304f6d912d5834da47e3b4eb25495..b6c0fd4ceee989dac55c7d54e52fef18
    }
  }
 diff --git a/unofficial.gni b/unofficial.gni
-index d7c717d5c2799692c7ea4537d7faea234faefaa2..bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a 100644
+index d278835be141d28c1514e404e63c33096cbcaa6b..6326abf521d0e5c8e86e9dfa8562f0a648a56a19 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -146,6 +146,7 @@ template("node_gn_build") {

--- a/patches/node/electron_build-time_v8_code_cache_for_the_electron_js2c_bundles.patch
+++ b/patches/node/electron_build-time_v8_code_cache_for_the_electron_js2c_bundles.patch
@@ -213,7 +213,7 @@ index 05b1c5bbc38f851b11383b7e3e48c1c92f47aba1..bea6aa2e57e4961edc273c742ef4caa4
  
  }  // namespace node
 diff --git a/unofficial.gni b/unofficial.gni
-index 1285f83662e4f252faa1730df04cafc588cd7556..e9dc3102d88965c8730c31fa041abb8e718c1c83 100644
+index 59bb1eddde665a4cd2086c632109d0112daf33a3..3ee9dafd548df94b442903ed4eabf84ee1aa45b6 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -159,6 +159,11 @@ template("node_gn_build") {

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -289,7 +289,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index e9dc3102d88965c8730c31fa041abb8e718c1c83..578af9bf758a7e162b74ac40b2bbdd4693583bd4 100644
+index 3ee9dafd548df94b442903ed4eabf84ee1aa45b6..a44a7f4f9cbc51efd8e022729bfcebdd99d6593b 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {

--- a/patches/node/fix_redefined_macos_sdk_header_symbols.patch
+++ b/patches/node/fix_redefined_macos_sdk_header_symbols.patch
@@ -10,7 +10,7 @@ change, it seems to introduce an incompatibility when compiling
 using clang modules. Disabling them resolves the issue.
 
 diff --git a/unofficial.gni b/unofficial.gni
-index bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a..1285f83662e4f252faa1730df04cafc588cd7556 100644
+index 6326abf521d0e5c8e86e9dfa8562f0a648a56a19..59bb1eddde665a4cd2086c632109d0112daf33a3 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -199,6 +199,10 @@ template("node_gn_build") {

--- a/patches/node/fix_use_a_dedicated_cppheappointertag_for_cppgc_wrappables.patch
+++ b/patches/node/fix_use_a_dedicated_cppheappointertag_for_cppgc_wrappables.patch
@@ -77,7 +77,7 @@ index c1fa104fa25bd5919e405a3df94f3701d0e234a2..17fb7dcbbf5838b7448ea29a82c2dcba
  
  void IsolateData::MemoryInfo(MemoryTracker* tracker) const {
 diff --git a/unofficial.gni b/unofficial.gni
-index 578af9bf758a7e162b74ac40b2bbdd4693583bd4..b4baa4a4da02818c6b66311830f15f1b0666392a 100644
+index a44a7f4f9cbc51efd8e022729bfcebdd99d6593b..21290af4119ebe9cef1ab193dfb852daa5d4ad8c 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -63,6 +63,12 @@ template("node_gn_build") {


### PR DESCRIPTION
#### Description of Change

Since #52874 the linux-arm (32-bit) build boots its main process from a Node startup snapshot generated in V8's snapshot toolchain, and `process.arch` in that main process came out as `'ia32'` while renderers and service workers reported `'arm'` (caught by the `webPreferences.sandbox` process-API and `ServiceWorkerMain` startup-data specs on the #52874 backports' arm test legs).

Node's GN build (`unofficial.gni`) picks `NODE_ARCH = "ia32"` whenever the *compiling* toolchain's `current_cpu` is `x86`, and `target_cpu` otherwise. The arm snapshot toolchain is x86-hosted, so the `node_mksnapshot` built there baked `arch: 'ia32'` into the process object the arm binary later deserializes. Keying the `ia32` spelling off `target_cpu` gives the right answer in the target toolchain and in every host toolchain that builds node for a snapshot; arm64/x64 cross builds were unaffected because their snapshot toolchains are x64-hosted. One line in `build_add_gn_build_files.patch`; the other patch files only pick up the new blob hashes.

This needs to ride along with the #52874 backports (folded into those PRs rather than trop'd on its own).

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
