### PR TITLE
fix: fix `additionalData` parsing when serialized form has null byte followed by whitespace

### DIFF
--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -65,7 +65,7 @@ index f076d0f783e2c0f6b5444002f756001adf2729bd..a03d99f929e2d354cdba969567d78156
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..1204affca14f73d84b57c1b3092079464a4d5430 100644
+index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d43bc42cd 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -619,6 +619,7 @@ class ProcessSingleton::LinuxWatcher
@@ -106,6 +106,15 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..1204affca14f73d84b57c1b309207946
    const size_t kMinMessageLength = kStartToken.length() + 4;
    if (bytes_read_ < kMinMessageLength) {
      buf_[bytes_read_] = 0;
+@@ -727,7 +733,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+       base::as_string_view(base::span(buf_).first(bytes_read_));
+   std::vector<std::string> tokens =
+       base::SplitString(str, std::string(1, kTokenDelimiter),
+-                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
++                        base::KEEP_WHITESPACE, base::SPLIT_WANT_ALL);
+ 
+   if (tokens.size() < 3 || tokens[0] != kStartToken) {
+     LOG(ERROR) << "Wrong message format: " << str;
 @@ -745,10 +751,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -359,6 +359,19 @@ describe('app module', () => {
       });
     });
 
+    it('preserves NUL followed by whitespace in additional data', async () => {
+      // The real invariant here is the V8-serialized format of the data. Using
+      // a string here is just a convenient way to test the invariant.
+      const expectedAdditionalData = {
+        value: 'foo\0\tbar'
+      };
+
+      await testArgumentPassing({
+        args: ['--send-data', `--data-content=${JSON.stringify(expectedAdditionalData)}`],
+        expectedAdditionalData
+      });
+    });
+
     it('sends and receives boolean data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=false'],


### PR DESCRIPTION
Backport of #52025

See that PR for details.

Manual backport notes: the new `KEEP_WHITESPACE` hunk in `feat_add_data_parameter_to_processsingleton.patch` is re-anchored for M148 (`@@ -727,7 +733,7 @@`); verified by reverse-applying this branch's patch to the M148 file and applying the updated one. Spec hunk identical to `main`.

Notes: Fixed an issue where some values passed into `requestSingleInstanceLock` could result in a crash.
