### PR TITLE
fix: tear down Node's per-process state before the process exits

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -334,6 +334,11 @@ int NodeMain() {
 
   v8::V8::Dispose();
 
+  // Matches node::InitializeOncePerProcess() above. In particular this joins
+  // the off-thread CA certificate loader that `require('tls')` starts, which
+  // would otherwise race the static destructors run by exit() and abort().
+  node::TearDownOncePerProcess();
+
   return exit_code;
 }
 

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -22,6 +22,7 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/login_item_settings_converter.h"
+#include "shell/common/node_bindings.h"
 #include "shell/common/thread_restrictions.h"
 
 namespace electron {
@@ -130,7 +131,11 @@ void Browser::Exit(gin::Arguments* args) {
 
 void Browser::ExitWithCode(int code) {
   if (!ElectronBrowserMainParts::Get()->SetExitCode(code)) {
-    // Message loop is not ready, quit directly.
+    // Message loop is not ready, quit directly. Nothing below us gets torn
+    // down on this path, so at least undo Node's per-process initialization
+    // before exit() starts running static destructors underneath any threads
+    // Node has started.
+    NodeBindings::TearDownOncePerProcess();
     exit(code);
   } else {
     // Prepare to quit when all windows have been closed.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -539,6 +539,17 @@ NodeBindings::~NodeBindings() {
   // Clean up worker loop
   if (in_worker_loop())
     stop_and_close_uv_loop(uv_loop_);
+
+  if (initialized_node_per_process_)
+    TearDownOncePerProcess();
+}
+
+// static
+void NodeBindings::TearDownOncePerProcess() {
+  if (!g_is_initialized)
+    return;
+  g_is_initialized = false;
+  node::TearDownOncePerProcess();
 }
 
 void NodeBindings::StopPolling() {
@@ -741,6 +752,7 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
   }
 
   g_is_initialized = true;
+  initialized_node_per_process_ = true;
 }
 
 std::shared_ptr<node::Environment> NodeBindings::CreateEnvironment(

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -122,6 +122,14 @@ class NodeBindings {
   static void RegisterBuiltinBindings();
   static bool IsInitialized();
 
+  // Undo node::InitializeOncePerProcess() for this process. Must run before
+  // the process exits whenever Node was initialized: among other things it
+  // joins the thread Node uses to load CA certificates off the main thread
+  // (started the first time `tls` is loaded), which otherwise races exit-time
+  // static destruction and abort()s. Safe to call more than once and when Node
+  // was never initialized.
+  static void TearDownOncePerProcess();
+
   virtual ~NodeBindings();
 
   // Setup V8, libuv.
@@ -230,6 +238,10 @@ class NodeBindings {
 
   // Indicates whether polling thread has been created.
   bool initialized_ = false;
+
+  // Whether this instance ran node::InitializeOncePerProcess() and so owns the
+  // matching TearDownOncePerProcess() in its destructor.
+  bool initialized_node_per_process_ = false;
 
   // Whether PrepareEmbedThread has initialized the semaphore and async handle.
   // Unlike |initialized_|, this is never reset — the handles live until the

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -236,6 +236,27 @@ describe('app module', () => {
       expect(code).to.equal(123, 'exit code should be 123, if you see this please tag @MarshallOfSound');
     });
 
+    // Exiting before 'ready' leaves browser start-up state unfreed by design,
+    // which LeakSanitizer reports and turns into exit code 1.
+    ifit(!process.env.IS_ASAN)('exits cleanly when called before ready right after loading tls', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'exit-before-ready-after-tls');
+      // This guards against a shutdown race that was lost roughly one run in
+      // five, so go a few rounds.
+      for (let i = 0; i < 15; i++) {
+        appProcess = cp.spawn(process.execPath, [appPath]);
+        let stderr = '';
+        appProcess.stderr!.on('data', (data) => {
+          stderr += data;
+        });
+        const [code, signal] = await once(appProcess, 'exit');
+        appProcess = null;
+        const message = `run ${i}: code=${code} signal=${signal}\n${stderr}`;
+        expect(signal).to.equal(null, message);
+        expect(code).to.equal(123, message);
+        expect(stderr).to.not.match(/Received signal \d+|Ignoring extra certs/, message);
+      }
+    });
+
     ifit(['darwin', 'linux'].includes(process.platform))('exits gracefully', async function () {
       const electronPath = process.execPath;
       const appPath = path.join(fixturesPath, 'api', 'singleton');

--- a/spec/fixtures/api/exit-before-ready-after-tls/main.js
+++ b/spec/fixtures/api/exit-before-ready-after-tls/main.js
@@ -1,0 +1,8 @@
+// Loading tls starts Node's off-main-thread CA certificate loader. Exiting
+// straight away, before 'ready', used to race that thread against exit-time
+// static destruction and abort().
+require('node:tls');
+
+const { app } = require('electron');
+
+app.exit(123);

--- a/spec/fixtures/api/exit-before-ready-after-tls/package.json
+++ b/spec/fixtures/api/exit-before-ready-after-tls/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-exit-before-ready-after-tls",
+  "main": "main.js"
+}


### PR DESCRIPTION
Backport of #52856

See that PR for details.

Manual backport notes: include-order conflict only (`browser.cc`); `node::TearDownOncePerProcess()` exists in this branch's Node.

Notes: Fixed a possible crash (SIGABRT) during process exit when the process had loaded `tls`/`https` shortly before exiting, affecting `app.exit()` before `ready` and short-lived `ELECTRON_RUN_AS_NODE` / `child_process.fork()` scripts.
