### PR TITLE
fix: remove 1px frame background color from the top of frameless windows on Linux

### DIFF
--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -225,7 +225,9 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   frame_background_->set_frame_color(GetFrameColor());
   frame_background_->set_use_custom_frame(true);
   frame_background_->set_is_active(active);
-  frame_background_->set_top_area_height(GetTopAreaHeight());
+  // Prevent the default system titlebar background from being drawn at the top
+  // of frameless windows. Does not affect WCO which draws its own top area.
+  frame_background_->set_top_area_height(0);
 
   const bool draw_shadow = showing_shadow && !linux_frame_layout_->tiled();
   auto shadow_values =


### PR DESCRIPTION
Backport of #52062

See that PR for details.

Manual backport notes: 42-x-y predates `ElectronFrameViewLinux` (#51161); here every frameless Linux window uses `OpaqueFrameView`, whose `OnPaint()` set the frame background's top-area height to `NonClientTopHeight()`. The fix is ported to that paint path (`set_top_area_height(0)` with the same comment). The reported regression range (41.0.4+) predates the refactor, so the bug should exist here too — would appreciate @mitchchn confirming this is the right spot.

Notes: Fixed an issue on Linux where the system theme color appeared at the top edge of frameless windows.
