### PR TITLE
test: clean up some test flakes with webFrameMain

### DIFF
--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -19,6 +19,25 @@ async function clipboardHasImageType(): Promise<boolean> {
   return clipboard.has('image/png');
 }
 
+/**
+ * Waits for the 'preload-unload' IPC that sub-frames/preload sends when a
+ * document detaches. Scoped to a single WebContents since windows torn down by
+ * cleanup send it too, and frame properties are read on arrival because they
+ * stop resolving once the frame is disposed.
+ */
+async function onceUnload(webContents: WebContents) {
+  let unload: { senderFrame: WebFrameMain | null; frameProcessId?: number; processId: number } | undefined;
+  const listener = (event: Electron.IpcMainEvent) => {
+    if (event.sender !== webContents) return;
+    const { processId, senderFrame } = event;
+    unload = { senderFrame, frameProcessId: senderFrame?.processId, processId };
+  };
+  ipcMain.on('preload-unload', listener);
+  defer(() => ipcMain.off('preload-unload', listener));
+  await waitUntil(() => unload !== undefined);
+  return unload!;
+}
+
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');
   const subframesPath = path.join(fixtures, 'sub-frames');
@@ -387,21 +406,12 @@ describe('webFrameMain module', () => {
         }
       });
       await w.webContents.loadURL(server.url);
-      const unloadPromise = new Promise<void>((resolve, reject) => {
-        ipcMain.once('preload-unload', (event) => {
-          try {
-            const { senderFrame } = event;
-            expect(senderFrame).to.not.be.null();
-            expect(senderFrame!.detached).to.be.true();
-            expect(senderFrame!.processId).to.equal(event.processId);
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
+      const unloadPromise = onceUnload(w.webContents);
       await w.webContents.loadURL(server.crossOriginUrl);
-      await expect(unloadPromise).to.eventually.be.fulfilled();
+      const { senderFrame, frameProcessId, processId } = await unloadPromise;
+      expect(senderFrame).to.not.be.null();
+      expect(senderFrame!.detached).to.be.true();
+      expect(frameProcessId).to.equal(processId);
     });
 
     it('disposes detached frame after cross-origin navigation', async () => {
@@ -412,23 +422,14 @@ describe('webFrameMain module', () => {
         }
       });
       await w.webContents.loadURL(server.url);
-      // eslint-disable-next-line prefer-const
-      let crossOriginPromise: Promise<void>;
-      const unloadPromise = new Promise<void>((resolve, reject) => {
-        ipcMain.once('preload-unload', async (event) => {
-          try {
-            const { senderFrame } = event;
-            expect(senderFrame!.detached).to.be.true();
-            await crossOriginPromise;
-            expect(() => senderFrame!.url).to.throw(/Render frame was disposed/);
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
-      crossOriginPromise = w.webContents.loadURL(server.crossOriginUrl);
-      await expect(unloadPromise).to.eventually.be.fulfilled();
+      const unloadPromise = onceUnload(w.webContents);
+      const crossOriginPromise = w.webContents.loadURL(server.crossOriginUrl);
+      const { senderFrame } = await unloadPromise;
+      expect(senderFrame!.detached).to.be.true();
+      await crossOriginPromise;
+      // The detached frame is not destroyed immediately, so wait until it is
+      await waitUntil(() => senderFrame!.isDestroyed());
+      expect(() => senderFrame!.url).to.throw(/Render frame was disposed/);
     });
 
     // Skip test as we don't have an offline repro yet

--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -1191,6 +1191,12 @@ describe('cpp heap', () => {
             await unloaded;
             await navigated;
 
+            // Ensure the detached frame has been destroyed before triggering GC
+            for (let i = 0; i < 100; i++) {
+              if (detachedFrame!.isDestroyed()) break;
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
             for (let i = 0; i < 10; i++) {
               await new Promise((resolve) => setTimeout(resolve, 0));
               v8Util.requestGarbageCollectionForTesting();
@@ -1248,7 +1254,9 @@ describe('cpp heap', () => {
         }
       });
 
-      expect(result).to.equal('rejected: Render frame was disposed before call stack was received');
+      // We're creating a race so the promise can either resolve or reject depending
+      // on timing, but it should always settle and not have a timeout occur
+      expect(result).to.be.oneOf(['resolved', 'rejected: Render frame was disposed before call stack was received']);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

These popped out of working on the UBSan build since the instrumented build is slower and caused these flakes to happen more often.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: none
