### PR TITLE
fix: remove 1px frame background color from the top of frameless windows on Linux

### DIFF
--- a/shell/browser/ui/views/opaque_frame_view.cc
+++ b/shell/browser/ui/views/opaque_frame_view.cc
@@ -226,7 +226,9 @@ void OpaqueFrameView::OnPaint(gfx::Canvas* canvas) {
   frame_background_->set_frame_color(GetFrameColor());
   frame_background_->set_use_custom_frame(true);
   frame_background_->set_is_active(active);
-  frame_background_->set_top_area_height(GetTopAreaHeight());
+  // Prevent the default system titlebar background from being drawn at the top
+  // of frameless windows. Does not affect WCO which draws its own top area.
+  frame_background_->set_top_area_height(0);
 
   const bool draw_shadow = showing_shadow && !linux_frame_layout_->tiled();
   auto shadow_values =


### PR DESCRIPTION
Backport of #52062

See that PR for details.

Manual backport notes: same port as the 42-x-y backport (#52978): frameless Linux windows use `OpaqueFrameView` on this branch, so the fix is applied in its `OnPaint()` (`set_top_area_height(0)`). Would appreciate @mitchchn confirming.

Notes: Fixed an issue on Linux where the system theme color appeared at the top edge of frameless windows.
