### PR TITLE
perf: cut first-window, ipc, contextBridge, Buffer and asar overhead (#52923)

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -650,6 +650,8 @@ filenames = {
     "shell/common/gin_converters/osr_converter.cc",
     "shell/common/gin_converters/osr_converter.h",
     "shell/common/gin_converters/serial_port_info_converter.h",
+    "shell/common/gin_converters/serialized_value_converter.cc",
+    "shell/common/gin_converters/serialized_value_converter.h",
     "shell/common/gin_converters/service_worker_converter.cc",
     "shell/common/gin_converters/service_worker_converter.h",
     "shell/common/gin_converters/std_converter.h",

--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -1008,21 +1008,27 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     }
   });
 
+  // Module resolution repeats most archive probes and an open archive's header
+  // never changes, so answers derived from it are kept (bounded).
+  const moduleStatCache = new Map<string, number>();
+  const kModuleStatCacheLimit = 16 * 1024;
   const { internalModuleStat } = binding;
   internalBinding('fs').internalModuleStat = (pathArgument: string) => {
     const pathInfo = splitPath(pathArgument);
     if (!pathInfo.isAsar) return internalModuleStat(pathArgument);
+    const cached = moduleStatCache.get(pathArgument);
+    if (cached !== undefined) return cached;
     const { asarPath, filePath } = pathInfo;
 
-    // -ENOENT
+    // -ENOENT; not cached, the archive may appear later.
     const archive = getOrCreateArchive(asarPath);
     if (!archive) return -34;
 
-    // -ENOENT
     const stats = archive.stat(filePath);
-    if (!stats) return -34;
-
-    return stats.type === AsarFileType.kDirectory ? 1 : 0;
+    const result = !stats ? -34 : stats.type === AsarFileType.kDirectory ? 1 : 0;
+    if (moduleStatCache.size >= kModuleStatCacheLimit) moduleStatCache.clear();
+    moduleStatCache.set(pathArgument, result);
+    return result;
   };
 
   const { kUsePromises } = binding;

--- a/shell/app/electron_main_linux.cc
+++ b/shell/app/electron_main_linux.cc
@@ -2,12 +2,17 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <cstdlib>
 
 #include "base/at_exit.h"
 #include "base/command_line.h"
 #include "base/compiler_specific.h"
+#include "base/files/scoped_file.h"
 #include "base/i18n/icu_util.h"
+#include "base/posix/eintr_wrapper.h"
 #include "base/strings/cstring_view.h"
 #include "content/public/app/content_main.h"
 #include "electron/fuses.h"
@@ -25,10 +30,20 @@ namespace {
   return indicator && *indicator;
 }
 
+// Linux grows the descriptor table in powers of two and, once the process has
+// threads, each expansion waits out an RCU grace period (tens of ms). Growing
+// it to 1024 entries now is free; content's zygote does the same for the
+// children it forks.
+void PreallocateFileDescriptorTable() {
+  base::ScopedFD high_fd(
+      HANDLE_EINTR(fcntl(STDIN_FILENO, F_DUPFD_CLOEXEC, 512)));
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
   FixStdioStreams();
+  PreallocateFileDescriptorTable();
 
   // Chromium expects the original argv in its original memory location
   // to update /proc/<pid>/cmdline.

--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -22,6 +22,7 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/handle.h"
@@ -129,7 +130,7 @@ void ServiceWorkerMain::Send(v8::Isolate* isolate,
                              bool internal,
                              const std::string& channel,
                              v8::Local<v8::Value> args) {
-  blink::CloneableMessage message;
+  electron::SerializedValue message;
   if (!gin::ConvertFromV8(isolate, args, &message)) {
     isolate->ThrowException(v8::Exception::Error(
         gin::StringToV8(isolate, "Failed to serialize arguments")));

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -27,6 +27,7 @@
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -317,7 +318,7 @@ void WebFrameMain::Send(v8::Isolate* isolate,
                         bool internal,
                         const std::string& channel,
                         v8::Local<v8::Value> args) {
-  blink::CloneableMessage message;
+  electron::SerializedValue message;
   if (!gin::ConvertFromV8(isolate, args, &message)) {
     isolate->ThrowException(v8::Exception::Error(
         gin::StringToV8(isolate, "Failed to serialize arguments")));

--- a/shell/browser/api/ipc_dispatcher.h
+++ b/shell/browser/api/ipc_dispatcher.h
@@ -12,7 +12,7 @@
 #include "shell/browser/api/message_port.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/api/api.mojom.h"
-#include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/handle.h"
@@ -31,14 +31,14 @@ class IpcDispatcher {
  public:
   void Message(v8::Local<v8::Object> event,
                const std::string& channel,
-               blink::CloneableMessage args) {
+               electron::SerializedValue args) {
     TRACE_EVENT1("electron", "IpcDispatcher::Message", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message", event, channel, args);
   }
 
   void Invoke(v8::Local<v8::Object> event,
               const std::string& channel,
-              blink::CloneableMessage arguments) {
+              electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::Invoke", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-invoke", event, channel,
                                 std::move(arguments));
@@ -61,7 +61,7 @@ class IpcDispatcher {
 
   void MessageSync(v8::Local<v8::Object> event,
                    const std::string& channel,
-                   blink::CloneableMessage arguments) {
+                   electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageSync", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message-sync", event, channel,
                                 std::move(arguments));
@@ -69,7 +69,7 @@ class IpcDispatcher {
 
   void MessageHost(v8::Local<v8::Object> event,
                    const std::string& channel,
-                   blink::CloneableMessage arguments) {
+                   electron::SerializedValue arguments) {
     TRACE_EVENT1("electron", "IpcDispatcher::MessageHost", "channel", channel);
     emitter()->EmitWithoutEvent("-ipc-message-host", event, channel,
                                 std::move(arguments));

--- a/shell/browser/electron_api_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_ipc_handler_impl.cc
@@ -43,7 +43,7 @@ void ElectronApiIPCHandlerImpl::OnConnectionError() {
 
 void ElectronApiIPCHandlerImpl::Message(bool internal,
                                         const std::string& channel,
-                                        blink::CloneableMessage arguments) {
+                                        electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -58,7 +58,7 @@ void ElectronApiIPCHandlerImpl::Message(bool internal,
 }
 void ElectronApiIPCHandlerImpl::Invoke(bool internal,
                                        const std::string& channel,
-                                       blink::CloneableMessage arguments,
+                                       electron::SerializedValue arguments,
                                        InvokeCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -93,7 +93,7 @@ void ElectronApiIPCHandlerImpl::ReceivePostMessage(
 
 void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
                                             const std::string& channel,
-                                            blink::CloneableMessage arguments,
+                                            electron::SerializedValue arguments,
                                             MessageSyncCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -109,8 +109,9 @@ void ElectronApiIPCHandlerImpl::MessageSync(bool internal,
   }
 }
 
-void ElectronApiIPCHandlerImpl::MessageHost(const std::string& channel,
-                                            blink::CloneableMessage arguments) {
+void ElectronApiIPCHandlerImpl::MessageHost(
+    const std::string& channel,
+    electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();

--- a/shell/browser/electron_api_ipc_handler_impl.h
+++ b/shell/browser/electron_api_ipc_handler_impl.h
@@ -43,19 +43,19 @@ class ElectronApiIPCHandlerImpl : public mojom::ElectronApiIPC,
   // mojom::ElectronApiIPC:
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void Invoke(bool internal,
               const std::string& channel,
-              blink::CloneableMessage arguments,
+              electron::SerializedValue arguments,
               InvokeCallback callback) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   blink::CloneableMessage arguments,
+                   electron::SerializedValue arguments,
                    MessageSyncCallback callback) override;
   void MessageHost(const std::string& channel,
-                   blink::CloneableMessage arguments) override;
+                   electron::SerializedValue arguments) override;
 
   base::WeakPtr<ElectronApiIPCHandlerImpl> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/shell/browser/electron_api_sw_ipc_handler_impl.cc
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.cc
@@ -70,7 +70,7 @@ void ElectronApiSWIPCHandlerImpl::RemoteDisconnected() {
 
 void ElectronApiSWIPCHandlerImpl::Message(bool internal,
                                           const std::string& channel,
-                                          blink::CloneableMessage arguments) {
+                                          electron::SerializedValue arguments) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -86,7 +86,7 @@ void ElectronApiSWIPCHandlerImpl::Message(bool internal,
 
 void ElectronApiSWIPCHandlerImpl::Invoke(bool internal,
                                          const std::string& channel,
-                                         blink::CloneableMessage arguments,
+                                         electron::SerializedValue arguments,
                                          InvokeCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
@@ -119,10 +119,11 @@ void ElectronApiSWIPCHandlerImpl::ReceivePostMessage(
   }
 }
 
-void ElectronApiSWIPCHandlerImpl::MessageSync(bool internal,
-                                              const std::string& channel,
-                                              blink::CloneableMessage arguments,
-                                              MessageSyncCallback callback) {
+void ElectronApiSWIPCHandlerImpl::MessageSync(
+    bool internal,
+    const std::string& channel,
+    electron::SerializedValue arguments,
+    MessageSyncCallback callback) {
   gin::WeakCell<api::Session>* session = GetSession();
   if (session && session->Get()) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
@@ -139,7 +140,7 @@ void ElectronApiSWIPCHandlerImpl::MessageSync(bool internal,
 
 void ElectronApiSWIPCHandlerImpl::MessageHost(
     const std::string& channel,
-    blink::CloneableMessage arguments) {
+    electron::SerializedValue arguments) {
   NOTIMPLEMENTED();  // Service workers have no <webview>
 }
 

--- a/shell/browser/electron_api_sw_ipc_handler_impl.h
+++ b/shell/browser/electron_api_sw_ipc_handler_impl.h
@@ -53,19 +53,19 @@ class ElectronApiSWIPCHandlerImpl : public mojom::ElectronApiIPC,
   // mojom::ElectronApiIPC:
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void Invoke(bool internal,
               const std::string& channel,
-              blink::CloneableMessage arguments,
+              electron::SerializedValue arguments,
               InvokeCallback callback) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   blink::CloneableMessage arguments,
+                   electron::SerializedValue arguments,
                    MessageSyncCallback callback) override;
   void MessageHost(const std::string& channel,
-                   blink::CloneableMessage arguments) override;
+                   electron::SerializedValue arguments) override;
 
   base::WeakPtr<ElectronApiSWIPCHandlerImpl> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/numerics/safe_conversions.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/file_url_loader.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -22,6 +23,7 @@
 #include "net/base/mime_util.h"
 #include "net/http/http_byte_range.h"
 #include "net/http/http_util.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/net/asar/asar_file_validator.h"
 #include "shell/common/asar/archive.h"
@@ -48,12 +50,16 @@ net::Error ConvertMojoResultToNetError(MojoResult result) {
   }
 }
 
-constexpr size_t kDefaultFileUrlPipeSize = 65536;
-
-// Because this makes things simpler.
-static_assert(kDefaultFileUrlPipeSize >= net::kMaxBytesToSniff,
-              "Default file data pipe size must be at least as large as a MIME-"
-              "type sniffing buffer.");
+// A pipe as large as the body up to what FileURLLoader uses for file://, so
+// small files do not pay for a 2 MB shared buffer and large ones are not fed
+// through in 64 KB slices. Never smaller than the MIME sniffing buffer, which
+// is written in one go.
+uint32_t ResponsePipeSize(uint64_t body_size) {
+  return base::saturated_cast<uint32_t>(std::clamp<uint64_t>(
+      body_size, net::kMaxBytesToSniff,
+      network::GetDataPipeDefaultAllocationSize(
+          network::DataPipeAllocationSize::kLargerSizeIfPossible)));
+}
 
 // Modified from the |FileURLLoader| in |file_url_loader_factory.cc|, to serve
 // asar files instead of normal files.
@@ -137,9 +143,40 @@ class AsarURLLoader : public network::mojom::URLLoader {
       info.offset = 0;
     }
 
+    auto range_header =
+        request.headers.GetHeader(net::HttpRequestHeaders::kRange);
+    net::HttpByteRange byte_range;
+    if (range_header) {
+      // Handle a simple Range header for a single range.
+      std::vector<net::HttpByteRange> ranges;
+      bool fail = false;
+      if (net::HttpUtil::ParseRangeHeader(range_header.value(), &ranges) &&
+          ranges.size() == 1) {
+        byte_range = ranges[0];
+        if (!byte_range.ComputeBounds(info.size))
+          fail = true;
+      } else {
+        fail = true;
+      }
+
+      if (fail) {
+        OnClientComplete(net::ERR_REQUEST_RANGE_NOT_SATISFIABLE);
+        return;
+      }
+    }
+
+    uint64_t first_byte_to_send = 0U;
+    uint64_t total_bytes_to_send = info.size;
+    if (byte_range.IsValid()) {
+      first_byte_to_send = byte_range.first_byte_position();
+      total_bytes_to_send =
+          byte_range.last_byte_position() - first_byte_to_send + 1;
+    }
+
     mojo::ScopedDataPipeProducerHandle producer_handle;
     mojo::ScopedDataPipeConsumerHandle consumer_handle;
-    if (mojo::CreateDataPipe(kDefaultFileUrlPipeSize, producer_handle,
+    if (mojo::CreateDataPipe(ResponsePipeSize(total_bytes_to_send),
+                             producer_handle,
                              consumer_handle) != MOJO_RESULT_OK) {
       OnClientComplete(net::ERR_FAILED);
       return;
@@ -187,37 +224,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
       return;
     }
 
-    auto range_header =
-        request.headers.GetHeader(net::HttpRequestHeaders::kRange);
-    net::HttpByteRange byte_range;
-    if (range_header) {
-      // Handle a simple Range header for a single range.
-      std::vector<net::HttpByteRange> ranges;
-      bool fail = false;
-      if (net::HttpUtil::ParseRangeHeader(range_header.value(), &ranges) &&
-          ranges.size() == 1) {
-        byte_range = ranges[0];
-        if (!byte_range.ComputeBounds(info.size))
-          fail = true;
-      } else {
-        fail = true;
-      }
-
-      if (fail) {
-        OnClientComplete(net::ERR_REQUEST_RANGE_NOT_SATISFIABLE);
-        return;
-      }
-    }
-
-    uint64_t first_byte_to_send = 0U;
     uint64_t total_bytes_dropped_from_head = initial_read_buffer.size();
-    uint64_t total_bytes_to_send = info.size;
-
-    if (byte_range.IsValid()) {
-      first_byte_to_send = byte_range.first_byte_position();
-      total_bytes_to_send =
-          byte_range.last_byte_position() - first_byte_to_send + 1;
-    }
 
     total_bytes_written_ = total_bytes_to_send;
 
@@ -225,8 +232,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
 
     if (first_byte_to_send < read_result.bytes_read) {
       // Write any data we read for MIME sniffing, constraining by range where
-      // applicable. This will always fit in the pipe (see assertion near
-      // |kDefaultFileUrlPipeSize| definition).
+      // applicable. This will always fit in the pipe (see ResponsePipeSize()).
       const size_t write_size = std::min(
           (read_result.bytes_read - first_byte_to_send), total_bytes_to_send);
       base::span<const uint8_t> bytes =

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/containers/fixed_flat_map.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
@@ -30,6 +31,7 @@
 #include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/cors/cors.h"
 #include "services/network/public/cpp/cors/cors_error_status.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
@@ -263,9 +265,18 @@ class URLPipeLoader : public network::mojom::URLLoader,
 
   void OnResponseStarted(const GURL& final_url,
                          const network::mojom::URLResponseHead& response_head) {
+    // The network service feeds this response through a 2 MB pipe; match it
+    // when the body is known to be that large instead of re-slicing to 64 KB.
+    const uint32_t pipe_size =
+        response_head.content_length > 0
+            ? base::saturated_cast<uint32_t>(std::min<int64_t>(
+                  response_head.content_length,
+                  network::GetDataPipeDefaultAllocationSize(
+                      network::DataPipeAllocationSize::kLargerSizeIfPossible)))
+            : 0;
     mojo::ScopedDataPipeProducerHandle producer;
     mojo::ScopedDataPipeConsumerHandle consumer;
-    MojoResult rv = mojo::CreateDataPipe(nullptr, producer, consumer);
+    MojoResult rv = mojo::CreateDataPipe(pipe_size, producer, consumer);
     if (rv != MOJO_RESULT_OK) {
       NotifyComplete(net::ERR_INSUFFICIENT_RESOURCES);
       return;
@@ -890,10 +901,13 @@ void ElectronURLLoaderFactory::SendContents(
   // Add header to ignore CORS.
   head->headers->AddHeader("Access-Control-Allow-Origin", "*");
 
-  // Code below follows the pattern of data_url_loader_factory.cc.
+  // Code below follows the pattern of data_url_loader_factory.cc, with the
+  // pipe sized to the body (up to the network service's default).
   mojo::ScopedDataPipeProducerHandle producer;
   mojo::ScopedDataPipeConsumerHandle consumer;
-  if (mojo::CreateDataPipe(nullptr, producer, consumer) != MOJO_RESULT_OK) {
+  const uint32_t pipe_size = base::saturated_cast<uint32_t>(std::clamp<size_t>(
+      data.size(), 1u, network::GetDataPipeDefaultAllocationSize()));
+  if (mojo::CreateDataPipe(pipe_size, producer, consumer) != MOJO_RESULT_OK) {
     client_remote->OnComplete(
         network::URLLoaderCompletionStatus(net::ERR_INSUFFICIENT_RESOURCES));
     return;

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -4,10 +4,13 @@
 
 #include "shell/browser/net/node_stream_loader.h"
 
+#include <algorithm>
 #include <string_view>
 #include <utility>
 
+#include "base/numerics/safe_conversions.h"
 #include "mojo/public/cpp/system/string_data_source.h"
+#include "services/network/public/cpp/loading_params.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/node_includes.h"
 
@@ -50,9 +53,19 @@ NodeStreamLoader::~NodeStreamLoader() {
 }
 
 void NodeStreamLoader::Start(network::mojom::URLResponseHeadPtr head) {
+  // A declared Content-Length larger than mojo's 64 KB default grows the pipe
+  // (up to the network service's default); it never shrinks it, since the
+  // header may describe an encoded upstream body rather than this stream.
+  constexpr int64_t kMojoDefaultPipeSize = 64 * 1024;
+  const uint32_t pipe_size =
+      head->content_length > kMojoDefaultPipeSize
+          ? base::saturated_cast<uint32_t>(
+                std::min<int64_t>(head->content_length,
+                                  network::GetDataPipeDefaultAllocationSize()))
+          : 0;
   mojo::ScopedDataPipeProducerHandle producer;
   mojo::ScopedDataPipeConsumerHandle consumer;
-  MojoResult rv = mojo::CreateDataPipe(nullptr, producer, consumer);
+  MojoResult rv = mojo::CreateDataPipe(pipe_size, producer, consumer);
   if (rv != MOJO_RESULT_OK) {
     NotifyComplete(net::ERR_INSUFFICIENT_RESOURCES);
     return;

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -1,7 +1,39 @@
 import("//mojo/public/tools/bindings/mojom.gni")
 
+source_set("serialized_value") {
+  sources = [
+    "serialized_value.cc",
+    "serialized_value.h",
+  ]
+  include_dirs = [ "//electron" ]
+  public_deps = [
+    "//base",
+    "//mojo/public/cpp/base",
+  ]
+}
+
 mojom("mojo") {
   sources = [ "api/api.mojom" ]
+
+  cpp_typemaps = [
+    {
+      types = [
+        {
+          mojom = "electron.mojom.SerializedValue"
+          cpp = "::electron::SerializedValue"
+          move_only = true
+        },
+      ]
+      traits_headers =
+          [ "//electron/shell/common/serialized_value_mojom_traits.h" ]
+      traits_sources =
+          [ "//electron/shell/common/serialized_value_mojom_traits.cc" ]
+      traits_public_deps = [
+        ":serialized_value",
+        "//mojo/public/cpp/base:shared_typemap_traits",
+      ]
+    },
+  ]
 
   public_deps = [
     "//mojo/public/mojom/base",

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -1,8 +1,8 @@
 module electron.mojom;
 
+import "mojo/public/mojom/base/big_buffer.mojom";
 import "mojo/public/mojom/base/string16.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
-import "third_party/blink/public/mojom/messaging/cloneable_message.mojom";
 import "third_party/blink/public/mojom/messaging/transferable_message.mojom";
 
 // A preload script and its contents, pushed to the renderer ahead of the
@@ -32,6 +32,13 @@ struct RendererStartupData {
   string helper_exec_path;
 };
 
+// A value serialized with electron::SerializeV8Value(), in the buffer it is
+// sent in. |buffer| may be larger than the |size| bytes that were written.
+struct SerializedValue {
+  mojo_base.mojom.BigBuffer buffer;
+  uint64 size;
+};
+
 // Per-frame associated interface ordered against content.mojom.Frame, so
 // SetStartupData() arrives before the CommitNavigation that follows it.
 interface ElectronFrameStartup {
@@ -42,7 +49,7 @@ interface ElectronRenderer {
   Message(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments);
+      SerializedValue arguments);
 
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
 
@@ -64,14 +71,14 @@ interface ElectronApiIPC {
   Message(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments);
+      SerializedValue arguments);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and returns the response.
   Invoke(
       bool internal,
       string channel,
-      blink.mojom.CloneableMessage arguments) => (blink.mojom.CloneableMessage result);
+      SerializedValue arguments) => (SerializedValue result);
 
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
 
@@ -81,9 +88,9 @@ interface ElectronApiIPC {
   MessageSync(
     bool internal,
     string channel,
-    blink.mojom.CloneableMessage arguments) => (blink.mojom.CloneableMessage result);
+    SerializedValue arguments) => (SerializedValue result);
 
   MessageHost(
     string channel,
-    blink.mojom.CloneableMessage arguments);
+    SerializedValue arguments);
 };

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -82,24 +83,62 @@ bool GetAsarArchivePath(const base::FilePath& full_path,
                         base::FilePath* asar_path,
                         base::FilePath* relative_path,
                         bool allow_root) {
-  base::FilePath iter = full_path;
+  using StringType = base::FilePath::StringType;
+  constexpr auto is_separator = &base::FilePath::IsSeparator;
+  const StringType& value = full_path.value();
+
+  // Walk the components from the deepest one up, the way repeated DirName()
+  // calls would, but on offsets into |value| instead of freshly built paths.
+  size_t end = value.size();
+  while (end > 0 && is_separator(value[end - 1]))
+    --end;
+  size_t component_end = end;
+  bool leaf = true;
   while (true) {
-    base::FilePath dirname = iter.DirName();
-    if (iter.MatchesExtension(kAsarExtension) && !IsDirectoryCached(iter))
-      break;
-    else if (iter == dirname)
+    size_t start = component_end;
+    while (start > 0 && !is_separator(value[start - 1]))
+      --start;
+    const auto component = base::FilePath::StringViewType{value}.substr(
+        start, component_end - start);
+    // ".asar" is five characters; MatchesExtension() decides the rest (case
+    // folding, dotfiles) exactly as it does for a whole path.
+    if (component.size() >= 5 &&
+        component[component.size() - 5] ==
+            base::FilePath::kExtensionSeparator &&
+        base::FilePath(component).MatchesExtension(kAsarExtension)) {
+      base::FilePath candidate =
+          leaf ? full_path : base::FilePath(value.substr(0, component_end));
+      if (!IsDirectoryCached(candidate)) {
+        if (leaf && !allow_root)
+          return false;
+        base::FilePath tail;
+        size_t pos = component_end;
+        while (pos < end) {
+          while (pos < end && is_separator(value[pos]))
+            ++pos;
+          size_t next = pos;
+          while (next < end && !is_separator(value[next]))
+            ++next;
+          if (next > pos) {
+            tail = tail.Append(
+                base::FilePath::StringViewType{value}.substr(pos, next - pos));
+          }
+          pos = next;
+        }
+        *asar_path = std::move(candidate);
+        *relative_path = std::move(tail);
+        return true;
+      }
+    }
+    if (start == 0)
       return false;
-    iter = dirname;
+    leaf = false;
+    component_end = start;
+    while (component_end > 0 && is_separator(value[component_end - 1]))
+      --component_end;
+    if (component_end == 0)
+      return false;
   }
-
-  base::FilePath tail;
-  if (!((allow_root && iter == full_path) ||
-        iter.AppendRelativePath(full_path, &tail)))
-    return false;
-
-  *asar_path = iter;
-  *relative_path = tail;
-  return true;
 }
 
 bool ReadFileToString(const base::FilePath& path, std::string* contents) {

--- a/shell/common/gin_converters/serialized_value_converter.cc
+++ b/shell/common/gin_converters/serialized_value_converter.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/gin_converters/serialized_value_converter.h"
+
+#include "shell/common/v8_util.h"
+
+namespace gin {
+
+v8::Local<v8::Value> Converter<electron::SerializedValue>::ToV8(
+    v8::Isolate* isolate,
+    const electron::SerializedValue& in) {
+  return electron::DeserializeV8Value(isolate, in);
+}
+
+bool Converter<electron::SerializedValue>::FromV8(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> val,
+    electron::SerializedValue* out) {
+  return electron::SerializeV8Value(isolate, val, out);
+}
+
+}  // namespace gin

--- a/shell/common/gin_converters/serialized_value_converter.h
+++ b/shell/common/gin_converters/serialized_value_converter.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_
+#define ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_
+
+#include "gin/converter.h"
+#include "shell/common/serialized_value.h"
+
+namespace gin {
+
+template <>
+struct Converter<electron::SerializedValue> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const electron::SerializedValue& in);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::SerializedValue* out);
+};
+
+}  // namespace gin
+
+#endif  // ELECTRON_SHELL_COMMON_GIN_CONVERTERS_SERIALIZED_VALUE_CONVERTER_H_

--- a/shell/common/gin_helper/reply_channel.cc
+++ b/shell/common/gin_helper/reply_channel.cc
@@ -7,7 +7,7 @@
 #include "gin/data_object_builder.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/javascript_environment.h"
-#include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "v8/include/cppgc/allocation.h"
 #include "v8/include/v8-cppgc.h"
@@ -46,7 +46,7 @@ bool ReplyChannel::SendReplyImpl(v8::Isolate* isolate,
   if (!callback)
     return false;
 
-  blink::CloneableMessage msg;
+  electron::SerializedValue msg;
   if (!gin::ConvertFromV8(isolate, arg, &msg))
     return false;
 

--- a/shell/common/serialized_value.cc
+++ b/shell/common/serialized_value.cc
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/serialized_value.h"
+
+#include <utility>
+
+#include "base/check_op.h"
+
+namespace electron {
+
+SerializedValue::SerializedValue() = default;
+
+SerializedValue::SerializedValue(mojo_base::BigBuffer buffer, size_t size)
+    : buffer_(std::move(buffer)), size_(size) {
+  CHECK_LE(size_, buffer_.size());
+}
+
+SerializedValue::SerializedValue(SerializedValue&& other)
+    : buffer_(std::move(other.buffer_)), size_(std::exchange(other.size_, 0)) {}
+
+SerializedValue& SerializedValue::operator=(SerializedValue&& other) {
+  buffer_ = std::move(other.buffer_);
+  size_ = std::exchange(other.size_, 0);
+  return *this;
+}
+
+SerializedValue::~SerializedValue() = default;
+
+}  // namespace electron

--- a/shell/common/serialized_value.h
+++ b/shell/common/serialized_value.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_
+#define ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "base/containers/span.h"
+#include "mojo/public/cpp/base/big_buffer.h"
+
+namespace electron {
+
+// A V8-serialized value held in the buffer it crosses the process boundary in:
+// inline bytes for small values, a shared memory region above
+// mojo_base::BigBuffer::kMaxInlineBytes. The region may be larger than the
+// payload; only the first size() bytes are meaningful.
+class SerializedValue {
+ public:
+  SerializedValue();
+  SerializedValue(mojo_base::BigBuffer buffer, size_t size);
+  SerializedValue(SerializedValue&&);
+  SerializedValue& operator=(SerializedValue&&);
+  SerializedValue(const SerializedValue&) = delete;
+  SerializedValue& operator=(const SerializedValue&) = delete;
+  ~SerializedValue();
+
+  base::span<const uint8_t> bytes() const {
+    return base::span(buffer_).first(size_);
+  }
+  size_t size() const { return size_; }
+  bool is_shared_memory() const {
+    return buffer_.storage_type() ==
+           mojo_base::BigBuffer::StorageType::kSharedMemory;
+  }
+
+  mojo_base::BigBuffer& buffer() { return buffer_; }
+
+ private:
+  mojo_base::BigBuffer buffer_;
+  size_t size_ = 0;
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_H_

--- a/shell/common/serialized_value_mojom_traits.cc
+++ b/shell/common/serialized_value_mojom_traits.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "electron/shell/common/serialized_value_mojom_traits.h"
+
+#include <utility>
+
+namespace mojo {
+
+// static
+bool StructTraits<electron::mojom::SerializedValueDataView,
+                  electron::SerializedValue>::
+    Read(electron::mojom::SerializedValueDataView data,
+         electron::SerializedValue* out) {
+  mojo_base::BigBuffer buffer;
+  if (!data.ReadBuffer(&buffer) || data.size() > buffer.size())
+    return false;
+  *out = electron::SerializedValue(std::move(buffer), data.size());
+  return true;
+}
+
+}  // namespace mojo

--- a/shell/common/serialized_value_mojom_traits.h
+++ b/shell/common/serialized_value_mojom_traits.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Anthropic GmbH.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_
+#define ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_
+
+#include <stdint.h>
+
+#include "electron/shell/common/api/api.mojom-shared.h"
+#include "electron/shell/common/serialized_value.h"
+#include "mojo/public/cpp/base/big_buffer.h"
+#include "mojo/public/cpp/base/big_buffer_mojom_traits.h"
+#include "mojo/public/cpp/bindings/struct_traits.h"
+
+namespace mojo {
+
+template <>
+struct StructTraits<electron::mojom::SerializedValueDataView,
+                    electron::SerializedValue> {
+  static mojo_base::BigBuffer& buffer(electron::SerializedValue& value) {
+    return value.buffer();
+  }
+  static uint64_t size(const electron::SerializedValue& value) {
+    return value.size();
+  }
+  static bool Read(electron::mojom::SerializedValueDataView data,
+                   electron::SerializedValue* out);
+};
+
+}  // namespace mojo
+
+#endif  // ELECTRON_SHELL_COMMON_SERIALIZED_VALUE_MOJOM_TRAITS_H_

--- a/shell/common/v8_util.cc
+++ b/shell/common/v8_util.cc
@@ -4,14 +4,19 @@
 
 #include "shell/common/v8_util.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <utility>
 #include <vector>
 
 #include "base/base_switches.h"
+#include "base/containers/heap_array.h"
 #include "base/memory/raw_ptr.h"
 #include "gin/converter.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "shell/common/api/electron_api_native_image.h"
+#include "shell/common/process_util.h"
+#include "shell/common/serialized_value.h"
 #include "skia/public/mojom/bitmap.mojom.h"
 #include "third_party/blink/public/common/messaging/cloneable_message.h"
 #include "third_party/blink/public/common/messaging/web_message_port.h"
@@ -44,30 +49,33 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   ~V8Serializer() override = default;
 
   bool Serialize(v8::Local<v8::Value> value, blink::CloneableMessage* out) {
-    v8::MicrotasksScope microtasks_scope(
-        isolate_->GetCurrentContext(),
-        v8::MicrotasksScope::kDoNotRunMicrotasks);
-    WriteBlinkEnvelope(19);
-
-    serializer_.WriteHeader();
-    bool wrote_value;
-    if (!serializer_.WriteValue(isolate_->GetCurrentContext(), value)
-             .To(&wrote_value)) {
-      isolate_->ThrowException(v8::Exception::Error(
-          gin::StringToV8(isolate_, "An object could not be cloned.")));
+    size_t length;
+    if (!Write(value, &length))
       return false;
-    }
-    DCHECK(wrote_value);
-
-    const auto [data_bytes, data_len] = serializer_.Release();
-    DCHECK_EQ(std::data(data_), data_bytes);
-    DCHECK_GE(std::size(data_), data_len);
-    data_.resize(data_len);
-    out->owned_encoded_message = std::move(data_);
+    heap_.resize(length);
+    out->owned_encoded_message = std::move(heap_);
     out->encoded_message = out->owned_encoded_message;
     out->sender_agent_cluster_id =
         blink::WebMessagePort::GetEmbedderAgentClusterID();
+    return true;
+  }
 
+  // Large values continue in the shared memory region they will be sent in.
+  // Only such a region may travel larger than the payload (its spare bytes are
+  // kernel-zeroed or this value's own); heap-backed results are trimmed.
+  bool Serialize(v8::Local<v8::Value> value, SerializedValue* out) {
+    use_transport_buffer_ = true;
+    size_t length;
+    if (!Write(value, &length))
+      return false;
+    if (transport_.size() == 0 ||
+        length <= mojo_base::BigBuffer::kMaxInlineBytes) {
+      base::span<const uint8_t> written =
+          transport_.size() ? base::span(transport_) : base::span(heap_);
+      mojo_base::BigBuffer exact(written.first(length));
+      transport_ = std::move(exact);
+    }
+    *out = SerializedValue(std::move(transport_), length);
     return true;
   }
 
@@ -75,15 +83,43 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   void* ReallocateBufferMemory(void* old_buffer,
                                size_t size,
                                size_t* actual_size) override {
-    DCHECK_EQ(old_buffer, data_.data());
-    data_.resize(size);
-    *actual_size = data_.capacity();
-    return data_.data();
+    base::span<const uint8_t> written =
+        transport_.size() ? base::span(transport_) : base::span(heap_);
+    // V8 asks for max(required, 2 * capacity) + 64, so a request beyond plain
+    // doubling tells how many bytes the value needs now; move to shared memory
+    // once that exceeds an inline message, and grow regions 4x after that.
+    const size_t needed = size > 2 * capacity_ + 64 ? size - 64 : capacity_ + 1;
+    if (use_transport_buffer_ &&
+        needed > mojo_base::BigBuffer::kMaxInlineBytes) {
+      mojo_base::BigBuffer bigger(std::max(size, 4 * capacity_));
+      // Only kernel-zeroed shared memory is adopted; if the region could not
+      // be created BigBuffer falls back to uninitialized heap, so stay on ours.
+      if (bigger.storage_type() ==
+          mojo_base::BigBuffer::StorageType::kSharedMemory) {
+        base::span(bigger).first(capacity_).copy_from(written.first(capacity_));
+        transport_ = std::move(bigger);
+        heap_ = {};
+        capacity_ = transport_.size();
+        *actual_size = capacity_;
+        return transport_.data();
+      }
+    }
+    if (transport_.size() != 0) {
+      base::span<const uint8_t> kept = written.first(capacity_);
+      std::vector<uint8_t> heap(kept.begin(), kept.end());
+      transport_ = {};
+      heap_ = std::move(heap);
+    }
+    heap_.resize(size);
+    capacity_ = heap_.size();
+    *actual_size = capacity_;
+    return heap_.data();
   }
 
   void FreeBufferMemory(void* buffer) override {
-    DCHECK_EQ(buffer, data_.data());
-    data_ = {};
+    heap_ = {};
+    transport_ = {};
+    capacity_ = 0;
   }
 
   v8::Maybe<bool> WriteHostObject(v8::Isolate* isolate,
@@ -114,6 +150,29 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   }
 
  private:
+  bool Write(v8::Local<v8::Value> value, size_t* length) {
+    v8::MicrotasksScope microtasks_scope(
+        isolate_->GetCurrentContext(),
+        v8::MicrotasksScope::kDoNotRunMicrotasks);
+    WriteBlinkEnvelope(19);
+
+    serializer_.WriteHeader();
+    bool wrote_value;
+    if (!serializer_.WriteValue(isolate_->GetCurrentContext(), value)
+             .To(&wrote_value)) {
+      isolate_->ThrowException(v8::Exception::Error(
+          gin::StringToV8(isolate_, "An object could not be cloned.")));
+      return false;
+    }
+    DCHECK(wrote_value);
+
+    const auto [data_bytes, data_len] = serializer_.Release();
+    DCHECK_EQ(data_bytes, transport_.size() ? transport_.data() : heap_.data());
+    DCHECK_LE(data_len, capacity_);
+    *length = data_len;
+    return true;
+  }
+
   void WriteTag(const uint8_t tag) { serializer_.WriteRawBytes(&tag, 1U); }
 
   void WriteBlinkEnvelope(uint32_t blink_version) {
@@ -124,7 +183,10 @@ class V8Serializer : public v8::ValueSerializer::Delegate {
   }
 
   raw_ptr<v8::Isolate> isolate_;
-  std::vector<uint8_t> data_;
+  std::vector<uint8_t> heap_;
+  mojo_base::BigBuffer transport_;
+  size_t capacity_ = 0;
+  bool use_transport_buffer_ = false;
   v8::ValueSerializer serializer_;
 };
 
@@ -240,9 +302,26 @@ bool SerializeV8Value(v8::Isolate* isolate,
   return V8Serializer(isolate).Serialize(value, out);
 }
 
+bool SerializeV8Value(v8::Isolate* isolate,
+                      v8::Local<v8::Value> value,
+                      SerializedValue* out) {
+  return V8Serializer(isolate).Serialize(value, out);
+}
+
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         const blink::CloneableMessage& in) {
   return V8Deserializer(isolate, in).Deserialize();
+}
+
+v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
+                                        const SerializedValue& in) {
+  // The process that sent a shared-memory payload can still write to it while
+  // it is parsed here; only renderers parse in place, everyone else a copy.
+  if (in.is_shared_memory() && !IsRendererProcess()) {
+    auto copy = base::HeapArray<uint8_t>::CopiedFrom(in.bytes());
+    return V8Deserializer(isolate, copy.as_span()).Deserialize();
+  }
+  return V8Deserializer(isolate, in.bytes()).Deserialize();
 }
 
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,

--- a/shell/common/v8_util.h
+++ b/shell/common/v8_util.h
@@ -22,11 +22,20 @@ struct CloneableMessage;
 
 namespace electron {
 
+class SerializedValue;
+
+// The CloneableMessage forms are for values that stay in this process or ride
+// inside a blink message; SerializedValue is what Electron's own IPC sends.
 bool SerializeV8Value(v8::Isolate* isolate,
                       v8::Local<v8::Value> value,
                       blink::CloneableMessage* out);
+bool SerializeV8Value(v8::Isolate* isolate,
+                      v8::Local<v8::Value> value,
+                      SerializedValue* out);
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         const blink::CloneableMessage& in);
+v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
+                                        const SerializedValue& in);
 v8::Local<v8::Value> DeserializeV8Value(v8::Isolate* isolate,
                                         base::span<const uint8_t> data);
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -4,6 +4,7 @@
 
 #include "shell/renderer/api/electron_api_context_bridge.h"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <set>
@@ -48,14 +49,16 @@ namespace api {
 
 namespace {
 
-constexpr std::string_view kProxyFunctionPrivateKey =
-    "electron_contextBridge_proxy_fn";
-constexpr std::string_view kProxyFunctionReceiverPrivateKey =
-    "electron_contextBridge_proxy_fn_receiver";
-constexpr std::string_view kSupportsDynamicPropertiesPrivateKey =
-    "electron_contextBridge_supportsDynamicProperties";
 constexpr std::string_view kOriginalFunctionPrivateKey =
     "electron_contextBridge_original_fn";
+
+// Slots of the array a proxy function carries as its v8::Function data.
+enum ProxyFunctionState : uint32_t {
+  kProxiedFunction = 0,
+  kProxiedFunctionReceiver,
+  kSupportsDynamicProperties,
+  kProxyFunctionStateLength,
+};
 
 static int kMaxRecursion = 1000;
 
@@ -161,7 +164,6 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     bool support_dynamic_properties,
     int recursion_depth,
     BridgeErrorTarget error_target) {
-  TRACE_EVENT0("electron", "ContextBridge::PassValueToOtherContextInner");
   if (recursion_depth >= kMaxRecursion) {
     v8::Context::Scope error_scope(error_target == BridgeErrorTarget::kSource
                                        ? source_context
@@ -214,14 +216,13 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
         return v8::MaybeLocal<v8::Value>(proxy_func);
       }
 
-      v8::Local<v8::Object> state = v8::Object::New(isolate);
-      SetPrivate(isolate, destination_context, state, kProxyFunctionPrivateKey,
-                 func);
-      SetPrivate(isolate, destination_context, state,
-                 kProxyFunctionReceiverPrivateKey, parent_value);
-      SetPrivate(isolate, destination_context, state,
-                 kSupportsDynamicPropertiesPrivateKey,
-                 gin::ConvertToV8(isolate, support_dynamic_properties));
+      v8::Local<v8::Value> slots[kProxyFunctionStateLength];
+      slots[kProxiedFunction] = func;
+      slots[kProxiedFunctionReceiver] = parent_value;
+      slots[kSupportsDynamicProperties] =
+          v8::Boolean::New(isolate, support_dynamic_properties);
+      v8::Local<v8::Array> state =
+          v8::Array::New(isolate, slots, kProxyFunctionStateLength);
 
       if (!v8::Function::New(destination_context, ProxyFunctionWrapper, state)
                .ToLocal(&proxy_func))
@@ -372,7 +373,8 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     v8::Context::Scope destination_context_scope(destination_context);
     v8::Local<v8::Array> arr = value.As<v8::Array>();
     size_t length = arr->Length();
-    v8::Local<v8::Array> cloned_arr = v8::Array::New(isolate, length);
+    v8::LocalVector<v8::Value> cloned(isolate);
+    cloned.reserve(length);
     for (size_t i = 0; i < length; i++) {
       auto value_for_array = PassValueToOtherContextInner(
           isolate, source_context, source_execution_context,
@@ -381,18 +383,18 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
           error_target);
       if (value_for_array.IsEmpty())
         return {};
-
-      if (!IsTrue(cloned_arr->Set(destination_context, static_cast<int>(i),
-                                  value_for_array.ToLocalChecked()))) {
-        return {};
-      }
+      cloned.push_back(value_for_array.ToLocalChecked());
     }
+    v8::Local<v8::Array> cloned_arr =
+        v8::Array::New(isolate, cloned.data(), cloned.size());
     object_cache->CacheProxiedObject(value, cloned_arr);
     return v8::MaybeLocal<v8::Value>(cloned_arr);
   }
 
-  // Clone certain DOM APIs only within Window contexts.
-  if (source_execution_context->IsWindow()) {
+  // Clone certain DOM APIs only within Window contexts. Only objects backed by
+  // an API template can be Blink wrappers, so plain objects skip the probes.
+  if (source_execution_context->IsWindow() && value->IsObject() &&
+      value.As<v8::Object>()->IsApiWrapper()) {
     // Custom logic to "clone" Element references
     blink::WebElement elem = blink::WebElement::FromV8Value(isolate, value);
     if (!elem.IsNull()) {
@@ -479,27 +481,24 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
 
 void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
   TRACE_EVENT0("electron", "ContextBridge::ProxyFunctionWrapper");
-  CHECK(info.Data()->IsObject());
-  v8::Local<v8::Object> data = info.Data().As<v8::Object>();
-  bool support_dynamic_properties = false;
+  CHECK(info.Data()->IsArray());
+  v8::Local<v8::Array> state = info.Data().As<v8::Array>();
   gin::Arguments args{info};
   v8::Isolate* const isolate = args.isolate();
   // Context the proxy function was called from
   v8::Local<v8::Context> calling_context = isolate->GetCurrentContext();
 
-  // Pull the original function and its context off of the data private key
-  v8::MaybeLocal<v8::Value> sdp_value = GetPrivate(
-      isolate, calling_context, data, kSupportsDynamicPropertiesPrivateKey);
-  v8::MaybeLocal<v8::Value> maybe_func =
-      GetPrivate(isolate, calling_context, data, kProxyFunctionPrivateKey);
-  v8::MaybeLocal<v8::Value> maybe_recv = GetPrivate(
-      isolate, calling_context, data, kProxyFunctionReceiverPrivateKey);
+  // Pull the original function and its receiver out of the state slots.
   v8::Local<v8::Value> func_value;
-  if (sdp_value.IsEmpty() || maybe_func.IsEmpty() || maybe_recv.IsEmpty() ||
-      !gin::ConvertFromV8(isolate, sdp_value.ToLocalChecked(),
-                          &support_dynamic_properties) ||
-      !maybe_func.ToLocal(&func_value))
+  v8::Local<v8::Value> recv;
+  v8::Local<v8::Value> sdp_value;
+  if (!state->Get(calling_context, kProxiedFunction).ToLocal(&func_value) ||
+      !state->Get(calling_context, kProxiedFunctionReceiver).ToLocal(&recv) ||
+      !state->Get(calling_context, kSupportsDynamicProperties)
+           .ToLocal(&sdp_value) ||
+      !func_value->IsFunction())
     return;
+  const bool support_dynamic_properties = sdp_value->IsTrue();
 
   v8::Local<v8::Function> func = func_value.As<v8::Function>();
   v8::Local<v8::Context> func_owning_context =
@@ -530,9 +529,8 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
     v8::Local<v8::Value> error_message;
     {
       v8::TryCatch try_catch(isolate);
-      maybe_return_value =
-          func->Call(func_owning_context, maybe_recv.ToLocalChecked(),
-                     proxied_args.size(), proxied_args.data());
+      maybe_return_value = func->Call(func_owning_context, recv,
+                                      proxied_args.size(), proxied_args.data());
       if (try_catch.HasCaught()) {
         did_error = true;
         v8::Local<v8::Value> exception = try_catch.Exception();
@@ -689,35 +687,30 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
         }
       }
 
+      v8::Local<v8::Value> value;
       {
         v8::Context::Scope source_context_scope(source_context);
-        v8::Local<v8::Value> value;
         if (!api.Get(key, &value))
           continue;
+      }
 
-        auto passed_value = PassValueToOtherContextInner(
-            isolate, source_context, source_execution_context,
-            destination_context, value, api.GetHandle(), object_cache,
-            support_dynamic_properties, recursion_depth + 1, error_target);
-        if (passed_value.IsEmpty())
-          return {};
+      auto passed_value = PassValueToOtherContextInner(
+          isolate, source_context, source_execution_context,
+          destination_context, value, api.GetHandle(), object_cache,
+          support_dynamic_properties, recursion_depth + 1, error_target);
+      if (passed_value.IsEmpty())
+        return {};
 
-        {
-          v8::Context::Scope inner_destination_context_scope(
-              destination_context);
-          // Use CreateDataProperty (not Set) so that a key named "__proto__"
-          // becomes an own data property instead of invoking the inherited
-          // Object.prototype.__proto__ setter and mutating the prototype.
-          v8::Local<v8::Value> proxied_value = passed_value.ToLocalChecked();
-          if (key->IsName()) {
-            std::ignore = proxy.GetHandle()->CreateDataProperty(
-                destination_context, key.As<v8::Name>(), proxied_value);
-          } else {
-            std::ignore = proxy.GetHandle()->CreateDataProperty(
-                destination_context, key.As<v8::Uint32>()->Value(),
-                proxied_value);
-          }
-        }
+      // Use CreateDataProperty (not Set) so that a key named "__proto__"
+      // becomes an own data property instead of invoking the inherited
+      // Object.prototype.__proto__ setter and mutating the prototype.
+      v8::Local<v8::Value> proxied_value = passed_value.ToLocalChecked();
+      if (key->IsName()) {
+        std::ignore = proxy.GetHandle()->CreateDataProperty(
+            destination_context, key.As<v8::Name>(), proxied_value);
+      } else {
+        std::ignore = proxy.GetHandle()->CreateDataProperty(
+            destination_context, key.As<v8::Uint32>()->Value(), proxied_value);
       }
     }
 

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -14,6 +14,7 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gc_plugin.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
@@ -22,6 +23,7 @@
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/serialized_value.h"
 #include "shell/common/v8_util.h"
 #include "shell/renderer/preload_realm_context.h"
 #include "shell/renderer/service_worker_data.h"
@@ -77,7 +79,7 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return;
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
@@ -93,18 +95,18 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return {};
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return {};
     }
-    gin_helper::Promise<blink::CloneableMessage> p(isolate);
+    gin_helper::Promise<electron::SerializedValue> p(isolate);
     auto handle = p.GetHandle();
 
     electron_ipc_remote_->Invoke(
         internal, channel, std::move(message),
         base::BindOnce(
-            [](gin_helper::Promise<blink::CloneableMessage> p,
-               blink::CloneableMessage result) { p.Resolve(result); },
+            [](gin_helper::Promise<electron::SerializedValue> p,
+               electron::SerializedValue result) { p.Resolve(result); },
             std::move(p)));
 
     return handle;
@@ -159,7 +161,7 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return;
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
@@ -175,12 +177,12 @@ class IPCBase : public gin::Wrappable<T> {
       thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
       return {};
     }
-    blink::CloneableMessage message;
+    electron::SerializedValue message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return {};
     }
 
-    blink::CloneableMessage result;
+    electron::SerializedValue result;
     electron_ipc_remote_->MessageSync(internal, channel, std::move(message),
                                       &result);
     return electron::DeserializeV8Value(isolate, result);

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -13,6 +13,7 @@
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/heap_snapshot.h"
 #include "shell/common/options_switches.h"
@@ -134,7 +135,7 @@ void ElectronApiServiceImpl::OnConnectionError() {
 
 void ElectronApiServiceImpl::Message(bool internal,
                                      const std::string& channel,
-                                     blink::CloneableMessage arguments) {
+                                     electron::SerializedValue arguments) {
   blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
   if (!frame)
     return;

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -42,7 +42,7 @@ class ElectronApiServiceImpl
   // mojom::ElectronRenderer
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,

--- a/shell/renderer/service_worker_data.cc
+++ b/shell/renderer/service_worker_data.cc
@@ -6,6 +6,7 @@
 
 #include "base/notimplemented.h"
 #include "shell/common/gin_converters/blink_converter.h"
+#include "shell/common/gin_converters/serialized_value_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/heap_snapshot.h"
 #include "shell/renderer/electron_ipc_native.h"
@@ -38,7 +39,7 @@ void ServiceWorkerData::OnElectronRendererRequest(
 
 void ServiceWorkerData::Message(bool internal,
                                 const std::string& channel,
-                                blink::CloneableMessage arguments) {
+                                electron::SerializedValue arguments) {
   v8::Isolate* isolate = isolate_.get();
   v8::HandleScope handle_scope(isolate);
 

--- a/shell/renderer/service_worker_data.h
+++ b/shell/renderer/service_worker_data.h
@@ -53,7 +53,7 @@ class ServiceWorkerData : public mojom::ElectronRenderer {
   // mojom::ElectronRenderer
   void Message(bool internal,
                const std::string& channel,
-               blink::CloneableMessage arguments) override;
+               electron::SerializedValue arguments) override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -144,6 +144,70 @@ describe('ipc module', () => {
     });
   });
 
+  describe('payloads across the shared-memory threshold', () => {
+    let w: BrowserWindow;
+    const sizes = [0, 1, 65535, 65536, 65537, 256 * 1024 + 3, 3 * 1024 * 1024 + 1];
+
+    before(async () => {
+      w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+      await w.loadURL('about:blank');
+      ipcMain.handle('echo-large', (_e, arg) => arg);
+      ipcMain.on('echo-large-sync', (e, arg) => {
+        e.returnValue = arg;
+      });
+      ipcMain.on('echo-large-send', (e, arg) => {
+        e.sender.send('echo-large-reply', arg);
+      });
+    });
+    after(async () => {
+      w.destroy();
+      ipcMain.removeHandler('echo-large');
+      ipcMain.removeAllListeners('echo-large-sync');
+      ipcMain.removeAllListeners('echo-large-send');
+    });
+
+    function digest(value: any): any {
+      if (typeof value === 'string') return { string: value.length, ends: value.slice(0, 4) + value.slice(-4) };
+      if (value instanceof Uint8Array) {
+        return { u8: value.length, sum: value.reduce((a: number, b: number) => (a + b) % 65521, 0) };
+      }
+      return { text: digest(value.text), bytes: digest(value.bytes), meta: value.meta };
+    }
+
+    function samples(n: number) {
+      const text = `<${'x'.repeat(n)}>`;
+      const bytes = new Uint8Array(n).map((_, i) => (i * 7) & 255);
+      return [text, bytes, { text, bytes, meta: { n, list: [1, 'two', { three: true }] } }];
+    }
+
+    it('round trips strings, typed arrays and nested objects of each size through invoke, sendSync and send', async () => {
+      const result = await w.webContents.executeJavaScript(
+        `(${async (sizes: number[], samples: (n: number) => any[], digest: (v: any) => any) => {
+          const { ipcRenderer } = require('electron');
+          const out: any[] = [];
+          for (const n of sizes) {
+            for (const value of samples(n)) {
+              out.push(digest(await ipcRenderer.invoke('echo-large', value)));
+              out.push(digest(ipcRenderer.sendSync('echo-large-sync', value)));
+              out.push(
+                digest(
+                  await new Promise((resolve) => {
+                    ipcRenderer.once('echo-large-reply', (_e: any, v: any) => resolve(v));
+                    ipcRenderer.send('echo-large-send', value);
+                  })
+                )
+              );
+            }
+          }
+          return out;
+        }})(${JSON.stringify(sizes)}, ${samples}, ${digest})`,
+        true
+      );
+      const expected = sizes.flatMap((n) => samples(n).flatMap((value) => Array(3).fill(digest(value))));
+      expect(result).to.deep.equal(expected);
+    });
+  });
+
   describe('ordering', () => {
     let w: BrowserWindow;
 

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1733,6 +1733,44 @@ describe('asar package', function () {
       });
     });
 
+    describe('splitPath', function () {
+      itremote('splits at the deepest .asar file component and normalizes the relative part', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        const archive = path.join(asarDir, 'a.asar');
+        expect(splitPath(path.join(archive, 'dir1', 'file1'))).to.deep.equal({
+          isAsar: true,
+          asarPath: archive,
+          filePath: ['dir1', 'file1'].join(path.sep)
+        });
+        expect(
+          splitPath(archive + path.sep + path.sep + 'dir1' + path.sep + path.sep + 'file1' + path.sep)
+        ).to.deep.equal({ isAsar: true, asarPath: archive, filePath: ['dir1', 'file1'].join(path.sep) });
+        expect(splitPath(path.join(archive, 'nested.asar', 'x'))).to.deep.equal({
+          isAsar: true,
+          asarPath: path.join(archive, 'nested.asar'),
+          filePath: 'x'
+        });
+        expect(splitPath(archive)).to.deep.equal({ isAsar: true, asarPath: archive, filePath: '' });
+      });
+
+      itremote('does not treat a real directory named like an archive as an archive', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        expect(splitPath(path.join(asarDir, 'file'))).to.deep.equal({ isAsar: false });
+        expect(splitPath(asarDir)).to.deep.equal({ isAsar: false });
+        expect(splitPath(path.join(fixtures, 'module', 'noop.js'))).to.deep.equal({ isAsar: false });
+      });
+
+      itremote('matches the archive extension the same way base::FilePath does', function () {
+        const { splitPath } = process._linkedBinding('electron_common_asar');
+        const dir = path.join(fixtures, 'module');
+        expect(splitPath(path.join(dir, 'X.ASAR', 'y')).isAsar).to.equal(true);
+        expect(splitPath(path.join(dir, '.asar', 'y')).isAsar).to.equal(true);
+        expect(splitPath(path.join(dir, 'x.asar.gz', 'y')).isAsar).to.equal(false);
+        expect(splitPath(path.join(dir, 'x.asarx', 'y')).isAsar).to.equal(false);
+        expect(splitPath(path.join(dir, 'asar', 'y')).isAsar).to.equal(false);
+      });
+    });
+
     describe('process.noAsar', function () {
       const errorName = process.platform === 'win32' ? 'ENOENT' : 'ENOTDIR';
 


### PR DESCRIPTION
Backport of #52923

See that PR for details. Trop could not cherry-pick it cleanly; the only conflicts were include lists that main has since pruned (#52469, #52566), and clang-format's older line breaking. The in-sandbox ArrayBuffer allocator commit ("give V8's in-sandbox allocator a PartitionAlloc backend outside renderers") is left out here: it installs itself through `v8::V8::SetInSandboxAllocator()`, which V8 only gained in the version that ships with 44-x-y, so `Buffer.allocUnsafe()` keeps its current cost on this line.

Notes:
* Fixed a stall of tens of milliseconds while creating the first `BrowserWindow` on Linux.
* Improved the performance of file lookups inside ASAR archives and of large files served from them to the renderer.
* Improved the performance of calls through `contextBridge`-exposed APIs.
* Reduced the main-thread cost of sending large values through `ipcRenderer`, `ipcMain` handlers and `webContents.send`.
