### PR TITLE
fix: relative defaultPath producing an unusable dialog location on Linux

### DIFF
--- a/script/dbus_mock.py
+++ b/script/dbus_mock.py
@@ -27,6 +27,9 @@ def start():
 
         DBusTestCase.start_session_bus()
         DBusTestCase.spawn_server_template('notification_daemon', None, log)
+        DBusTestCase.spawn_server_template(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'dbusmock_xdg_file_chooser_portal.py'), None, log)
 
 
 if __name__ == '__main__':

--- a/script/dbusmock_xdg_file_chooser_portal.py
+++ b/script/dbusmock_xdg_file_chooser_portal.py
@@ -1,0 +1,62 @@
+"""python-dbusmock template for the xdg-desktop-portal FileChooser interface.
+
+Loaded onto the fake session bus by script/dbus_mock.py. Records every
+OpenFile/SaveFile request (inspectable via org.freedesktop.DBus.Mock
+GetCalls) and answers it with a "user cancelled" Response so dialogs
+resolve without interaction.
+"""
+
+import dbus
+
+from dbusmock import mockobject
+from gi.repository import GLib
+
+BUS_NAME = 'org.freedesktop.portal.Desktop'
+MAIN_OBJ = '/org/freedesktop/portal/desktop'
+MAIN_IFACE = 'org.freedesktop.portal.FileChooser'
+SYSTEM_BUS = False
+
+REQUEST_IFACE = 'org.freedesktop.portal.Request'
+
+# https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
+RESPONSE_USER_CANCELLED = 1
+
+
+def load(mock, parameters):
+    """Set up the FileChooser interface on the mock object."""
+    mock.request_serial = 0
+    mock.AddProperty(MAIN_IFACE, 'version',
+                     dbus.UInt32(parameters.get('version', 4)))
+    mock.AddMethods(MAIN_IFACE, [
+        ('OpenFile', 'ssa{sv}', 'o', handle_file_chooser_call),
+        ('SaveFile', 'ssa{sv}', 'o', handle_file_chooser_call),
+    ])
+
+
+def handle_file_chooser_call(self, _parent_window, _title, _options):
+    """Create a Request object and cancel it shortly afterwards."""
+    self.request_serial += 1
+    request_path = f'{MAIN_OBJ}/request/mock/{self.request_serial}'
+    self.AddObject(request_path, REQUEST_IFACE, {},
+                   [('Close', '', '', 'self.response_pending = False')])
+    request = mockobject.objects[request_path]
+    request.response_pending = True
+
+    # Emit the Response on a delay so the client has re-subscribed to the
+    # returned request path, and repeat it until the client acknowledges by
+    # closing the request (a slow subscriber cannot miss it).
+    state = {'remaining': 25}
+
+    def emit_response():
+        if not request.response_pending:
+            return False
+        request.EmitSignal(
+            REQUEST_IFACE, 'Response', 'ua{sv}',
+            [dbus.UInt32(RESPONSE_USER_CANCELLED),
+             dbus.Dictionary({}, signature='sv')])
+        state['remaining'] -= 1
+        return state['remaining'] > 0
+
+    GLib.timeout_add(200, emit_response)
+
+    return dbus.ObjectPath(request_path)

--- a/shell/browser/ui/file_dialog_linux.cc
+++ b/shell/browser/ui/file_dialog_linux.cc
@@ -5,11 +5,14 @@
 #include <algorithm>
 #include <vector>
 
+#include "base/base_paths.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
+#include "chrome/common/chrome_paths.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/ui/file_dialog.h"
@@ -17,6 +20,7 @@
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/thread_restrictions.h"
 #include "ui/shell_dialogs/select_file_dialog.h"
 #include "ui/shell_dialogs/select_file_policy.h"
 #include "ui/shell_dialogs/selected_file_info.h"
@@ -58,6 +62,22 @@ ui::SelectFileDialog::FileTypeInfo GetFilterInfo(const Filters& filters) {
   return file_type_info;
 }
 
+// A relative defaultPath (e.g. a bare filename) would make the file chooser
+// open at the unusable relative directory ".", so anchor it to the user's
+// Downloads (or home) directory instead.
+base::FilePath GetDefaultDialogPath(const DialogSettings& settings) {
+  if (settings.default_path.empty() || settings.default_path.IsAbsolute())
+    return settings.default_path;
+  base::FilePath dir;
+  electron::ScopedAllowBlockingForElectron allow_blocking;
+  if (!(base::PathService::Get(chrome::DIR_DEFAULT_DOWNLOADS, &dir) &&
+        base::DirectoryExists(dir)) &&
+      !base::PathService::Get(base::DIR_HOME, &dir)) {
+    return settings.default_path;
+  }
+  return dir.Append(settings.default_path);
+}
+
 void LogIfNeededAboutUnsupportedPortalFeature(const DialogSettings& settings) {
   if (!settings.default_path.empty() && IsPortalAvailable() &&
       GetPortalVersion() < 4) {
@@ -81,14 +101,16 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
     ui::SelectFileDialog::FileTypeInfo file_info =
         GetFilterInfo(settings.filters);
     ApplySettings(settings);
-    dialog_->SelectFile(
-        ui::SelectFileDialog::SELECT_SAVEAS_FILE,
-        base::UTF8ToUTF16(settings.title), settings.default_path,
-        &file_info /* file_types */, 0 /* file_type_index */,
-        base::FilePath::StringType() /* default_extension */,
-        settings.parent_window ? settings.parent_window->GetNativeWindow()
-                               : nullptr,
-        nullptr);
+    base::FilePath default_path = GetDefaultDialogPath(settings);
+
+    dialog_->SelectFile(ui::SelectFileDialog::SELECT_SAVEAS_FILE,
+                        base::UTF8ToUTF16(settings.title), default_path,
+                        &file_info /* file_types */, 0 /* file_type_index */,
+                        base::FilePath::StringType() /* default_extension */,
+                        settings.parent_window
+                            ? settings.parent_window->GetNativeWindow()
+                            : nullptr,
+                        nullptr);
   }
 
   void RunSaveDialog(gin_helper::Promise<gin_helper::Dictionary> promise,
@@ -108,9 +130,11 @@ class FileChooserDialog : public ui::SelectFileDialog::Listener {
     ui::SelectFileDialog::FileTypeInfo file_info =
         GetFilterInfo(settings.filters);
     ApplySettings(settings);
+    base::FilePath default_path = GetDefaultDialogPath(settings);
+
     dialog_->SelectFile(
         GetDialogType(settings.properties), base::UTF8ToUTF16(settings.title),
-        settings.default_path, &file_info, 0 /* file_type_index */,
+        default_path, &file_info, 0 /* file_type_index */,
         base::FilePath::StringType() /* default_extension */,
         settings.parent_window ? settings.parent_window->GetNativeWindow()
                                : nullptr,

--- a/spec/api-dialog-spec.ts
+++ b/spec/api-dialog-spec.ts
@@ -1,9 +1,11 @@
-import { dialog, BaseWindow, BrowserWindow } from 'electron/main';
+import { app, dialog, BaseWindow, BrowserWindow } from 'electron/main';
 
 import { expect } from 'chai';
+import * as dbus from 'dbus-native';
 
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import { promisify } from 'node:util';
 
 import { ifdescribe, ifit } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
@@ -1036,4 +1038,101 @@ describe('dialog module', () => {
       });
     }
   );
+
+  // Asserts on the D-Bus requests received by the mock xdg-desktop-portal
+  // FileChooser that script/dbus_mock.py hosts on the fake session bus. The
+  // mock records each request and auto-cancels the dialog.
+  ifdescribe(
+    process.platform === 'linux' &&
+      process.arch !== 'ia32' &&
+      !process.arch.startsWith('arm') &&
+      !!process.env.DBUS_SESSION_BUS_ADDRESS
+  )('file dialogs (Linux portal)', () => {
+    let bus: any;
+    let getCalls: () => Promise<any[]>;
+    let clearCalls: () => Promise<void>;
+
+    before(async () => {
+      bus = dbus.sessionBus();
+      const service = bus.getService('org.freedesktop.portal.Desktop');
+      const getInterface = promisify(service.getInterface.bind(service));
+      const mock: any = await getInterface('/org/freedesktop/portal/desktop', 'org.freedesktop.DBus.Mock');
+      getCalls = promisify(mock.GetCalls.bind(mock));
+      clearCalls = promisify(mock.ClearCalls.bind(mock));
+    });
+
+    after(() => {
+      bus?.connection.end();
+    });
+
+    beforeEach(async () => {
+      await clearCalls();
+    });
+
+    // A call is [timestamp, methodName, [parent_window, title, options]];
+    // args and dict values are [signature, [value]] variant pairs.
+    function getLoggedOptions(call: any) {
+      const options: Record<string, any> = {};
+      for (const entry of call[2][2][1][0]) {
+        options[entry[0]] = entry[1][1][0];
+      }
+      return options;
+    }
+
+    // current_folder is an 'ay' (null-terminated byte array).
+    function getCurrentFolder(options: Record<string, any>) {
+      const bytes = Buffer.from(options.current_folder);
+      const nul = bytes.indexOf(0);
+      return bytes.toString('utf8', 0, nul === -1 ? bytes.length : nul);
+    }
+
+    async function getSingleCall(method: string) {
+      const calls = (await getCalls()).filter((call) => call[1] === method);
+      expect(calls).to.have.lengthOf(1);
+      return calls[0];
+    }
+
+    describe('showSaveDialog', () => {
+      it('sends the defaultPath as current_folder and current_name', async () => {
+        const defaultDir = path.join(__dirname, 'fixtures');
+        const { canceled } = await dialog.showSaveDialog({
+          defaultPath: path.join(defaultDir, 'save-target.txt')
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('SaveFile'));
+        expect(options.current_name).to.equal('save-target.txt');
+        expect(getCurrentFolder(options)).to.equal(defaultDir);
+      });
+
+      // https://github.com/electron/electron/issues/52051
+      it('sends an absolute current_folder for a directory-less defaultPath', async () => {
+        const { canceled } = await dialog.showSaveDialog({
+          defaultPath: 'test.jpeg'
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('SaveFile'));
+        expect(options.current_name).to.equal('test.jpeg');
+        const currentFolder = getCurrentFolder(options);
+        expect(currentFolder).to.satisfy(path.isAbsolute);
+        expect([app.getPath('downloads'), app.getPath('home')]).to.include(currentFolder);
+      });
+    });
+
+    describe('showOpenDialog', () => {
+      it('sends an absolute current_folder for a directory-less defaultPath', async () => {
+        const { canceled } = await dialog.showOpenDialog({
+          defaultPath: 'test.jpeg',
+          properties: ['openFile']
+        });
+        expect(canceled).to.be.true();
+
+        const options = getLoggedOptions(await getSingleCall('OpenFile'));
+        const currentFolder = getCurrentFolder(options);
+        expect(currentFolder).to.satisfy(path.isAbsolute);
+        expect([app.getPath('downloads'), app.getPath('home')]).to.include(currentFolder);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Backport of #52243

See that PR for details.

Manual backport notes: the original builds on `electron::GetDefaultPath()` from #49868 (semver/minor, `no-backport`), which 42-x-y does not have. Here `GetDefaultDialogPath()` only anchors *relative* `defaultPath`s (to Downloads, falling back to home — the same lookup #49868 uses) and leaves an empty `defaultPath` behaving exactly as before on this branch. The portal mock, `dbus_mock.py` wiring and spec are identical to `main` (the spec only asserts the relative-path case).

Notes: Fixed `dialog.showOpenDialog`/`dialog.showSaveDialog` opening at an unusable location on Linux when `defaultPath` is a bare filename without a directory.
