### PR TITLE
test: enforce awaiting promise returning helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,10 @@
     {
       "name": "no-only-tests",
       "specifier": "./script/lint-plugins/no-only-tests.mjs"
+    },
+    {
+      "name": "no-floating-spec-helpers",
+      "specifier": "./script/lint-plugins/no-floating-spec-helpers.mjs"
     }
   ],
   "categories": {
@@ -344,7 +348,8 @@
         "spec/**/*.mjs"
       ],
       "rules": {
-        "no-only-tests/no-only-tests": "error"
+        "no-only-tests/no-only-tests": "error",
+        "no-floating-spec-helpers/no-floating-spec-helpers": "error"
       }
     },
     {

--- a/script/lint-plugins/no-floating-spec-helpers.mjs
+++ b/script/lint-plugins/no-floating-spec-helpers.mjs
@@ -1,0 +1,34 @@
+// Spec helpers whose only purpose is the promise they return - discarding it
+// silently skips the wait (and any assertion inside it).
+const MUST_AWAIT = new Set([
+  'waitUntil',
+  'repeatedly',
+  'closeWindow',
+  'closeAllWindows',
+  'cleanupWebContents',
+  'runCleanupFunctions'
+]);
+
+export default {
+  meta: { name: 'no-floating-spec-helpers' },
+  rules: {
+    'no-floating-spec-helpers': {
+      meta: { type: 'problem' },
+      create(context) {
+        return {
+          ExpressionStatement(node) {
+            const call = node.expression;
+            if (call.type !== 'CallExpression') return;
+            if (call.callee.type !== 'Identifier') return;
+            if (!MUST_AWAIT.has(call.callee.name)) return;
+
+            context.report({
+              node: call.callee,
+              message: `${call.callee.name}() returns a promise that must be awaited`
+            });
+          }
+        };
+      }
+    }
+  }
+};

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1447,7 +1447,7 @@ describe('BrowserWindow module', () => {
         expect(w.isVisible()).to.be.true('parent is visible');
         expect(c.isVisible()).to.be.true('child is visible');
 
-        closeWindow(c);
+        await closeWindow(c);
       });
     });
 
@@ -4705,7 +4705,7 @@ describe('BrowserWindow module', () => {
           // w.title should update after 'page-title-updated'.
           // It happens right *after* the event fires though,
           // so we have to waitUntil it changes
-          waitUntil(() => w.title === newTitle);
+          await waitUntil(() => w.title === newTitle);
         });
 
         it('works for stop events', async () => {
@@ -5469,8 +5469,8 @@ describe('BrowserWindow module', () => {
     const savePageJsPath = path.join(savePageDir, 'save_page_files', 'test.js');
     const savePageCssPath = path.join(savePageDir, 'save_page_files', 'test.css');
 
-    afterEach(() => {
-      closeAllWindows();
+    afterEach(async () => {
+      await closeAllWindows();
 
       try {
         fs.unlinkSync(savePageCssPath);

--- a/spec/api-local-ai-handler-spec.ts
+++ b/spec/api-local-ai-handler-spec.ts
@@ -76,9 +76,9 @@ ifdescribe(features.isPromptAPIEnabled())('localAIHandler module', () => {
     await w.loadFile(path.join(fixtures, 'api', 'blank.html'));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     w.webContents.session.registerLocalAIHandler(null);
-    closeAllWindows();
+    await closeAllWindows();
   });
 
   describe('LanguageModel.availability()', () => {

--- a/spec/api-native-theme-spec.ts
+++ b/spec/api-native-theme-spec.ts
@@ -22,7 +22,7 @@ describe('nativeTheme module', () => {
       // Wait for any pending events to emit
       await setTimeout(20);
 
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     it('is system by default', () => {

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -2372,9 +2372,9 @@ describe('session module', () => {
       });
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       w.webContents.session.registerLocalAIHandler(null);
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     it('registers a utility process as the AI handler', async () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -4278,8 +4278,8 @@ describe('webContents module', () => {
       });
     });
 
-    afterEach(() => {
-      closeAllWindows();
+    afterEach(async () => {
+      await closeAllWindows();
       if (server) {
         server.close();
       }

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -374,7 +374,7 @@ describe('webFrameMain module', () => {
       await w.webContents.loadURL(server.crossOriginUrl);
       // senderFrame now points to a disposed RenderFrameHost. It should
       // be null when attempting to access the lazily evaluated property.
-      waitUntil(() => {
+      await waitUntil(() => {
         return event.senderFrame === null;
       });
     });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1350,12 +1350,12 @@ describe('chromium features', () => {
   describe('File System API,', () => {
     let w: BrowserWindow | null = null;
 
-    afterEach(() => {
+    afterEach(async () => {
       ipcMain.removeAllListeners('did-create-file-handle');
       ipcMain.removeAllListeners('did-create-directory-handle');
       session.defaultSession.setPermissionCheckHandler(null);
       session.defaultSession.setPermissionRequestHandler(null);
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     it('allows access by default to reading an OPFS file', async () => {
@@ -4488,9 +4488,9 @@ describe('paste execCommand', () => {
     ses = session.fromPartition(`paste-execCommand-${Math.random()}`);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     ses.setPermissionCheckHandler(null);
-    closeAllWindows();
+    await closeAllWindows();
   });
 
   it('is disabled by default', async () => {
@@ -4635,9 +4635,9 @@ ifdescribe(process.platform !== 'linux')('navigator.setAppBadge/clearAppBadge', 
       await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
     });
 
-    after(() => {
+    after(async () => {
       app.badgeCount = 0;
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     it('setAppBadge can set a numerical value', async () => {
@@ -4674,9 +4674,9 @@ ifdescribe(process.platform !== 'linux')('navigator.setAppBadge/clearAppBadge', 
       });
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       app.badgeCount = 0;
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     it('setAppBadge can be called in a ServiceWorker', (done) => {
@@ -4790,9 +4790,9 @@ describe('navigator.hid', () => {
   const findValidDevice = (deviceList: Electron.HIDDevice[]) =>
     deviceList.find((device) => device.name && device.name !== '' && device.serialNumber && device.serialNumber !== '');
 
-  after(() => {
+  after(async () => {
     server.close();
-    closeAllWindows();
+    await closeAllWindows();
   });
 
   afterEach(() => {
@@ -5002,9 +5002,9 @@ describe('navigator.usb', () => {
 
   const notFoundError = "NotFoundError: Failed to execute 'requestDevice' on 'USB': No device selected.";
 
-  after(() => {
+  after(async () => {
     server.close();
-    closeAllWindows();
+    await closeAllWindows();
   });
 
   afterEach(() => {

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -540,7 +540,7 @@ describe('<webview> tag', function () {
       // Specifically this is async on macOS but can be on other platforms too
       await setTimeout(1000);
 
-      closeAllWindows();
+      await closeAllWindows();
     });
 
     ifit(process.platform !== 'darwin')('should make parent frame element fullscreen too (non-macOS)', async () => {


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

There are a couple dozen places where we aren't awaiting promises in tests, which can lead to flaky behavior or tests not checking what they intend to test. The failure to await `waitUntil` is particularly problematic, since its unhandled rejection will currently be silently swallowed (may address this in a follow up PR).

Oxlint has a similar rule for this (`typescript/no-floating-promises`) but it requires type aware linting (which we don't have enabled currently) and applies to all promises. Opting to fix the immediate problem for now and we can adopt `typescript/no-floating-promises` in the future if we turn on type aware linting.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: none