### PR TITLE
fix: terminate utility processes immediately on Windows instead of running CRT exit

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -42,6 +42,8 @@ namespace {
 const char kUserDataDir[] = "user-data-dir";
 const char kProcessType[] = "type";
 const char kUtilityProcess[] = "utility";
+const char kUtilitySubType[] = "utility-sub-type";
+const char kNodeService[] = "node.mojom.NodeService";
 
 [[nodiscard]] bool IsEnvSet(const base::cstring_view name) {
   size_t required_size = 0;
@@ -232,7 +234,10 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   int rc = content::ContentMain(std::move(params));
   // System DLLs loaded into utility processes crash in their DLL_PROCESS_DETACH
   // handlers during CRT exit, so leave the way Chrome does: without running it.
-  if (process_type == kUtilityProcess)
+  // Node utility processes keep the normal exit for their addons' handlers.
+  if (process_type == kUtilityProcess &&
+      command_line->GetSwitchValueASCII(kUtilitySubType) != kNodeService) {
     base::Process::TerminateCurrentProcessImmediately(rc);
+  }
   return rc;
 }

--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -17,6 +17,7 @@
 #include "base/at_exit.h"
 #include "base/debug/alias.h"
 #include "base/i18n/icu_util.h"
+#include "base/process/process.h"
 #include "base/strings/cstring_view.h"
 #include "base/win/atl.h"  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
 #include "base/win/dark_mode_support.h"
@@ -40,6 +41,7 @@ namespace {
 // from //electron:electron_app
 const char kUserDataDir[] = "user-data-dir";
 const char kProcessType[] = "type";
+const char kUtilityProcess[] = "utility";
 
 [[nodiscard]] bool IsEnvSet(const base::cstring_view name) {
   size_t required_size = 0;
@@ -227,5 +229,10 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   content::ContentMainParams params(&delegate);
   params.instance = instance;
   params.sandbox_info = &sandbox_info;
-  return content::ContentMain(std::move(params));
+  int rc = content::ContentMain(std::move(params));
+  // System DLLs loaded into utility processes crash in their DLL_PROCESS_DETACH
+  // handlers during CRT exit, so leave the way Chrome does: without running it.
+  if (process_type == kUtilityProcess)
+    base::Process::TerminateCurrentProcessImmediately(rc);
+  return rc;
 }


### PR DESCRIPTION
#### Description of Change

A utility process returns from `ContentMain()` into the CRT's `exit()`, which runs the detach handler of every loaded DLL. On Windows 11 24H2 and 25H2 the system DLLs loaded into short-lived utility services (shell icon reading, the proxy resolver) crash in those handlers: a delay-load into combase's private api-set from a `DllMain`, and WIL's shutdown probe calling `GetProcAddress` on ntdll, both reading freed memory.

Chrome has terminated utility processes with `TerminateCurrentProcessImmediately()` since https://crrev.com/c/2623747 for this reason; do the same once `ContentMain()` returns.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Fixed utility process crashes at exit on Windows 11 24H2 and later.