### PR TITLE
feat: capture Node.js trace categories via Perfetto

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -259,3 +259,4 @@ cherry-pick-adbdd928eb27.patch
 cherry-pick-278468608392.patch
 cherry-pick-e09d67f7844c.patch
 cherry-pick-01036c1aead2.patch
+chore_register_node_as_a_dynamic_trace_category_prefix.patch

--- a/patches/chromium/chore_register_node_as_a_dynamic_trace_category_prefix.patch
+++ b/patches/chromium/chore_register_node_as_a_dynamic_trace_category_prefix.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Tue, 31 Mar 2026 09:03:39 +0900
+Subject: chore: register node as a dynamic trace category prefix
+
+This allows Node.js trace categories to be treated as dynamic Perfetto
+categories in the Chromium build. Without this, the categories
+must be registered in the static registry base/trace_event/builtin_categories.h
+which is backed by constexpr function ValidateCategories() that
+recursively validates to a depth of index + longest_category_name_length,
+adding the node categories exceeds the current constexpr recursion depth
+of 512 and requires additional patching to add `-fconstexpr-depth` to //base
+target. Given neither the static nor the dynamic registration can be
+upstreamed, the minimal of the two changes is chosen here.
+
+diff --git a/base/trace_event/builtin_categories.h b/base/trace_event/builtin_categories.h
+index 976221d0303036ecae500b7861931ff96e9ea0c1..5b5582aab913fc7106d9a4133c9fa03fd1a3d5f7 100644
+--- a/base/trace_event/builtin_categories.h
++++ b/base/trace_event/builtin_categories.h
+@@ -14,6 +14,7 @@ PERFETTO_DEFINE_TEST_CATEGORY_PREFIXES("cat",
+                                        "foo",
+                                        "test",
+                                        "kTest",
++                                       "node",
+                                        "noise",
+                                        "Testing",
+                                        "NotTesting",

--- a/patches/node/api_remove_deprecated_getisolate.patch
+++ b/patches/node/api_remove_deprecated_getisolate.patch
@@ -133,10 +133,10 @@ index 31277621e92b4d3583a67140f4ab8a74a9c6df3b..caa109871b71926f3355491767b8064b
    // Recreate the buffer in the constructor.
    InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);
 diff --git a/src/env.cc b/src/env.cc
-index 82aee7e38bbd859e1a76eedcc3a51278a1b3a793..a09603573c02466c0d25431fe6168ca33ee4692e 100644
+index dd8be35de7c447c9a77f8b9849a6a3de19bc55af..79a309661aff7ebb18f96e64d0d2b860ab80dc57 100644
 --- a/src/env.cc
 +++ b/src/env.cc
-@@ -1764,10 +1764,10 @@ void AsyncHooks::Deserialize(Local<Context> context) {
+@@ -1763,10 +1763,10 @@ void AsyncHooks::Deserialize(Local<Context> context) {
          context->GetDataFromSnapshotOnce<Array>(
              info_->js_execution_async_resources).ToLocalChecked();
    } else {
@@ -149,7 +149,7 @@ index 82aee7e38bbd859e1a76eedcc3a51278a1b3a793..a09603573c02466c0d25431fe6168ca3
  
    // The native_execution_async_resources_ field requires v8::Local<> instances
    // for async calls whose resources were on the stack as JS objects when they
-@@ -1807,7 +1807,7 @@ AsyncHooks::SerializeInfo AsyncHooks::Serialize(Local<Context> context,
+@@ -1806,7 +1806,7 @@ AsyncHooks::SerializeInfo AsyncHooks::Serialize(Local<Context> context,
    info.async_id_fields = async_id_fields_.Serialize(context, creator);
    if (!js_execution_async_resources_.IsEmpty()) {
      info.js_execution_async_resources = creator->AddData(
@@ -398,7 +398,7 @@ index fea0426496978c0003fe1481afcf93fc9c23edca..c9588880d05435ab9f4e23fcff74c933
  
    CHECK(
 diff --git a/src/node_contextify.cc b/src/node_contextify.cc
-index 211bc074161b5fd4ac6f2d9a23b201d79ae362ef..469c85642e995024b354abaa67dd865933867fc7 100644
+index 0a692075dfeab6fb880b2ca6d52c2d45ce527276..c69ff16bd85427d3c26d8b42029c8ebb618dea41 100644
 --- a/src/node_contextify.cc
 +++ b/src/node_contextify.cc
 @@ -109,6 +109,8 @@ using v8::Value;
@@ -419,7 +419,7 @@ index 211bc074161b5fd4ac6f2d9a23b201d79ae362ef..469c85642e995024b354abaa67dd8659
  
    PropertyAttribute attributes = PropertyAttribute::None;
    bool is_declared =
-@@ -1668,7 +1670,7 @@ static MaybeLocal<Function> CompileFunctionForCJSLoader(
+@@ -1667,7 +1669,7 @@ static MaybeLocal<Function> CompileFunctionForCJSLoader(
      bool* cache_rejected,
      bool is_cjs_scope,
      ScriptCompiler::CachedData* cached_data) {
@@ -473,10 +473,10 @@ index dc55d1c0d9fcbbbb99d6f459280e09e2d37cb04b..a222e7078b3a92ff21bd009ab00361fc
    READONLY_PROPERTY(target, "exitCodes", exit_codes);
  
 diff --git a/src/node_file.cc b/src/node_file.cc
-index d828e7e78f9b41e053c306b01a71ad3ad847aaf6..c24c952538cfd28d46209299550bae0bfa7317dc 100644
+index 0bd206a6b4f423a67b6fedc0790faa6eb35d5b97..83d02f0e9cc56025d37247d6323b154052f94e63 100644
 --- a/src/node_file.cc
 +++ b/src/node_file.cc
-@@ -3899,7 +3899,7 @@ void BindingData::Deserialize(Local<Context> context,
+@@ -3906,7 +3906,7 @@ void BindingData::Deserialize(Local<Context> context,
                                int index,
                                InternalFieldInfoBase* info) {
    DCHECK_IS_SNAPSHOT_SLOT(index);

--- a/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
+++ b/patches/node/build_allow_unbundling_of_node_js_dependencies.patch
@@ -14,10 +14,10 @@ We don't need to do this for zlib, as the existing gn workflow uses the same
 Upstreamed at https://github.com/nodejs/node/pull/55903
 
 diff --git a/unofficial.gni b/unofficial.gni
-index df0ae804a5338d8f2ec4d331a1e2ed053c3c3955..07ebc4706c6b3208dc9136e6ba0e4d795c238d61 100644
+index eeffbafa4023ed68f56410c858e459f569ed6344..d7c717d5c2799692c7ea4537d7faea234faefaa2 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -199,7 +199,17 @@ template("node_gn_build") {
+@@ -203,7 +203,17 @@ template("node_gn_build") {
        configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
        configs += [ "//build/config/gcc:symbol_visibility_default" ]
      }
@@ -36,7 +36,7 @@ index df0ae804a5338d8f2ec4d331a1e2ed053c3c3955..07ebc4706c6b3208dc9136e6ba0e4d79
      if (v8_enable_i18n_support) {
        deps += [ "//third_party/icu" ]
      }
-@@ -232,6 +242,19 @@ template("node_gn_build") {
+@@ -236,6 +246,19 @@ template("node_gn_build") {
        sources += node_inspector.node_inspector_sources +
                   node_inspector.node_inspector_generated_sources
      }

--- a/patches/node/build_enable_perfetto.patch
+++ b/patches/node/build_enable_perfetto.patch
@@ -3,20 +3,14 @@ From: Shelley Vohr <shelley.vohr@gmail.com>
 Date: Wed, 17 Apr 2024 08:17:49 -0400
 Subject: build: enable perfetto
 
-Enable perfetto by default in Node.js. Node.js disables perfetto by
-default but is broken on build - they don't currently add guards for
-`V8_USE_PERFETTO` and upstream only defines certain functions
-on `v8::TracingController` if perfetto is disabled. Electron already
-had minimal to no support for Node.js trace events, so the impact of
-adding associated guards there should be relatively small.
-
-We should upstream this as it will eventually impact Node.js as well.
+Enable perfetto by default in Node.js and wire track events
+through legacy shim.
 
 diff --git a/lib/internal/constants.js b/lib/internal/constants.js
-index 8d7204f6cb48f783adc4d1c1eb2de0c83b7fffe2..a154559a56bf383d3c26af523c9bb07b564ef600 100644
+index 8d7204f6cb48f783adc4d1c1eb2de0c83b7fffe2..8061013fcfe3c3b02aabaca0447069423ac853b2 100644
 --- a/lib/internal/constants.js
 +++ b/lib/internal/constants.js
-@@ -5,12 +5,15 @@ const isWindows = process.platform === 'win32';
+@@ -5,12 +5,16 @@ const isWindows = process.platform === 'win32';
  module.exports = {
    // Alphabet chars.
    CHAR_UPPERCASE_A: 65, /* A */
@@ -28,61 +22,216 @@ index 8d7204f6cb48f783adc4d1c1eb2de0c83b7fffe2..a154559a56bf383d3c26af523c9bb07b
    CHAR_LOWERCASE_B: 98, /* b */
 +  CHAR_UPPERCASE_E: 69, /* E */
    CHAR_LOWERCASE_E: 101, /* e */
++  CHAR_UPPERCASE_I: 73, /* I */
 +
    CHAR_LOWERCASE_N: 110, /* n */
  
    // Non-alphabetic chars.
 diff --git a/lib/internal/http.js b/lib/internal/http.js
-index 116d699f505a4f53ec816ccb83b634cccdf2a67c..6459b3bdbc91b5cc988e5dce2b3b7d9e795d3447 100644
+index 116d699f505a4f53ec816ccb83b634cccdf2a67c..65af9f464fcd60ab5ecb2c5c2c119cde3119137f 100644
 --- a/lib/internal/http.js
 +++ b/lib/internal/http.js
-@@ -11,8 +11,8 @@ const {
- const { setUnrefTimeout } = require('internal/timers');
- const { getCategoryEnabledBuffer, trace } = internalBinding('trace_events');
- const {
--  CHAR_LOWERCASE_B,
--  CHAR_LOWERCASE_E,
-+  CHAR_UPPERCASE_B,
-+  CHAR_UPPERCASE_E,
- } = require('internal/constants');
+@@ -9,7 +9,7 @@ const {
+ } = primordials;
  
- const { URL } = require('internal/url');
-@@ -51,11 +51,13 @@ function isTraceHTTPEnabled() {
- const traceEventCategory = 'node,node.http';
+ const { setUnrefTimeout } = require('internal/timers');
+-const { getCategoryEnabledBuffer, trace } = internalBinding('trace_events');
++const { isTraceCategoryEnabled, trace } = internalBinding('trace_events');
+ const {
+   CHAR_LOWERCASE_B,
+   CHAR_LOWERCASE_E,
+@@ -42,13 +42,11 @@ function getNextTraceEventId() {
+   return ++traceEventId;
+ }
+ 
+-const httpEnabled = getCategoryEnabledBuffer('node.http');
+-
+ function isTraceHTTPEnabled() {
+-  return httpEnabled[0] > 0;
++  return isTraceCategoryEnabled('node.http');
+ }
+ 
+-const traceEventCategory = 'node,node.http';
++const traceEventCategory = 'node.http';
  
  function traceBegin(...args) {
--  trace(CHAR_LOWERCASE_B, traceEventCategory, ...args);
-+  // See v8/src/builtins/builtins-trace.cc - must be uppercase for perfetto
-+  trace(CHAR_UPPERCASE_B, traceEventCategory, ...args);
+   trace(CHAR_LOWERCASE_B, traceEventCategory, ...args);
+diff --git a/lib/internal/perf/usertiming.js b/lib/internal/perf/usertiming.js
+index 88bb63ead2d3d620dea6b54db043a404b484ead9..a37386bbf51b55b26a140cd81fbaf26d78015f21 100644
+--- a/lib/internal/perf/usertiming.js
++++ b/lib/internal/perf/usertiming.js
+@@ -13,6 +13,12 @@ const { PerformanceEntry, kSkipThrow } = require('internal/perf/performance_entr
+ const { now } = require('internal/perf/utils');
+ const { enqueue, bufferUserTiming } = require('internal/perf/observe');
+ const nodeTiming = require('internal/perf/nodetiming');
++const { isTraceCategoryEnabled, trace } = internalBinding('trace_events');
++const {
++  CHAR_LOWERCASE_B,
++  CHAR_LOWERCASE_E,
++  CHAR_UPPERCASE_I
++} = require('internal/constants');
+ 
+ const {
+   validateNumber,
+@@ -41,6 +47,9 @@ const kDetail = Symbol('kDetail');
+ 
+ const markTimings = new SafeMap();
+ 
++const traceEventCategory = 'node.perf.usertiming';
++let traceEventId = 0;
++
+ const nodeTimingReadOnlyAttributes = new SafeSet(new SafeArrayIterator([
+   'nodeStart',
+   'v8Start',
+@@ -168,6 +177,10 @@ function mark(name, options) {
+   const mark = new PerformanceMark(name, options);
+   enqueue(mark);
+   bufferUserTiming(mark);
++  if (isTraceCategoryEnabled(traceEventCategory)) {
++    trace(CHAR_UPPERCASE_I, traceEventCategory, name, undefined,
++          { startTime: mark.startTime });
++  }
+   return mark;
  }
  
- function traceEnd(...args) {
--  trace(CHAR_LOWERCASE_E, traceEventCategory, ...args);
-+  // See v8/src/builtins/builtins-trace.cc - must be uppercase for perfetto
-+  trace(CHAR_UPPERCASE_E, traceEventCategory, ...args);
+@@ -233,6 +246,13 @@ function measure(name, startOrMeasureOptions, endMark) {
+   const measure = createPerformanceMeasure(name, start, duration, detail);
+   enqueue(measure);
+   bufferUserTiming(measure);
++  if (isTraceCategoryEnabled(traceEventCategory)) {
++    const id = ++traceEventId;
++    trace(CHAR_LOWERCASE_B, traceEventCategory, name, id,
++          { startTime: start });
++    trace(CHAR_LOWERCASE_E, traceEventCategory, name, id,
++          { startTime: start, duration });
++  }
+   return measure;
  }
  
- function ipToInt(ip) {
+diff --git a/lib/internal/trace_events_async_hooks.js b/lib/internal/trace_events_async_hooks.js
+index a9f517ffc9e4eea5bc68997ffadc85d43dde2a52..e85bcd2f500ff3f5bbd2b25922c13cb29de50993 100644
+--- a/lib/internal/trace_events_async_hooks.js
++++ b/lib/internal/trace_events_async_hooks.js
+@@ -20,7 +20,7 @@ const {
+ // the specific C++ macros.
+ const kBeforeEvent = CHAR_LOWERCASE_B;
+ const kEndEvent = CHAR_LOWERCASE_E;
+-const kTraceEventCategory = 'node,node.async_hooks';
++const kTraceEventCategory = 'node.async_hooks';
+ 
+ const kEnabled = Symbol('enabled');
+ 
+diff --git a/lib/internal/util/debuglog.js b/lib/internal/util/debuglog.js
+index 06a4f8a239855571dcc67cd81e7da7a255a9ebfd..1fa9e314ad796cdf74f718f0eb2a15530f5833d3 100644
+--- a/lib/internal/util/debuglog.js
++++ b/lib/internal/util/debuglog.js
+@@ -20,7 +20,7 @@ const {
+   CHAR_LOWERCASE_N: kTraceInstant,
+ } = require('internal/constants');
+ const { inspect, format, formatWithOptions } = require('internal/util/inspect');
+-const { getCategoryEnabledBuffer, trace } = internalBinding('trace_events');
++const { isTraceCategoryEnabled, trace } = internalBinding('trace_events');
+ 
+ // `debugImpls` and `testEnabled` are deliberately not initialized so any call
+ // to `debuglog()` before `initializeDebugEnv()` is called will throw.
+@@ -386,14 +386,13 @@ function debugWithTimer(set, cb) {
+   }
+ 
+   const traceCategory = `node,node.${StringPrototypeToLowerCase(set)}`;
+-  let traceCategoryBuffer;
+   let debugLogCategoryEnabled = false;
+   let timerFlags = kNone;
+ 
+   function ensureTimerFlagsAreUpdated() {
+     timerFlags &= ~kSkipTrace;
+ 
+-    if (traceCategoryBuffer[0] === 0) {
++    if (!isTraceCategoryEnabled(traceCategory)) {
+       timerFlags |= kSkipTrace;
+     }
+   }
+@@ -467,7 +466,6 @@ function debugWithTimer(set, cb) {
+     }
+     emitWarningIfNeeded(set);
+     debugLogCategoryEnabled = testEnabled(set);
+-    traceCategoryBuffer = getCategoryEnabledBuffer(traceCategory);
+ 
+     timerFlags = kNone;
+ 
+@@ -475,7 +473,7 @@ function debugWithTimer(set, cb) {
+       timerFlags |= kSkipLog;
+     }
+ 
+-    if (traceCategoryBuffer[0] === 0) {
++    if (!isTraceCategoryEnabled(traceCategory)) {
+       timerFlags |= kSkipTrace;
+     }
+ 
 diff --git a/node.gyp b/node.gyp
-index 6387b945506278085dff461aeff51e5d20f457e6..e55a714a3a412d7889f3576d44ec3865f115752b 100644
+index 6387b945506278085dff461aeff51e5d20f457e6..679941992c86ca02070d3df55e194d6904bda646 100644
 --- a/node.gyp
 +++ b/node.gyp
-@@ -186,7 +186,6 @@
+@@ -186,9 +186,9 @@
        'src/timers.cc',
        'src/timer_wrap.cc',
        'src/tracing/agent.cc',
 -      'src/tracing/node_trace_buffer.cc',
        'src/tracing/node_trace_writer.cc',
        'src/tracing/trace_event.cc',
++      'src/tracing/trace_categories.cc',
        'src/tracing/traced_value.cc',
-@@ -322,7 +321,6 @@
+       'src/tty_wrap.cc',
+       'src/udp_wrap.cc',
+@@ -322,9 +322,9 @@
        'src/tcp_wrap.h',
        'src/timers.h',
        'src/tracing/agent.h',
 -      'src/tracing/node_trace_buffer.h',
        'src/tracing/node_trace_writer.h',
        'src/tracing/trace_event.h',
++      'src/tracing/trace_categories.h',
        'src/tracing/trace_event_common.h',
+       'src/tracing/traced_value.h',
+       'src/timer_wrap.h',
+diff --git a/src/async_wrap.cc b/src/async_wrap.cc
+index b7d0041d0737f7e0315216748e3a5908428c7d1c..b48efd7e1a611dddb5724d65d623c8a20168d252 100644
+--- a/src/async_wrap.cc
++++ b/src/async_wrap.cc
+@@ -110,8 +110,7 @@ void AsyncWrap::EmitPromiseResolve(Environment* env, double async_id) {
+ }
+ 
+ void AsyncWrap::EmitTraceAsyncStart() const {
+-  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+-          TRACING_CATEGORY_NODE1(async_hooks))) {
++  if (NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE1(async_hooks))) {
+     tracing::AsyncWrapArgs data(env()->execution_async_id(),
+                                 get_trigger_async_id());
+     TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE1(async_hooks),
+diff --git a/src/env.cc b/src/env.cc
+index bbb30dd8a50f7b8550caf1967de8547cc7d8af47..ef6e14245fa668d04d0e9b1f71fcce48ec267f4e 100644
+--- a/src/env.cc
++++ b/src/env.cc
+@@ -649,8 +649,8 @@ void TrackingTraceStateObserver::UpdateTraceCategoryState() {
+     return;
+   }
+ 
+-  bool async_hooks_enabled = (*(TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+-                                 TRACING_CATEGORY_NODE1(async_hooks)))) != 0;
++  bool async_hooks_enabled =
++      NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE1(async_hooks));
+ 
+   Isolate* isolate = env_->isolate();
+   HandleScope handle_scope(isolate);
+@@ -892,8 +892,7 @@ Environment::Environment(IsolateData* isolate_data,
+       time_origin_timestamp_,
+       MAYBE_FIELD_PTR(env_info, performance_state));
+ 
+-  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+-          TRACING_CATEGORY_NODE1(environment)) != 0) {
++  if (NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE1(environment))) {
+     tracing::EnvironmentArgs traced_value(args, exec_args);
+     TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE1(environment),
+                                       "Environment",
 diff --git a/src/inspector/tracing_agent.cc b/src/inspector/tracing_agent.cc
 index 40c8aea35c931c46fc62b717c978eab0659645fd..348cdfb0b42aa18f352c220cea0b896c09f67753 100644
 --- a/src/inspector/tracing_agent.cc
@@ -104,6 +253,156 @@ index 40c8aea35c931c46fc62b717c978eab0659645fd..348cdfb0b42aa18f352c220cea0b896c
    void Flush(bool) override {
      if (!json_writer_)
        return;
+diff --git a/src/node.cc b/src/node.cc
+index 6f899ec0621ada45fb04c921359bc9b9ea79132b..4178e13dc8b5769c06fb720b2fcc655eb46aef5a 100644
+--- a/src/node.cc
++++ b/src/node.cc
+@@ -78,6 +78,11 @@
+ 
+ #include "large_pages/node_large_page.h"
+ 
++#if defined(V8_USE_PERFETTO)
++#include "perfetto/tracing/tracing.h"
++#include "tracing/trace_categories.h"
++#endif
++
+ #if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
+ #define NODE_USE_V8_WASM_TRAP_HANDLER 1
+ #else
+@@ -1264,6 +1269,14 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
+     absl::SetMutexDeadlockDetectionMode(absl::OnDeadlockCycle::kIgnore);
+   }
+ 
++#if defined(V8_USE_PERFETTO)
++  // Register Node's Perfetto TrackEvent data source so that trace
++  // categories are available.
++  if (perfetto::Tracing::IsInitialized()) {
++    node::perfetto_track_event::TrackEvent::Register();
++  }
++#endif
++
+ #if NODE_USE_V8_WASM_TRAP_HANDLER
+   bool use_wasm_trap_handler =
+       !per_process::cli_options->disable_wasm_trap_handler;
+diff --git a/src/node_contextify.cc b/src/node_contextify.cc
+index 211bc074161b5fd4ac6f2d9a23b201d79ae362ef..0a692075dfeab6fb880b2ca6d52c2d45ce527276 100644
+--- a/src/node_contextify.cc
++++ b/src/node_contextify.cc
+@@ -1028,8 +1028,7 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+ 
+   ContextifyScript* contextify_script = New(env, args.This());
+ 
+-  if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+-          TRACING_CATEGORY_NODE2(vm, script)) != 0) {
++  if (NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE2(vm, script))) {
+     Utf8Value fn(isolate, filename);
+     TRACE_EVENT_BEGIN1(TRACING_CATEGORY_NODE2(vm, script),
+                        "ContextifyScript::New",
+diff --git a/src/node_dir.cc b/src/node_dir.cc
+index c9173d404c79a69743fc75ddb6bba0ac9579c1ef..8ffac047a69b3900f37d712334c504a1c65c83fd 100644
+--- a/src/node_dir.cc
++++ b/src/node_dir.cc
+@@ -61,18 +61,25 @@ static const char* get_dir_func_name_by_type(uv_fs_type req_type) {
+ 
+ #define TRACE_NAME(name) "fs_dir.sync." #name
+ #define GET_TRACE_ENABLED                                                      \
+-  (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(                                \
+-       TRACING_CATEGORY_NODE2(fs_dir, sync)) != 0)
++  NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE2(fs_dir, sync))
+ #define FS_DIR_SYNC_TRACE_BEGIN(syscall, ...)                                  \
+   if (GET_TRACE_ENABLED)                                                       \
+     TRACE_EVENT_BEGIN(TRACING_CATEGORY_NODE2(fs_dir, sync),                    \
+                       TRACE_NAME(syscall),                                     \
+                       ##__VA_ARGS__);
++#if defined(V8_USE_PERFETTO)
++// Perfetto's TRACE_EVENT_END does not accept a name; it matches the prior
++// TRACE_EVENT_BEGIN on the same thread.
++#define FS_DIR_SYNC_TRACE_END(syscall, ...)                                    \
++  if (GET_TRACE_ENABLED)                                                       \
++    TRACE_EVENT_END(TRACING_CATEGORY_NODE2(fs_dir, sync), ##__VA_ARGS__);
++#else
+ #define FS_DIR_SYNC_TRACE_END(syscall, ...)                                    \
+   if (GET_TRACE_ENABLED)                                                       \
+     TRACE_EVENT_END(TRACING_CATEGORY_NODE2(fs_dir, sync),                      \
+                     TRACE_NAME(syscall),                                       \
+                     ##__VA_ARGS__);
++#endif
+ 
+ #define FS_DIR_ASYNC_TRACE_BEGIN0(fs_type, id)                                 \
+   TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(TRACING_CATEGORY_NODE2(fs_dir, async),     \
+diff --git a/src/node_file.cc b/src/node_file.cc
+index d828e7e78f9b41e053c306b01a71ad3ad847aaf6..0bd206a6b4f423a67b6fedc0790faa6eb35d5b97 100644
+--- a/src/node_file.cc
++++ b/src/node_file.cc
+@@ -147,16 +147,23 @@ static const char* get_fs_func_name_by_type(uv_fs_type req_type) {
+ 
+ #define TRACE_NAME(name) "fs.sync." #name
+ #define GET_TRACE_ENABLED                                                      \
+-  (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(                                \
+-       TRACING_CATEGORY_NODE2(fs, sync)) != 0)
++  NODE_TRACE_CATEGORY_ENABLED(TRACING_CATEGORY_NODE2(fs, sync))
+ #define FS_SYNC_TRACE_BEGIN(syscall, ...)                                      \
+   if (GET_TRACE_ENABLED)                                                       \
+     TRACE_EVENT_BEGIN(                                                         \
+         TRACING_CATEGORY_NODE2(fs, sync), TRACE_NAME(syscall), ##__VA_ARGS__);
++#if defined(V8_USE_PERFETTO)
++// Perfetto's TRACE_EVENT_END does not accept a name; it matches the prior
++// TRACE_EVENT_BEGIN on the same thread.
++#define FS_SYNC_TRACE_END(syscall, ...)                                        \
++  if (GET_TRACE_ENABLED)                                                       \
++    TRACE_EVENT_END(TRACING_CATEGORY_NODE2(fs, sync), ##__VA_ARGS__);
++#else
+ #define FS_SYNC_TRACE_END(syscall, ...)                                        \
+   if (GET_TRACE_ENABLED)                                                       \
+     TRACE_EVENT_END(                                                           \
+         TRACING_CATEGORY_NODE2(fs, sync), TRACE_NAME(syscall), ##__VA_ARGS__);
++#endif
+ 
+ #define FS_ASYNC_TRACE_BEGIN0(fs_type, id)                                     \
+   TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(TRACING_CATEGORY_NODE2(fs, async),         \
+diff --git a/src/node_internals.h b/src/node_internals.h
+index 8e930a6fecd6589b858293d91b2454ea14ae7c73..a95dd02d4149a02ff40c759010e130c89ad1d848 100644
+--- a/src/node_internals.h
++++ b/src/node_internals.h
+@@ -315,6 +315,14 @@ class ThreadPoolWork {
+   const char* type_;
+ };
+ 
++#if defined(V8_USE_PERFETTO)
++// Perfetto categories must be single strings (not comma-separated).
++#define TRACING_CATEGORY_NODE "node"
++#define TRACING_CATEGORY_NODE1(one) "node." #one
++#define TRACING_CATEGORY_NODE2(one, two) "node." #one "." #two
++#define NODE_TRACE_CATEGORY_ENABLED(category) \
++    TRACE_EVENT_CATEGORY_ENABLED(category)
++#else
+ #define TRACING_CATEGORY_NODE "node"
+ #define TRACING_CATEGORY_NODE1(one)                                           \
+     TRACING_CATEGORY_NODE ","                                                 \
+@@ -323,6 +331,9 @@ class ThreadPoolWork {
+     TRACING_CATEGORY_NODE ","                                                 \
+     TRACING_CATEGORY_NODE "." #one ","                                        \
+     TRACING_CATEGORY_NODE "." #one "." #two
++#define NODE_TRACE_CATEGORY_ENABLED(category) \
++    (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category) != 0)
++#endif
+ 
+ // Functions defined in node.cc that are exposed via the bootstrapper object
+ 
+diff --git a/src/node_trace_events.cc b/src/node_trace_events.cc
+index f1a0a87f760da50d11ef9fa14d6157589a584ce9..2a07ce3a82b50e71bae2ed999f96f9afcba801c7 100644
+--- a/src/node_trace_events.cc
++++ b/src/node_trace_events.cc
+@@ -135,7 +135,8 @@ static void GetCategoryEnabledBuffer(const FunctionCallbackInfo<Value>& args) {
+   node::Utf8Value category_name(isolate, args[0]);
+ 
+   const uint8_t* enabled_pointer =
+-      TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_name.out());
++      tracing::TraceEventHelper::GetCategoryGroupEnabled(
++          category_name.out());
+   uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(enabled_pointer);
+   uint8_t size = sizeof(*enabled_pointer_cast);
+ 
 diff --git a/src/tracing/agent.cc b/src/tracing/agent.cc
 index eddcf6c3bf91b730d6ca72960e3048ceed7e7844..184e8647b2148bc597d9d3eb63f86ae99917c642 100644
 --- a/src/tracing/agent.cc
@@ -297,48 +596,138 @@ index 88a802425fcbbe1cdadc05c09d2af2de1eb6109c..d63475977313f2a65c24a71863dda57e
    void Flush(bool blocking) override;
  
    static const int kTracesPerFile = 1 << 19;
+diff --git a/src/tracing/trace_categories.cc b/src/tracing/trace_categories.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..4abc4dc5d9ef9c2a9b2e3d85d858f4bbf5ac6432
+--- /dev/null
++++ b/src/tracing/trace_categories.cc
+@@ -0,0 +1,5 @@
++#include "tracing/trace_categories.h"
++
++#if defined(V8_USE_PERFETTO)
++PERFETTO_TRACK_EVENT_STATIC_STORAGE_IN_NAMESPACE(node);
++#endif
+diff --git a/src/tracing/trace_categories.h b/src/tracing/trace_categories.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..b28d4baa7bf766301c9281b80e0d29729ef9832e
+--- /dev/null
++++ b/src/tracing/trace_categories.h
+@@ -0,0 +1,66 @@
++#ifndef SRC_TRACING_TRACE_CATEGORIES_H_
++#define SRC_TRACING_TRACE_CATEGORIES_H_
++
++#if defined(V8_USE_PERFETTO)
++
++#ifdef BASE_TRACE_EVENT_BUILTIN_CATEGORIES_H_
++// Compiling mode where Chromium's Perfetto TrackEvent
++// is already set up (via PERFETTO_USE_CATEGORIES_FROM_NAMESPACE(base)).
++// Node trace categories (node.perf, node.async_hooks, etc.) will be treated
++// as dynamic categories.
++#else
++// Set up Node's own Perfetto TrackEvent data source with its trace categories,
++// following the same pattern V8 uses (PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE).
++#define PERFETTO_ENABLE_LEGACY_TRACE_EVENTS 1
++
++#include "perfetto/tracing/track_event.h"
++#include "perfetto/tracing/track_event_legacy.h"
++
++// Register Node.js trace categories as static Perfetto categories in the
++// 'node' namespace.
++PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE(
++    node,
++    perfetto::Category("__metadata"),
++    perfetto::Category("node"),
++    perfetto::Category("node.perf"),
++    perfetto::Category("node.perf.timerify"),
++    perfetto::Category("node.perf.usertiming"),
++    perfetto::Category("node.perf.event_loop"),
++    perfetto::Category("node.async_hooks"),
++    perfetto::Category("node.bootstrap"),
++    perfetto::Category("node.dns.native"),
++    perfetto::Category("node.environment"),
++    perfetto::Category("node.fs.async"),
++    perfetto::Category("node.fs.sync"),
++    perfetto::Category("node.fs_dir.async"),
++    perfetto::Category("node.fs_dir.sync"),
++    perfetto::Category("node.http"),
++    perfetto::Category("node.net.native"),
++    perfetto::Category("node.promises.rejections"),
++    perfetto::Category("node.realm"),
++    perfetto::Category("node.threadpoolwork.async"),
++    perfetto::Category("node.threadpoolwork.sync"),
++    perfetto::Category("node.vm.script"),
++    perfetto::Category("v8"));
++
++// Make Node's categories available through the default TrackEvent namespace
++// so that TRACE_EVENT macros work without qualification.
++PERFETTO_USE_CATEGORIES_FROM_NAMESPACE(node);
++
++// These deprecated phase constants are not defined by Perfetto's legacy shim
++// but are still exported to JavaScript by node_constants.cc.
++#ifndef TRACE_EVENT_PHASE_ENTER_CONTEXT
++#define TRACE_EVENT_PHASE_ENTER_CONTEXT ('(')
++#endif
++#ifndef TRACE_EVENT_PHASE_LEAVE_CONTEXT
++#define TRACE_EVENT_PHASE_LEAVE_CONTEXT (')')
++#endif
++#ifndef TRACE_EVENT_PHASE_LINK_IDS
++#define TRACE_EVENT_PHASE_LINK_IDS ('=')
++#endif
++
++#endif  // BASE_TRACE_EVENT_BUILTIN_CATEGORIES_H_
++
++#endif  // defined(V8_USE_PERFETTO)
++
++#endif  // SRC_TRACING_TRACE_CATEGORIES_H_
 diff --git a/src/tracing/trace_event.h b/src/tracing/trace_event.h
-index a662a081dc3bf356bf93e4063fcb043e4d8df07b..c89cdfe2b2681fbf9946200a03d7d1f7bad21226 100644
+index a662a081dc3bf356bf93e4063fcb043e4d8df07b..a7d0363e15a260feaaa5c7826a3b3137be531934 100644
 --- a/src/tracing/trace_event.h
 +++ b/src/tracing/trace_event.h
-@@ -69,8 +69,16 @@ enum CategoryGroupEnabledFlags {
- // for best performance when tracing is disabled.
- // const uint8_t*
- //     TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(const char* category_group)
-+#ifndef V8_USE_PERFETTO
- #define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED              \
-   node::tracing::TraceEventHelper::GetCategoryGroupEnabled
-+#else
-+#define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_group) \
-+  ([](const char*) -> const uint8_t* { \
-+    static uint8_t no = 0; \
-+    return &no; \
-+  })(category_group)
-+#endif
+@@ -7,13 +7,23 @@
  
- // Get the number of times traces have been recorded. This is used to implement
- // the TRACE_EVENT_IS_NEW_TRACE facility.
-@@ -114,10 +122,15 @@ enum CategoryGroupEnabledFlags {
- //     const uint8_t* category_group_enabled,
- //     const char* name,
- //     uint64_t id)
-+#ifndef V8_USE_PERFETTO
- #define TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION                           \
-   if (auto controller =                                                       \
-          node::tracing::TraceEventHelper::GetTracingController())             \
-       controller->UpdateTraceEventDuration
-+#else
-+#define TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION(category_group_enabled, name, event_handle) \
-+  (void)(category_group_enabled), (void)(name), (void)(event_handle)
-+#endif
+ #include "v8-platform.h"
+ #include "tracing/agent.h"
+-#include "trace_event_common.h"
+ #include <atomic>
  
- // Adds a metadata event to the trace log. The |AppendValueAsTraceFormat| method
- // on the convertable value will be called at flush time.
-@@ -319,12 +332,15 @@ class TraceEventHelper {
++#if defined(V8_USE_PERFETTO)
++#include "tracing/trace_categories.h"
++#else
++#include "trace_event_common.h"
++#endif
++
+ // This header file defines implementation details of how the trace macros in
+ // trace_event_common.h collect and store trace events. Anything not
+ // implementation-specific should go in trace_macros_common.h instead of here.
+ 
++#if !defined(V8_USE_PERFETTO)
++// When Perfetto is enabled, all trace event macros and their internal
++// implementation are provided by Perfetto's track event legacy shim
++// (included via trace_categories.h). The following definitions are only
++// needed for the non-Perfetto tracing backend.
+ 
+ // The pointer returned from GetCategoryGroupEnabled() points to a
+ // value with zero or more of the following bits. Used in this class only.
+@@ -301,6 +311,8 @@ enum CategoryGroupEnabledFlags {
+   INTERNAL_TRACE_EVENT_UID(ScopedContext)                                  \
+   INTERNAL_TRACE_EVENT_UID(scoped_context)(context);
+ 
++#endif  // !defined(V8_USE_PERFETTO)
++
+ namespace node {
+ namespace tracing {
+ 
+@@ -319,15 +331,24 @@ class TraceEventHelper {
    static void SetAgent(Agent* agent);
  
    static inline const uint8_t* GetCategoryGroupEnabled(const char* group) {
-+#ifndef V8_USE_PERFETTO
++#if defined(V8_USE_PERFETTO)
++    // Under Perfetto, callers should use TRACE_EVENT_CATEGORY_ENABLED()
++    // instead. This function exists only for backward compatibility with
++    // non-Perfetto builds.
++    static const uint8_t disabled = 0;
++    return &disabled;
++#else
      v8::TracingController* controller = GetTracingController();
      static const uint8_t disabled = 0;
      if (controller == nullptr) [[unlikely]] {
@@ -346,56 +735,90 @@ index a662a081dc3bf356bf93e4063fcb043e4d8df07b..c89cdfe2b2681fbf9946200a03d7d1f7
      }
      return controller->GetCategoryGroupEnabled(group);
 +#endif
-+    return 0;
    }
  };
  
-@@ -462,6 +478,7 @@ static inline uint64_t AddTraceEventImpl(
-     const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
-     const char** arg_names, const uint8_t* arg_types,
-     const uint64_t* arg_values, unsigned int flags) {
-+#ifndef V8_USE_PERFETTO
-   std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
-   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-     arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
-@@ -478,6 +495,8 @@ static inline uint64_t AddTraceEventImpl(
++#if !defined(V8_USE_PERFETTO)
+ // TraceID encapsulates an ID that can either be an integer or pointer. Pointers
+ // are by default mangled with the Process ID so that they are unlikely to
+ // collide when the same pointer is used on different processes.
+@@ -478,6 +499,7 @@ static inline uint64_t AddTraceEventImpl(
    return controller->AddTraceEvent(phase, category_group_enabled, name, scope, id,
                                     bind_id, num_args, arg_names, arg_types,
                                     arg_values, arg_convertibles, flags);
-+#endif
 +  return 0;
  }
  
  static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
-@@ -485,6 +504,7 @@ static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
-     const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
-     const char** arg_names, const uint8_t* arg_types,
-     const uint64_t* arg_values, unsigned int flags, int64_t timestamp) {
-+#ifndef V8_USE_PERFETTO
-   std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
-   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-     arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
-@@ -501,12 +521,15 @@ static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
+@@ -501,6 +523,7 @@ static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
    return controller->AddTraceEventWithTimestamp(
        phase, category_group_enabled, name, scope, id, bind_id, num_args,
        arg_names, arg_types, arg_values, arg_convertibles, flags, timestamp);
-+#endif
 +  return 0;
  }
  
  static V8_INLINE void AddMetadataEventImpl(
-     const uint8_t* category_group_enabled, const char* name, int32_t num_args,
-     const char** arg_names, const uint8_t* arg_types,
-     const uint64_t* arg_values, unsigned int flags) {
-+#ifndef V8_USE_PERFETTO
-   std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
-   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-     arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
-@@ -522,6 +545,7 @@ static V8_INLINE void AddMetadataEventImpl(
-   return agent->GetTracingController()->AddMetadataEvent(
-       category_group_enabled, name, num_args, arg_names, arg_types, arg_values,
-       arg_convertibles, flags);
-+#endif
- }
+@@ -716,6 +739,8 @@ class ScopedTracer {
+   Data data_;
+ };
  
- // Define SetTraceValue for each allowed type. It stores the type and
++#endif  // !defined(V8_USE_PERFETTO)
++
+ }  // namespace tracing
+ }  // namespace node
+ 
+diff --git a/src/tracing/traced_value.h b/src/tracing/traced_value.h
+index 0bc9df81d87562243817a6618641a49b602654e3..b6dd8b9a9c21051f3d385d5ecea9c50c8b8b1629 100644
+--- a/src/tracing/traced_value.h
++++ b/src/tracing/traced_value.h
+@@ -11,6 +11,26 @@
+ #include <span>
+ #include <string>
+ 
++#if defined(V8_USE_PERFETTO)
++#include "perfetto/tracing/traced_value.h"
++
++namespace perfetto {
++
++template <>
++struct TraceFormatTraits<
++    std::unique_ptr<v8::ConvertableToTraceFormat>> {
++  static void WriteIntoTrace(
++      TracedValue context,
++      const std::unique_ptr<v8::ConvertableToTraceFormat>& value) {
++    std::string json;
++    value->AppendAsTraceFormat(&json);
++    std::move(context).WriteString(json);
++  }
++};
++
++}  // namespace perfetto
++#endif  // defined(V8_USE_PERFETTO)
++
+ namespace node {
+ namespace tracing {
+ 
+diff --git a/unofficial.gni b/unofficial.gni
+index df0ae804a5338d8f2ec4d331a1e2ed053c3c3955..eeffbafa4023ed68f56410c858e459f569ed6344 100644
+--- a/unofficial.gni
++++ b/unofficial.gni
+@@ -143,7 +143,10 @@ template("node_gn_build") {
+                             [ "node.gyp" ])
+ 
+   source_set("libnode") {
+-    configs += [ ":node_internal_config" ]
++    configs += [
++      ":node_internal_config",
++      "$node_v8_path:v8_tracing_config",
++    ]
+     public_configs = [
+       ":node_external_config",
+       "deps/googletest:googletest_config",
+@@ -173,6 +176,7 @@ template("node_gn_build") {
+       "//third_party/zstd:headers",
+       "$node_simdutf_path",
+       "$node_v8_path:v8_libplatform",
++      "$node_v8_path:v8_tracing",
+     ]
+ 
+     cflags_cc = [

--- a/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
+++ b/patches/node/chore_exclude_electron_node_folder_from_exit-time-destructors.patch
@@ -20,22 +20,18 @@ index ab7dc27de3e304f6d912d5834da47e3b4eb25495..b6c0fd4ceee989dac55c7d54e52fef18
    }
  }
 diff --git a/unofficial.gni b/unofficial.gni
-index 07ebc4706c6b3208dc9136e6ba0e4d795c238d61..8844e2c3916541b62418c4b891b5a834b910bea4 100644
+index d7c717d5c2799692c7ea4537d7faea234faefaa2..bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -143,7 +143,10 @@ template("node_gn_build") {
-                             [ "node.gyp" ])
- 
-   source_set("libnode") {
--    configs += [ ":node_internal_config" ]
-+    configs += [
-+      ":node_internal_config",
+@@ -146,6 +146,7 @@ template("node_gn_build") {
+     configs += [
+       ":node_internal_config",
+       "$node_v8_path:v8_tracing_config",
 +      "//build/config/compiler:no_exit_time_destructors"
-+    ]
+     ]
      public_configs = [
        ":node_external_config",
-       "deps/googletest:googletest_config",
-@@ -366,6 +369,7 @@ template("node_gn_build") {
+@@ -370,6 +371,7 @@ template("node_gn_build") {
        "src/builtin_info.h",
      ]
      include_dirs = [ "src", "tools" ]

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -260,7 +260,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c603e431cd 100644
+index 1285f83662e4f252faa1730df04cafc588cd7556..fe2c6786a10f94fc0a15d4b6a0d3bfffb79f2e33 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,12 @@ template("node_gn_build") {
@@ -277,7 +277,7 @@ index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c6
        defines += [ "NODE_USE_V8_PLATFORM=1" ]
      } else {
        defines += [ "NODE_USE_V8_PLATFORM=0" ]
-@@ -184,7 +189,10 @@ template("node_gn_build") {
+@@ -186,7 +191,10 @@ template("node_gn_build") {
      ]
  
      sources = [
@@ -289,7 +289,7 @@ index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c6
        "$root_gen_dir/electron_natives.cc",
        "$target_gen_dir/node_javascript.cc",
      ] + gypi_values.node_sources
-@@ -274,20 +282,12 @@ template("node_gn_build") {
+@@ -276,20 +284,12 @@ template("node_gn_build") {
      sources = [ "src/node_main.cc" ]
      deps = [
        ":libnode",
@@ -314,7 +314,7 @@ index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c6
      output_name = "node"
  
      if (is_apple) {
-@@ -303,12 +303,36 @@ template("node_gn_build") {
+@@ -305,12 +305,36 @@ template("node_gn_build") {
    if (node_use_node_snapshot) {
      if (current_toolchain == v8_snapshot_toolchain) {
        executable("node_mksnapshot") {
@@ -356,7 +356,7 @@ index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c6
        }
  
        # This config disables a link time optimization "ICF", which may merge
-@@ -323,14 +347,19 @@ template("node_gn_build") {
+@@ -325,14 +349,19 @@ template("node_gn_build") {
            ldflags = [ "/OPT:NOICF" ]  # link.exe, but also lld-link.exe.
          } else if (is_apple && !use_lld) {
            ldflags = [ "-Wl,-no_deduplicate" ]  # ld64.
@@ -378,7 +378,7 @@ index 15bd82cad8c6927362f4e852bed49c7d10b71c61..71e8ac54bae3d1f272070aaf97ceb2c6
        script = "$node_v8_path/tools/run.py"
        sources = []
        data = []
-@@ -342,10 +371,89 @@ template("node_gn_build") {
+@@ -344,10 +373,89 @@ template("node_gn_build") {
        args = [
          "./" + rebase_path(mksnapshot_dir + "/node_mksnapshot", root_build_dir),
          rebase_path("$target_gen_dir/node_snapshot.cc", root_build_dir),

--- a/patches/node/feat_disable_js_source_phase_imports_by_default.patch
+++ b/patches/node/feat_disable_js_source_phase_imports_by_default.patch
@@ -18,10 +18,10 @@ Stage 3.
 Upstreamed in https://github.com/nodejs/node/pull/60364
 
 diff --git a/src/node.cc b/src/node.cc
-index 1eb6f416de221a82a67a06c912134d1d4e6b632d..eee192d99e01888add94c7d9162fe640c8b0b428 100644
+index 704032d332c78d059eb79a26d616bfdbb2df8f27..901494e2d4675a2d6c181a62cc7940301e93a38b 100644
 --- a/src/node.cc
 +++ b/src/node.cc
-@@ -778,7 +778,7 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
+@@ -783,7 +783,7 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
  
    if (std::ranges::find(v8_args, "--no-js-source-phase-imports") ==
        v8_args.end()) {

--- a/patches/node/fix_cppgc_initializing_twice.patch
+++ b/patches/node/fix_cppgc_initializing_twice.patch
@@ -12,10 +12,10 @@ This can be removed/refactored once Node.js upgrades to a version of V8
 containing the above CL.
 
 diff --git a/src/node.cc b/src/node.cc
-index 6f899ec0621ada45fb04c921359bc9b9ea79132b..1eb6f416de221a82a67a06c912134d1d4e6b632d 100644
+index 4178e13dc8b5769c06fb720b2fcc655eb46aef5a..704032d332c78d059eb79a26d616bfdbb2df8f27 100644
 --- a/src/node.cc
 +++ b/src/node.cc
-@@ -1247,7 +1247,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
+@@ -1252,7 +1252,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
      result->platform_ = per_process::v8_platform.Platform();
    }
  

--- a/patches/node/fix_preserve_node_symbols_and_vtables_under_thinlto.patch
+++ b/patches/node/fix_preserve_node_symbols_and_vtables_under_thinlto.patch
@@ -39,10 +39,10 @@ Three classes of fixes, all of which give the affected symbols strong
 Observed on macOS arm64 official builds; latent on Linux/Windows.
 
 diff --git a/src/env.cc b/src/env.cc
-index a09603573c02466c0d25431fe6168ca33ee4692e..8c9affd0d259fa2f3a6512deb636b1b47ccae9ed 100644
+index 79a309661aff7ebb18f96e64d0d2b860ab80dc57..10266fd1233d9b117eefbbbb4f455289b002785a 100644
 --- a/src/env.cc
 +++ b/src/env.cc
-@@ -2267,4 +2267,8 @@ v8::CpuProfile* Environment::StopCpuProfile(v8::ProfilerId profile_id) {
+@@ -2266,4 +2266,8 @@ v8::CpuProfile* Environment::StopCpuProfile(v8::ProfilerId profile_id) {
    return profile;
  }
  

--- a/patches/node/fix_redefined_macos_sdk_header_symbols.patch
+++ b/patches/node/fix_redefined_macos_sdk_header_symbols.patch
@@ -10,10 +10,10 @@ change, it seems to introduce an incompatibility when compiling
 using clang modules. Disabling them resolves the issue.
 
 diff --git a/unofficial.gni b/unofficial.gni
-index 8844e2c3916541b62418c4b891b5a834b910bea4..15bd82cad8c6927362f4e852bed49c7d10b71c61 100644
+index bf44e39c0debe9d3dce4dcb490b6ce3bc16dca2a..1285f83662e4f252faa1730df04cafc588cd7556 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -197,6 +197,10 @@ template("node_gn_build") {
+@@ -199,6 +199,10 @@ template("node_gn_build") {
          "CoreFoundation.framework",
          "Security.framework",
        ]
@@ -24,7 +24,7 @@ index 8844e2c3916541b62418c4b891b5a834b910bea4..15bd82cad8c6927362f4e852bed49c7d
      }
      if (is_posix) {
        configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
-@@ -371,6 +375,12 @@ template("node_gn_build") {
+@@ -373,6 +377,12 @@ template("node_gn_build") {
      include_dirs = [ "src", "tools" ]
      configs += [ "//build/config/compiler:no_exit_time_destructors" ]
  

--- a/patches/node/fix_suppress_nodiscard_warning_for_copy_options_operator.patch
+++ b/patches/node/fix_suppress_nodiscard_warning_for_copy_options_operator.patch
@@ -7,10 +7,10 @@ libc++ added [[nodiscard]] to std::filesystem::copy_options operator|=
 which causes build failures with -Werror.
 
 diff --git a/src/node_file.cc b/src/node_file.cc
-index c24c952538cfd28d46209299550bae0bfa7317dc..91f4c514e93299e325bff8f51fe3a8f19a1f15b1 100644
+index 83d02f0e9cc56025d37247d6323b154052f94e63..36317f9c68ec7a5df9b31f5a2c97013bce3eb8db 100644
 --- a/src/node_file.cc
 +++ b/src/node_file.cc
-@@ -3509,11 +3509,11 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
+@@ -3516,11 +3516,11 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
  
    auto file_copy_opts = std::filesystem::copy_options::recursive;
    if (force) {

--- a/patches/node/refactor_attach_cppgc_heap_on_v8_isolate_creation.patch
+++ b/patches/node/refactor_attach_cppgc_heap_on_v8_isolate_creation.patch
@@ -89,7 +89,7 @@ index fb2af584a4ae777022c9ef8c20ada1edcbbbefdc..fe6300a5d5d2d6602a84cbd33736c213
  #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
  
 diff --git a/src/env.cc b/src/env.cc
-index bbb30dd8a50f7b8550caf1967de8547cc7d8af47..82aee7e38bbd859e1a76eedcc3a51278a1b3a793 100644
+index ef6e14245fa668d04d0e9b1f71fcce48ec267f4e..dd8be35de7c447c9a77f8b9849a6a3de19bc55af 100644
 --- a/src/env.cc
 +++ b/src/env.cc
 @@ -610,7 +610,7 @@ IsolateData::~IsolateData() {}

--- a/patches/node/src_stop_using_v8_propertycallbackinfo_t_this.patch
+++ b/patches/node/src_stop_using_v8_propertycallbackinfo_t_this.patch
@@ -19,7 +19,7 @@ index 2c95ac99be70b0750372e9c858753bf519498e3d..5ab30502fd232196739ca2b450e35cc9
    Local<Module> module = obj->module_.Get(isolate);
    if (module->GetStatus() < Module::kInstantiated) {
 diff --git a/src/node_contextify.cc b/src/node_contextify.cc
-index 469c85642e995024b354abaa67dd865933867fc7..a9cf726d260cf13a741997f434409d747d7342f0 100644
+index c69ff16bd85427d3c26d8b42029c8ebb618dea41..17d820b567f395eaf6479404236b650bbfe233df 100644
 --- a/src/node_contextify.cc
 +++ b/src/node_contextify.cc
 @@ -453,7 +453,7 @@ ContextifyContext* ContextifyContext::Get(const PropertyCallbackInfo<T>& args) {

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -14,3 +14,4 @@ cherry-pick-c3ea7757b190.patch
 cherry-pick-b80a7539b736.patch
 cherry-pick-2a21c7560310.patch
 cherry-pick-d6a92ca48587.patch
+src_use_legacy_trace_macros_in_perfetto_to_support_all_phases.patch

--- a/patches/v8/src_use_legacy_trace_macros_in_perfetto_to_support_all_phases.patch
+++ b/patches/v8/src_use_legacy_trace_macros_in_perfetto_to_support_all_phases.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: deepak1556 <hop2deep@gmail.com>
+Date: Tue, 31 Mar 2026 07:05:17 +0900
+Subject: src: use legacy trace macros in perfetto to support all phases
+
+Replace the phase-specific SDK macros with the INTERNAL_TRACE_EVENT_ADD
+and INTERNAL_TRACE_EVENT_ADD_WITH_ID legacy shim macros, which accept an
+arbitrary phase character and forward it through Perfetto's legacy
+compatibility layer. This supports nestable async ('b'/'e'/'n')
+and counter ('C') trace event phases needed for Node.js.
+
+Additionally:
+
+1. Clear TRACE_EVENT_FLAG_COPY before calling Perfetto macros. Perfetto
+   manages string lifetimes internally via DynamicString and
+   TRACE_STR_COPY; passing FLAG_COPY triggers a CHECK failure in
+   Perfetto's legacy shim.
+
+2. Default instant events (phase 'I') with GLOBAL scope to THREAD scope.
+   Under Perfetto, global-scope instant events land on Track::Global(0),
+   producing pid:0/tid:0 in the trace output, making them effectively
+   invisible in trace viewers.
+
+diff --git a/src/builtins/builtins-trace.cc b/src/builtins/builtins-trace.cc
+index c17d72d477d4c28d25e3f385d8af3c5b7024f7f7..5990e6cee1d08ba0e86059cb7f3affc878dcc632 100644
+--- a/src/builtins/builtins-trace.cc
++++ b/src/builtins/builtins-trace.cc
+@@ -181,37 +181,44 @@ BUILTIN(Trace) {
+   }
+ 
+ #if defined(V8_USE_PERFETTO)
+-  // TODO(skyostil): Use interned names to reduce trace size.
+-  auto trace_args = [&](perfetto::EventContext ctx) {
++  // Perfetto handles string lifetimes internally (via DynamicString and
++  // TRACE_STR_COPY), so TRACE_EVENT_FLAG_COPY must not be set — Perfetto's
++  // legacy shim CHECKs against it.
++  flags &= ~TRACE_EVENT_FLAG_COPY;
++
++  // Default instant events to thread scope under Perfetto. Without this,
++  // scope bits are 0 (GLOBAL), which puts events on Track::Global(0)
++  // resulting in pid:0/tid:0 in the trace output.
++  if (phase == TRACE_EVENT_PHASE_INSTANT) {
++    auto scope = flags & TRACE_EVENT_FLAG_SCOPE_MASK;
++    if (scope == TRACE_EVENT_SCOPE_GLOBAL) {
++      flags = (flags & ~TRACE_EVENT_FLAG_SCOPE_MASK) | TRACE_EVENT_SCOPE_THREAD;
++    }
++  }
++
++  // Use the legacy trace event macros which support all phase types
++  // (including nestable async 'b'/'e'/'n' and counter 'C' used by Node.js)
++  if (flags & TRACE_EVENT_FLAG_HAS_ID) {
+     if (num_args) {
+       MaybeUtf8 arg_contents(isolate, Cast<String>(arg_json));
+-      auto annotation = ctx.event()->add_debug_annotations();
+-      annotation->set_name(arg_name);
+-      annotation->set_legacy_json_value(*arg_contents);
++      INTERNAL_TRACE_EVENT_ADD_WITH_ID(
++          phase, dynamic_category, perfetto::DynamicString(*name), id, flags,
++          arg_name, TRACE_STR_COPY(*arg_contents));
++    } else {
++      INTERNAL_TRACE_EVENT_ADD_WITH_ID(
++          phase, dynamic_category, perfetto::DynamicString(*name), id, flags);
+     }
+-    if (flags & TRACE_EVENT_FLAG_HAS_ID) {
+-      auto legacy_event = ctx.event()->set_legacy_event();
+-      legacy_event->set_global_id(id);
++  } else {
++    if (num_args) {
++      MaybeUtf8 arg_contents(isolate, Cast<String>(arg_json));
++      INTERNAL_TRACE_EVENT_ADD(
++          phase, dynamic_category, perfetto::DynamicString(*name), flags,
++          arg_name, TRACE_STR_COPY(*arg_contents));
++    } else {
++      INTERNAL_TRACE_EVENT_ADD(phase, dynamic_category,
++                               perfetto::DynamicString(*name), flags);
+     }
+-  };
+-
+-  switch (phase) {
+-    case TRACE_EVENT_PHASE_BEGIN:
+-      TRACE_EVENT_BEGIN(dynamic_category, perfetto::DynamicString(*name),
+-                        trace_args);
+-      break;
+-    case TRACE_EVENT_PHASE_END:
+-      TRACE_EVENT_END(dynamic_category, trace_args);
+-      break;
+-    case TRACE_EVENT_PHASE_INSTANT:
+-      TRACE_EVENT_INSTANT(dynamic_category, perfetto::DynamicString(*name),
+-                          trace_args);
+-      break;
+-    default:
+-      THROW_NEW_ERROR_RETURN_FAILURE(
+-          isolate, NewTypeError(MessageTemplate::kTraceEventPhaseError));
+   }
+-
+ #else   // !defined(V8_USE_PERFETTO)
+   uint8_t arg_type;
+   uint64_t arg_value;

--- a/spec/api-content-tracing-spec.ts
+++ b/spec/api-content-tracing-spec.ts
@@ -468,4 +468,112 @@ ifdescribe(!['arm', 'arm64'].includes(process.arch) || process.platform !== 'lin
       expect(parsed.metadata['os-arch']).to.not.be.empty();
     });
   });
+
+  describe('node trace categories', () => {
+    it('captures performance.mark() as instant trace events', async function () {
+      const { performance } = require('node:perf_hooks');
+
+      await contentTracing.startRecording({
+        included_categories: ['node.perf.usertiming']
+      });
+
+      performance.mark('test-trace-mark');
+
+      const resultPath = await contentTracing.stopRecording();
+      const data = fs.readFileSync(resultPath, 'utf8');
+      const parsed = JSON.parse(data);
+
+      const markEvents = parsed.traceEvents.filter(
+        (x: any) => x.cat === 'node.perf.usertiming' && x.name === 'test-trace-mark'
+      );
+      expect(markEvents).to.have.lengthOf.at.least(1, 'should have node.perf.usertiming events for performance.mark()');
+      expect(markEvents[0].ph).to.equal('I', 'performance.mark() should emit instant (I) phase events');
+    });
+
+    it('captures performance.measure() as nestable async begin/end trace events', async function () {
+      const { performance } = require('node:perf_hooks');
+
+      await contentTracing.startRecording({
+        included_categories: ['node.perf.usertiming']
+      });
+
+      performance.mark('trace-measure-start');
+      await setTimeout(100);
+      performance.mark('trace-measure-end');
+      performance.measure('test-trace-measure', 'trace-measure-start', 'trace-measure-end');
+
+      const resultPath = await contentTracing.stopRecording();
+      const data = fs.readFileSync(resultPath, 'utf8');
+      const parsed = JSON.parse(data);
+
+      const measureEvents = parsed.traceEvents.filter(
+        (x: any) => x.cat === 'node.perf.usertiming' && x.name === 'test-trace-measure'
+      );
+      expect(measureEvents.some((x: any) => x.ph === 'b')).to.be.true('should have nestable async begin (b) event');
+      expect(measureEvents.some((x: any) => x.ph === 'e')).to.be.true('should have nestable async end (e) event');
+    });
+
+    it('captures node.fs.sync trace events for file operations', async function () {
+      await contentTracing.startRecording({
+        included_categories: ['node.fs.sync']
+      });
+
+      fs.readFileSync(__filename, 'utf8');
+
+      const resultPath = await contentTracing.stopRecording();
+      const data = fs.readFileSync(resultPath, 'utf8');
+      const parsed = JSON.parse(data);
+
+      const fsEvents = parsed.traceEvents.filter(
+        (x: any) => typeof x.cat === 'string' && x.cat.includes('node.fs.sync')
+      );
+      expect(fsEvents).to.have.lengthOf.at.least(1, 'should have node.fs.sync trace events');
+    });
+
+    it('captures multiple node categories simultaneously', async function () {
+      const vm = require('node:vm');
+
+      await contentTracing.startRecording({
+        included_categories: ['node.async_hooks', 'node.vm.script']
+      });
+
+      vm.runInNewContext('1 + 1');
+      await fs.promises.readFile(__filename, 'utf8');
+
+      const resultPath = await contentTracing.stopRecording();
+      const data = fs.readFileSync(resultPath, 'utf8');
+      const parsed = JSON.parse(data);
+
+      const asyncHooksEvents = parsed.traceEvents.filter(
+        (x: any) => typeof x.cat === 'string' && x.cat.includes('node.async_hooks')
+      );
+      const vmEvents = parsed.traceEvents.filter(
+        (x: any) => typeof x.cat === 'string' && x.cat.includes('node.vm.script')
+      );
+      expect(asyncHooksEvents).to.have.lengthOf.at.least(1, 'should have node.async_hooks events');
+      expect(vmEvents).to.have.lengthOf.at.least(1, 'should have node.vm.script events');
+    });
+
+    it('captures events using wildcard category pattern node.fs.*', async function () {
+      await contentTracing.startRecording({
+        included_categories: ['node.fs.*']
+      });
+
+      fs.readFileSync(__filename, 'utf8');
+      await fs.promises.readFile(__filename, 'utf8');
+
+      const resultPath = await contentTracing.stopRecording();
+      const data = fs.readFileSync(resultPath, 'utf8');
+      const parsed = JSON.parse(data);
+
+      const syncEvents = parsed.traceEvents.filter(
+        (x: any) => typeof x.cat === 'string' && x.cat.includes('node.fs.sync')
+      );
+      const asyncEvents = parsed.traceEvents.filter(
+        (x: any) => typeof x.cat === 'string' && x.cat.includes('node.fs.async')
+      );
+      expect(syncEvents).to.have.lengthOf.at.least(1, 'should have node.fs.sync events from wildcard pattern');
+      expect(asyncEvents).to.have.lengthOf.at.least(1, 'should have node.fs.async events from wildcard pattern');
+    });
+  });
 });


### PR DESCRIPTION
Backport of #50591

See that PR for details.

Manual backport notes: `patches/node` was regenerated against this branch's Node (v24.18.1) rather than text-merged: 42-x-y's series plus the new `build_enable_perfetto.patch` were applied to a v24.18.1 tree (one context fix-up in `unofficial.gni` for `chore_exclude_electron_node_folder_from_exit-time-destructors.patch`) and re-exported with `script/lib/git.py`. The resulting `build_enable_perfetto.patch` content is identical to the original change; the other node patch diffs are index/offset-only. The chromium and v8 patches are unchanged from the original (this branch is on the same Chromium major the original landed against) and apply cleanly to 148.0.7778.280. The spec additions are appended to this branch's larger `api-content-tracing-spec.ts`. Supersedes the earlier trop attempt #50885 (approved, then closed as stale).

Notes: Fixed contentTracing module to capture Node.js trace categories.
