### PR TITLE
fix: key sandboxed preload code cache entries by consuming site

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -110,7 +110,6 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/osr/osr_render_widget_host_view.h"
 #include "shell/browser/osr/osr_web_contents_view.h"
-#include "shell/browser/preload_code_cache.h"
 #include "shell/browser/preload_script.h"
 #include "shell/browser/renderer_startup_data.h"
 #include "shell/browser/session_preferences.h"
@@ -2274,10 +2273,6 @@ void WebContents::MaybeSendRendererStartupData(
   if (!rfh || !rfh->IsRenderFrameLive())
     return;
 
-  // Build the ordered preload list: session-registered preloads of type
-  // 'frame' first (in registration order), then the per-WebContents
-  // webPreferences.preload last — same order as the legacy
-  // BROWSER_SANDBOX_LOAD handler's getPreloadScriptsFromEvent().
   mojom::RendererStartupDataPtr data;
   {
     // We're on the UI thread. The asar is mmap'd and offset-indexed so warm
@@ -2285,29 +2280,7 @@ void WebContents::MaybeSendRendererStartupData(
     // parked waiting on us here — we haven't sent CommitNavigation yet — so
     // unlike the old sync IPC handler this can't amplify under contention.
     ScopedAllowBlockingForElectron allow_blocking;
-    data = renderer_startup_data::Build(rfh->GetBrowserContext(),
-                                        PreloadScript::ScriptType::kWebFrame);
-    std::optional<base::FilePath> preload;
-    if (web_prefs)
-      preload = web_prefs->GetPreloadPath();
-    if (preload && preload->IsAbsolute()) {
-      auto ps = mojom::PreloadScriptData::New();
-      ps->id = preload_code_cache::IdForWebPreferencesPreload(*preload);
-      ps->file_path = preload->AsUTF8Unsafe();
-      std::string contents;
-      if (asar::ReadFileToString(*preload, &contents)) {
-        ps->contents.assign(contents.begin(), contents.end());
-        std::vector<uint8_t> cache =
-            preload_code_cache::Get(ps->id, ps->contents);
-        if (!cache.empty())
-          ps->code_cache = std::move(cache);
-      } else {
-        ps->contents.clear();
-        ps->error =
-            "ENOENT: no such file or directory, open '" + ps->file_path + "'";
-      }
-      data->preload_scripts.push_back(std::move(ps));
-    }
+    data = renderer_startup_data::BuildForFrame(rfh);
   }
 
   // GetRemoteAssociatedInterfaces() routes over the same channel as

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -107,7 +107,6 @@
 #include "shell/browser/network_hints_handler_impl.h"
 #include "shell/browser/notifications/notification_presenter.h"
 #include "shell/browser/notifications/platform_notification_service.h"
-#include "shell/browser/preload_code_cache.h"
 #include "shell/browser/preload_script.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/browser/renderer_startup_data.h"
@@ -123,7 +122,6 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/application_info.h"
-#include "shell/common/asar/asar_util.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/logging.h"
 #include "shell/common/options_switches.h"
@@ -750,34 +748,11 @@ ElectronBrowserClient::GetExtraCreateNewWindowReplyData(
     return std::nullopt;
   if (!WebContentsPreferences::ShouldUseSandbox(web_contents))
     return std::nullopt;
-  auto* web_prefs = WebContentsPreferences::From(web_contents);
 
   mojom::RendererStartupDataPtr data;
   {
     ScopedAllowBlockingForElectron allow_blocking;
-    data = renderer_startup_data::Build(web_contents->GetBrowserContext(),
-                                        PreloadScript::ScriptType::kWebFrame);
-    std::optional<base::FilePath> preload;
-    if (web_prefs)
-      preload = web_prefs->GetPreloadPath();
-    if (preload && preload->IsAbsolute()) {
-      auto ps = mojom::PreloadScriptData::New();
-      ps->id = preload_code_cache::IdForWebPreferencesPreload(*preload);
-      ps->file_path = preload->AsUTF8Unsafe();
-      std::string contents;
-      if (asar::ReadFileToString(*preload, &contents)) {
-        ps->contents.assign(contents.begin(), contents.end());
-        std::vector<uint8_t> cache =
-            preload_code_cache::Get(ps->id, ps->contents);
-        if (!cache.empty())
-          ps->code_cache = std::move(cache);
-      } else {
-        ps->contents.clear();
-        ps->error =
-            "ENOENT: no such file or directory, open '" + ps->file_path + "'";
-      }
-      data->preload_scripts.push_back(std::move(ps));
-    }
+    data = renderer_startup_data::BuildForFrame(new_window_main_frame);
   }
   // Opaque blob — Chromium can't depend on Electron's mojom types.
   return mojo_base::BigBuffer(mojom::RendererStartupData::Serialize(&data));

--- a/shell/browser/electron_web_contents_utility_handler_impl.cc
+++ b/shell/browser/electron_web_contents_utility_handler_impl.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/electron_web_contents_utility_handler_impl.h"
 
-#include <algorithm>
-#include <optional>
 #include <utility>
 
 #include "content/public/browser/browser_context.h"
@@ -15,41 +13,10 @@
 #include "content/public/browser/render_process_host.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "shell/browser/preload_code_cache.h"
-#include "shell/browser/session_preferences.h"
 #include "shell/browser/web_contents_permission_helper.h"
-#include "shell/browser/web_contents_preferences.h"
 #include "third_party/blink/public/mojom/permissions/permission_status.mojom.h"
 
 namespace electron {
-
-namespace {
-
-// True if |id| names a preload script served to this frame — a renderer must
-// not be able to write cache entries for preloads it was never given.
-bool IsPreloadIdServedToFrame(content::RenderFrameHost* rfh,
-                              const std::string& id) {
-  if (!rfh)
-    return false;
-  auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
-  if (auto* web_prefs = WebContentsPreferences::From(web_contents)) {
-    std::optional<base::FilePath> preload = web_prefs->GetPreloadPath();
-    if (preload &&
-        id == preload_code_cache::IdForWebPreferencesPreload(*preload)) {
-      return true;
-    }
-  }
-  auto* session_prefs =
-      SessionPreferences::FromBrowserContext(rfh->GetBrowserContext());
-  if (!session_prefs)
-    return false;
-  const auto& scripts = session_prefs->preload_scripts();
-  return std::ranges::any_of(scripts, [&id](const PreloadScript& script) {
-    return script.id == id &&
-           script.script_type == PreloadScript::ScriptType::kWebFrame;
-  });
-}
-
-}  // namespace
 
 ElectronWebContentsUtilityHandlerImpl::ElectronWebContentsUtilityHandlerImpl(
     content::RenderFrameHost* frame_host,
@@ -100,12 +67,13 @@ void ElectronWebContentsUtilityHandlerImpl::SetPreloadCodeCache(
     mojo_base::BigBuffer cache) {
   // Persist the freshly produced V8 code cache so subsequent navigations and
   // launches compile this preload from bytecode instead of re-parsing source.
-  // |source_hash| must come from the renderer — only it knows which source
-  // the blob was compiled from; hashing the file here would race a
-  // concurrent preload change and pin a stale blob under the new hash.
-  if (!IsPreloadIdServedToFrame(GetRenderFrameHost(), id))
-    return;
-  preload_code_cache::Set(id, source_hash, base::span<const uint8_t>(cache));
+  // Nothing the renderer sends here is trusted as cache-validation metadata:
+  // SetFromRenderer() only accepts the write if |id| was served to this exact
+  // frame and |source_hash| matches the hash the browser recorded for the
+  // bytes it served, and it persists the entry under that browser-recorded
+  // hash plus this frame's site.
+  preload_code_cache::SetFromRenderer(GetRenderFrameHost(), id, source_hash,
+                                      base::span<const uint8_t>(cache));
 }
 
 void ElectronWebContentsUtilityHandlerImpl::CanAccessClipboardDeprecated(

--- a/shell/browser/preload_code_cache.cc
+++ b/shell/browser/preload_code_cache.cc
@@ -5,22 +5,27 @@
 #include "shell/browser/preload_code_cache.h"
 
 #include <algorithm>
-#include <array>
 #include <optional>
 #include <utility>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/flat_set.h"
 #include "base/containers/span.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
-#include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/thread_pool.h"
-#include "chrome/common/chrome_paths.h"
+#include "content/browser/process_lock.h"  // nogncheck
+#include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
-#include "crypto/hash.h"
+#include "content/public/browser/global_routing_id.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
 
 namespace electron::preload_code_cache {
 
@@ -31,15 +36,16 @@ namespace {
 constexpr std::array<uint8_t, 4> kMagic{'E', 'P', 'C', '1'};
 
 struct Entry {
-  std::array<uint8_t, crypto::hash::kSha256Size> source_hash;
+  SourceHash source_hash;
   std::vector<uint8_t> blob;
 };
 
-// In-memory tier. The optional<> memoizes a disk miss so it isn't re-tried
-// per navigation. UI-thread only: both Get() (from the navigation push paths)
-// and Set() (from the ElectronWebContentsUtility associated receiver on the
-// RenderFrameHost) are dispatched on the UI thread, so the map needs no lock
-// and concurrent SetPreloadCodeCache messages can't race it.
+// In-memory tier, keyed by (scope, id). The optional<> memoizes a disk miss
+// so it isn't re-tried per navigation. UI-thread only: both Get() (from the
+// navigation push paths) and SetFromRenderer() (from the
+// ElectronWebContentsUtility associated receiver on the RenderFrameHost) are
+// dispatched on the UI thread, so the map needs no lock and concurrent
+// SetPreloadCodeCache messages can't race it.
 using Cache = base::flat_map<std::string, std::optional<Entry>>;
 Cache& GetMemoryCache() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -47,15 +53,83 @@ Cache& GetMemoryCache() {
   return *cache;
 }
 
-base::FilePath PathForId(const std::string& id) {
-  base::FilePath dir;
-  if (!base::PathService::Get(chrome::DIR_USER_DATA, &dir))
+// sha256(served contents) per preload id, recorded per frame when the
+// browser pushes RendererStartupData. This is the trust anchor for
+// SetFromRenderer(): a renderer can only persist a cache entry for a preload
+// the browser served to that exact frame, and only under the hash the
+// browser computed from the bytes it served. UI-thread only.
+using ServedHashes = base::flat_map<std::string, SourceHash>;
+using ServedPreloads =
+    base::flat_map<content::GlobalRenderFrameHostToken, ServedHashes>;
+ServedPreloads& GetServedPreloads() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  static base::NoDestructor<ServedPreloads> served;
+  return *served;
+}
+
+// Erases the served-preload records of a WebContents' frames when they (or
+// the WebContents itself) go away, so GetServedPreloads() can't accumulate
+// entries for dead frames. Owned by the WebContents it observes, so cleanup
+// doesn't depend on any Electron-side wrapper existing for that WebContents
+// (window.open contents are recorded before api::WebContents adopts them).
+class ServedPreloadTracker final
+    : private content::WebContentsObserver,
+      public content::WebContentsUserData<ServedPreloadTracker> {
+ public:
+  ~ServedPreloadTracker() override { Purge(); }
+
+  static void Track(content::RenderFrameHost* rfh) {
+    auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+    if (!web_contents)
+      return;
+    CreateForWebContents(web_contents);
+    FromWebContents(web_contents)->tokens_.insert(rfh->GetGlobalFrameToken());
+  }
+
+ private:
+  friend class content::WebContentsUserData<ServedPreloadTracker>;
+  explicit ServedPreloadTracker(content::WebContents* web_contents)
+      : content::WebContentsObserver(web_contents),
+        content::WebContentsUserData<ServedPreloadTracker>(*web_contents) {}
+
+  // content::WebContentsObserver:
+  void RenderFrameDeleted(content::RenderFrameHost* rfh) override {
+    const content::GlobalRenderFrameHostToken token =
+        rfh->GetGlobalFrameToken();
+    if (tokens_.erase(token))
+      GetServedPreloads().erase(token);
+  }
+  void WebContentsDestroyed() override { Purge(); }
+
+  void Purge() {
+    for (const auto& token : tokens_)
+      GetServedPreloads().erase(token);
+    tokens_.clear();
+  }
+
+  base::flat_set<content::GlobalRenderFrameHostToken> tokens_;
+
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+};
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(ServedPreloadTracker);
+
+// One slot per (scope, id): different principals consuming the same preload
+// keep separate entries instead of evicting each other's.
+std::string CacheKey(const Scope& scope, const std::string& id) {
+  return scope.context_id + '\n' + scope.process_lock + '\n' + id;
+}
+
+// sha256(id)-sha256(process lock) keeps the filename filesystem-safe and
+// bounded while giving each (preload, principal) pair its own file. The
+// BrowserContext is implied by |scope.dir|.
+base::FilePath PathForEntry(const Scope& scope, const std::string& id) {
+  if (scope.dir.empty())
     return {};
-  // sha256(id) keeps the filename filesystem-safe and bounded.
-  std::string digest = base::HexEncode(crypto::hash::Sha256(id));
-  return dir.AppendASCII("Code Cache")
-      .AppendASCII("electron-preload")
-      .AppendASCII(digest + ".cache");
+  std::string digest =
+      base::HexEncode(crypto::hash::Sha256(id)) + "-" +
+      base::HexEncode(crypto::hash::Sha256(scope.process_lock));
+  return scope.dir.AppendASCII(digest + ".cache");
 }
 
 std::optional<Entry> ParseDiskEntry(const std::string& file_contents) {
@@ -86,49 +160,112 @@ std::string IdForWebPreferencesPreload(const base::FilePath& path) {
   return "preload-" + path.AsUTF8Unsafe();
 }
 
-std::vector<uint8_t> Get(const std::string& id,
-                         base::span<const uint8_t> contents) {
+Scope::Scope() = default;
+Scope::Scope(const Scope&) = default;
+Scope::Scope(Scope&&) = default;
+Scope::~Scope() = default;
+
+// ProcessLock::ToString() is a //content-internal debug string with no
+// format contract; it is used only as opaque bytes to hash into the entry's
+// filename. If a Chromium roll changes its formatting the old files simply
+// stop matching and the cache re-warms (one cold compile), which is the
+// intended failure mode rather than a bug.
+Scope ScopeForFrame(content::RenderFrameHost* rfh) {
+  Scope scope;
+  if (!rfh)
+    return scope;
+  auto* browser_context = rfh->GetBrowserContext();
+  scope.context_id = browser_context->UniqueId();
+  scope.process_lock = rfh->GetProcess()->GetProcessLock().ToString();
+  if (!browser_context->IsOffTheRecord()) {
+    scope.dir = browser_context->GetPath()
+                    .AppendASCII("Code Cache")
+                    .AppendASCII("electron-preload");
+  }
+  return scope;
+}
+
+std::vector<uint8_t> Get(const Scope& scope,
+                         const std::string& id,
+                         const SourceHash& source_hash) {
   auto& cache = GetMemoryCache();
-  auto it = cache.find(id);
+  const std::string key = CacheKey(scope, id);
+  auto it = cache.find(key);
   if (it == cache.end()) {
     // Cold lookup: read disk once and memoize (including misses).
     std::optional<Entry> entry;
     std::string file_contents;
-    base::FilePath path = PathForId(id);
+    base::FilePath path = PathForEntry(scope, id);
     if (!path.empty() && base::ReadFileToString(path, &file_contents))
       entry = ParseDiskEntry(file_contents);
-    it = cache.insert_or_assign(it, id, std::move(entry));
+    it = cache.insert_or_assign(it, key, std::move(entry));
   }
   const std::optional<Entry>& entry = it->second;
-  if (!entry || entry->source_hash != crypto::hash::Sha256(contents))
+  if (!entry || entry->source_hash != source_hash)
     return {};
   return entry->blob;
 }
 
-void Set(const std::string& id,
-         base::span<const uint8_t> source_hash,
-         base::span<const uint8_t> blob) {
-  if (blob.empty() || source_hash.size() != crypto::hash::kSha256Size)
+void RecordServedPreloads(content::RenderFrameHost* rfh,
+                          std::vector<ServedPreload> served) {
+  if (!rfh)
     return;
-  // No first-writer-wins guard: Set() must always overwrite. Get() memoizes
+  const content::GlobalRenderFrameHostToken token = rfh->GetGlobalFrameToken();
+  if (served.empty()) {
+    GetServedPreloads().erase(token);
+    return;
+  }
+  ServedPreloadTracker::Track(rfh);
+  GetServedPreloads().insert_or_assign(token, ServedHashes(std::move(served)));
+}
+
+void SetFromRenderer(content::RenderFrameHost* rfh,
+                     const std::string& id,
+                     base::span<const uint8_t> claimed_source_hash,
+                     base::span<const uint8_t> blob) {
+  if (!rfh || blob.empty())
+    return;
+  // Only accept writes for a preload id the browser actually served to this
+  // exact frame, and only when the renderer's claim about which source it
+  // compiled matches the bytes the browser served. The renderer-supplied
+  // hash is never persisted — the browser-recorded one is — so a compromised
+  // renderer cannot make the browser vouch for bytecode under metadata of
+  // its choosing. A mismatch (e.g. a write racing a newer push after the
+  // preload changed on disk) just drops the write; the next navigation
+  // re-produces the cache.
+  const auto& served = GetServedPreloads();
+  const auto frame_it = served.find(rfh->GetGlobalFrameToken());
+  if (frame_it == served.end())
+    return;
+  const auto hash_it = frame_it->second.find(id);
+  if (hash_it == frame_it->second.end())
+    return;
+  if (claimed_source_hash.size() != crypto::hash::kSha256Size ||
+      !std::ranges::equal(claimed_source_hash, hash_it->second)) {
+    return;
+  }
+
+  // No first-writer-wins guard: writes must always overwrite. Get() memoizes
   // whatever is on disk *including a corrupt blob* (only V8 in the renderer
   // can validate it), so a renderer that rejected a stale/corrupt cache and
-  // re-produced a good one calls Set() to self-heal — skipping that because
-  // the memoized entry is "non-empty" would pin the bad cache forever. The
-  // duplicate-ship case (two renderers, same preload, first launch) just
-  // writes identical bytes twice; harmless and rare, and Set() is UI-thread
-  // serialized so it's not a data race.
+  // re-produced a good one calls SetPreloadCodeCache() to self-heal —
+  // skipping that because the memoized entry is "non-empty" would pin the
+  // bad cache forever. The duplicate-ship case (two renderers, same preload,
+  // first launch) just writes identical bytes twice; harmless and rare, and
+  // SetFromRenderer() is UI-thread serialized so it's not a data race.
   Entry entry;
-  std::ranges::copy(source_hash, entry.source_hash.begin());
+  entry.source_hash = hash_it->second;
   entry.blob.assign(blob.begin(), blob.end());
 
   std::vector<uint8_t> payload;
-  payload.reserve(kMagic.size() + source_hash.size() + blob.size());
+  payload.reserve(kMagic.size() + entry.source_hash.size() + entry.blob.size());
   payload.insert(payload.end(), kMagic.begin(), kMagic.end());
-  payload.insert(payload.end(), source_hash.begin(), source_hash.end());
-  payload.insert(payload.end(), blob.begin(), blob.end());
+  payload.insert(payload.end(), entry.source_hash.begin(),
+                 entry.source_hash.end());
+  payload.insert(payload.end(), entry.blob.begin(), entry.blob.end());
 
-  GetMemoryCache().insert_or_assign(id, std::move(entry));
+  const Scope scope = ScopeForFrame(rfh);
+  GetMemoryCache().insert_or_assign(CacheKey(scope, id), std::move(entry));
   // Fire-and-forget; a lost write just costs one cold compile next launch.
   // SKIP_ON_SHUTDOWN so an in-flight write finishes (no torn cache file)
   // rather than being abandoned mid-write during teardown.
@@ -136,7 +273,8 @@ void Set(const std::string& id,
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
        base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&WriteToDisk, PathForId(id), std::move(payload)));
+      base::BindOnce(&WriteToDisk, PathForEntry(scope, id),
+                     std::move(payload)));
 }
 
 }  // namespace electron::preload_code_cache

--- a/shell/browser/preload_code_cache.h
+++ b/shell/browser/preload_code_cache.h
@@ -5,38 +5,85 @@
 #ifndef ELECTRON_SHELL_BROWSER_PRELOAD_CODE_CACHE_H_
 #define ELECTRON_SHELL_BROWSER_PRELOAD_CODE_CACHE_H_
 
+#include <array>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/containers/span.h"
+#include "base/files/file_path.h"
+#include "crypto/hash.h"
 
-namespace base {
-class FilePath;
+namespace content {
+class RenderFrameHost;
 }
 
 namespace electron::preload_code_cache {
 
+// sha256 of a preload script's source bytes.
+using SourceHash = std::array<uint8_t, crypto::hash::kSha256Size>;
+
+// One preload served to a frame: its cache id and the sha256 of the exact
+// bytes the browser served.
+using ServedPreload = std::pair<std::string, SourceHash>;
+
 // Cache id for a webPreferences.preload script (stable across launches).
 std::string IdForWebPreferencesPreload(const base::FilePath& path);
 
-// Returns the V8 code cache blob recorded for |id| and these exact
-// |contents|, or empty. Checks an in-memory tier first, then disk
-// (userData/Code Cache/electron-preload/). Disk I/O is synchronous (call
-// behind a ScopedAllowBlocking) and happens at most once per id per session.
+// Who a cache entry belongs to: the frame's BrowserContext (its data dir,
+// under which the disk tier lives) plus its renderer's process lock (site,
+// origin keying, sandboxing, guest and cross-origin-isolation status,
+// storage partition). Entries are only ever served back within an equal
+// scope, so a blob produced by one principal's renderer is never handed to
+// another. |dir| is empty for off-the-record contexts (memory tier only).
+struct Scope {
+  Scope();
+  Scope(const Scope&);
+  Scope(Scope&&);
+  ~Scope();
+
+  base::FilePath dir;
+  std::string context_id;
+  std::string process_lock;
+};
+Scope ScopeForFrame(content::RenderFrameHost* rfh);
+
+// Returns the V8 code cache blob recorded for |id| within |scope| and bound
+// to source bytes whose sha256 is |source_hash| — or empty. Checks an
+// in-memory tier first, then |scope.dir|. Disk I/O is synchronous (call behind
+// a ScopedAllowBlocking) and happens at most once per (scope, id) per session.
 //
-// Entries are bound to sha256(contents): V8's own CachedData source check
+// Entries are bound to the source hash: V8's own CachedData source check
 // hashes only the source *length*, so without this a same-length source
 // change would execute stale bytecode. V8 still validates version/flags at
 // consume time.
-std::vector<uint8_t> Get(const std::string& id,
-                         base::span<const uint8_t> contents);
+std::vector<uint8_t> Get(const Scope& scope,
+                         const std::string& id,
+                         const SourceHash& source_hash);
 
-// Stores a blob compiled from source whose sha256 is |source_hash| (32
-// bytes; other sizes are ignored). The in-memory tier is written
-// immediately; the disk write is fire-and-forget on the thread pool.
-void Set(const std::string& id,
-         base::span<const uint8_t> source_hash,
-         base::span<const uint8_t> blob);
+// Records the preloads — id plus the sha256 of the exact bytes — that the
+// browser served to |rfh| in a RendererStartupData push, replacing any
+// previous record for that frame. SetFromRenderer() only accepts cache
+// writes for tuples recorded here: the browser, not the renderer, is the
+// authority for which source bytes a cache entry validates against. The
+// record's lifetime is tied to the frame (cleared when the frame or its
+// WebContents goes away).
+void RecordServedPreloads(content::RenderFrameHost* rfh,
+                          std::vector<ServedPreload> served);
+
+// Stores a code cache blob reported by |rfh|'s renderer for a preload that
+// was served to it. The write is dropped unless RecordServedPreloads()
+// recorded the id for this exact frame and |claimed_source_hash| equals the
+// browser-recorded hash of the served bytes. The claimed hash is only a
+// cross-check (it detects a write racing a newer push after the preload
+// changed on disk); what is persisted is the browser-recorded hash, keyed by
+// the frame's Scope — the renderer never supplies the metadata that future
+// loads validate against. The in-memory tier is written immediately; the
+// disk write is fire-and-forget on the thread pool.
+void SetFromRenderer(content::RenderFrameHost* rfh,
+                     const std::string& id,
+                     base::span<const uint8_t> claimed_source_hash,
+                     base::span<const uint8_t> blob);
 
 }  // namespace electron::preload_code_cache
 

--- a/shell/browser/renderer_startup_data.cc
+++ b/shell/browser/renderer_startup_data.cc
@@ -4,16 +4,23 @@
 
 #include "shell/browser/renderer_startup_data.h"
 
+#include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/path_service.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/content_paths.h"
+#include "crypto/hash.h"
 #include "shell/browser/preload_code_cache.h"
 #include "shell/browser/session_preferences.h"
+#include "shell/browser/web_contents_preferences.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/thread_restrictions.h"
@@ -47,10 +54,44 @@ base::FilePath GetHelperExecPath() {
   return path;
 }
 
-}  // namespace
+// Reads one preload script into a PreloadScriptData. When |served| is
+// non-null the script participates in the preload code cache: the source is
+// hashed once, the hash both gates the same-Scope cache lookup and is
+// appended to |served| so it can be recorded as the trust anchor that
+// SetPreloadCodeCache writes from the frame are validated against. Service
+// worker realms pass null — they have no code-cache producer.
+mojom::PreloadScriptDataPtr ReadPreloadScript(
+    const std::string& id,
+    const base::FilePath& path,
+    const preload_code_cache::Scope& scope,
+    std::vector<preload_code_cache::ServedPreload>* served) {
+  auto ps = mojom::PreloadScriptData::New();
+  ps->id = id;
+  ps->file_path = path.AsUTF8Unsafe();
+  std::string contents;
+  if (!asar::ReadFileToString(path, &contents)) {
+    ps->error =
+        "ENOENT: no such file or directory, open '" + ps->file_path + "'";
+    return ps;
+  }
+  ps->contents.assign(contents.begin(), contents.end());
+  if (served) {
+    const preload_code_cache::SourceHash hash =
+        crypto::hash::Sha256(ps->contents);
+    std::vector<uint8_t> cache = preload_code_cache::Get(scope, id, hash);
+    if (!cache.empty())
+      ps->code_cache = std::move(cache);
+    served->emplace_back(id, hash);
+  }
+  return ps;
+}
 
-mojom::RendererStartupDataPtr Build(content::BrowserContext* browser_context,
-                                    PreloadScript::ScriptType type) {
+// Session-registered preloads of |type| plus the env/execPath snapshot.
+mojom::RendererStartupDataPtr BuildInternal(
+    content::BrowserContext* browser_context,
+    PreloadScript::ScriptType type,
+    const preload_code_cache::Scope& scope,
+    std::vector<preload_code_cache::ServedPreload>* served) {
   auto data = mojom::RendererStartupData::New();
 
   auto* session_prefs = SessionPreferences::FromBrowserContext(browser_context);
@@ -60,27 +101,51 @@ mojom::RendererStartupDataPtr Build(content::BrowserContext* browser_context,
         continue;
       if (!script.file_path.IsAbsolute())
         continue;
-      auto ps = mojom::PreloadScriptData::New();
-      ps->id = script.id;
-      ps->file_path = script.file_path.AsUTF8Unsafe();
-      std::string contents;
-      if (asar::ReadFileToString(script.file_path, &contents)) {
-        ps->contents.assign(contents.begin(), contents.end());
-        std::vector<uint8_t> cache =
-            preload_code_cache::Get(script.id, ps->contents);
-        if (!cache.empty())
-          ps->code_cache = std::move(cache);
-      } else {
-        ps->contents.clear();
-        ps->error =
-            "ENOENT: no such file or directory, open '" + ps->file_path + "'";
-      }
-      data->preload_scripts.push_back(std::move(ps));
+      data->preload_scripts.push_back(
+          ReadPreloadScript(script.id, script.file_path, scope, served));
     }
   }
 
   data->environment = CaptureBrowserEnvironment();
   data->helper_exec_path = GetHelperExecPath().AsUTF8Unsafe();
+  return data;
+}
+
+}  // namespace
+
+mojom::RendererStartupDataPtr Build(content::BrowserContext* browser_context,
+                                    PreloadScript::ScriptType type) {
+  return BuildInternal(browser_context, type, preload_code_cache::Scope(),
+                       nullptr);
+}
+
+mojom::RendererStartupDataPtr BuildForFrame(content::RenderFrameHost* rfh) {
+  const preload_code_cache::Scope scope =
+      preload_code_cache::ScopeForFrame(rfh);
+  std::vector<preload_code_cache::ServedPreload> served;
+  auto data =
+      BuildInternal(rfh->GetBrowserContext(),
+                    PreloadScript::ScriptType::kWebFrame, scope, &served);
+
+  // The per-WebContents webPreferences.preload runs last. May be absent for a
+  // WebContents that never went through a BrowserWindow/webContents
+  // constructor (extension pages, devtools); such a WebContents has no per-WC
+  // preload but still gets session preloads + env.
+  auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+  auto* web_prefs = WebContentsPreferences::From(web_contents);
+  std::optional<base::FilePath> preload;
+  if (web_prefs)
+    preload = web_prefs->GetPreloadPath();
+  if (preload && preload->IsAbsolute()) {
+    data->preload_scripts.push_back(ReadPreloadScript(
+        preload_code_cache::IdForWebPreferencesPreload(*preload), *preload,
+        scope, &served));
+  }
+
+  // Remember exactly what was served to this frame; SetPreloadCodeCache()
+  // only accepts cache writes that match this record, so the renderer never
+  // gets to pick the source a cache entry is validated against.
+  preload_code_cache::RecordServedPreloads(rfh, std::move(served));
   return data;
 }
 

--- a/shell/browser/renderer_startup_data.h
+++ b/shell/browser/renderer_startup_data.h
@@ -10,17 +10,28 @@
 
 namespace content {
 class BrowserContext;
+class RenderFrameHost;
 }  // namespace content
 
 namespace electron::renderer_startup_data {
 
 // Builds a RendererStartupData for the given session containing the registered
-// preload scripts of |type| (kWebFrame for the per-frame ElectronFrameStartup
-// push, or kServiceWorker for the GetServiceWorkerStartupData blob), the
-// browser env snapshot, and process.helperExecPath. Reads preload contents
-// synchronously — call behind a ScopedAllowBlockingForElectron.
+// preload scripts of |type| (kServiceWorker for the GetServiceWorkerStartupData
+// blob), the browser env snapshot, and process.helperExecPath. No preload code
+// cache is attached — that only exists for frame realms. Reads preload
+// contents synchronously — call behind a ScopedAllowBlockingForElectron.
 mojom::RendererStartupDataPtr Build(content::BrowserContext* browser_context,
                                     PreloadScript::ScriptType type);
+
+// Builds the RendererStartupData pushed to a frame: session-registered
+// kWebFrame preloads (in registration order) followed by the per-WebContents
+// webPreferences.preload — the same order as the legacy BROWSER_SANDBOX_LOAD
+// handler's getPreloadScriptsFromEvent(). Attaches any preload code cache
+// previously produced for |rfh|'s site, and records the served (id, hash)
+// tuples with preload_code_cache so SetPreloadCodeCache writes from this
+// frame can be validated against exactly what was served. Reads preload
+// contents synchronously — call behind a ScopedAllowBlockingForElectron.
+mojom::RendererStartupDataPtr BuildForFrame(content::RenderFrameHost* rfh);
 
 }  // namespace electron::renderer_startup_data
 

--- a/shell/common/web_contents_utility.mojom
+++ b/shell/common/web_contents_utility.mojom
@@ -22,11 +22,15 @@ interface ElectronWebContentsUtility {
       blink.mojom.LocalFrameToken frame_token) => (blink.mojom.PermissionStatus status);
 
   // Reports a V8 code cache produced by compiling a preload script, plus the
-  // sha256 of the source that was compiled. The browser persists both and
-  // only ships the blob while the preload's contents still match (V8's own
-  // CachedData source check is length-only, so it cannot reject a
-  // same-length source change). Sent off the FCP critical path, after the
-  // preload runs.
+  // sha256 of the source that was compiled. The browser only accepts the
+  // write if |id| names a preload it served to this exact frame and
+  // |source_hash| matches the hash it recorded for the bytes it served — the
+  // hash here is a cross-check, never the validation authority. The entry is
+  // persisted under the browser-recorded hash and the producing frame's
+  // site, and only shipped back to same-site documents while the preload's
+  // contents still match (V8's own CachedData source check is length-only,
+  // so it cannot reject a same-length source change). Sent off the FCP
+  // critical path, after the preload runs.
   SetPreloadCodeCache(string id, array<uint8, 32> source_hash,
                       mojo_base.mojom.BigBuffer cache);
 };

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4056,15 +4056,18 @@ describe('BrowserWindow module', () => {
 
     describe('preload code cache', () => {
       // Sandboxed preload scripts are compiled with a persistent V8 code cache
-      // keyed by sha256(scriptId) under userData/Code Cache/electron-preload/.
-      // The id for a webPreferences.preload is `preload-${absolutePath}`.
+      // stored as `${sha256(scriptId)}-${sha256(processLock)}.cache` under the
+      // session's `Code Cache/electron-preload/` dir, where `processLock` is
+      // the consuming frame's renderer process lock — entries are only served
+      // back to documents of the same principal. The id for a
+      // webPreferences.preload is `preload-${absolutePath}`.
       //
       // The cache has an in-memory tier that lives for the browser process's
       // lifetime and shadows the disk tier, so each test gets a fresh preload
       // *path* (a unique temp copy of the fixture) → fresh cache key → no
       // cross-test in-memory contamination.
       const fixture = path.join(fixtures, 'module', 'preload-code-cache.js');
-      const cacheDir = path.join(app.getPath('userData'), 'Code Cache', 'electron-preload');
+      const cacheDir = path.join(app.getPath('sessionData'), 'Code Cache', 'electron-preload');
 
       let preload: string;
       let cacheFile: string;
@@ -4072,7 +4075,7 @@ describe('BrowserWindow module', () => {
         preload = path.join(os.tmpdir(), `preload-code-cache-${crypto.randomUUID()}.js`);
         fs.copyFileSync(fixture, preload);
         const cacheKey = crypto.createHash('sha256').update(`preload-${preload}`).digest('hex').toUpperCase();
-        cacheFile = path.join(cacheDir, `${cacheKey}.cache`);
+        cacheFile = path.join(cacheDir, `${cacheKey}-${fileLockHash}.cache`);
       });
       const waitFor = async (predicate: () => boolean, what: string, timeoutMs = 5000) => {
         const start = Date.now();
@@ -4107,6 +4110,43 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: { sandbox: true, contextIsolation: true, preload }
         });
+
+      const cacheFilesFor = (cacheKey: string) =>
+        fs.existsSync(cacheDir)
+          ? fs.readdirSync(cacheDir).filter((f) => f.startsWith(`${cacheKey}-`) && f.endsWith('.cache'))
+          : [];
+
+      // The `${sha256(processLock)}` half of the filename is an implementation
+      // detail of the browser process. Most tests here load file:// documents,
+      // so learn that suffix once by producing a probe entry and reading the
+      // name of the file it creates.
+      let fileLockHash: string;
+      before(async () => {
+        const probePreload = path.join(os.tmpdir(), `preload-code-cache-probe-${crypto.randomUUID()}.js`);
+        fs.copyFileSync(fixture, probePreload);
+        const probeKey = crypto.createHash('sha256').update(`preload-${probePreload}`).digest('hex').toUpperCase();
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: { sandbox: true, contextIsolation: true, preload: probePreload }
+        });
+        const ran = once(ipcMain, 'preload-code-cache-ran');
+        await w.loadFile(path.join(fixtures, 'api', 'blank.html'));
+        await ran;
+        try {
+          let probeFile: string | undefined;
+          await waitFor(() => {
+            probeFile = cacheFilesFor(probeKey)[0];
+            return !!probeFile && fs.statSync(path.join(cacheDir, probeFile)).size > 0;
+          }, 'probe cache file to be written');
+          fileLockHash = probeFile!.slice(probeKey.length + 1, -'.cache'.length);
+        } finally {
+          w.destroy();
+          await removeFile(probePreload);
+          for (const f of cacheFilesFor(probeKey)) {
+            await removeFile(path.join(cacheDir, f));
+          }
+        }
+      });
 
       it('produces and persists a code cache after the first compile', async () => {
         const w = makeWindow();
@@ -4163,6 +4203,36 @@ describe('BrowserWindow module', () => {
         // blobs are several hundred bytes minimum.
         await waitFor(() => fs.statSync(cacheFile).size > 100, 'cache file to be overwritten');
         expect(fs.statSync(cacheFile).size).to.be.greaterThan(100);
+      });
+
+      it('keeps a separate entry for each principal that consumes the preload', async () => {
+        // The same preload on two different-site documents is two principals,
+        // so it must produce two entries rather than one site's blob being
+        // served to (or clobbered by) the other's.
+        const server = http.createServer((_req, res) => {
+          res.setHeader('Content-Type', 'text/html');
+          res.end('<title>blank</title>');
+        });
+        const { port } = await listen(server);
+        try {
+          for (const host of ['127.0.0.1', 'localhost']) {
+            const w = makeWindow();
+            const ran = once(ipcMain, 'preload-code-cache-ran');
+            await w.loadURL(`http://${host}:${port}/`);
+            await ran;
+            w.destroy();
+          }
+          const cacheKey = crypto.createHash('sha256').update(`preload-${preload}`).digest('hex').toUpperCase();
+          await waitFor(
+            () => cacheFilesFor(cacheKey).filter((f) => fs.statSync(path.join(cacheDir, f)).size > 0).length === 2,
+            'a cache file per site'
+          );
+          for (const f of cacheFilesFor(cacheKey)) {
+            await removeFile(path.join(cacheDir, f));
+          }
+        } finally {
+          server.close();
+        }
       });
 
       it('does not consume a cache produced from different source of the same length', async () => {


### PR DESCRIPTION
Backport of #52480

See that PR for details.

Manual backport notes: include-only conflict in `electron_web_contents_utility_handler_impl.cc`, and `#include "shell/common/asar/asar_util.h"` is kept in `electron_api_web_contents.cc` because 42-x-y still calls `asar::GetExtractedFileURL` there. `preload_code_cache.*`, `renderer_startup_data.*` and the mojom end up identical to `main` at that commit.

Notes: none
