### PR TITLE
fix: shutdown crash when unregistering power notification on windows

### DIFF
--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -84,6 +84,9 @@ class PowerMonitor final : public gin_helper::DeprecatedWrappable<PowerMonitor>,
 
   // The window used for processing events.
   HWND window_;
+
+  // Handle returned by RegisterSuspendResumeNotification.
+  HPOWERNOTIFY power_notify_handle_ = nullptr;
 #endif
 
 #if BUILDFLAG(IS_LINUX)

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -45,14 +45,19 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
 
   // For Windows 8 and later, a new "connected standby" mode has been added and
   // we must explicitly register for its notifications.
-  RegisterSuspendResumeNotification(static_cast<HANDLE>(window_),
-                                    DEVICE_NOTIFY_WINDOW_HANDLE);
+  power_notify_handle_ = RegisterSuspendResumeNotification(
+      static_cast<HANDLE>(window_), DEVICE_NOTIFY_WINDOW_HANDLE);
+  PLOG_IF(ERROR, !power_notify_handle_)
+      << "RegisterSuspendResumeNotification failed";
 }
 
 void PowerMonitor::DestroyPlatformSpecificMonitors() {
   if (window_) {
     WTSUnRegisterSessionNotification(window_);
-    UnregisterSuspendResumeNotification(static_cast<HANDLE>(window_));
+    if (power_notify_handle_) {
+      UnregisterSuspendResumeNotification(power_notify_handle_);
+      power_notify_handle_ = nullptr;
+    }
     gfx::SetWindowUserData(window_, nullptr);
     DestroyWindow(window_);
     window_ = nullptr;
@@ -90,7 +95,8 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     }
     if (should_treat_as_current_session) {
       if (wparam == WTS_SESSION_LOCK) {
-        // SelfKeepAlive prevents GC of this object, so Unretained is safe.
+        // PowerMonitor is pinned for the lifetime of the process, so
+        // Unretained is safe.
         content::GetUIThreadTaskRunner({})->PostTask(
             FROM_HERE,
             base::BindOnce([](PowerMonitor* pm) { pm->Emit("lock-screen"); },


### PR DESCRIPTION
Backport of #50878

See that PR for details.

Manual backport notes: `PowerMonitor` is not cppgc-managed on 41-x-y, so only the actual fix is carried (keep the `HPOWERNOTIFY` returned by `RegisterSuspendResumeNotification` and unregister with it); the `SelfKeepAlive` removal and the cppgc heap-snapshot spec from the 42-x-y backport (#50893) don't apply here.

Notes: Fixed shutdown crash on windows when power monitor notifications were subscribed.
