### PR TITLE
ci: bump build-tools SHA (`4b75f1f`)

### DIFF
--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -15,7 +15,7 @@ runs:
         git config --global core.preloadindex true
         git config --global core.longpaths true
       fi
-      export BUILD_TOOLS_SHA=1b7bd25dae4a780bb3170fff56c9327b53aaf7eb
+      export BUILD_TOOLS_SHA=4b75f1f7bd42fa15a91abc71694d1e35ac4361c6
       npm i -g @electron/build-tools
       # Update depot_tools to ensure python
       e d update_depot_tools

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -142,7 +142,7 @@ jobs:
           export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
         fi
 
-        e build --only-gen
+        e build --gen=only
 
         cd src/electron
         node script/yarn.js lint:clang-tidy --jobs 8 --out-dir ../out/${ELECTRON_OUT_DIR}

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -144,7 +144,7 @@ jobs:
             export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
           fi
 
-          e build --only-gen
+          e build --gen=only
 
           e d gn check ../out/Default //electron:electron_lib
           e d gn check ../out/Default //electron:electron_app


### PR DESCRIPTION
Backport of #52059

See that PR for details.

Manual backport notes: 42-x-y moves `BUILD_TOOLS_SHA` from `1b7bd25` to `4b75f1f` (28 build-tools commits; includes electron/build-tools#861 which keeps the `CHROMIUM_BUILDTOOLS_PATH` fallback this branch's CI still relies on). Also picks up the `e build --only-gen` → `--gen=only` rename from #51445, which never targeted 42-x-y and is required with this build-tools revision (the old flag now gets forwarded to ninja and breaks the gn-check/clang-tidy jobs).

Notes: none
