### PR TITLE
build: faster symbol archives, skip test artifacts on publish

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: 'true'
   generate-test-artifacts:
-    description: 'Generate artifacts only consumed by test jobs (src artifacts, cross-arch snapshots, mksnapshot fixup). Only disable when no test job consumes this build.'
+    description: 'Generate artifacts only consumed by test jobs (src artifacts, cross-arch snapshots; mksnapshot fixup on non-release builds). Only disable when no test job consumes this build.'
     required: false
     default: 'true'
 runs:
@@ -131,9 +131,12 @@ runs:
           fi
           electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.${{ inputs.target-arch }}.manifest
         fi
+    # mksnapshot_args is consumed by both the mksnapshot tests and by
+    # @electron/mksnapshot from the released mksnapshot.zip, so this is needed
+    # whenever either tests or a release consume this build.
     - name: Fixup Mksnapshot ${{ inputs.step-suffix }}
       shell: bash
-      if: ${{ inputs.generate-test-artifacts == 'true' }}
+      if: ${{ inputs.generate-test-artifacts == 'true' || inputs.is-release == 'true' }}
       run: |
         cd src
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG=1 e d gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
@@ -214,8 +217,12 @@ runs:
         # Needed for msdia140.dll on 64-bit windows
         cd src
         export PATH="$PATH:$(pwd)/third_party/llvm-build/Release+Asserts/bin"
+    # symbols.zip / pdb.zip / dsym archives are only consumed by the release
+    # uploader; every testing/PGO build passes generate-symbols: false and this
+    # was still spending 8-13 minutes per Windows build zipping PDBs nobody reads.
     - name: Zip Symbols ${{ inputs.step-suffix }}
       shell: bash
+      if: ${{ inputs.generate-symbols == 'true' }}
       run: |
         cd src
         export BUILD_PATH="$(pwd)/out/Default"

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -84,6 +84,8 @@ jobs:
       target-platform: linux
       target-arch: x64
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -104,6 +106,8 @@ jobs:
       target-platform: linux
       target-arch: arm
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -124,6 +128,8 @@ jobs:
       target-platform: linux
       target-arch: arm64
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -88,6 +88,8 @@ jobs:
       target-arch: x64
       target-variant: darwin
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -108,6 +110,8 @@ jobs:
       target-arch: x64
       target-variant: mas
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -128,6 +132,8 @@ jobs:
       target-arch: arm64
       target-variant: darwin
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -148,6 +154,8 @@ jobs:
       target-arch: arm64
       target-variant: mas
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -88,6 +88,8 @@ jobs:
       target-platform: win
       target-arch: x64
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -107,6 +109,8 @@ jobs:
       target-platform: win
       target-arch: arm64
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
@@ -126,6 +130,8 @@ jobs:
       target-platform: win
       target-arch: x86
       is-release: true
+      # No test job consumes a publish build - skip src_artifacts / cross-arch snapshots.
+      generate-test-artifacts: false
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -66,28 +66,50 @@ def download(text, url, path):
   return path
 
 
+# Deflate level 6 is ~1.7x faster than level 9 on the multi-GB debug info
+# archives this is used for (pdb.zip, dsym-snapshot.zip, debug.zip), and the
+# output is only ~0.4% larger.
+ZIP_COMPRESSION_LEVEL = 6
+
 def make_zip(zip_file_path, files, dirs):
   safe_unlink(zip_file_path)
   if sys.platform == 'darwin':
     allfiles = files + dirs
-    execute(['zip', '-r', '-y', '-9', zip_file_path] + allfiles)
+    execute(['zip', '-r', '-y', f'-{ZIP_COMPRESSION_LEVEL}', zip_file_path]
+            + allfiles)
   else:
     with zipfile.ZipFile(zip_file_path, "w",
                          zipfile.ZIP_DEFLATED,
-                         allowZip64=True) as zip_file:
+                         allowZip64=True,
+                         compresslevel=ZIP_COMPRESSION_LEVEL) as zip_file:
       for filename in files:
-        zip_file.write(filename, filename, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+        zip_file.write(filename, filename)
       for dirname in dirs:
         for root, _, filenames in os.walk(dirname):
           for f in filenames:
-            zip_file.write(os.path.join(root, f), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+            zip_file.write(os.path.join(root, f))
       zip_file.close()
 
 
 def make_tar_xz(tar_file_path, files, dirs):
   safe_unlink(tar_file_path)
   allfiles = files + dirs
-  execute(['tar', '-cJf', tar_file_path] + allfiles)
+  # xz is single threaded by default, which takes 30+ minutes for the ~7GB of
+  # dSYMs this is used for. Multi-threaded xz splits the input into
+  # independently compressed blocks (~1% larger, still a standard .xz stream
+  # that any xz decoder can read) and scales ~linearly with core count.
+  tar_version = subprocess.run(['tar', '--version'], capture_output=True,
+                               text=True, check=False).stdout
+  if 'bsdtar' in tar_version:
+    # macOS ships bsdtar, whose xz filter is configured via --options; a
+    # thread count of 0 means "one per CPU".
+    args = ['tar', '--options', 'xz:threads=0', '-cJf', tar_file_path]
+    env = None
+  else:
+    # GNU tar shells out to the xz binary, which reads XZ_OPT.
+    args = ['tar', '-cJf', tar_file_path]
+    env = dict(os.environ, XZ_OPT='-T0')
+  execute(args + allfiles, env=env)
 
 
 def rm_rf(path):


### PR DESCRIPTION
Backport of #52745

See that PR for details.

Manual backport notes: 42-x-y's publish workflows still use `pipeline-segment-electron-publish.yml` (no `publish:` input) and have the extra linux `arm` / windows `x86` jobs, so `generate-test-artifacts: false` was added to every publish job in `linux-publish.yml`, `macos-publish.yml` and `windows-publish.yml`; `release-build.yml` does not exist on this branch and is dropped. The `build-electron/action.yml` and `script/lib/util.py` hunks are identical to `main`.

Notes: none
