### PR TITLE
refactor: api::cookies managed by cppgc

### DIFF
--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -29,9 +29,10 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/handle.h"
-#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/gin_helper/wrappable_pointer_tags.h"
+#include "v8/include/cppgc/allocation.h"
+#include "v8/include/v8-cppgc.h"
 
 namespace gin {
 
@@ -295,7 +296,8 @@ bool IsDeletion(net::CookieChangeCause cause) {
 
 }  // namespace
 
-gin::DeprecatedWrapperInfo Cookies::kWrapperInfo = {gin::kEmbedderNativeGin};
+gin::WrapperInfo Cookies::kWrapperInfo =
+    electron::MakeWrapperInfo(electron::kElectronCookies);
 
 Cookies::Cookies(ElectronBrowserContext* browser_context)
     : browser_context_{browser_context} {
@@ -463,10 +465,10 @@ void Cookies::OnCookieChanged(const net::CookieChangeInfo& change) {
 }
 
 // static
-gin_helper::Handle<Cookies> Cookies::Create(
-    v8::Isolate* isolate,
-    ElectronBrowserContext* browser_context) {
-  return gin_helper::CreateHandle(isolate, new Cookies{browser_context});
+Cookies* Cookies::Create(v8::Isolate* isolate,
+                         ElectronBrowserContext* browser_context) {
+  return cppgc::MakeGarbageCollected<Cookies>(
+      isolate->GetCppHeap()->GetAllocationHandle(), browser_context);
 }
 
 gin::ObjectTemplateBuilder Cookies::GetObjectTemplateBuilder(
@@ -479,8 +481,12 @@ gin::ObjectTemplateBuilder Cookies::GetObjectTemplateBuilder(
       .SetMethod("flushStore", &Cookies::FlushStore);
 }
 
-const char* Cookies::GetTypeName() {
-  return "Cookies";
+const gin::WrapperInfo* Cookies::wrapper_info() const {
+  return &kWrapperInfo;
+}
+
+const char* Cookies::GetHumanReadableName() const {
+  return "Electron / Cookies";
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -10,15 +10,13 @@
 #include "base/callback_list.h"
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
+#include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gin_helper/wrappable.h"
 
 class GURL;
 
 namespace gin_helper {
 class Dictionary;
-template <typename T>
-class Handle;
 }  // namespace gin_helper
 
 namespace net {
@@ -31,27 +29,29 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class Cookies final : public gin_helper::DeprecatedWrappable<Cookies>,
+class Cookies final : public gin::Wrappable<Cookies>,
                       public gin_helper::EventEmitterMixin<Cookies> {
  public:
-  static gin_helper::Handle<Cookies> Create(
-      v8::Isolate* isolate,
-      ElectronBrowserContext* browser_context);
+  static Cookies* Create(v8::Isolate* isolate,
+                         ElectronBrowserContext* browser_context);
 
-  // gin_helper::Wrappable
-  static gin::DeprecatedWrapperInfo kWrapperInfo;
+  // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
+  static const char* GetClassName() { return "Cookies"; }
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override;
-  const char* GetTypeName() override;
+  const gin::WrapperInfo* wrapper_info() const override;
+  const char* GetHumanReadableName() const override;
+
+  // Make public for cppgc::MakeGarbageCollected.
+  explicit Cookies(ElectronBrowserContext* browser_context);
+  ~Cookies() override;
 
   // disable copy
   Cookies(const Cookies&) = delete;
   Cookies& operator=(const Cookies&) = delete;
 
- protected:
-  explicit Cookies(ElectronBrowserContext* browser_context);
-  ~Cookies() override;
-
+ private:
   v8::Local<v8::Promise> Get(v8::Isolate*,
                              const gin_helper::Dictionary& filter);
   v8::Local<v8::Promise> Set(v8::Isolate*, base::DictValue details);
@@ -63,7 +63,6 @@ class Cookies final : public gin_helper::DeprecatedWrappable<Cookies>,
   // CookieChangeNotifier subscription:
   void OnCookieChanged(const net::CookieChangeInfo& change);
 
- private:
   base::CallbackListSubscription cookie_change_subscription_;
 
   // Weak reference; ElectronBrowserContext is guaranteed to outlive us.

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -104,7 +104,6 @@
 #include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "url/origin.h"
-#include "v8/include/v8-traced-handle.h"
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "shell/browser/api/electron_api_extensions.h"
@@ -1340,12 +1339,11 @@ v8::Local<v8::Promise> Session::GetSharedDictionaryUsageInfo() {
   return handle;
 }
 
-v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
-  if (cookies_.IsEmptyThreadSafe()) {
-    auto handle = Cookies::Create(isolate, browser_context());
-    cookies_.Reset(isolate, handle.ToV8());
+api::Cookies* Session::Cookies(v8::Isolate* isolate) {
+  if (!cookies_) {
+    cookies_ = Cookies::Create(isolate, browser_context());
   }
-  return cookies_.Get(isolate);
+  return cookies_;
 }
 
 api::Extensions* Session::Extensions(v8::Isolate* isolate) {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -45,11 +45,6 @@ namespace net {
 class ProxyConfig;
 }
 
-namespace v8 {
-template <typename T>
-class TracedReference;
-}
-
 namespace electron {
 
 class ElectronBrowserContext;
@@ -57,6 +52,7 @@ struct PreloadScript;
 
 namespace api {
 
+class Cookies;
 class Extensions;
 class NetLog;
 class Protocol;
@@ -166,7 +162,7 @@ class Session final : public gin::Wrappable<Session>,
   v8::Local<v8::Promise> ClearSharedDictionaryCache();
   v8::Local<v8::Promise> ClearSharedDictionaryCacheForIsolationKey(
       const gin_helper::Dictionary& options);
-  v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
+  api::Cookies* Cookies(v8::Isolate* isolate);
   api::Extensions* Extensions(v8::Isolate* isolate);
   api::Protocol* Protocol();
   api::ServiceWorkerContext* ServiceWorkerContext();
@@ -212,8 +208,7 @@ class Session final : public gin::Wrappable<Session>,
   void SetDisplayMediaRequestHandler(v8::Isolate* isolate,
                                      v8::Local<v8::Value> val);
 
-  // Cached gin_helper::Wrappable objects.
-  v8::TracedReference<v8::Value> cookies_;
+  cppgc::Member<api::Cookies> cookies_;
   cppgc::Member<api::Extensions> extensions_;
   cppgc::Member<api::Protocol> protocol_;
   cppgc::Member<api::NetLog> net_log_;

--- a/shell/common/gin_helper/wrappable_pointer_tags.h
+++ b/shell/common/gin_helper/wrappable_pointer_tags.h
@@ -13,6 +13,7 @@ namespace electron {
 // Electron-specific WrappablePointerTag values that extend gin's tag range.
 enum ElectronWrappablePointerTag : uint16_t {
   kElectronApp = gin::kLastPointerTag + 1,  // electron::api::App
+  kElectronCookies,                         // electron::api::Cookies
   kElectronDataPipeHolder,                  // electron::api::DataPipeHolder
   kElectronDebugger,                        // electron::api::Debugger
   kElectronEvent,                           // gin_helper::internal::Event

--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -104,7 +104,7 @@ describe('cpp heap', () => {
           const canTraceJSReferences = containsRetainingPath(state.snapshot, [
             'C++ Persistent roots',
             'Electron / Session',
-            'Cookies'
+            'Electron / Cookies'
           ]);
           return numSessions && canTraceJSReferences;
         },
@@ -112,6 +112,56 @@ describe('cpp heap', () => {
         path.join(__dirname, 'lib', 'heapsnapshot-helpers.js')
       );
       expect(result).to.equal(true);
+    });
+  });
+
+  describe('cookies module', () => {
+    it('should return the same Cookies instance for the same session', async () => {
+      const { remotely } = await startRemoteControlApp();
+      const result = await remotely(async () => {
+        const { session } = require('electron');
+        const ses = session.fromPartition('cookies-identity');
+        const cookies1 = ses.cookies;
+        const cookies2 = ses.cookies;
+        return cookies1 === cookies2;
+      });
+      expect(result).to.equal(true, 'cookies getter should return the same instance');
+    });
+
+    it('should survive GC when only referenced through session', async () => {
+      const { remotely } = await startRemoteControlApp(['--expose-internals', '--js-flags=--expose-gc']);
+      const result = await remotely(
+        async (heap: string, snapshotHelper: string) => {
+          const { session } = require('electron');
+          const { recordState } = require(heap);
+          const { containsRetainingPath } = require(snapshotHelper);
+          const v8Util = (process as any)._linkedBinding('electron_common_v8_util');
+
+          // Access cookies to create the C++ object, then drop the JS reference.
+          const ses = session.defaultSession;
+          let cookies: any = ses.cookies;
+          await cookies.get({});
+          cookies = null;
+
+          // Force GC — the Cookies object should survive because
+          // Session traces it via cppgc::Member.
+          for (let i = 0; i < 10; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            v8Util.requestGarbageCollectionForTesting();
+          }
+
+          const state = recordState();
+          const stillAlive = containsRetainingPath(state.snapshot, [
+            'C++ Persistent roots',
+            'Electron / Session',
+            'Electron / Cookies'
+          ]);
+          return stillAlive;
+        },
+        path.join(__dirname, '../../third_party/electron_node/test/common/heap'),
+        path.join(__dirname, 'lib', 'heapsnapshot-helpers.js')
+      );
+      expect(result).to.equal(true, 'Cookies should survive GC when traced from Session');
     });
   });
 


### PR DESCRIPTION
Backport of #51196

See that PR for details.

Notes: none
