### PR TITLE
build: enable Clang Static Analyzer clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,13 @@
 ---
-Checks: '-modernize-use-nullptr'
+Checks: '-modernize-use-nullptr,
+         clang-analyzer-core.*,
+         clang-analyzer-cplusplus.*,
+         clang-analyzer-deadcode.*,
+         clang-analyzer-nullability.*,
+         clang-analyzer-osx.*,
+         clang-analyzer-security.*,
+         clang-analyzer-unix.*,
+         -clang-analyzer-core.CallAndMessage,
+         -clang-analyzer-security.PointerSub'
 InheritParentConfig: true
 ...

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -340,9 +340,12 @@ std::optional<int> ElectronMainDelegate::PreBrowserMain() {
   // flags and we need to make sure the feature list is initialized before the
   // service manager reads the features.
   if (!base::FieldTrialList::GetInstance()) {
-    base::FieldTrialList* leaked_field_trial_list = new base::FieldTrialList();
+    // Intentionally never destroyed: the FieldTrialList has to outlive
+    // everything that reads field trials. Storing it in a static keeps the
+    // allocation reachable, both for static analysis and for LeakSanitizer.
+    [[maybe_unused]] static base::FieldTrialList* leaked_field_trial_list =
+        new base::FieldTrialList();
     ANNOTATE_LEAKING_OBJECT_PTR(leaked_field_trial_list);
-    std::ignore = leaked_field_trial_list;
   }
   InitializeFeatureList();
   // Initialize mojo core as soon as we have a valid feature list

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1888,14 +1888,11 @@ void ConfigureHostResolver(v8::Isolate* isolate,
 
 // static
 App* App::Get() {
-  return Create(nullptr);
-}
-
-// static
-App* App::Create(v8::Isolate* isolate) {
-  static base::NoDestructor<cppgc::Persistent<App>> instance(
-      cppgc::MakeGarbageCollected<App>(
-          isolate->GetCppHeap()->GetAllocationHandle()));
+  static base::NoDestructor<cppgc::Persistent<App>> instance([] {
+    v8::Isolate* const isolate = JavascriptEnvironment::GetIsolate();
+    return cppgc::Persistent<App>(cppgc::MakeGarbageCollected<App>(
+        isolate->GetCppHeap()->GetAllocationHandle()));
+  }());
   return instance->Get();
 }
 
@@ -2102,7 +2099,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* const isolate = electron::JavascriptEnvironment::GetIsolate();
   gin_helper::Dictionary dict{isolate, exports};
-  dict.Set("app", electron::api::App::Create(isolate));
+  dict.Set("app", electron::api::App::Get());
 }
 
 }  // namespace

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -101,6 +101,7 @@
 
 #if BUILDFLAG(IS_MAC)
 #include <CoreFoundation/CoreFoundation.h>
+#include "base/apple/scoped_cftyperef.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/browser/mac_helpers.h"
@@ -1006,9 +1007,9 @@ std::string App::GetLocaleCountryCode() {
     base::WideToUTF8(locale_name, wcslen(locale_name), &region);
   }
 #elif BUILDFLAG(IS_MAC)
-  CFLocaleRef locale = CFLocaleCopyCurrent();
-  auto value =
-      static_cast<CFStringRef>(CFLocaleGetValue(locale, kCFLocaleCountryCode));
+  base::apple::ScopedCFTypeRef<CFLocaleRef> locale(CFLocaleCopyCurrent());
+  auto value = static_cast<CFStringRef>(
+      CFLocaleGetValue(locale.get(), kCFLocaleCountryCode));
   if (value != nil) {
     char temporaryCString[3];
     const CFIndex kCStringSize = sizeof(temporaryCString);

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -64,7 +64,6 @@ class App final : public gin::Wrappable<App>,
                   private content::GpuDataManagerObserver,
                   private content::BrowserChildProcessObserver {
  public:
-  static App* Create(v8::Isolate* isolate);
   static App* Get();
 
   // gin::Wrappable

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -409,7 +409,7 @@ void SystemPreferences::SetUserDefault(const std::string& name,
 }
 
 std::string SystemPreferences::GetAccentColor() {
-  NSColor* sysColor = sysColor = [NSColor controlAccentColor];
+  NSColor* sysColor = [NSColor controlAccentColor];
   return ToRGBAHex(NSSystemColorToSkColor(sysColor), false /* include_hash */);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1487,7 +1487,12 @@ content::WebContents* WebContents::AddNewContents(
            window_features.bounds.width(), window_features.bounds.height(),
            tracker->url, tracker->frame_name, tracker->referrer,
            tracker->raw_features, tracker->body)) {
-    api_web_contents->Destroy();
+    // Destroy() may synchronously `delete this`, so drop the handle's
+    // reference first. Otherwise it is left dangling until the handle goes
+    // out of scope below.
+    auto* contents = api_web_contents.get();
+    api_web_contents.Clear();
+    contents->Destroy();
   }
 
   return nullptr;

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -244,7 +244,7 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   // Optional userGesture parameter
-  bool user_gesture;
+  bool user_gesture = false;
   if (!args->PeekNext().IsEmpty()) {
     if (args->PeekNext()->IsBoolean()) {
       args->GetNext(&user_gesture);
@@ -252,8 +252,6 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
       args->ThrowTypeError("userGesture must be a boolean");
       return handle;
     }
-  } else {
-    user_gesture = false;
   }
 
   if (render_frame_disposed_) {

--- a/shell/browser/auto_updater_mac.mm
+++ b/shell/browser/auto_updater_mac.mm
@@ -64,9 +64,19 @@ void AutoUpdater::SetFeedURL(gin::Arguments* const args) {
   if (!delegate)
     return;
 
-  GetFeedURL() = feed;
+  NSString* feed_string = base::SysUTF8ToNSString(feed);
+  if (!feed_string) {
+    args->ThrowTypeError("Expected 'url' to be a valid URL");
+    return;
+  }
 
-  NSURL* url = [NSURL URLWithString:base::SysUTF8ToNSString(feed)];
+  NSURL* url = [NSURL URLWithString:feed_string];
+  if (!url) {
+    args->ThrowTypeError("Expected 'url' to be a valid URL");
+    return;
+  }
+
+  GetFeedURL() = feed;
   NSMutableURLRequest* urlRequest = [NSMutableURLRequest requestWithURL:url];
 
   for (const auto& it : requestHeaders) {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1275,7 +1275,7 @@ class FileURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
     base::MakeSelfDeleting<FileURLLoaderFactory>(
         child_id, pending_remote.InitWithNewPipeAndPassReceiver());
 
-    return pending_remote;
+    return pending_remote;  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
   }
 
   // disable copy

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -141,8 +141,8 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
 #endif
               restorationHandler {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
-  NSURL* url = userActivity.webpageURL;
-  NSDictionary* details = url ? @{@"webpageURL" : url.absoluteString} : @{};
+  NSString* webpage_url = userActivity.webpageURL.absoluteString;
+  NSDictionary* details = webpage_url ? @{@"webpageURL" : webpage_url} : @{};
   NSDictionary* user_info = userActivity.userInfo ?: @{};
 
   electron::Browser* browser = electron::Browser::Get();

--- a/shell/browser/mac/in_app_purchase.mm
+++ b/shell/browser/mac/in_app_purchase.mm
@@ -168,9 +168,11 @@ void FinishTransactionByDate(const std::string& date) {
 
   for (SKPaymentTransaction* transaction in SKPaymentQueue.defaultQueue
            .transactions) {
+    NSDate* purchaseDate = transaction.transactionDate;
+    if (!purchaseDate)
+      continue;
     if ([transactionDate
-            isEqualToString:[dateFormatter
-                                stringFromDate:transaction.transactionDate]]) {
+            isEqualToString:[dateFormatter stringFromDate:purchaseDate]]) {
       [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
     }
   }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -412,8 +412,8 @@ void NativeWindowMac::Close() {
   // even after the user has ended the sheet.
   // Ensure it's closed before calling [window_ performClose:nil].
   // If multiple sheets are open, they must all be closed.
-  while ([window_ attachedSheet]) {
-    [window_ endSheet:[window_ attachedSheet]];
+  while (NSWindow* sheet = [window_ attachedSheet]) {
+    [window_ endSheet:sheet];
   }
   DCHECK_EQ([[window_ sheets] count], 0UL);
 
@@ -509,8 +509,8 @@ void NativeWindowMac::Hide() {
   // If a sheet is attached to the window when we call [window_ orderOut:nil],
   // the sheet won't be able to show again on the same window.
   // Ensure it's closed before calling [window_ orderOut:nil].
-  if ([window_ attachedSheet])
-    [window_ endSheet:[window_ attachedSheet]];
+  if (NSWindow* sheet = [window_ attachedSheet])
+    [window_ endSheet:sheet];
 
   if (is_modal() && parent()) {
     [window_ orderOut:nil];
@@ -556,8 +556,8 @@ void NativeWindowMac::SetEnabled(bool enable) {
           NSLog(@"main window disabled");
           return;
         }];
-  } else if ([window_ attachedSheet]) {
-    [window_ endSheet:[window_ attachedSheet]];
+  } else if (NSWindow* sheet = [window_ attachedSheet]) {
+    [window_ endSheet:sheet];
   }
 }
 

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/compiler_specific.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/file_url_loader.h"
@@ -76,6 +77,8 @@ class AsarURLLoader : public network::mojom::URLLoader {
     auto* asar_url_loader = new AsarURLLoader;
     asar_url_loader->Start(request, std::move(loader), std::move(client),
                            std::move(extra_response_headers));
+    // Tell analyzer to ignore the leak of the self-owned AsarURLLoader
+    ANALYZER_SKIP_THIS_PATH();
   }
 
   // network::mojom::URLLoader:

--- a/shell/browser/net/asar/asar_url_loader_factory.cc
+++ b/shell/browser/net/asar/asar_url_loader_factory.cc
@@ -21,7 +21,7 @@ AsarURLLoaderFactory::Create() {
   base::MakeSelfDeleting<AsarURLLoaderFactory>(
       pending_remote.InitWithNewPipeAndPassReceiver());
 
-  return pending_remote;
+  return pending_remote;  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 AsarURLLoaderFactory::AsarURLLoaderFactory(

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -486,7 +486,7 @@ ElectronURLLoaderFactory::Create(
       type, handler, std::move(browser_context),
       pending_remote.InitWithNewPipeAndPassReceiver());
 
-  return pending_remote;
+  return pending_remote;  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
 ElectronURLLoaderFactory::ElectronURLLoaderFactory(

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -515,27 +515,6 @@ ui::Compositor* OffScreenRenderWidgetHostView::GetCompositor() {
   return compositor_.get();
 }
 
-content::RenderWidgetHostViewBase*
-OffScreenRenderWidgetHostView::CreateViewForWidget(
-    content::RenderWidgetHost* render_widget_host,
-    content::RenderWidgetHost* embedder_render_widget_host,
-    content::WebContentsView* web_contents_view) {
-  if (auto* rwhv = render_widget_host->GetView())
-    return static_cast<content::RenderWidgetHostViewBase*>(rwhv);
-
-  OffScreenRenderWidgetHostView* embedder_host_view = nullptr;
-  if (embedder_render_widget_host) {
-    embedder_host_view = static_cast<OffScreenRenderWidgetHostView*>(
-        embedder_render_widget_host->GetView());
-  }
-
-  return new OffScreenRenderWidgetHostView(
-      transparent_, offscreen_use_shared_texture_,
-      offscreen_shared_texture_pixel_format_, offscreen_device_scale_factor_,
-      true, embedder_host_view->frame_rate(), callback_, render_widget_host,
-      embedder_host_view, size());
-}
-
 const viz::FrameSinkId& OffScreenRenderWidgetHostView::GetFrameSinkId() const {
   return delegated_frame_host()->frame_sink_id();
 }

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -23,7 +23,6 @@
 #include "content/browser/renderer_host/input/mouse_wheel_phase_handler.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
-#include "content/browser/web_contents/web_contents_view.h"  // nogncheck
 #include "shell/browser/osr/osr_paint_event.h"
 #include "shell/browser/osr/osr_view_proxy.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
@@ -165,11 +164,6 @@ class OffScreenRenderWidgetHostView
   gfx::Size GetCompositorViewportPixelSize() override;
   ui::Compositor* GetCompositor() override;
   display::ScreenInfos GetNewScreenInfosForUpdate() override;
-
-  content::RenderWidgetHostViewBase* CreateViewForWidget(
-      content::RenderWidgetHost*,
-      content::RenderWidgetHost*,
-      content::WebContentsView*);
 
   const viz::LocalSurfaceId& GetLocalSurfaceId() const override;
   const viz::FrameSinkId& GetFrameSinkId() const override;

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/osr/osr_web_contents_view.h"
 
+#include "base/check.h"
 #include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
@@ -142,6 +143,7 @@ OffScreenWebContentsView::CreateViewForChildWidget(
     embedder_host_view = static_cast<OffScreenRenderWidgetHostView*>(
         web_contents_impl->GetRenderWidgetHostView());
   }
+  CHECK(embedder_host_view);
 
   return new OffScreenRenderWidgetHostView(
       transparent_, offscreen_use_shared_texture_,

--- a/shell/browser/ui/cocoa/electron_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/electron_bundle_mover.mm
@@ -51,15 +51,16 @@ NSString* ContainingDiskImageDevice(NSString* bundlePath) {
       stringWithFileSystemRepresentation:fs.f_mntfromname
                                   length:strlen(fs.f_mntfromname)];
 
+  NSPipe* stdoutPipe = [NSPipe pipe];
+
   NSTask* hdiutil = [[NSTask alloc] init];
   [hdiutil setLaunchPath:@"/usr/bin/hdiutil"];
   [hdiutil setArguments:[NSArray arrayWithObjects:@"info", @"-plist", nil]];
-  [hdiutil setStandardOutput:[NSPipe pipe]];
+  [hdiutil setStandardOutput:stdoutPipe];
   [hdiutil launch];
   [hdiutil waitUntilExit];
 
-  NSData* data =
-      [[[hdiutil standardOutput] fileHandleForReading] readDataToEndOfFile];
+  NSData* data = [[stdoutPipe fileHandleForReading] readDataToEndOfFile];
 
   NSDictionary* info =
       [NSPropertyListSerialization propertyListWithData:data

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -260,6 +260,8 @@ NSArray* ConvertSharingItemToNS(const SharingItem& item) {
   const NSInteger count = source.numberOfItems;
   for (NSInteger index = 0; index < count; index++) {
     NSMenuItem* removedItem = [source itemAtIndex:0];
+    if (!removedItem)
+      return;
     [source removeItemAtIndex:0];
     [destination addItem:removedItem];
   }

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -140,6 +140,8 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
       class_getInstanceMethod([view class], @selector(swipeWithEvent:));
   Method new_swipe_with_event =
       class_getInstanceMethod([SwizzledMethodsClass class], swiz_selector);
+  CHECK(original_swipe_with_event);
+  CHECK(new_swipe_with_event);
   method_setImplementation(original_swipe_with_event,
                            method_getImplementation(new_swipe_with_event));
 }

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -777,7 +777,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
              viewForItemAtIndex:(NSInteger)index {
   std::string s_id = base::SysNSStringToUTF8(scrubber.identifier);
   if (![self hasItemWithID:s_id])
-    return nil;
+    return [[NSScrubberItemView alloc] initWithFrame:NSZeroRect];
 
   v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
@@ -785,33 +785,32 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   gin_helper::PersistentDictionary settings = settings_[s_id];
   std::vector<gin_helper::PersistentDictionary> items;
   if (!settings.Get("items", &items))
-    return nil;
+    return [[NSScrubberItemView alloc] initWithFrame:NSZeroRect];
 
   if (index >= static_cast<NSInteger>(items.size()))
-    return nil;
+    return [[NSScrubberItemView alloc] initWithFrame:NSZeroRect];
 
   gin_helper::PersistentDictionary item = items[index];
 
-  NSScrubberItemView* itemView;
   std::string title;
 
   if (item.Get("label", &title)) {
     NSScrubberTextItemView* view =
         [scrubber makeItemWithIdentifier:TextScrubberItemIdentifier owner:self];
+    if (!view)
+      return [[NSScrubberItemView alloc] initWithFrame:NSZeroRect];
     view.title = base::SysUTF8ToNSString(title);
-    itemView = view;
-  } else {
-    NSScrubberImageItemView* view =
-        [scrubber makeItemWithIdentifier:ImageScrubberItemIdentifier
-                                   owner:self];
-    gfx::Image image;
-    if (item.Get("icon", &image)) {
-      view.image = image.AsNSImage();
-    }
-    itemView = view;
+    return view;
   }
 
-  return itemView;
+  NSScrubberImageItemView* view =
+      [scrubber makeItemWithIdentifier:ImageScrubberItemIdentifier owner:self];
+  if (!view)
+    return [[NSScrubberItemView alloc] initWithFrame:NSZeroRect];
+  gfx::Image image;
+  if (item.Get("icon", &image))
+    view.image = image.AsNSImage();
+  return view;
 }
 
 - (NSSize)scrubber:(NSScrubber*)scrubber

--- a/shell/browser/ui/cocoa/window_buttons_proxy.mm
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.mm
@@ -162,17 +162,16 @@
 }
 
 - (void)updateButtonsVisibility {
-  NSArray* buttons = @[
-    [window_ standardWindowButton:NSWindowCloseButton],
-    [window_ standardWindowButton:NSWindowMiniaturizeButton],
-    [window_ standardWindowButton:NSWindowZoomButton],
-  ];
   // Show buttons when mouse hovers above them.
   BOOL hidden = show_on_hover_ && !mouse_inside_;
   // Always show buttons under fullscreen.
   if ([window_ styleMask] & NSWindowStyleMaskFullScreen)
     hidden = NO;
-  for (NSView* button in buttons) {
+  for (NSWindowButton button_type :
+       {NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton}) {
+    NSButton* button = [window_ standardWindowButton:button_type];
+    if (!button)
+      continue;
     [button setHidden:hidden];
     [button setNeedsDisplay:YES];
   }

--- a/shell/browser/ui/drag_util_mac.mm
+++ b/shell/browser/ui/drag_util_mac.mm
@@ -78,6 +78,8 @@ void DragFileItems(const std::vector<base::FilePath>& files,
                       eventNumber:0
                        clickCount:1
                          pressure:1.0];
+  if (!dragEvent)
+    return;
 
   // Run the drag operation.
   [native_view beginDraggingSessionWithItems:file_items

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -273,10 +273,14 @@ int RunModalDialog(NSSavePanel* dialog, const DialogSettings& settings) {
 
 // Create bookmark data and serialise it into a base64 string.
 std::string GetBookmarkDataFromNSURL(NSURL* url) {
+  NSString* path = [url path];
+  if (!path)
+    return "";
+
   // Create the file if it doesn't exist (necessary for NSSavePanel options).
   NSFileManager* defaultManager = [NSFileManager defaultManager];
-  if (![defaultManager fileExistsAtPath:[url path]]) {
-    [defaultManager createFileAtPath:[url path] contents:nil attributes:nil];
+  if (![defaultManager fileExistsAtPath:path]) {
+    [defaultManager createFileAtPath:path contents:nil attributes:nil];
   }
 
   NSError* error = nil;
@@ -306,6 +310,8 @@ void ReadDialogPathsWithBookmarks(NSOpenPanel* dialog,
       continue;
 
     NSString* path = [url path];
+    if (!path)
+      continue;
 
     // There's a bug in macOS where despite a request to disallow file
     // selection, files/packages can be selected. If file selection

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -201,15 +201,19 @@
   // arrived here from VoiceOver, which does not pass an event.
   // Create a synthetic event to pass to the click handler.
   if (![event respondsToSelector:@selector(locationInWindow)]) {
-    event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
-                               location:NSMakePoint(0, 0)
-                          modifierFlags:0
-                              timestamp:NSApp.currentEvent.timestamp
-                           windowNumber:0
-                                context:nil
-                            eventNumber:0
-                             clickCount:1
-                               pressure:1.0];
+    NSEvent* synthetic_event =
+        [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+                           location:NSMakePoint(0, 0)
+                      modifierFlags:0
+                          timestamp:NSApp.currentEvent.timestamp
+                       windowNumber:0
+                            context:nil
+                        eventNumber:0
+                         clickCount:1
+                           pressure:1.0];
+    if (!synthetic_event)
+      return;
+    event = synthetic_event;
 
     // We also need to explicitly call the click handler here, since
     // VoiceOver won't trigger mouseUp.

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -32,6 +32,8 @@ namespace electron::api {
 
 NSData* bufferFromNSImage(NSImage* image) {
   CGImageRef ref = [image CGImageForProposedRect:nil context:nil hints:nil];
+  if (!ref)
+    return nil;
   NSBitmapImageRep* rep = [[NSBitmapImageRep alloc] initWithCGImage:ref];
   [rep setSize:[image size]];
   return [rep representationUsingType:NSBitmapImageFileTypePNG
@@ -77,11 +79,12 @@ v8::Local<v8::Promise> NativeImage::CreateThumbnailFromPath(
   CGSize cg_size = size.ToCGSize();
 
   NSURL* nsurl = base::apple::FilePathToNSURL(path);
+  NSString* ns_path = [nsurl path];
 
   // We need to explicitly check if the user has passed an invalid path
   // because QLThumbnailGenerationRequest will generate a stock file icon
   // and pass silently if we do not.
-  if (![[NSFileManager defaultManager] fileExistsAtPath:[nsurl path]]) {
+  if (!ns_path || ![[NSFileManager defaultManager] fileExistsAtPath:ns_path]) {
     promise.RejectWithErrorMessage(
         "unable to retrieve thumbnail preview image for the given path");
     return handle;

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -113,7 +113,7 @@ void ElectronBindings::OnCallNextTick(uv_async_t* handle) {
 // static
 void ElectronBindings::Crash() {
   volatile int* zero = nullptr;
-  *zero = 0;
+  *zero = 0;  // NOLINT(clang-analyzer-core.NullDereference)
 }
 
 // static

--- a/shell/common/gin_converters/osr_converter.cc
+++ b/shell/common/gin_converters/osr_converter.cc
@@ -56,10 +56,7 @@ struct OffscreenReleaseHolderMonitor {
     CHECK(holder);
   }
 
-  void ReleaseTexture() {
-    delete holder_;
-    holder_ = nullptr;
-  }
+  void ReleaseTexture() { holder_.ClearAndDelete(); }
 
   [[nodiscard]] bool IsTextureReleased() const { return holder_ == nullptr; }
 

--- a/shell/common/gin_helper/handle.h
+++ b/shell/common/gin_helper/handle.h
@@ -36,7 +36,7 @@ class Handle {
 
   void Clear() {
     wrapper_.Clear();
-    object_ = NULL;
+    object_ = nullptr;
   }
 
   T* operator->() const { return object_; }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -188,7 +188,7 @@ void V8FatalErrorCallback(const char* location, const char* message) {
 #endif
 
   volatile int* zero = nullptr;
-  *zero = 0;
+  *zero = 0;  // NOLINT(clang-analyzer-core.NullDereference)
 }
 
 void V8OOMErrorCallback(const char* location, const v8::OOMDetails& details) {

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -63,7 +63,7 @@ void V8FatalErrorCallback(const char* location, const char* message) {
 #endif
 
   volatile int* zero = nullptr;
-  *zero = 0;
+  *zero = 0;  // NOLINT(clang-analyzer-core.NullDereference)
 }
 
 URLLoaderBundle::URLLoaderBundle() = default;

--- a/spec/api-auto-updater-spec.ts
+++ b/spec/api-auto-updater-spec.ts
@@ -62,6 +62,30 @@ ifdescribe(!process.mas)('autoUpdater module', function () {
           "Expected options object to contain a 'url' string property in setFeedUrl call"
         );
       });
+
+      ifit(process.platform === 'darwin')('throws if the url is not valid UTF-8', () => {
+        const url = 'http://feedurl.local';
+        try {
+          autoUpdater.setFeedURL({ url });
+        } catch {
+          /* ignore */
+        }
+        expect(() => autoUpdater.setFeedURL({ url: '\uD800' })).to.throw("Expected 'url' to be a valid URL");
+        expect(autoUpdater.getFeedURL()).to.equal(url);
+      });
+
+      ifit(process.platform === 'darwin')('throws if the url is not parseable', () => {
+        const url = 'http://feedurl.local';
+        try {
+          autoUpdater.setFeedURL({ url });
+        } catch {
+          /* ignore */
+        }
+        expect(() => autoUpdater.setFeedURL({ url: 'http://feed url.local' })).to.throw(
+          "Expected 'url' to be a valid URL"
+        );
+        expect(autoUpdater.getFeedURL()).to.equal(url);
+      });
     });
   });
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

This enables a bunch of `clang-analyzer-*` (static analysis) checks in `clang-tidy` and fixes the errors that popped out. The fixes are mostly separated out by commit with the check name, but some fixes went into the original commit as they were trivial or `// NOLINT`.

Other fixes from these checks were spun off into their own PRs when feasible and test coverage for the underlying issue was added when possible:
* #52474
* #52545
* #52569
* #52764 
* #52773
* #52710

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
