### PR TITLE
fix: setting WCO rgba(0,0,0,0) color falling back to default value

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -234,12 +234,20 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 
   if (gin_helper::Dictionary od; options.Get(options::ktitleBarOverlay, &od)) {
     if (std::string val; od.Get(options::kOverlayButtonColor, &val)) {
-      bool success = content::ParseCssColorString(val, &overlay_button_color_);
+      SkColor overlay_button_color;
+      bool success = content::ParseCssColorString(val, &overlay_button_color);
       DCHECK(success);
+      if (success) {
+        overlay_button_color_ = overlay_button_color;
+      }
     }
     if (std::string val; od.Get(options::kOverlaySymbolColor, &val)) {
-      bool success = content::ParseCssColorString(val, &overlay_symbol_color_);
+      SkColor overlay_symbol_color;
+      bool success = content::ParseCssColorString(val, &overlay_symbol_color);
       DCHECK(success);
+      if (success) {
+        overlay_symbol_color_ = overlay_symbol_color;
+      }
     }
   }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -196,18 +196,22 @@ class NativeWindowViews : public NativeWindow,
   bool has_thick_frame() const { return thick_frame_; }
 #endif
 
-  SkColor overlay_button_color() const { return overlay_button_color_; }
-  SkColor overlay_symbol_color() const { return overlay_symbol_color_; }
+  std::optional<SkColor> overlay_button_color() const {
+    return overlay_button_color_;
+  }
+  std::optional<SkColor> overlay_symbol_color() const {
+    return overlay_symbol_color_;
+  }
 
 #if BUILDFLAG(IS_LINUX)
   LinuxFrameLayout* GetLinuxFrameLayout();
 #endif
 
  private:
-  void set_overlay_button_color(SkColor color) {
+  void set_overlay_button_color(std::optional<SkColor> color) {
     overlay_button_color_ = color;
   }
-  void set_overlay_symbol_color(SkColor color) {
+  void set_overlay_symbol_color(std::optional<SkColor> color) {
     overlay_symbol_color_ = color;
   }
 
@@ -287,8 +291,8 @@ class NativeWindowViews : public NativeWindow,
 #endif
 
   // The color to use as the theme and symbol colors respectively for WCO.
-  SkColor overlay_button_color_ = SkColor();
-  SkColor overlay_symbol_color_ = SkColor();
+  std::optional<SkColor> overlay_button_color_;
+  std::optional<SkColor> overlay_symbol_color_;
 
   // The last background color set via SetBackgroundColor(). Tracked because the
   // root view does not always reflect it (e.g. it is transparent for CSD

--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/views/opaque_frame_view.h"
 
+#include <optional>
+
 #include "base/containers/adapters.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_paint_utils_linux.h"  // nogncheck
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"  // nogncheck
@@ -248,10 +250,13 @@ void OpaqueFrameView::PaintAsActiveChanged() {
 
 void OpaqueFrameView::UpdateFrameCaptionButtons() {
   const bool active = ShouldPaintAsActive();
-  const SkColor symbol_color = window()->overlay_symbol_color();
-  const SkColor background_color = window()->overlay_button_color();
+  const SkColor symbol_color =
+      window()->overlay_symbol_color().value_or(SkColor());
+  const std::optional<SkColor> background_color =
+      window()->overlay_button_color();
+  // Frame color is used for blending, force it to be opaque
   SkColor frame_color =
-      background_color == SkColor() ? GetFrameColor() : background_color;
+      SkColorSetA(background_color.value_or(GetFrameColor()), SK_AlphaOPAQUE);
 
   for (views::Button* button :
        {minimize_button_, maximize_button_, restore_button_, close_button_}) {
@@ -267,8 +272,8 @@ void OpaqueFrameView::UpdateFrameCaptionButtons() {
 
 void OpaqueFrameView::UpdateCaptionButtonPlaceholderContainerBackground() {
   if (caption_button_placeholder_container_) {
-    const SkColor obc = window()->overlay_button_color();
-    const SkColor bg_color = obc == SkColor() ? GetFrameColor() : obc;
+    const std::optional<SkColor> obc = window()->overlay_button_color();
+    const SkColor bg_color = obc.value_or(GetFrameColor());
     caption_button_placeholder_container_->SetBackground(
         views::CreateSolidBackground(bg_color));
   }

--- a/shell/browser/ui/views/win_caption_button.cc
+++ b/shell/browser/ui/views/win_caption_button.cc
@@ -68,7 +68,8 @@ void WinCaptionButton::OnPaintBackground(gfx::Canvas* canvas) {
   // Paint the background of the button (the semi-transparent rectangle that
   // appears when you hover or press the button).
 
-  const SkColor bg_color = frame_view_->window()->overlay_button_color();
+  const SkColor bg_color =
+      frame_view_->window()->overlay_button_color().value_or(SkColor());
   const SkAlpha theme_alpha = SkColorGetA(bg_color);
 
   gfx::Rect bounds = GetContentsBounds();
@@ -159,7 +160,8 @@ int WinCaptionButton::GetButtonDisplayOrderIndex() const {
 }
 
 void WinCaptionButton::PaintSymbol(gfx::Canvas* canvas) {
-  SkColor symbol_color = frame_view_->window()->overlay_symbol_color();
+  SkColor symbol_color =
+      frame_view_->window()->overlay_symbol_color().value_or(SkColor());
 
   if (button_type_ == VIEW_ID_CLOSE_BUTTON &&
       hover_animation().is_animating()) {

--- a/shell/browser/ui/views/win_caption_button_container.cc
+++ b/shell/browser/ui/views/win_caption_button_container.cc
@@ -137,7 +137,8 @@ void WinCaptionButtonContainer::OnWidgetBoundsChanged(
 }
 
 void WinCaptionButtonContainer::UpdateBackground() {
-  const SkColor bg_color = frame_view_->window()->overlay_button_color();
+  const SkColor bg_color =
+      frame_view_->window()->overlay_button_color().value_or(SkColor());
   const SkAlpha theme_alpha = SkColorGetA(bg_color);
   SetBackground(views::CreateSolidBackground(bg_color));
   SetPaintToLayer();


### PR DESCRIPTION
Backport of #51017

See that PR for details.

Manual backport notes: same port as the 42-x-y backport (#52976): 41-x-y predates `ElectronFrameViewLinux` (#51161), so the Linux hunk is applied to the equivalent code in `OpaqueFrameView::UpdateFrameCaptionButtons()` / `UpdateCaptionButtonPlaceholderContainerBackground()`; `native_window_views.*` and Windows hunks identical to `main`.

Notes: Fixed titleBarOverlay.color set to `rgba(0,0,0,0)` failing back to default frame color.
