### PR TITLE
ci: log Datadog upload failure instead of failing job

### DIFF
--- a/.github/workflows/macos-disk-cleanup.yml
+++ b/.github/workflows/macos-disk-cleanup.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Free space after: ${FREE_AFTER_GB}GB"
           echo "Space freed: ${SPACE_FREED_GB}GB"
 
-          curl -s -X POST "https://api.datadoghq.com/api/v2/series" \
+          if curl -sS -X POST "https://api.datadoghq.com/api/v2/series" \
             -H "Content-Type: application/json" \
             -H "DD-API-KEY: ${DD_API_KEY}" \
             -d @- << EOF
@@ -101,5 +101,8 @@ jobs:
             ]
           }
           EOF
-
-          echo "Disk space metrics logged to Datadog"
+          then
+            echo "Disk space metrics logged to Datadog"
+          else
+            echo "::warning::Datadog metrics upload failed"
+          fi


### PR DESCRIPTION
Backport of #52352

See that PR for details.

Manual backport notes: on 42-x-y only `macos-disk-cleanup.yml` has a Datadog upload step; the `build-electron/action.yml` step comes from #51843 (`no-backport`) and `clean-src-cache.yml`'s from a later change, so those hunks are dropped.

Notes: none
