### PR TITLE
fix: illegal access errors when a same-process child window or subframe closes

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -262,6 +262,7 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   if (context.IsEmpty()) {
     node_env_->context()->Enter();
   }
+  node_bindings_->SetUpIsolate(isolate);
 
   node_env_->set_trace_sync_io(node_env_->options()->trace_sync_io);
 

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -180,7 +180,8 @@ ElectronBrowserMainParts* ElectronBrowserMainParts::self_ = nullptr;
 ElectronBrowserMainParts::ElectronBrowserMainParts()
     : fake_browser_process_(std::make_unique<BrowserProcessImpl>()),
       node_bindings_{
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser)},
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::kBrowser,
+                               uv_default_loop())},
       electron_bindings_{
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())},
       browser_{std::make_unique<Browser>()} {

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -749,6 +749,78 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
   initialized_node_per_process_ = true;
 }
 
+void NodeBindings::SetUpIsolate(v8::Isolate* const isolate) {
+  node::IsolateSettings is;
+
+  // Use a custom fatal error callback to allow us to add
+  // crash message and location to CrashReports.
+  is.fatal_error_callback = V8FatalErrorCallback;
+  is.oom_error_callback = V8OOMErrorCallback;
+
+  // We don't want to abort either in the renderer or browser processes.
+  // We already listen for uncaught exceptions and handle them there.
+  // For utility process we expect the process to behave as standard
+  // Node.js runtime and abort the process with appropriate exit
+  // code depending on a handler being set for `uncaughtException` event.
+  if (browser_env_ != BrowserEnvironment::kUtility) {
+    is.should_abort_on_uncaught_exception_callback = [](v8::Isolate*) {
+      return false;
+    };
+  }
+
+  // Use a custom callback here to allow us to leverage Blink's logic in the
+  // renderer process.
+  is.allow_wasm_code_generation_callback = AllowWasmCodeGenerationCallback;
+  is.flags |= node::IsolateSettingsFlags::
+      ALLOW_MODIFY_CODE_GENERATION_FROM_STRINGS_CALLBACK;
+  is.modify_code_generation_from_strings_callback =
+      ModifyCodeGenerationFromStrings;
+
+  if (browser_env_ == BrowserEnvironment::kBrowser ||
+      browser_env_ == BrowserEnvironment::kUtility) {
+    // Node.js requires that microtask checkpoints be explicitly invoked.
+    is.policy = v8::MicrotasksPolicy::kExplicit;
+    // node::CreateEnvironment already added Node's listener if it built the
+    // environment from the Node snapshot; keep exactly one.
+    isolate->RemoveMessageListeners(node::errors::PerIsolateMessageListener);
+  } else {
+    // Blink expects the microtasks policy to be kScoped, but Node.js expects it
+    // to be kExplicit. In the renderer, there can be many contexts within the
+    // same isolate, so we don't want to change the existing policy here, which
+    // could be either kExplicit or kScoped depending on whether we're executing
+    // from within a Node.js or a Blink entrypoint. Instead, the policy is
+    // toggled to kExplicit when entering Node.js through UvRunOnce.
+    is.policy = isolate->GetMicrotasksPolicy();
+
+    // We do not want to use Node.js' message listener as it interferes with
+    // Blink's. Instead we add our own to ensure that the async hook stack is
+    // properly cleared when errors are thrown.
+    is.flags &= ~node::IsolateSettingsFlags::MESSAGE_LISTENER_WITH_ERROR_LEVEL;
+    isolate->AddMessageListenerWithErrorLevel(ErrorMessageListener,
+                                              v8::Isolate::kMessageError);
+
+    // We do not want to use the promise rejection callback that Node.js uses,
+    // because it does not send PromiseRejectionEvents to the global script
+    // context. We need to use the one Blink already provides.
+    is.flags |=
+        node::IsolateSettingsFlags::SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK;
+
+    // We do not want to use the stack trace callback that Node.js uses,
+    // because it relies on Node.js being aware of the current Context and
+    // that's not always the case. We need to use the one Blink already
+    // provides.
+    is.flags |=
+        node::IsolateSettingsFlags::SHOULD_NOT_SET_PREPARE_STACK_TRACE_CALLBACK;
+  }
+
+  node::SetIsolateUpForNode(isolate, is);
+  isolate->SetHostImportModuleDynamicallyCallback(HostImportModuleDynamically);
+  isolate->SetHostImportModuleWithPhaseDynamicallyCallback(
+      HostImportModuleWithPhaseDynamically);
+  isolate->SetHostInitializeImportMetaObjectCallback(
+      HostInitializeImportMetaObject);
+}
+
 std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
     v8::Isolate* isolate,
     v8::Local<v8::Context> context,
@@ -879,89 +951,6 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
     gin_helper::internal::Event::GetConstructor(
         isolate, context, &gin_helper::internal::Event::kWrapperInfo);
   }
-
-  node::IsolateSettings is;
-
-  // Use a custom fatal error callback to allow us to add
-  // crash message and location to CrashReports.
-  is.fatal_error_callback = V8FatalErrorCallback;
-  is.oom_error_callback = V8OOMErrorCallback;
-
-  // We don't want to abort either in the renderer or browser processes.
-  // We already listen for uncaught exceptions and handle them there.
-  // For utility process we expect the process to behave as standard
-  // Node.js runtime and abort the process with appropriate exit
-  // code depending on a handler being set for `uncaughtException` event.
-  if (browser_env_ != BrowserEnvironment::kUtility) {
-    is.should_abort_on_uncaught_exception_callback = [](v8::Isolate*) {
-      return false;
-    };
-  }
-
-  // Use a custom callback here to allow us to leverage Blink's logic in the
-  // renderer process.
-  is.allow_wasm_code_generation_callback = AllowWasmCodeGenerationCallback;
-  is.flags |= node::IsolateSettingsFlags::
-      ALLOW_MODIFY_CODE_GENERATION_FROM_STRINGS_CALLBACK;
-  is.modify_code_generation_from_strings_callback =
-      ModifyCodeGenerationFromStrings;
-
-  if (browser_env_ == BrowserEnvironment::kBrowser ||
-      browser_env_ == BrowserEnvironment::kUtility) {
-    // Node.js requires that microtask checkpoints be explicitly invoked.
-    is.policy = v8::MicrotasksPolicy::kExplicit;
-  } else {
-    // Blink expects the microtasks policy to be kScoped, but Node.js expects it
-    // to be kExplicit. In the renderer, there can be many contexts within the
-    // same isolate, so we don't want to change the existing policy here, which
-    // could be either kExplicit or kScoped depending on whether we're executing
-    // from within a Node.js or a Blink entrypoint. Instead, the policy is
-    // toggled to kExplicit when entering Node.js through UvRunOnce.
-    is.policy = isolate->GetMicrotasksPolicy();
-
-    // We do not want to use Node.js' message listener as it interferes with
-    // Blink's.
-    is.flags &= ~node::IsolateSettingsFlags::MESSAGE_LISTENER_WITH_ERROR_LEVEL;
-
-    // Instead we add our own to ensure that the async hook stack is properly
-    // cleared when errors are thrown. Listeners are additive and this runs for
-    // every environment created on the isolate, so drop the previous one.
-    isolate->RemoveMessageListeners(ErrorMessageListener);
-    isolate->AddMessageListenerWithErrorLevel(ErrorMessageListener,
-                                              v8::Isolate::kMessageError);
-
-    // We do not want to use the promise rejection callback that Node.js uses,
-    // because it does not send PromiseRejectionEvents to the global script
-    // context. We need to use the one Blink already provides.
-    is.flags |=
-        node::IsolateSettingsFlags::SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK;
-
-    // We do not want to use the stack trace callback that Node.js uses,
-    // because it relies on Node.js being aware of the current Context and
-    // that's not always the case. We need to use the one Blink already
-    // provides.
-    is.flags |=
-        node::IsolateSettingsFlags::SHOULD_NOT_SET_PREPARE_STACK_TRACE_CALLBACK;
-  }
-
-  if (from_snapshot) {
-    // node::CreateEnvironment already registered the per-isolate message
-    // listener while deserializing the snapshot (SetIsolateErrorHandlers in
-    // node's src/api/environment.cc, taken only on the snapshot path).
-    // Message listeners are additive, so letting SetIsolateUpForNode add it
-    // again would deliver every uncaught error -- and the resulting
-    // uncaughtException -- twice. Keep the snapshot's listener and skip the
-    // duplicate; the custom fatal/OOM handlers above are setters and still
-    // take effect.
-    is.flags &= ~node::IsolateSettingsFlags::MESSAGE_LISTENER_WITH_ERROR_LEVEL;
-  }
-
-  node::SetIsolateUpForNode(isolate, is);
-  isolate->SetHostImportModuleDynamicallyCallback(HostImportModuleDynamically);
-  isolate->SetHostImportModuleWithPhaseDynamicallyCallback(
-      HostImportModuleWithPhaseDynamically);
-  isolate->SetHostInitializeImportMetaObjectCallback(
-      HostInitializeImportMetaObject);
 
   gin_helper::Dictionary process(isolate, env->process_object());
   process.SetReadOnly("type", process_type);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -923,9 +923,10 @@ std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(
     // Blink's.
     is.flags &= ~node::IsolateSettingsFlags::MESSAGE_LISTENER_WITH_ERROR_LEVEL;
 
-    // Isolate message listeners are additive (you can add multiple), so instead
-    // we add an extra one here to ensure that the async hook stack is properly
-    // cleared when errors are thrown.
+    // Instead we add our own to ensure that the async hook stack is properly
+    // cleared when errors are thrown. Listeners are additive and this runs for
+    // every environment created on the isolate, so drop the previous one.
+    isolate->RemoveMessageListeners(ErrorMessageListener);
     isolate->AddMessageListenerWithErrorLevel(ErrorMessageListener,
                                               v8::Isolate::kMessageError);
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -534,19 +534,25 @@ base::FilePath GetResourcesPath() {
 }
 }  // namespace
 
-NodeBindings::NodeBindings(BrowserEnvironment browser_env)
+NodeBindings::NodeBindings(BrowserEnvironment browser_env, uv_loop_t* loop)
     : browser_env_{browser_env},
-      uv_loop_{InitEventLoop(browser_env, &worker_loop_)} {}
+      uv_loop_{loop ? loop : &owned_loop_.emplace()} {
+  if (owned_loop_)
+    CHECK_EQ(0, uv_loop_init(uv_loop_));
+
+  // Interrupt embed polling when a handle is started.
+  uv_loop_configure(uv_loop_, UV_LOOP_INTERRUPT_ON_IO_CHANGE);
+}
 
 NodeBindings::~NodeBindings() {
   StopPolling();
 
-  // Clear uv.
-  uv_sem_destroy(&embed_sem_);
-  dummy_uv_handle_.reset();
+  if (embed_thread_prepared_) {
+    uv_sem_destroy(&embed_sem_);
+    dummy_uv_handle_.reset();
+  }
 
-  // Clean up worker loop
-  if (in_worker_loop())
+  if (owned_loop_)
     stop_and_close_uv_loop(uv_loop_);
 
   if (initialized_node_per_process_)
@@ -589,38 +595,6 @@ void NodeBindings::StopPolling() {
   // Allow PrepareEmbedThread + StartPolling to restart.
   embed_closed_ = false;
   initialized_ = false;
-}
-
-node::IsolateData* NodeBindings::isolate_data(
-    v8::Local<v8::Context> context) const {
-  if (context->GetNumberOfEmbedderDataFields() <=
-      kElectronContextEmbedderDataIndex) {
-    return nullptr;
-  }
-  auto* isolate_data = static_cast<node::IsolateData*>(
-      context->GetAlignedPointerFromEmbedderData(
-          kElectronContextEmbedderDataIndex, v8::kEmbedderDataTypeTagDefault));
-  CHECK(isolate_data);
-  CHECK(isolate_data->event_loop());
-  return isolate_data;
-}
-
-// static
-uv_loop_t* NodeBindings::InitEventLoop(BrowserEnvironment browser_env,
-                                       uv_loop_t* worker_loop) {
-  uv_loop_t* event_loop = nullptr;
-
-  if (browser_env == BrowserEnvironment::kWorker) {
-    uv_loop_init(worker_loop);
-    event_loop = worker_loop;
-  } else {
-    event_loop = uv_default_loop();
-  }
-
-  // Interrupt embed polling when a handle is started.
-  uv_loop_configure(event_loop, UV_LOOP_INTERRUPT_ON_IO_CHANGE);
-
-  return event_loop;
 }
 
 void NodeBindings::RegisterBuiltinBindings() {

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -137,6 +137,10 @@ class NodeBindings {
   // Setup V8, libuv.
   void Initialize(v8::Isolate* isolate, v8::Local<v8::Context> context);
 
+  // Installs the isolate-wide callbacks Node.js needs. Once per isolate; where
+  // the environment comes from the Node snapshot, after CreateEnvironment().
+  void SetUpIsolate(v8::Isolate* isolate);
+
   std::vector<std::string> ParseNodeCliFlags();
 
   // Create the environment and load node.js.

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -118,7 +118,9 @@ class NodeBindings {
  public:
   enum class BrowserEnvironment { kBrowser, kRenderer, kUtility, kWorker };
 
-  static std::unique_ptr<NodeBindings> Create(BrowserEnvironment browser_env);
+  // Integrates |loop|, or a new loop owned by this instance when null.
+  static std::unique_ptr<NodeBindings> Create(BrowserEnvironment browser_env,
+                                              uv_loop_t* loop);
   static void RegisterBuiltinBindings();
   static bool IsInitialized();
 
@@ -171,8 +173,6 @@ class NodeBindings {
   // environment teardown but reuse the same NodeBindings for the next context.
   void StopPolling();
 
-  node::IsolateData* isolate_data(v8::Local<v8::Context> context) const;
-
   // Gets/sets the environment to wrap uv loop.
   void set_uv_env(node::Environment* env) { uv_env_ = env; }
   node::Environment* uv_env() const { return uv_env_; }
@@ -188,7 +188,7 @@ class NodeBindings {
   void JoinAppCode();
 
  protected:
-  explicit NodeBindings(BrowserEnvironment browser_env);
+  NodeBindings(BrowserEnvironment browser_env, uv_loop_t* loop);
 
   // Called to poll events in new thread.
   virtual void PollEvents() = 0;
@@ -200,24 +200,16 @@ class NodeBindings {
   void WakeupEmbedThread();
 
  private:
-  static uv_loop_t* InitEventLoop(BrowserEnvironment browser_env,
-                                  uv_loop_t* worker_loop);
-
   // Run the libuv loop for once.
   void UvRunOnce();
-
-  [[nodiscard]] constexpr bool in_worker_loop() const {
-    return browser_env_ == BrowserEnvironment::kWorker;
-  }
 
   // Which environment we are running.
   const BrowserEnvironment browser_env_;
 
-  // Loop used when constructed in WORKER mode
-  uv_loop_t worker_loop_;
+  // Engaged when this instance created its loop instead of integrating one.
+  std::optional<uv_loop_t> owned_loop_;
 
-  // Current thread's libuv loop.
-  // depends-on: worker_loop_
+  // depends-on: owned_loop_
   const raw_ptr<uv_loop_t> uv_loop_;
 
   // Current thread's MessageLoop.
@@ -266,9 +258,6 @@ class NodeBindings {
 
   // Environment that to wrap the uv loop.
   raw_ptr<node::Environment> uv_env_ = nullptr;
-
-  // Isolate data used in creating the environment
-  raw_ptr<node::IsolateData> isolate_data_ = nullptr;
 
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 };

--- a/shell/common/node_bindings_linux.cc
+++ b/shell/common/node_bindings_linux.cc
@@ -8,8 +8,9 @@
 
 namespace electron {
 
-NodeBindingsLinux::NodeBindingsLinux(BrowserEnvironment browser_env)
-    : NodeBindings(browser_env), epoll_(epoll_create(1)) {
+NodeBindingsLinux::NodeBindingsLinux(BrowserEnvironment browser_env,
+                                     uv_loop_t* loop)
+    : NodeBindings(browser_env, loop), epoll_(epoll_create(1)) {
   auto* const event_loop = uv_loop();
 
   int backend_fd = uv_backend_fd(event_loop);
@@ -33,8 +34,9 @@ void NodeBindingsLinux::PollEvents() {
 }
 
 // static
-std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
-  return std::make_unique<NodeBindingsLinux>(env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env,
+                                                   uv_loop_t* loop) {
+  return std::make_unique<NodeBindingsLinux>(env, loop);
 }
 
 }  // namespace electron

--- a/shell/common/node_bindings_linux.h
+++ b/shell/common/node_bindings_linux.h
@@ -11,7 +11,7 @@ namespace electron {
 
 class NodeBindingsLinux : public NodeBindings {
  public:
-  explicit NodeBindingsLinux(BrowserEnvironment browser_env);
+  NodeBindingsLinux(BrowserEnvironment browser_env, uv_loop_t* loop);
 
  private:
   // NodeBindings

--- a/shell/common/node_bindings_mac.cc
+++ b/shell/common/node_bindings_mac.cc
@@ -12,8 +12,9 @@
 
 namespace electron {
 
-NodeBindingsMac::NodeBindingsMac(BrowserEnvironment browser_env)
-    : NodeBindings(browser_env) {}
+NodeBindingsMac::NodeBindingsMac(BrowserEnvironment browser_env,
+                                 uv_loop_t* loop)
+    : NodeBindings(browser_env, loop) {}
 
 void NodeBindingsMac::PollEvents() {
   auto* const event_loop = uv_loop();
@@ -33,8 +34,9 @@ void NodeBindingsMac::PollEvents() {
 }
 
 // static
-std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
-  return std::make_unique<NodeBindingsMac>(env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env,
+                                                   uv_loop_t* loop) {
+  return std::make_unique<NodeBindingsMac>(env, loop);
 }
 
 }  // namespace electron

--- a/shell/common/node_bindings_mac.h
+++ b/shell/common/node_bindings_mac.h
@@ -11,7 +11,7 @@ namespace electron {
 
 class NodeBindingsMac : public NodeBindings {
  public:
-  explicit NodeBindingsMac(BrowserEnvironment browser_env);
+  NodeBindingsMac(BrowserEnvironment browser_env, uv_loop_t* loop);
 
  private:
   // NodeBindings

--- a/shell/common/node_bindings_win.cc
+++ b/shell/common/node_bindings_win.cc
@@ -10,8 +10,9 @@
 
 namespace electron {
 
-NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
-    : NodeBindings(browser_env) {
+NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env,
+                                 uv_loop_t* loop)
+    : NodeBindings(browser_env, loop) {
   auto* const event_loop = uv_loop();
 
   // on single-core the io comp port NumberOfConcurrentThreads needs to be 2
@@ -49,8 +50,9 @@ void NodeBindingsWin::PollEvents() {
 }
 
 // static
-std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env) {
-  return std::make_unique<NodeBindingsWin>(env);
+std::unique_ptr<NodeBindings> NodeBindings::Create(BrowserEnvironment env,
+                                                   uv_loop_t* loop) {
+  return std::make_unique<NodeBindingsWin>(env, loop);
 }
 
 }  // namespace electron

--- a/shell/common/node_bindings_win.h
+++ b/shell/common/node_bindings_win.h
@@ -11,7 +11,7 @@ namespace electron {
 
 class NodeBindingsWin : public NodeBindings {
  public:
-  explicit NodeBindingsWin(BrowserEnvironment browser_env);
+  NodeBindingsWin(BrowserEnvironment browser_env, uv_loop_t* loop);
 
  private:
   // NodeBindings

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -194,16 +194,12 @@ v8::Local<v8::Object> CreateAbortController(v8::Isolate* isolate) {
 
 ExplicitMicrotasksScope::ExplicitMicrotasksScope(v8::MicrotaskQueue* queue)
     : microtask_queue_(queue), original_policy_(queue->microtasks_policy()) {
-  // In browser-like processes, some nested run loops (macOS usually) may
-  // re-enter. This is safe because we expect the policy was explicit in the
-  // first place for those processes. However, in renderer processes, there may
-  // be unexpected behavior if this code is triggered within a pending microtask
-  // scope.
-  if (electron::IsBrowserProcess() || electron::IsUtilityProcess()) {
+  // Browser-like processes already run with kExplicit, nested run loops
+  // included. Renderers can get here from inside script (a frame's environment
+  // freed by element.remove()); explicit checkpoints are then no-ops until the
+  // enclosing scope unwinds.
+  if (electron::IsBrowserProcess() || electron::IsUtilityProcess())
     DCHECK_EQ(original_policy_, v8::MicrotasksPolicy::kExplicit);
-  } else {
-    DCHECK_EQ(microtask_queue_->GetMicrotasksScopeDepth(), 0);
-  }
 
   microtask_queue_->set_microtasks_policy(v8::MicrotasksPolicy::kExplicit);
 }

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -213,20 +213,15 @@ void ElectronRenderFrameObserver::CreateIsolatedWorldContext() {
 bool ElectronRenderFrameObserver::ShouldNotifyClient(int world_id) const {
   const auto& prefs = render_frame_->GetBlinkPreferences();
 
-  // This is necessary because if an iframe is created and a source is not
-  // set, the iframe loads about:blank and creates a script context for the
-  // same. We don't want to create a Node.js environment here because if the src
-  // is later set, the JS necessary to do that triggers illegal access errors
-  // when the initial about:blank Node.js environment is cleaned up. See:
-  // https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394
-  const bool allow_node_in_sub_frames = prefs.node_integration_in_sub_frames;
-  if (allow_node_in_sub_frames && !render_frame_->IsMainFrame()) {
-    if (GURL{render_frame_->GetWebFrame()->GetDocument().Url()}.IsAboutBlank())
-      return false;
-  }
+  // about:blank subframes commit synchronously in the renderer and never get
+  // the browser's preload startup data (see MaybeSendRendererStartupData), so
+  // they are left without preload scripts and Node.js integration.
+  if (prefs.node_integration_in_sub_frames && !render_frame_->IsMainFrame() &&
+      GURL{render_frame_->GetWebFrame()->GetDocument().Url()}.IsAboutBlank())
+    return false;
 
   if (prefs.context_isolation &&
-      (render_frame_->IsMainFrame() || allow_node_in_sub_frames))
+      (render_frame_->IsMainFrame() || prefs.node_integration_in_sub_frames))
     return is_isolated_world(world_id);
 
   return is_main_world(world_id);

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -129,6 +129,10 @@ void ElectronRendererClient::DidCreateScriptContext(
   if (!node_integration_initialized_) {
     node_integration_initialized_ = true;
     node_bindings_->Initialize(isolate, renderer_context);
+    node_bindings_->SetUpIsolate(isolate);
+    // SetUpIsolate registers Node's WebAssembly streaming callback, whose JS
+    // side kNoBrowserGlobals never installs; put Blink's back.
+    blink::WasmResponseExtensions::Initialize(isolate);
   }
 
   CHECK(!environments_.contains(render_frame));
@@ -159,13 +163,6 @@ void ElectronRendererClient::DidCreateScriptContext(
                           base::Unretained(this), render_frame));
   frame_env->environment = env;
   node_bindings->set_uv_env(env.get());
-
-  // CreateEnvironment calls SetIsolateUpForNode which unconditionally
-  // registers Node's WebAssembly streaming callback. With kNoBrowserGlobals
-  // the JS side of that callback is never installed, so it would crash on
-  // use; restore Blink's implementation so WebAssembly.compileStreaming
-  // keeps working with Blink's fetch.
-  blink::WasmResponseExtensions::Initialize(isolate);
 
   // If we have disabled the site instance overrides we should prevent loading
   // any non-context aware native module.
@@ -264,7 +261,7 @@ void ElectronRendererClient::WorkerScriptReadyForEvaluationOnWorkerThread(
 
   auto* current = WebWorkerObserver::GetCurrent();
   if (!current)
-    current = WebWorkerObserver::Create();
+    current = WebWorkerObserver::Create(v8::Isolate::GetCurrent());
   current->WorkerScriptReadyForEvaluation(context);
 }
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -15,6 +15,7 @@
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/node_util.h"
 #include "shell/common/v8_util.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/web_worker_observer.h"
@@ -202,7 +203,7 @@ void ElectronRendererClient::WillReleaseScriptContext(
     v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
   node::Environment* env = GetEnvironment(render_frame);
-  if (!env)
+  if (!env || env->context() != context)
     return;
   gin_helper::EmitEvent(isolate, env->process_object(), "exit");
 
@@ -214,6 +215,8 @@ void ElectronRendererClient::WillReleaseScriptContext(
   frame_env->node_bindings->set_uv_env(nullptr);
   frame_env->node_bindings->StopPolling();
   frame_env->electron_bindings->EnvironmentDestroyed(env);
+  // Freeing the environment runs its loop, i.e. enters Node.js.
+  util::ExplicitMicrotasksScope microtasks_scope(context->GetMicrotaskQueue());
   frame_env->environment.reset();
 }
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -29,11 +29,12 @@
 namespace electron {
 
 struct ElectronRendererClient::FrameEnvironment {
-  // |primary| integrates uv_default_loop() and is borrowed while no other
-  // environment occupies it; otherwise this frame gets a loop of its own.
-  FrameEnvironment(NodeBindings* primary,
+  // A main frame borrows |primary|, which integrates uv_default_loop(), while
+  // no other environment occupies it; every other frame gets its own loop.
+  FrameEnvironment(bool is_main_frame,
+                   NodeBindings* primary,
                    ElectronBindings* primary_electron_bindings) {
-    if (primary->uv_env() == nullptr) {
+    if (is_main_frame && primary->uv_env() == nullptr) {
       node_bindings = primary;
       electron_bindings = primary_electron_bindings;
       return;
@@ -136,8 +137,9 @@ void ElectronRendererClient::DidCreateScriptContext(
   }
 
   CHECK(!environments_.contains(render_frame));
-  auto frame_env = std::make_unique<FrameEnvironment>(node_bindings_.get(),
-                                                      electron_bindings_.get());
+  auto frame_env = std::make_unique<FrameEnvironment>(
+      render_frame->IsMainFrame(), node_bindings_.get(),
+      electron_bindings_.get());
   NodeBindings* node_bindings = frame_env->node_bindings;
 
   // Setup node tracing controller.

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -4,8 +4,9 @@
 
 #include "shell/renderer/electron_renderer_client.h"
 
-#include <algorithm>
-
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/task/sequenced_task_runner.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/fuses.h"
 #include "net/http/http_request_headers.h"
@@ -14,7 +15,6 @@
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
-#include "shell/common/node_util.h"
 #include "shell/common/v8_util.h"
 #include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/web_worker_observer.h"
@@ -28,9 +28,36 @@
 
 namespace electron {
 
+struct ElectronRendererClient::FrameEnvironment {
+  // |primary| integrates uv_default_loop() and is borrowed while no other
+  // environment occupies it; otherwise this frame gets a loop of its own.
+  FrameEnvironment(NodeBindings* primary,
+                   ElectronBindings* primary_electron_bindings) {
+    if (primary->uv_env() == nullptr) {
+      node_bindings = primary;
+      electron_bindings = primary_electron_bindings;
+      return;
+    }
+    own_node_bindings = NodeBindings::Create(
+        NodeBindings::BrowserEnvironment::kRenderer, nullptr);
+    own_electron_bindings =
+        std::make_unique<ElectronBindings>(own_node_bindings->uv_loop());
+    node_bindings = own_node_bindings.get();
+    electron_bindings = own_electron_bindings.get();
+  }
+
+  std::unique_ptr<NodeBindings> own_node_bindings;
+  std::unique_ptr<ElectronBindings> own_electron_bindings;
+  raw_ptr<NodeBindings> node_bindings;
+  raw_ptr<ElectronBindings> electron_bindings;
+  std::shared_ptr<node::Environment> environment;
+  base::WeakPtrFactory<FrameEnvironment> weak_factory{this};
+};
+
 ElectronRendererClient::ElectronRendererClient()
     : node_bindings_{
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kRenderer)},
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::kRenderer,
+                               uv_default_loop())},
       electron_bindings_{
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())} {}
 
@@ -99,13 +126,15 @@ void ElectronRendererClient::DidCreateScriptContext(
   if (!ShouldLoadPreload(isolate, renderer_context, render_frame))
     return;
 
-  injected_frames_.insert(render_frame);
-
   if (!node_integration_initialized_) {
     node_integration_initialized_ = true;
     node_bindings_->Initialize(isolate, renderer_context);
-    node_bindings_->PrepareEmbedThread();
   }
+
+  CHECK(!environments_.contains(render_frame));
+  auto frame_env = std::make_unique<FrameEnvironment>(node_bindings_.get(),
+                                                      electron_bindings_.get());
+  NodeBindings* node_bindings = frame_env->node_bindings;
 
   // Setup node tracing controller.
   if (!node::tracing::TraceEventHelper::GetAgent()) {
@@ -124,10 +153,12 @@ void ElectronRendererClient::DidCreateScriptContext(
   render_frame->GetWebFrame()->GetDocumentLoader()->SetDefersLoading(
       blink::LoaderFreezeMode::kStrict);
 
-  std::shared_ptr<node::Environment> env = node_bindings_->CreateEnvironment(
+  std::shared_ptr<node::Environment> env = node_bindings->CreateEnvironment(
       isolate, renderer_context, nullptr, 0,
       base::BindRepeating(&ElectronRendererClient::UndeferLoad,
                           base::Unretained(this), render_frame));
+  frame_env->environment = env;
+  node_bindings->set_uv_env(env.get());
 
   // CreateEnvironment calls SetIsolateUpForNode which unconditionally
   // registers Node's WebAssembly streaming callback. With kNoBrowserGlobals
@@ -143,53 +174,48 @@ void ElectronRendererClient::DidCreateScriptContext(
   // We do not want to crash the renderer process on unhandled rejections.
   env->options()->unhandled_rejections = "warn-with-error-code";
 
-  environments_.insert(env);
-
   // Add Electron extended APIs.
-  electron_bindings_->BindTo(env->isolate(), env->process_object());
+  frame_env->electron_bindings->BindTo(env->isolate(), env->process_object());
   gin_helper::Dictionary process_dict(env->isolate(), env->process_object());
   BindProcess(env->isolate(), &process_dict, render_frame);
 
-  // Load everything.
-  node_bindings_->LoadEnvironment(env.get());
+  base::WeakPtr<FrameEnvironment> weak_frame_env =
+      frame_env->weak_factory.GetWeakPtr();
+  environments_[render_frame] = std::move(frame_env);
 
-  if (node_bindings_->uv_env() == nullptr) {
-    // Make uv loop being wrapped by window context.
-    node_bindings_->set_uv_env(env.get());
+  node_bindings->LoadEnvironment(env.get());
 
-    // Give the node loop a run to make sure everything is ready.
-    node_bindings_->StartPolling();
-  }
+  // This context may have been created from inside a script (e.g. the opener's
+  // window.open() call), so give the loop its first run from a fresh task.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(
+                     [](base::WeakPtr<FrameEnvironment> frame_env) {
+                       if (!frame_env)
+                         return;
+                       frame_env->node_bindings->PrepareEmbedThread();
+                       frame_env->node_bindings->StartPolling();
+                     },
+                     weak_frame_env));
 }
 
 void ElectronRendererClient::WillReleaseScriptContext(
     v8::Isolate* const isolate,
     v8::Local<v8::Context> context,
     content::RenderFrame* render_frame) {
-  if (injected_frames_.erase(render_frame) == 0)
+  node::Environment* env = GetEnvironment(render_frame);
+  if (!env)
     return;
-
-  node::Environment* env = node::Environment::GetCurrent(context);
-  const auto iter = std::ranges::find_if(
-      environments_, [env](auto& item) { return env == item.get(); });
-  if (iter == environments_.end())
-    return;
-
   gin_helper::EmitEvent(isolate, env->process_object(), "exit");
 
-  // The main frame may be replaced.
-  if (env == node_bindings_->uv_env())
-    node_bindings_->set_uv_env(nullptr);
+  auto iter = environments_.find(render_frame);
+  std::unique_ptr<FrameEnvironment> frame_env = std::move(iter->second);
+  environments_.erase(iter);
 
-  // Destroying the node environment will also run the uv loop.
-  {
-    util::ExplicitMicrotasksScope microtasks_scope(
-        context->GetMicrotaskQueue());
-    environments_.erase(iter);
-  }
-
-  // ElectronBindings is tracking node environments.
-  electron_bindings_->EnvironmentDestroyed(env);
+  // Park the embed thread so FreeEnvironment's uv_run is the loop's only user.
+  frame_env->node_bindings->set_uv_env(nullptr);
+  frame_env->node_bindings->StopPolling();
+  frame_env->electron_bindings->EnvironmentDestroyed(env);
+  frame_env->environment.reset();
 }
 
 namespace {
@@ -268,17 +294,9 @@ void ElectronRendererClient::SetUpWebAssemblyTrapHandler() {
 
 node::Environment* ElectronRendererClient::GetEnvironment(
     content::RenderFrame* render_frame) const {
-  if (!injected_frames_.contains(render_frame))
-    return nullptr;
-  v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
-  auto context =
-      GetContext(render_frame->GetWebFrame(), v8::Isolate::GetCurrent());
-  node::Environment* env = node::Environment::GetCurrent(context);
-
-  return std::ranges::contains(environments_, env,
-                               [](auto const& item) { return item.get(); })
-             ? env
-             : nullptr;
+  auto iter = environments_.find(render_frame);
+  return iter == environments_.end() ? nullptr
+                                     : iter->second->environment.get();
 }
 
 }  // namespace electron

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "base/containers/flat_set.h"
+#include "base/containers/flat_map.h"
 #include "shell/renderer/renderer_client_base.h"
 
 namespace node {
@@ -51,23 +51,23 @@ class ElectronRendererClient : public RendererClientBase {
       v8::Local<v8::Context> context) override;
   void SetUpWebAssemblyTrapHandler() override;
 
+  // A frame's node::Environment and the uv loop integration driving it. Every
+  // environment gets its own loop so that freeing one, which runs its loop
+  // until its handles close, never dispatches another environment's callbacks.
+  struct FrameEnvironment;
+
   node::Environment* GetEnvironment(content::RenderFrame* frame) const;
 
   // Whether the node integration has been initialized.
   bool node_integration_initialized_ = false;
 
+  // Integrates uv_default_loop() for the whole process; hosts whichever
+  // environment is created while it is free (normally the main frame's).
   const std::unique_ptr<NodeBindings> node_bindings_;
   const std::unique_ptr<ElectronBindings> electron_bindings_;
 
-  // The node::Environment::GetCurrent API does not return nullptr when it
-  // is called for a context without node::Environment, so we have to keep
-  // a book of the environments created.
-  base::flat_set<std::shared_ptr<node::Environment>> environments_;
-
-  // Getting main script context from web frame would lazily initializes
-  // its script context. Doing so in a web page without scripts would trigger
-  // assertion, so we have to keep a book of injected web frames.
-  base::flat_set<content::RenderFrame*> injected_frames_;
+  base::flat_map<content::RenderFrame*, std::unique_ptr<FrameEnvironment>>
+      environments_;
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -61,8 +61,8 @@ class ElectronRendererClient : public RendererClientBase {
   // Whether the node integration has been initialized.
   bool node_integration_initialized_ = false;
 
-  // Integrates uv_default_loop() for the whole process; hosts whichever
-  // environment is created while it is free (normally the main frame's).
+  // Integrates uv_default_loop() for the whole process and hosts a main
+  // frame's environment while one exists; subframes never borrow it.
   const std::unique_ptr<NodeBindings> node_bindings_;
   const std::unique_ptr<ElectronBindings> electron_bindings_;
 

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -58,7 +58,8 @@ WebWorkerObserver* WebWorkerObserver::Create() {
 
 WebWorkerObserver::WebWorkerObserver()
     : node_bindings_(
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kWorker)),
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::kWorker,
+                               nullptr)),
       electron_bindings_(
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {}
 

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -49,19 +49,24 @@ WebWorkerObserver* WebWorkerObserver::GetCurrent() {
 }
 
 // static
-WebWorkerObserver* WebWorkerObserver::Create() {
-  auto obs = std::make_unique<WebWorkerObserver>();
+WebWorkerObserver* WebWorkerObserver::Create(v8::Isolate* isolate) {
+  auto obs = std::make_unique<WebWorkerObserver>(isolate);
   auto* obs_raw = obs.get();
   lazy_tls->Set(std::move(obs));
   return obs_raw;
 }
 
-WebWorkerObserver::WebWorkerObserver()
+WebWorkerObserver::WebWorkerObserver(v8::Isolate* isolate)
     : node_bindings_(
           NodeBindings::Create(NodeBindings::BrowserEnvironment::kWorker,
                                nullptr)),
       electron_bindings_(
-          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {}
+          std::make_unique<ElectronBindings>(node_bindings_->uv_loop())) {
+  node_bindings_->SetUpIsolate(isolate);
+  // SetUpIsolate registers Node's WebAssembly streaming callback, whose JS
+  // side kNoBrowserGlobals never installs; put Blink's back.
+  blink::WasmResponseExtensions::Initialize(isolate);
+}
 
 WebWorkerObserver::~WebWorkerObserver() = default;
 
@@ -106,13 +111,6 @@ void WebWorkerObserver::InitializeNewEnvironment(
   CHECK(!initialized.IsNothing() && initialized.FromJust());
   std::shared_ptr<node::Environment> env =
       node_bindings_->CreateEnvironment(isolate, worker_context, nullptr);
-
-  // CreateEnvironment calls SetIsolateUpForNode which unconditionally
-  // registers Node's WebAssembly streaming callback. With kNoBrowserGlobals
-  // the JS side of that callback is never installed, so it would crash on
-  // use; restore Blink's implementation so WebAssembly.compileStreaming
-  // keeps working with Blink's fetch.
-  blink::WasmResponseExtensions::Initialize(isolate);
 
   // We do not want to crash Web Workers on unhandled rejections.
   env->options()->unhandled_rejections = "warn-with-error-code";

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -24,13 +24,13 @@ class NodeBindings;
 // Watches for WebWorker and insert node integration to it.
 class WebWorkerObserver {
  public:
-  WebWorkerObserver();
+  explicit WebWorkerObserver(v8::Isolate* isolate);
   ~WebWorkerObserver();
 
   // Returns the WebWorkerObserver for current worker thread.
   static WebWorkerObserver* GetCurrent();
-  // Creates a new WebWorkerObserver for a given context.
-  static WebWorkerObserver* Create();
+  // Creates the WebWorkerObserver for the current worker thread's isolate.
+  static WebWorkerObserver* Create(v8::Isolate* isolate);
 
   // disable copy
   WebWorkerObserver(const WebWorkerObserver&) = delete;

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -104,7 +104,8 @@ bool URLLoaderBundle::ShouldUseNetworkObserverfromURLLoaderFactory() const {
 NodeService::NodeService(
     mojo::PendingReceiver<node::mojom::NodeService> receiver)
     : node_bindings_{
-          NodeBindings::Create(NodeBindings::BrowserEnvironment::kUtility)},
+          NodeBindings::Create(NodeBindings::BrowserEnvironment::kUtility,
+                               uv_default_loop())},
       electron_bindings_{
           std::make_unique<ElectronBindings>(node_bindings_->uv_loop())} {
   if (receiver.is_valid())

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -187,6 +187,7 @@ void NodeService::Initialize(
       params->exec_args);
   if (context.IsEmpty())
     node_env_->context()->Enter();
+  node_bindings_->SetUpIsolate(isolate);
 
   // Override the default handler set by NodeBindings.
   node_env_->isolate()->SetFatalErrorHandler(V8FatalErrorCallback);

--- a/spec/fixtures/native-addon/echo/binding.cc
+++ b/spec/fixtures/native-addon/echo/binding.cc
@@ -21,10 +21,57 @@ napi_value Print(napi_env env, napi_callback_info info) {
   return args[0];
 }
 
+struct AsyncEcho {
+  napi_async_work work = NULL;
+  napi_ref value = NULL;
+  napi_ref callback = NULL;
+};
+
+void ExecuteAsyncEcho(napi_env env, void* data) {}
+
+void CompleteAsyncEcho(napi_env env, napi_status status, void* data) {
+  AsyncEcho* echo = static_cast<AsyncEcho*>(data);
+  napi_value box, value, callback, global;
+  napi_get_reference_value(env, echo->value, &box);
+  napi_get_named_property(env, box, "value", &value);
+  napi_get_reference_value(env, echo->callback, &callback);
+  napi_get_global(env, &global);
+  napi_call_function(env, global, callback, 1, &value, NULL);
+  napi_delete_reference(env, echo->value);
+  napi_delete_reference(env, echo->callback);
+  napi_delete_async_work(env, echo->work);
+  delete echo;
+}
+
+// Calls back with its first argument once a round trip through the libuv
+// threadpool completes.
+napi_value PrintAsync(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  if (napi_get_cb_info(env, info, &argc, args, NULL, NULL) != napi_ok ||
+      argc != 2) {
+    napi_throw_error(env, NULL, "Expected a value and a callback");
+    return NULL;
+  }
+
+  AsyncEcho* echo = new AsyncEcho();
+  napi_value name, box;
+  napi_create_string_utf8(env, "echo", NAPI_AUTO_LENGTH, &name);
+  napi_create_object(env, &box);
+  napi_set_named_property(env, box, "value", args[0]);
+  napi_create_reference(env, box, 1, &echo->value);
+  napi_create_reference(env, args[1], 1, &echo->callback);
+  napi_create_async_work(env, NULL, name, ExecuteAsyncEcho, CompleteAsyncEcho,
+                         echo, &echo->work);
+  napi_queue_async_work(env, echo->work);
+  return NULL;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor descriptors[] = {
-      {"Print", NULL, Print, NULL, NULL, NULL, napi_default, NULL}};
+      {"Print", NULL, Print, NULL, NULL, NULL, napi_default, NULL},
+      {"PrintAsync", NULL, PrintAsync, NULL, NULL, NULL, napi_default, NULL}};
 
   status = napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);

--- a/spec/fixtures/native-addon/echo/binding.cc
+++ b/spec/fixtures/native-addon/echo/binding.cc
@@ -2,6 +2,8 @@
 #include <node_api.h>
 #include <v8-cppgc.h>
 
+#include <thread>
+
 namespace {
 
 napi_value Print(napi_env env, napi_callback_info info) {
@@ -67,11 +69,67 @@ napi_value PrintAsync(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+struct ThreadsafeEcho {
+  napi_threadsafe_function function = NULL;
+  napi_ref value = NULL;
+  std::thread thread;
+};
+
+void CallThreadsafeEcho(napi_env env,
+                        napi_value callback,
+                        void* context,
+                        void* data) {
+  if (env == NULL)
+    return;
+  ThreadsafeEcho* echo = static_cast<ThreadsafeEcho*>(context);
+  napi_value box, value, global;
+  napi_get_reference_value(env, echo->value, &box);
+  napi_get_named_property(env, box, "value", &value);
+  napi_get_global(env, &global);
+  napi_call_function(env, global, callback, 1, &value, NULL);
+}
+
+void FinalizeThreadsafeEcho(napi_env env, void* data, void* hint) {
+  ThreadsafeEcho* echo = static_cast<ThreadsafeEcho*>(data);
+  echo->thread.join();
+  napi_delete_reference(env, echo->value);
+  delete echo;
+}
+
+// Calls back with its first argument through a thread-safe function invoked
+// from another thread.
+napi_value PrintThreadsafe(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  if (napi_get_cb_info(env, info, &argc, args, NULL, NULL) != napi_ok ||
+      argc != 2) {
+    napi_throw_error(env, NULL, "Expected a value and a callback");
+    return NULL;
+  }
+
+  ThreadsafeEcho* echo = new ThreadsafeEcho();
+  napi_value name, box;
+  napi_create_string_utf8(env, "echo", NAPI_AUTO_LENGTH, &name);
+  napi_create_object(env, &box);
+  napi_set_named_property(env, box, "value", args[0]);
+  napi_create_reference(env, box, 1, &echo->value);
+  napi_create_threadsafe_function(env, args[1], NULL, name, 0, 1, echo,
+                                  FinalizeThreadsafeEcho, echo,
+                                  CallThreadsafeEcho, &echo->function);
+  echo->thread = std::thread([function = echo->function] {
+    napi_call_threadsafe_function(function, NULL, napi_tsfn_blocking);
+    napi_release_threadsafe_function(function, napi_tsfn_release);
+  });
+  return NULL;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor descriptors[] = {
       {"Print", NULL, Print, NULL, NULL, NULL, napi_default, NULL},
-      {"PrintAsync", NULL, PrintAsync, NULL, NULL, NULL, napi_default, NULL}};
+      {"PrintAsync", NULL, PrintAsync, NULL, NULL, NULL, napi_default, NULL},
+      {"PrintThreadsafe", NULL, PrintThreadsafe, NULL, NULL, NULL, napi_default,
+       NULL}};
 
   status = napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors);

--- a/spec/fixtures/native-addon/echo/lib/echo.js
+++ b/spec/fixtures/native-addon/echo/lib/echo.js
@@ -2,3 +2,4 @@ const binding = require('../build/Release/echo.node');
 
 module.exports = binding.Print;
 module.exports.async = binding.PrintAsync;
+module.exports.threadsafe = binding.PrintThreadsafe;

--- a/spec/fixtures/native-addon/echo/lib/echo.js
+++ b/spec/fixtures/native-addon/echo/lib/echo.js
@@ -1,1 +1,4 @@
-module.exports = require('../build/Release/echo.node').Print;
+const binding = require('../build/Release/echo.node');
+
+module.exports = binding.Print;
+module.exports.async = binding.PrintAsync;

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -510,12 +510,13 @@ describe('node feature', () => {
       setTimeout(done, 10);
     })`;
 
-    const loopWork = ['immediate', 'fs', 'napi'];
+    const loopWork = ['immediate', 'fs', 'napi async work', 'napi threadsafe function'];
     const exerciseLoop = (wc: Electron.WebContents) =>
       wc.executeJavaScript(`Promise.all([
         new Promise((resolve) => setImmediate(() => resolve('immediate'))),
         new Promise((resolve) => require('node:fs').readFile(__filename, () => resolve('fs'))),
-        new Promise((resolve) => require('@electron-ci/echo').async('napi', resolve))
+        new Promise((resolve) => require('@electron-ci/echo').async('napi async work', resolve)),
+        new Promise((resolve) => require('@electron-ci/echo').threadsafe('napi threadsafe function', resolve))
       ])`);
 
     const openWindow = async (webPreferences = {}) => {

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -1,4 +1,4 @@
-import { webContents } from 'electron/main';
+import { BrowserWindow, webContents } from 'electron/main';
 
 import { expect } from 'chai';
 
@@ -27,6 +27,7 @@ import {
   startRemoteControlApp,
   useRemoteContext
 } from './lib/spec-helpers';
+import { closeAllWindows } from './lib/window-helpers';
 
 const mainFixturesPath = path.resolve(__dirname, 'fixtures');
 
@@ -483,6 +484,72 @@ describe('node feature', () => {
           }, 10);
         });
       });
+    });
+  });
+
+  describe('environments sharing a renderer', () => {
+    afterEach(closeAllWindows);
+
+    const nodePreferences = { nodeIntegration: true, contextIsolation: false, sandbox: false };
+
+    const churnDuring = (teardown: string) => `new Promise((resolve) => {
+      const fs = require('node:fs');
+      let immediates = 0;
+      const spin = () => { if (++immediates < 200) setImmediate(spin); };
+      setImmediate(spin);
+      let read = false;
+      fs.readFile(__filename, () => { read = true; });
+      let closed = 0;
+      const watchers = Array.from({ length: 5 }, () => fs.watch(__filename));
+      for (const w of watchers) w.on('close', () => closed++);
+      for (const w of watchers) w.close();
+      ${teardown};
+      const done = () => immediates < 200 || !read ? setTimeout(done, 10) : resolve({ immediates, read, closed });
+      setTimeout(done, 10);
+    })`;
+
+    const openWindow = async (webPreferences = {}) => {
+      const w = new BrowserWindow({ show: false, webPreferences: { ...nodePreferences, ...webPreferences } });
+      const errors: string[] = [];
+      w.webContents.on('console-message', ({ level, message }) => {
+        if (level === 'error') errors.push(message);
+      });
+      await w.loadFile(path.join(fixtures, 'pages', 'blank.html'));
+      return { w, errors };
+    };
+
+    it('keeps the opener working when a same-process child window closes', async () => {
+      const { w, errors } = await openWindow();
+      w.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: { show: false, webPreferences: nodePreferences }
+      }));
+      for (let i = 0; i < 3; i++) {
+        const childCreated = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow, any]>;
+        await w.webContents.executeJavaScript("window.child = window.open('base-page.html'); undefined");
+        const [child] = await childCreated;
+        if (child.webContents.isLoading()) await once(child.webContents, 'did-finish-load');
+        const closed = once(child, 'closed');
+        const result = await w.webContents.executeJavaScript(churnDuring('window.child.close()'));
+        await closed;
+        expect(result).to.deep.equal({ immediates: 200, read: true, closed: 5 });
+      }
+      expect(errors).to.deep.equal([]);
+    });
+
+    it('keeps the parent frame working when a node-integrated iframe is removed', async () => {
+      const { w, errors } = await openWindow({ nodeIntegrationInSubFrames: true });
+      for (let i = 0; i < 3; i++) {
+        await w.webContents.executeJavaScript(`new Promise((resolve) => {
+          const frame = document.createElement('iframe');
+          frame.src = 'base-page.html';
+          frame.onload = () => resolve();
+          document.body.appendChild(window.frame = frame);
+        })`);
+        const result = await w.webContents.executeJavaScript(churnDuring('window.frame.remove()'));
+        expect(result).to.deep.equal({ immediates: 200, read: true, closed: 5 });
+      }
+      expect(errors).to.deep.equal([]);
     });
   });
 

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -499,17 +499,31 @@ describe('node feature', () => {
       setImmediate(spin);
       let read = false;
       fs.readFile(__filename, () => { read = true; });
+      let echoed = false;
+      require('@electron-ci/echo').async(true, (value) => { echoed = value; });
       let closed = 0;
       const watchers = Array.from({ length: 5 }, () => fs.watch(__filename));
       for (const w of watchers) w.on('close', () => closed++);
       for (const w of watchers) w.close();
       ${teardown};
-      const done = () => immediates < 200 || !read ? setTimeout(done, 10) : resolve({ immediates, read, closed });
+      const done = () => immediates < 200 || !read || !echoed ? setTimeout(done, 10) : resolve({ immediates, read, echoed, closed });
       setTimeout(done, 10);
     })`;
 
+    const loopWork = ['immediate', 'fs', 'napi'];
+    const exerciseLoop = (wc: Electron.WebContents) =>
+      wc.executeJavaScript(`Promise.all([
+        new Promise((resolve) => setImmediate(() => resolve('immediate'))),
+        new Promise((resolve) => require('node:fs').readFile(__filename, () => resolve('fs'))),
+        new Promise((resolve) => require('@electron-ci/echo').async('napi', resolve))
+      ])`);
+
     const openWindow = async (webPreferences = {}) => {
       const w = new BrowserWindow({ show: false, webPreferences: { ...nodePreferences, ...webPreferences } });
+      w.webContents.setWindowOpenHandler(() => ({
+        action: 'allow',
+        overrideBrowserWindowOptions: { show: false, webPreferences: nodePreferences }
+      }));
       const errors: string[] = [];
       w.webContents.on('console-message', ({ level, message }) => {
         if (level === 'error') errors.push(message);
@@ -518,21 +532,46 @@ describe('node feature', () => {
       return { w, errors };
     };
 
+    const openChild = async (w: BrowserWindow, url: string) => {
+      const childCreated = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow, any]>;
+      await w.webContents.executeJavaScript(`window.child = window.open(${JSON.stringify(url)}); undefined`);
+      const [child] = await childCreated;
+      if (child.webContents.isLoading()) await once(child.webContents, 'did-finish-load');
+      expect(child.webContents.getOSProcessId()).to.equal(w.webContents.getOSProcessId());
+      return child;
+    };
+
+    it('runs each same-process child window on a working loop of its own', async () => {
+      const { w, errors } = await openWindow();
+      const child = await openChild(w, 'base-page.html');
+      await expect(exerciseLoop(child.webContents)).to.eventually.deep.equal(loopWork);
+      const blankChild = await openChild(w, 'about:blank');
+      await expect(exerciseLoop(blankChild.webContents)).to.eventually.deep.equal(loopWork);
+      expect(errors).to.deep.equal([]);
+    });
+
+    it('keeps a child window working while its opener reloads', async () => {
+      const { w, errors } = await openWindow();
+      const child = await openChild(w, 'base-page.html');
+      for (let i = 0; i < 2; i++) {
+        const pending = exerciseLoop(child.webContents);
+        w.webContents.reload();
+        await once(w.webContents, 'did-finish-load');
+        await expect(pending).to.eventually.deep.equal(loopWork);
+        await expect(exerciseLoop(child.webContents)).to.eventually.deep.equal(loopWork);
+      }
+      await expect(exerciseLoop(w.webContents)).to.eventually.deep.equal(loopWork);
+      expect(errors).to.deep.equal([]);
+    });
+
     it('keeps the opener working when a same-process child window closes', async () => {
       const { w, errors } = await openWindow();
-      w.webContents.setWindowOpenHandler(() => ({
-        action: 'allow',
-        overrideBrowserWindowOptions: { show: false, webPreferences: nodePreferences }
-      }));
       for (let i = 0; i < 3; i++) {
-        const childCreated = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow, any]>;
-        await w.webContents.executeJavaScript("window.child = window.open('base-page.html'); undefined");
-        const [child] = await childCreated;
-        if (child.webContents.isLoading()) await once(child.webContents, 'did-finish-load');
+        const child = await openChild(w, 'base-page.html');
         const closed = once(child, 'closed');
         const result = await w.webContents.executeJavaScript(churnDuring('window.child.close()'));
         await closed;
-        expect(result).to.deep.equal({ immediates: 200, read: true, closed: 5 });
+        expect(result).to.deep.equal({ immediates: 200, read: true, echoed: true, closed: 5 });
       }
       expect(errors).to.deep.equal([]);
     });
@@ -547,7 +586,7 @@ describe('node feature', () => {
           document.body.appendChild(window.frame = frame);
         })`);
         const result = await w.webContents.executeJavaScript(churnDuring('window.frame.remove()'));
-        expect(result).to.deep.equal({ immediates: 200, read: true, closed: 5 });
+        expect(result).to.deep.equal({ immediates: 200, read: true, echoed: true, closed: 5 });
       }
       expect(errors).to.deep.equal([]);
     });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33868.
Closes https://github.com/electron/electron/issues/36858.
Closes https://github.com/electron/electron/issues/40607.
Closes https://github.com/electron/electron/issues/51860.

Every Node.js environment on the renderer main thread (the main frame, `nodeIntegrationInSubFrames` iframes, same-process `window.open()` children) shared `uv_default_loop()`. Freeing one of them runs that loop until its handles close, with JavaScript disallowed on the isolate, so whatever immediates, timers, fs or threadpool callbacks the surviving page had pending fired inside that window and either threw `Uncaught illegal access` or aborted the renderer. The shared loop was also pumped under the main frame's context only, so napi async work and thread-safe functions used from a child window or subframe aborted in `InternalCallbackScope` (#33868).

Each frame's environment now gets its own loop integration, the same way worker environments already do: `NodeBindings` can integrate a given loop or own one, and the renderer keeps a `NodeBindings` + `ElectronBindings` pair per frame. A main frame's environment borrows the process-lifetime `uv_default_loop()` integration while it is free, so native modules that use the default loop keep working there; subframes and any further main frames own their loop. Tearing an environment down parks that loop's embed thread and frees it without touching other environments' handles.

- Environments are keyed by `RenderFrame`, which replaces the `uv_env` hand-off between main-frame environments and the injected-frames bookkeeping.
- A new environment gets its first loop run from a fresh task, since child contexts can be created from inside a script (`window.open('about:blank')`).
- Isolate-level Node.js setup (`NodeBindings::SetUpIsolate`) now runs once per isolate instead of once per environment, so renderer frames no longer stack a V8 message listener each; the about:blank subframe skip's comment gives its remaining reason (sandboxed preload startup data) instead of this bug.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `Uncaught illegal access` errors and renderer crashes when closing a same-process child window or removing an iframe with `nodeIntegrationInSubFrames` enabled, and when native modules use napi async work or thread-safe functions from such windows and frames.

