### PR TITLE
ci: parallelize independent setup steps in build and test jobs

### DIFF
--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -125,12 +125,13 @@ jobs:
         CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
         AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Safe to background: it only deletes preinstalled toolchains/simulators that
+    # none of the setup steps below read; the wait-all before the src cache
+    # restore (the step that needs the freed disk) is a no-op on win/linux.
     - name: Free up space (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/free-space-macos
-    - name: Check disk space after freeing up space
-      if: ${{ inputs.target-platform == 'macos' }}
-      run: df -h
+      background: true
     - name: Setup Node.js/npm
       if: ${{ inputs.target-platform == 'macos' }}
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
@@ -140,9 +141,6 @@ jobs:
         cache-dependency-path: src/electron/yarn.lock
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
-    - name: Install AZCopy
-      if: ${{ inputs.target-platform == 'macos' }}
-      run: brew install azcopy
     - name: Set GN_EXTRA_ARGS for Linux
       if: ${{ inputs.target-platform == 'linux' }}
       run: |
@@ -168,6 +166,16 @@ jobs:
         DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
         echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
         echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
+    - name: Wait for space cleanup to finish
+      wait-all:
+    - name: Check disk space after freeing up space
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: df -h
+    # Must stay after the wait: free-space-macos runs brew uninstall/autoremove,
+    # which cannot overlap another brew invocation.
+    - name: Install AZCopy
+      if: ${{ inputs.target-platform == 'macos' }}
+      run: brew install azcopy
     - name: Restore src cache via AZCopy
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/restore-cache-azcopy

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -136,9 +136,7 @@ jobs:
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos
-      - name: Check disk space after freeing up space
-        if: ${{ inputs.target-platform == 'macos' }}
-        run: df -h
+        background: true
       - name: Setup Node.js/npm
         if: ${{ inputs.target-platform == 'macos' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
@@ -148,9 +146,6 @@ jobs:
           cache-dependency-path: src/electron/yarn.lock
       - name: Install Dependencies
         uses: ./src/electron/.github/actions/install-dependencies
-      - name: Install AZCopy
-        if: ${{ inputs.target-platform == 'macos' }}
-        run: brew install azcopy
       - name: Set GN_EXTRA_ARGS for Linux
         if: ${{ inputs.target-platform == 'linux' }}
         run: >
@@ -177,6 +172,14 @@ jobs:
           DEPSHASH=v2-src-cache-$(cat src/electron/.depshash)
           echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
           echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
+      - name: Wait for space cleanup to finish
+        wait-all: null
+      - name: Check disk space after freeing up space
+        if: ${{ inputs.target-platform == 'macos' }}
+        run: df -h
+      - name: Install AZCopy
+        if: ${{ inputs.target-platform == 'macos' }}
+        run: brew install azcopy
       - name: Restore src cache via AZCopy
         if: ${{ inputs.target-platform != 'linux' }}
         uses: ./src/electron/.github/actions/restore-cache-azcopy

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -164,42 +164,47 @@ jobs:
         CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
         AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install Dependencies
-      uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
-    - name: Get Depot Tools
-      timeout-minutes: 5
-      run: |
-        git config --global core.filemode false
-        git config --global core.autocrlf false
-        git config --global branch.autosetuprebase always
-        git config --global core.fscache true
-        git config --global core.longpaths true
-        git config --global core.preloadindex true
-        git config --global core.longpaths true
-        git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
-        # Ensure depot_tools does not update.
-        test -d depot_tools && cd depot_tools
-        touch .disable_auto_update
-    - name: Add Depot Tools to PATH
-      run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
     - name: Load ASan specific environment variables
       if: ${{ inputs.is-asan == true }}
       run: |
         echo "ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_asan" >> $GITHUB_ENV
         echo "DISABLE_CRASH_REPORTER_TESTS=true" >> $GITHUB_ENV
         echo "IS_ASAN=true" >> $GITHUB_ENV
-    - name: Download Generated Artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
-      with:
-        name: generated_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
-    - name: Download Src Artifacts
-      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
-      with:
-        name: src_artifacts_${{ env.ARTIFACT_KEY }}
-        path: ./src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
+    # Safe to parallelize: each step writes a disjoint location (src/electron
+    # node_modules, ./depot_tools, ./generated_artifacts_*, ./src_artifacts_*)
+    # and none reads another's output; the env/PATH changes they make are only
+    # consumed after the group's implicit wait.
+    - parallel:
+        - name: Install Dependencies
+          uses: ./src/electron/.github/actions/install-dependencies
+        - name: Get Depot Tools
+          timeout-minutes: 5
+          run: |
+            git config --global core.filemode false
+            git config --global core.autocrlf false
+            git config --global branch.autosetuprebase always
+            git config --global core.fscache true
+            git config --global core.longpaths true
+            git config --global core.preloadindex true
+            git config --global core.longpaths true
+            git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+            # Ensure depot_tools does not update.
+            test -d depot_tools && cd depot_tools
+            touch .disable_auto_update
+        - name: Download Generated Artifacts
+          uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+          with:
+            name: generated_artifacts_${{ env.ARTIFACT_KEY }}
+            path: ./generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
+        - name: Download Src Artifacts
+          uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+          with:
+            name: src_artifacts_${{ env.ARTIFACT_KEY }}
+            path: ./src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
+    - name: Add Depot Tools to PATH
+      run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
     - name: Restore Generated Artifacts
       run: ./src/electron/script/actions/restore-artifacts.sh
     - name: Unzip Dist (win)


### PR DESCRIPTION
Backport of #52721

See that PR for details.

Manual backport notes: the test-job `parallel:` group is built from this branch's own steps (its `download-artifact` pin; there is no CUPS printer step here). The build-segment hunks applied as-is and `script/copy-pipeline-segment-publish.js` regenerates the publish segment with no further diff.

Notes: none
