### PR TITLE
Feat/linux background portal login items

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1568,6 +1568,8 @@ Returns `Object`:
 <!--
 ```YAML history
 changes:
+  - pr-url: https://github.com/electron/electron/pull/53052
+    description: "This method now returns a Promise."
   - pr-url: https://github.com/electron/electron/pull/52351
     description: "Removed `openAsHidden` option."
 ```
@@ -1597,6 +1599,9 @@ changes:
   * `name` string (optional) _Windows_ - value name to write into registry. Defaults to the app's AppUserModelId().
 
 Set the app's login item settings.
+
+Returns `Promise<void>` - Resolves when the operating system has handled the
+request.
 
 To work with Electron's `autoUpdater` on Windows, which uses [Squirrel][Squirrel-Windows],
 you'll want to set the launch path to your executable's name but a directory up, which is

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1542,7 +1542,7 @@ changes:
 -->
 
 * `options` Object (optional)
-  * `type` string (optional) _macOS_ - Can be `mainAppService`, `agentService`, `daemonService`, or `loginItemService`. Defaults to `mainAppService`. See [app.setLoginItemSettings](app.md#appsetloginitemsettingssettings-macos-windows) for more information about each type.
+  * `type` string (optional) _macOS_ - Can be `mainAppService`, `agentService`, `daemonService`, or `loginItemService`. Defaults to `mainAppService`. See [app.setLoginItemSettings](app.md#appsetloginitemsettingssettings-macos-windows-linux) for more information about each type.
   * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default.
   * `path` string (optional) _Windows_ - The executable path to compare against. Defaults to `process.execPath`.
   * `args` string[] (optional) _Windows_ - The command-line arguments to compare against. Defaults to an empty array.
@@ -1563,7 +1563,7 @@ Returns `Object`:
   * `scope` string _Windows_ - can be `user` or `machine`. Indicates whether the registry entry is under `HKEY_CURRENT USER` or `HKEY_LOCAL_MACHINE`.
   * `enabled` boolean _Windows_ - `true` if the app registry key is startup approved and therefore shows as `enabled` in Task Manager and Windows settings.
 
-### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
+### `app.setLoginItemSettings(settings)` _macOS_ _Windows_ _Linux_
 
 <!--
 ```YAML history
@@ -1587,11 +1587,11 @@ changes:
     * `daemonService` string (optional) _macOS_ - The property list name for a launch agent. The property list name must correspond to a property list in the app’s `Contents/Library/LaunchDaemons` directory.
     * `loginItemService` string (optional) _macOS_ - The property list name for a login item service. The property list name must correspond to a property list in the app’s `Contents/Library/LoginItems` directory.
   * `serviceName` string (optional) _macOS_ - The name of the service. Required if `type` is non-default.
-  * `path` string (optional) _Windows_ - The executable to launch at login.
+  * `path` string (optional) _Windows_ _Linux_ - The executable to launch at login.
     Defaults to `process.execPath`.
-  * `args` string[] (optional) _Windows_ - The command-line arguments to pass to
-    the executable. Defaults to an empty array. Take care to wrap paths in
-    quotes.
+  * `args` string[] (optional) _Windows_ _Linux_ - The command-line arguments to
+    pass to the executable. Defaults to an empty array. On Windows, take care to
+    wrap paths in quotes.
   * `enabled` boolean (optional) _Windows_ - `true` will change the startup approved registry key and `enable / disable` the App in Task Manager and Windows Settings.
     Defaults to `true`.
   * `name` string (optional) _Windows_ - value name to write into registry. Defaults to the app's AppUserModelId().
@@ -1623,6 +1623,13 @@ app.setLoginItemSettings({
 ```
 
 For more information about setting different services as login items on macOS, see [`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc).
+
+On Linux, this API uses the [Background XDG desktop portal][background-portal]
+to request autostart changes. Apps should set `desktopName` in `package.json` or
+call `app.setDesktopName(name)` before the `ready` event, using the base filename
+of their installed `.desktop` file. The `.desktop` suffix is optional.
+`app.getLoginItemSettings()` is not available on Linux because the portal does
+not expose a way to read the persisted autostart state.
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 
@@ -1945,6 +1952,7 @@ A `string` property that returns the app's [Toast Activator CLSID][toast-activat
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/documentation/coreservices/1441725-lscopydefaulthandlerforurlscheme?language=objc
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html
 [activity-type]: https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSUserActivity_Class/index.html#//apple_ref/occ/instp/NSUserActivity/activityType
+[background-portal]: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Background.html
 [Squirrel-Windows]: https://github.com/Squirrel/Squirrel.Windows
 [JumpListBeginListMSDN]: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-icustomdestinationlist-beginlist
 [about-panel-options]: https://developer.apple.com/reference/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith?language=objc

--- a/script/dbus_mock.py
+++ b/script/dbus_mock.py
@@ -4,9 +4,46 @@ import os
 import subprocess
 import sys
 
+import dbus
 from dbusmock import DBusTestCase
 
 from lib.config import is_verbose_mode
+
+
+PORTAL_SERVICE = 'org.freedesktop.portal.Desktop'
+PORTAL_PATH = '/org/freedesktop/portal/desktop'
+BACKGROUND_INTERFACE = 'org.freedesktop.portal.Background'
+REGISTRY_INTERFACE = 'org.freedesktop.host.portal.Registry'
+MOCK_INTERFACE = 'org.freedesktop.DBus.Mock'
+
+
+REQUEST_BACKGROUND_CODE = '''
+import dbus
+import threading
+
+options = args[1]
+autostart = bool(options.get('autostart', False))
+handle_token = str(options.get('handle_token', 'electron_login_item'))
+request_path = '/org/freedesktop/portal/desktop/request/mock/' + handle_token
+
+def respond(mock=self, path=request_path, enabled=autostart, dbus_module=dbus):
+    mock._emit_signal(
+        'org.freedesktop.portal.Request',
+        'Response',
+        'ua{sv}',
+        [
+            dbus_module.UInt32(0),
+            {
+                'background': dbus_module.Boolean(True, variant_level=1),
+                'autostart': dbus_module.Boolean(enabled, variant_level=1),
+            },
+        ],
+        {'path': path},
+    )
+
+threading.Timer(0.05, respond).start()
+ret = dbus.ObjectPath(request_path)
+'''
 
 
 def stop():
@@ -30,6 +67,13 @@ def start():
         DBusTestCase.spawn_server_template(
             os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          'dbusmock_xdg_file_chooser_portal.py'), None, log)
+        DBusTestCase.wait_for_bus_object(PORTAL_SERVICE, PORTAL_PATH)
+
+        portal = DBusTestCase.get_dbus().get_object(PORTAL_SERVICE, PORTAL_PATH)
+        mock = dbus.Interface(portal, MOCK_INTERFACE)
+        mock.AddMethod(REGISTRY_INTERFACE, 'Register', 'sa{sv}', '', '')
+        mock.AddMethod(BACKGROUND_INTERFACE, 'RequestBackground', 'sa{sv}', 'o',
+                       REQUEST_BACKGROUND_CODE)
 
 
 if __name__ == '__main__':

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -33,6 +33,11 @@
 #include "content/public/browser/profiling_utils.h"
 #endif
 
+#if BUILDFLAG(IS_LINUX)
+#include "components/dbus/xdg/request.h"
+#include "dbus/bus.h"
+#endif
+
 namespace electron {
 
 LoginItemSettings::LoginItemSettings() = default;
@@ -66,6 +71,9 @@ Browser::Browser() {
 }
 
 Browser::~Browser() {
+#if BUILDFLAG(IS_LINUX)
+  ResetLoginItemPortalRequest(/*release_request=*/true);
+#endif
   WindowList::RemoveObserver(this);
 }
 

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -35,7 +35,6 @@
 
 #if BUILDFLAG(IS_LINUX)
 #include "components/dbus/xdg/request.h"
-#include "dbus/bus.h"
 #endif
 
 namespace electron {
@@ -71,9 +70,6 @@ Browser::Browser() {
 }
 
 Browser::~Browser() {
-#if BUILDFLAG(IS_LINUX)
-  ResetLoginItemPortalRequest(/*release_request=*/true);
-#endif
   WindowList::RemoveObserver(this);
 }
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/observer_list.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
@@ -28,6 +29,10 @@
 
 class GURL;
 
+namespace dbus {
+class Bus;
+}  // namespace dbus
+
 namespace gin {
 class Arguments;
 }
@@ -36,6 +41,10 @@ namespace gin_helper {
 template <typename T>
 class Promise;
 }  // namespace gin_helper
+
+namespace dbus_xdg {
+class Request;
+}  // namespace dbus_xdg
 
 namespace v8 {
 template <typename T>
@@ -388,6 +397,13 @@ class Browser : private WindowListObserver {
   std::unique_ptr<ui::ScopedPasswordInputEnabler> password_input_enabler_;
   base::Time last_dock_show_;
   bool was_launched_at_login_;
+#endif
+
+#if BUILDFLAG(IS_LINUX)
+  void ResetLoginItemPortalRequest(bool release_request);
+
+  scoped_refptr<dbus::Bus> login_item_bus_;
+  std::unique_ptr<dbus_xdg::Request> login_item_request_;
 #endif
 
   base::DictValue about_panel_options_;

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_BROWSER_H_
 #define ELECTRON_SHELL_BROWSER_BROWSER_H_
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -176,7 +177,8 @@ class Browser : private WindowListObserver {
   bool SetBadgeCount(std::optional<int> count);
   [[nodiscard]] int badge_count() const { return badge_count_; }
 
-  void SetLoginItemSettings(LoginItemSettings settings);
+  v8::Local<v8::Promise> SetLoginItemSettings(v8::Isolate* isolate,
+                                              LoginItemSettings settings);
   v8::Local<v8::Value> GetLoginItemSettings(const LoginItemSettings& options);
 
 #if BUILDFLAG(IS_MAC)
@@ -396,11 +398,10 @@ class Browser : private WindowListObserver {
 #endif
 
 #if BUILDFLAG(IS_LINUX)
-  void FinishLoginItemPortalRequest();
+  void FinishLoginItemPortalRequest(size_t request_id);
 
-  bool login_item_request_in_flight_ = false;
-  std::optional<LoginItemSettings> pending_login_item_settings_;
-  std::unique_ptr<dbus_xdg::Request> login_item_request_;
+  size_t next_login_item_request_id_ = 0;
+  std::map<size_t, std::unique_ptr<dbus_xdg::Request>> login_item_requests_;
 #endif
 
   base::DictValue about_panel_options_;

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
-#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
@@ -28,10 +28,6 @@
 #endif
 
 class GURL;
-
-namespace dbus {
-class Bus;
-}  // namespace dbus
 
 namespace gin {
 class Arguments;
@@ -400,9 +396,10 @@ class Browser : private WindowListObserver {
 #endif
 
 #if BUILDFLAG(IS_LINUX)
-  void ResetLoginItemPortalRequest(bool release_request);
+  void FinishLoginItemPortalRequest();
 
-  scoped_refptr<dbus::Bus> login_item_bus_;
+  bool login_item_request_in_flight_ = false;
+  std::optional<LoginItemSettings> pending_login_item_settings_;
   std::unique_ptr<dbus_xdg::Request> login_item_request_;
 #endif
 
@@ -415,6 +412,10 @@ class Browser : private WindowListObserver {
 
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
+#endif
+
+#if BUILDFLAG(IS_LINUX)
+  base::WeakPtrFactory<Browser> login_item_weak_factory_{this};
 #endif
 };
 

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -21,16 +21,11 @@
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
-#include "base/memory/ref_counted.h"
 #include "base/path_service.h"
-#include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
-#include "base/task/lazy_thread_pool_task_runner.h"
-#include "base/task/sequenced_task_runner.h"
-#include "base/task/single_thread_task_runner_thread_mode.h"
-#include "base/task/task_traits.h"
-#include "components/dbus/utils/call_method.h"
+#include "components/dbus/thread_linux/dbus_thread_linux.h"
 #include "components/dbus/utils/variant.h"
+#include "components/dbus/xdg/portal.h"
 #include "components/dbus/xdg/request.h"
 #include "dbus/bus.h"
 #include "dbus/object_path.h"
@@ -45,7 +40,6 @@
 #include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
-#include "shell/common/platform_util.h"
 #include "shell/common/thread_restrictions.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/glib/glib_cast.h"
@@ -63,21 +57,11 @@ const char kFreedesktopPortalName[] = "org.freedesktop.portal.Desktop";
 const char kFreedesktopPortalPath[] = "/org/freedesktop/portal/desktop";
 const char kFreedesktopPortalBackground[] =
     "org.freedesktop.portal.Background";
-const char kFreedesktopPortalRegistry[] =
-    "org.freedesktop.host.portal.Registry";
 const char kMethodRequestBackground[] = "RequestBackground";
-const char kMethodRegister[] = "Register";
 
 const char kAutostartKey[] = "autostart";
 const char kBackgroundKey[] = "background";
 const char kCommandlineKey[] = "commandline";
-
-using RegisterResult = dbus_utils::CallMethodResultSig<"">;
-
-base::LazyThreadPoolSingleThreadTaskRunner g_login_item_dbus_task_runner =
-    LAZY_THREAD_POOL_SINGLE_THREAD_TASK_RUNNER_INITIALIZER(
-        base::TaskTraits(base::MayBlock(), base::TaskPriority::USER_BLOCKING),
-        base::SingleThreadTaskRunnerThreadMode::SHARED);
 
 bool SetDefaultWebClient(const std::string& protocol) {
   const auto env = base::Environment::Create();
@@ -286,61 +270,6 @@ void LogLoginItemPortalResponse(bool open_at_login,
   }
 }
 
-scoped_refptr<dbus::Bus> CreateLoginItemPortalBus() {
-  dbus::Bus::Options options;
-  options.bus_type = dbus::Bus::SESSION;
-  options.connection_type = dbus::Bus::PRIVATE;
-  options.dbus_task_runner = g_login_item_dbus_task_runner.Get();
-  return base::MakeRefCounted<dbus::Bus>(std::move(options));
-}
-
-bool ConnectLoginItemPortalBus(scoped_refptr<dbus::Bus> bus) {
-  base::RunLoop run_loop;
-  bool connected = false;
-  std::string connection_name;
-
-  bus->GetDBusTaskRunner()->PostTask(
-      FROM_HERE,
-      base::BindOnce(
-          [](scoped_refptr<dbus::Bus> bus,
-             scoped_refptr<base::SequencedTaskRunner> origin_task_runner,
-             bool* connected, std::string* connection_name,
-             base::OnceClosure quit) {
-            *connected = bus->Connect();
-            if (*connected) {
-              *connection_name = bus->GetConnectionName();
-            }
-            origin_task_runner->PostTask(FROM_HERE, std::move(quit));
-          },
-          std::move(bus), base::SequencedTaskRunner::GetCurrentDefault(),
-          &connected, &connection_name, run_loop.QuitClosure()));
-
-  run_loop.Run();
-
-  return connected && !connection_name.empty();
-}
-
-void RegisterLoginItemPortalAppId(dbus::ObjectProxy* object_proxy,
-                                  const std::string& app_id) {
-  dbus_utils::CallMethod<"sa{sv}", "">(
-      object_proxy, kFreedesktopPortalRegistry, kMethodRegister,
-      base::BindOnce([](RegisterResult result) {
-        if (result.has_value()) {
-          return;
-        }
-
-        const auto& error = result.error();
-        if (error.error_message.empty()) {
-          VLOG(1) << "Failed to register app ID with XDG portal: "
-                  << static_cast<int>(error.status);
-        } else {
-          VLOG(1) << "Failed to register app ID with XDG portal: "
-                  << error.error_message;
-        }
-      }),
-      app_id, dbus_xdg::Dictionary());
-}
-
 }  // namespace
 
 void Browser::AddRecentDocument(const base::FilePath& path) {}
@@ -445,6 +374,11 @@ bool Browser::SetBadgeCount(std::optional<int> count) {
 }
 
 void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+  if (login_item_request_in_flight_) {
+    pending_login_item_settings_ = std::move(settings);
+    return;
+  }
+
   dbus_xdg::Dictionary options;
   options[kAutostartKey] =
       dbus_utils::Variant::Wrap<"b">(settings.open_at_login);
@@ -461,49 +395,59 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
         dbus_utils::Variant::Wrap<"as">(std::move(commandline));
   }
 
-  ResetLoginItemPortalRequest(/*release_request=*/false);
-
-  login_item_bus_ = CreateLoginItemPortalBus();
-  if (!ConnectLoginItemPortalBus(login_item_bus_)) {
-    VLOG(1) << "Failed to connect to D-Bus for XDG Background portal login "
+  auto bus = dbus_thread_linux::GetSharedSessionBus();
+  if (!bus) {
+    VLOG(1) << "Failed to get session D-Bus for XDG Background portal login "
                "item.";
-    ResetLoginItemPortalRequest(/*release_request=*/false);
     return;
   }
 
-  auto* object_proxy = login_item_bus_->GetObjectProxy(
-      kFreedesktopPortalName, dbus::ObjectPath(kFreedesktopPortalPath));
-
-  const std::optional<std::string> app_id = platform_util::GetXdgAppId();
-  // Register is queued before RequestBackground on the same D-Bus connection,
-  // so the portal can associate this host process with the app's desktop ID.
-  if (app_id && !app_id->empty()) {
-    RegisterLoginItemPortalAppId(object_proxy, *app_id);
-  }
-
-  login_item_request_ = std::make_unique<dbus_xdg::Request>(
-      login_item_bus_, object_proxy, kFreedesktopPortalBackground,
-      kMethodRequestBackground, std::move(options),
+  login_item_request_in_flight_ = true;
+  dbus_xdg::RequestXdgDesktopPortal(
+      bus.get(),
       base::BindOnce(
-          [](Browser* browser, bool open_at_login, dbus_xdg::Results results) {
-            LogLoginItemPortalResponse(open_at_login, std::move(results));
-            browser->ResetLoginItemPortalRequest(/*release_request=*/false);
+          [](base::WeakPtr<Browser> browser, scoped_refptr<dbus::Bus> bus,
+             dbus_xdg::Dictionary options, bool open_at_login,
+             uint32_t portal_version) {
+            if (!browser) {
+              return;
+            }
+            if (portal_version == 0) {
+              VLOG(1) << "Failed to initialize XDG portal for login item.";
+              browser->FinishLoginItemPortalRequest();
+              return;
+            }
+
+            auto* object_proxy = bus->GetObjectProxy(
+                kFreedesktopPortalName,
+                dbus::ObjectPath(kFreedesktopPortalPath));
+            browser->login_item_request_ =
+                std::make_unique<dbus_xdg::Request>(
+                    bus, object_proxy, kFreedesktopPortalBackground,
+                    kMethodRequestBackground, std::move(options),
+                    base::BindOnce(
+                        [](base::WeakPtr<Browser> browser, bool open_at_login,
+                           dbus_xdg::Results results) {
+                          LogLoginItemPortalResponse(open_at_login,
+                                                     std::move(results));
+                          if (browser) {
+                            browser->FinishLoginItemPortalRequest();
+                          }
+                        },
+                        browser, open_at_login),
+                    std::string());
           },
-          base::Unretained(this), settings.open_at_login),
-      std::string());
+          login_item_weak_factory_.GetWeakPtr(), std::move(bus),
+          std::move(options), settings.open_at_login));
 }
 
-void Browser::ResetLoginItemPortalRequest(bool release_request) {
-  if (login_item_request_) {
-    if (release_request) {
-      login_item_request_->Release();
-    }
-    login_item_request_.reset();
-  }
-
-  if (login_item_bus_) {
-    login_item_bus_->ShutdownOnDBusThreadAndBlock();
-    login_item_bus_.reset();
+void Browser::FinishLoginItemPortalRequest() {
+  login_item_request_.reset();
+  login_item_request_in_flight_ = false;
+  if (pending_login_item_settings_) {
+    LoginItemSettings settings = std::move(*pending_login_item_settings_);
+    pending_login_item_settings_.reset();
+    SetLoginItemSettings(std::move(settings));
   }
 }
 

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -6,7 +6,10 @@
 
 #include <fcntl.h>
 
+#include <optional>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #if BUILDFLAG(IS_LINUX)
 #include <gio/gdesktopappinfo.h>
@@ -16,8 +19,22 @@
 
 #include "base/environment.h"
 #include "base/files/file_path.h"
+#include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/memory/ref_counted.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/lazy_thread_pool_task_runner.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/single_thread_task_runner_thread_mode.h"
+#include "base/task/task_traits.h"
+#include "components/dbus/utils/call_method.h"
+#include "components/dbus/utils/variant.h"
+#include "components/dbus/xdg/request.h"
+#include "dbus/bus.h"
+#include "dbus/object_path.h"
+#include "dbus/object_proxy.h"
 #include "electron/electron_version.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/linux/launcher_entry.h"
@@ -28,6 +45,7 @@
 #include "shell/common/gin_converters/login_item_settings_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
+#include "shell/common/platform_util.h"
 #include "shell/common/thread_restrictions.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/base/glib/glib_cast.h"
@@ -40,6 +58,26 @@
 namespace electron {
 
 namespace {
+
+const char kFreedesktopPortalName[] = "org.freedesktop.portal.Desktop";
+const char kFreedesktopPortalPath[] = "/org/freedesktop/portal/desktop";
+const char kFreedesktopPortalBackground[] =
+    "org.freedesktop.portal.Background";
+const char kFreedesktopPortalRegistry[] =
+    "org.freedesktop.host.portal.Registry";
+const char kMethodRequestBackground[] = "RequestBackground";
+const char kMethodRegister[] = "Register";
+
+const char kAutostartKey[] = "autostart";
+const char kBackgroundKey[] = "background";
+const char kCommandlineKey[] = "commandline";
+
+using RegisterResult = dbus_utils::CallMethodResultSig<"">;
+
+base::LazyThreadPoolSingleThreadTaskRunner g_login_item_dbus_task_runner =
+    LAZY_THREAD_POOL_SINGLE_THREAD_TASK_RUNNER_INITIALIZER(
+        base::TaskTraits(base::MayBlock(), base::TaskPriority::USER_BLOCKING),
+        base::SingleThreadTaskRunnerThreadMode::SHARED);
 
 bool SetDefaultWebClient(const std::string& protocol) {
   const auto env = base::Environment::Create();
@@ -158,6 +196,151 @@ bool SetDefaultWebClient(const std::string& protocol) {
   return gfx::Image(image_skia);
 }
 
+std::string QuoteLoginItemCommandLineArg(std::string_view arg) {
+  const bool needs_quotes = arg.empty() || arg.front() == '-' ||
+                            arg.find_first_of(" \t\n\"'\\><~|&;$*?#()`") !=
+                                std::string_view::npos;
+  std::string quoted;
+  quoted.reserve(arg.size() + (needs_quotes ? 2 : 0));
+  if (needs_quotes) {
+    quoted += '"';
+  }
+
+  for (const char c : arg) {
+    if (c == '%') {
+      quoted += "%%";
+      continue;
+    }
+    if (needs_quotes && (c == '"' || c == '`' || c == '$' || c == '\\')) {
+      quoted += '\\';
+    }
+    quoted += c;
+  }
+
+  if (needs_quotes) {
+    quoted += '"';
+  }
+  return quoted;
+}
+
+std::vector<std::string> BuildLoginItemCommandLine(
+    const LoginItemSettings& settings) {
+  std::vector<std::string> commandline;
+  if (settings.path.empty()) {
+    base::FilePath executable_path;
+    if (!base::PathService::Get(base::FILE_EXE, &executable_path)) {
+      return commandline;
+    }
+    commandline.push_back(
+        QuoteLoginItemCommandLineArg(executable_path.value()));
+  } else {
+    commandline.push_back(
+        QuoteLoginItemCommandLineArg(base::UTF16ToUTF8(settings.path)));
+  }
+
+  for (const auto& arg : settings.args) {
+    commandline.push_back(QuoteLoginItemCommandLineArg(base::UTF16ToUTF8(arg)));
+  }
+
+  return commandline;
+}
+
+std::optional<bool> TakeLoginItemPortalResponseBool(
+    dbus_xdg::Dictionary& results,
+    const std::string& key) {
+  auto iter = results.find(key);
+  if (iter == results.end()) {
+    return std::nullopt;
+  }
+
+  return std::move(iter->second).Take<bool>();
+}
+
+void LogLoginItemPortalResponse(bool open_at_login,
+                                dbus_xdg::Results results) {
+  if (!results.has_value()) {
+    VLOG(1) << "Failed to set login item with XDG Background portal: "
+            << static_cast<int>(results.error());
+    return;
+  }
+
+  dbus_xdg::Dictionary response = std::move(results).value();
+  std::optional<bool> background =
+      TakeLoginItemPortalResponseBool(response, kBackgroundKey);
+  std::optional<bool> autostart =
+      TakeLoginItemPortalResponseBool(response, kAutostartKey);
+
+  if (!background || !autostart) {
+    VLOG(1) << "XDG Background portal response was missing login item state.";
+    return;
+  }
+
+  if (*autostart != open_at_login) {
+    VLOG(1) << "XDG Background portal reported autostart=" << *autostart
+            << " after Electron requested autostart=" << open_at_login << ".";
+  }
+
+  if (open_at_login && !*background) {
+    VLOG(1) << "XDG Background portal allowed autostart without background "
+               "activity.";
+  }
+}
+
+scoped_refptr<dbus::Bus> CreateLoginItemPortalBus() {
+  dbus::Bus::Options options;
+  options.bus_type = dbus::Bus::SESSION;
+  options.connection_type = dbus::Bus::PRIVATE;
+  options.dbus_task_runner = g_login_item_dbus_task_runner.Get();
+  return base::MakeRefCounted<dbus::Bus>(std::move(options));
+}
+
+bool ConnectLoginItemPortalBus(scoped_refptr<dbus::Bus> bus) {
+  base::RunLoop run_loop;
+  bool connected = false;
+  std::string connection_name;
+
+  bus->GetDBusTaskRunner()->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](scoped_refptr<dbus::Bus> bus,
+             scoped_refptr<base::SequencedTaskRunner> origin_task_runner,
+             bool* connected, std::string* connection_name,
+             base::OnceClosure quit) {
+            *connected = bus->Connect();
+            if (*connected) {
+              *connection_name = bus->GetConnectionName();
+            }
+            origin_task_runner->PostTask(FROM_HERE, std::move(quit));
+          },
+          std::move(bus), base::SequencedTaskRunner::GetCurrentDefault(),
+          &connected, &connection_name, run_loop.QuitClosure()));
+
+  run_loop.Run();
+
+  return connected && !connection_name.empty();
+}
+
+void RegisterLoginItemPortalAppId(dbus::ObjectProxy* object_proxy,
+                                  const std::string& app_id) {
+  dbus_utils::CallMethod<"sa{sv}", "">(
+      object_proxy, kFreedesktopPortalRegistry, kMethodRegister,
+      base::BindOnce([](RegisterResult result) {
+        if (result.has_value()) {
+          return;
+        }
+
+        const auto& error = result.error();
+        if (error.error_message.empty()) {
+          VLOG(1) << "Failed to register app ID with XDG portal: "
+                  << static_cast<int>(error.status);
+        } else {
+          VLOG(1) << "Failed to register app ID with XDG portal: "
+                  << error.error_message;
+        }
+      }),
+      app_id, dbus_xdg::Dictionary());
+}
+
 }  // namespace
 
 void Browser::AddRecentDocument(const base::FilePath& path) {}
@@ -261,7 +444,68 @@ bool Browser::SetBadgeCount(std::optional<int> count) {
   return true;
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {}
+void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+  dbus_xdg::Dictionary options;
+  options[kAutostartKey] =
+      dbus_utils::Variant::Wrap<"b">(settings.open_at_login);
+
+  if (settings.open_at_login) {
+    auto commandline = BuildLoginItemCommandLine(settings);
+    if (commandline.empty() || commandline.front().empty()) {
+      VLOG(1) << "Failed to determine executable path for XDG Background "
+                 "portal login item.";
+      return;
+    }
+
+    options[kCommandlineKey] =
+        dbus_utils::Variant::Wrap<"as">(std::move(commandline));
+  }
+
+  ResetLoginItemPortalRequest(/*release_request=*/false);
+
+  login_item_bus_ = CreateLoginItemPortalBus();
+  if (!ConnectLoginItemPortalBus(login_item_bus_)) {
+    VLOG(1) << "Failed to connect to D-Bus for XDG Background portal login "
+               "item.";
+    ResetLoginItemPortalRequest(/*release_request=*/false);
+    return;
+  }
+
+  auto* object_proxy = login_item_bus_->GetObjectProxy(
+      kFreedesktopPortalName, dbus::ObjectPath(kFreedesktopPortalPath));
+
+  const std::optional<std::string> app_id = platform_util::GetXdgAppId();
+  // Register is queued before RequestBackground on the same D-Bus connection,
+  // so the portal can associate this host process with the app's desktop ID.
+  if (app_id && !app_id->empty()) {
+    RegisterLoginItemPortalAppId(object_proxy, *app_id);
+  }
+
+  login_item_request_ = std::make_unique<dbus_xdg::Request>(
+      login_item_bus_, object_proxy, kFreedesktopPortalBackground,
+      kMethodRequestBackground, std::move(options),
+      base::BindOnce(
+          [](Browser* browser, bool open_at_login, dbus_xdg::Results results) {
+            LogLoginItemPortalResponse(open_at_login, std::move(results));
+            browser->ResetLoginItemPortalRequest(/*release_request=*/false);
+          },
+          base::Unretained(this), settings.open_at_login),
+      std::string());
+}
+
+void Browser::ResetLoginItemPortalRequest(bool release_request) {
+  if (login_item_request_) {
+    if (release_request) {
+      login_item_request_->Release();
+    }
+    login_item_request_.reset();
+  }
+
+  if (login_item_bus_) {
+    login_item_bus_->ShutdownOnDBusThreadAndBlock();
+    login_item_bus_.reset();
+  }
+}
 
 v8::Local<v8::Value> Browser::GetLoginItemSettings(
     const LoginItemSettings& options) {

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -373,10 +373,18 @@ bool Browser::SetBadgeCount(std::optional<int> count) {
   return true;
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
-  if (login_item_request_in_flight_) {
-    pending_login_item_settings_ = std::move(settings);
-    return;
+v8::Local<v8::Promise> Browser::SetLoginItemSettings(
+    v8::Isolate* isolate,
+    LoginItemSettings settings) {
+  gin_helper::Promise<void> promise(isolate);
+  const auto handle = promise.GetHandle();
+
+  auto bus = dbus_thread_linux::GetSharedSessionBus();
+  if (!bus) {
+    VLOG(1) << "Failed to get session D-Bus for XDG Background portal login "
+               "item.";
+    promise.Resolve();
+    return handle;
   }
 
   dbus_xdg::Dictionary options;
@@ -388,67 +396,62 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
     if (commandline.empty() || commandline.front().empty()) {
       VLOG(1) << "Failed to determine executable path for XDG Background "
                  "portal login item.";
-      return;
+      promise.Resolve();
+      return handle;
     }
 
     options[kCommandlineKey] =
         dbus_utils::Variant::Wrap<"as">(std::move(commandline));
   }
 
-  auto bus = dbus_thread_linux::GetSharedSessionBus();
-  if (!bus) {
-    VLOG(1) << "Failed to get session D-Bus for XDG Background portal login "
-               "item.";
-    return;
-  }
-
-  login_item_request_in_flight_ = true;
   dbus_xdg::RequestXdgDesktopPortal(
       bus.get(),
       base::BindOnce(
           [](base::WeakPtr<Browser> browser, scoped_refptr<dbus::Bus> bus,
              dbus_xdg::Dictionary options, bool open_at_login,
+             gin_helper::Promise<void> promise,
              uint32_t portal_version) {
             if (!browser) {
               return;
             }
             if (portal_version == 0) {
               VLOG(1) << "Failed to initialize XDG portal for login item.";
-              browser->FinishLoginItemPortalRequest();
+              promise.Resolve();
               return;
             }
 
             auto* object_proxy = bus->GetObjectProxy(
                 kFreedesktopPortalName,
                 dbus::ObjectPath(kFreedesktopPortalPath));
-            browser->login_item_request_ =
+            const size_t request_id = browser->next_login_item_request_id_++;
+            browser->login_item_requests_.emplace(
+                request_id,
                 std::make_unique<dbus_xdg::Request>(
                     bus, object_proxy, kFreedesktopPortalBackground,
                     kMethodRequestBackground, std::move(options),
                     base::BindOnce(
-                        [](base::WeakPtr<Browser> browser, bool open_at_login,
+                        [](base::WeakPtr<Browser> browser, size_t request_id,
+                           bool open_at_login,
+                           gin_helper::Promise<void> promise,
                            dbus_xdg::Results results) {
                           LogLoginItemPortalResponse(open_at_login,
                                                      std::move(results));
+                          promise.Resolve();
                           if (browser) {
-                            browser->FinishLoginItemPortalRequest();
+                            browser->FinishLoginItemPortalRequest(request_id);
                           }
                         },
-                        browser, open_at_login),
-                    std::string());
+                        browser, request_id, open_at_login,
+                        std::move(promise)),
+                    std::string()));
           },
           login_item_weak_factory_.GetWeakPtr(), std::move(bus),
-          std::move(options), settings.open_at_login));
+          std::move(options), settings.open_at_login, std::move(promise)));
+  return handle;
 }
 
-void Browser::FinishLoginItemPortalRequest() {
-  login_item_request_.reset();
-  login_item_request_in_flight_ = false;
-  if (pending_login_item_settings_) {
-    LoginItemSettings settings = std::move(*pending_login_item_settings_);
-    pending_login_item_settings_.reset();
-    SetLoginItemSettings(std::move(settings));
-  }
+void Browser::FinishLoginItemPortalRequest(size_t request_id) {
+  login_item_requests_.erase(request_id);
 }
 
 v8::Local<v8::Value> Browser::GetLoginItemSettings(

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -394,15 +394,18 @@ v8::Local<v8::Value> Browser::GetLoginItemSettings(
   return gin::ConvertToV8(isolate, settings);
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+v8::Local<v8::Promise> Browser::SetLoginItemSettings(
+    v8::Isolate* isolate,
+    LoginItemSettings settings) {
   if (settings.type != "mainAppService" && settings.service_name.empty()) {
-    gin_helper::ErrorThrower(JavascriptEnvironment::GetIsolate())
-        .ThrowTypeError("'name' is required when type is not mainAppService");
-    return;
+    gin_helper::ErrorThrower(isolate).ThrowTypeError(
+        "'name' is required when type is not mainAppService");
+    return {};
   }
 
   platform_util::SetLoginItemEnabled(settings.type, settings.service_name,
                                      settings.open_at_login);
+  return gin_helper::Promise<void>::ResolvedPromise(isolate);
 }
 
 std::string Browser::GetExecutableFileVersion() const {

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -678,7 +678,9 @@ void Browser::UpdateBadgeContents(
   taskbar_host_.SetOverlayIcon(hwnd, badge, badge_alt_string);
 }
 
-void Browser::SetLoginItemSettings(LoginItemSettings settings) {
+v8::Local<v8::Promise> Browser::SetLoginItemSettings(
+    v8::Isolate* isolate,
+    LoginItemSettings settings) {
   base::win::RegKey key(HKEY_CURRENT_USER, Run.c_str(), KEY_ALL_ACCESS);
 
   base::win::RegKey startup_approved_key(
@@ -713,6 +715,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
     startup_approved_key.DeleteValue(key_name);
     key.DeleteValue(key_name);
   }
+  return gin_helper::Promise<void>::ResolvedPromise(isolate);
 }
 
 v8::Local<v8::Value> Browser::GetLoginItemSettings(

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, session, net as electronNet, WebContents, utilityProcess } from 'electron/main';
 
 import { assert, expect } from 'chai';
+import * as dbus from 'dbus-native';
 
 import * as cp from 'node:child_process';
 import { once } from 'node:events';
@@ -1104,6 +1105,123 @@ describe('app module', () => {
       expect(app.getLoginItemSettings()).to.deep.equal(expectation);
     });
   });
+
+  ifdescribe(process.platform === 'linux' && !!process.env.DBUS_SESSION_BUS_ADDRESS)(
+    'app.setLoginItemSettings API (Linux portal)',
+    () => {
+      const serviceName = 'org.freedesktop.portal.Desktop';
+      const portalPath = '/org/freedesktop/portal/desktop';
+      const mockInterfaceName = 'org.freedesktop.DBus.Mock';
+
+      let getCalls: () => Promise<any[]>;
+      let clearCalls: () => Promise<void>;
+      let originalDesktopName: string | undefined;
+
+      before(async () => {
+        originalDesktopName = process.env.CHROME_DESKTOP;
+        app.setDesktopName('electron-api-app-spec.desktop');
+
+        const bus = dbus.sessionBus();
+        const service = bus.getService(serviceName);
+        const getInterface = promisify(service.getInterface.bind(service));
+        const mock: any = await getInterface(portalPath, mockInterfaceName);
+        getCalls = promisify(mock.GetCalls.bind(mock));
+        clearCalls = promisify(mock.ClearCalls.bind(mock));
+      });
+
+      after(() => {
+        if (originalDesktopName === undefined) {
+          delete process.env.CHROME_DESKTOP;
+        } else {
+          process.env.CHROME_DESKTOP = originalDesktopName;
+        }
+      });
+
+      beforeEach(async () => {
+        await clearCalls();
+      });
+
+      async function waitForPortalCall(methodName: string) {
+        await waitUntil(async () => {
+          const calls = await getCalls();
+          return calls.some((call) => call[1] === methodName);
+        });
+
+        const calls = await getCalls();
+        const matchingCalls = calls.filter((call) => call[1] === methodName);
+        // Let the mock response complete so the next test starts without an
+        // in-flight request.
+        await setTimeout(100);
+        return matchingCalls[matchingCalls.length - 1];
+      }
+
+      function unmarshalDBusValue(value: any): any {
+        if (
+          Array.isArray(value) &&
+          value.length === 2 &&
+          typeof value[0] !== 'string' &&
+          Array.isArray(value[1]) &&
+          value[1].length === 1
+        ) {
+          return unmarshalDBusValue(value[1][0]);
+        }
+
+        if (Array.isArray(value)) {
+          const isDictionary =
+            value.length > 0 &&
+            value.every((entry) => {
+              return Array.isArray(entry) && entry.length === 2 && typeof entry[0] === 'string';
+            });
+          if (isDictionary) {
+            return Object.fromEntries(
+              value.map(([key, entryValue]: [string, any]) => [key, unmarshalDBusValue(entryValue)])
+            );
+          }
+
+          return value.map(unmarshalDBusValue);
+        }
+
+        return value;
+      }
+
+      function unmarshalOptions(call: any) {
+        return unmarshalDBusValue(call[2][1]);
+      }
+
+      it('defaults the commandline to process.execPath', async () => {
+        app.setLoginItemSettings({ openAtLogin: true });
+
+        const call = await waitForPortalCall('RequestBackground');
+        const options = unmarshalOptions(call);
+
+        expect(options.autostart).to.equal(true);
+        expect(options.commandline).to.deep.equal([process.execPath]);
+      });
+
+      it('escapes a custom commandline for a desktop Exec entry', async () => {
+        const executable = '/tmp/electron app';
+        const args = ['--flag=value with spaces', '100%', ''];
+
+        app.setLoginItemSettings({ openAtLogin: true, path: executable, args });
+
+        const call = await waitForPortalCall('RequestBackground');
+        const options = unmarshalOptions(call);
+
+        expect(options.autostart).to.equal(true);
+        expect(options.commandline).to.deep.equal(['"/tmp/electron app"', '"--flag=value with spaces"', '100%%', '""']);
+      });
+
+      it('requests autostart to be disabled', async () => {
+        app.setLoginItemSettings({ openAtLogin: false });
+
+        const call = await waitForPortalCall('RequestBackground');
+        const options = unmarshalOptions(call);
+
+        expect(options.autostart).to.equal(false);
+        expect(options).to.not.have.property('commandline');
+      });
+    }
+  );
 
   ifdescribe(process.platform !== 'linux')('accessibility support functionality', () => {
     it('is mutable', () => {

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1141,17 +1141,9 @@ describe('app module', () => {
         await clearCalls();
       });
 
-      async function waitForPortalCall(methodName: string) {
-        await waitUntil(async () => {
-          const calls = await getCalls();
-          return calls.some((call) => call[1] === methodName);
-        });
-
+      async function getPortalCall(methodName: string) {
         const calls = await getCalls();
         const matchingCalls = calls.filter((call) => call[1] === methodName);
-        // Let the mock response complete so the next test starts without an
-        // in-flight request.
-        await setTimeout(100);
         return matchingCalls[matchingCalls.length - 1];
       }
 
@@ -1189,9 +1181,9 @@ describe('app module', () => {
       }
 
       it('defaults the commandline to process.execPath', async () => {
-        app.setLoginItemSettings({ openAtLogin: true });
+        await app.setLoginItemSettings({ openAtLogin: true });
 
-        const call = await waitForPortalCall('RequestBackground');
+        const call = await getPortalCall('RequestBackground');
         const options = unmarshalOptions(call);
 
         expect(options.autostart).to.equal(true);
@@ -1202,29 +1194,27 @@ describe('app module', () => {
         const executable = '/tmp/electron app';
         const args = ['--flag=value with spaces', '100%', ''];
 
-        app.setLoginItemSettings({ openAtLogin: true, path: executable, args });
+        await app.setLoginItemSettings({ openAtLogin: true, path: executable, args });
 
-        const call = await waitForPortalCall('RequestBackground');
+        const call = await getPortalCall('RequestBackground');
         const options = unmarshalOptions(call);
 
         expect(options.autostart).to.equal(true);
         expect(options.commandline).to.deep.equal(['"/tmp/electron app"', '"--flag=value with spaces"', '100%%', '""']);
       });
 
-      it('applies the latest setting after an in-flight request', async () => {
-        app.setLoginItemSettings({ openAtLogin: true });
-        app.setLoginItemSettings({ openAtLogin: false });
+      it('settles concurrent requests', async () => {
+        await Promise.all([
+          app.setLoginItemSettings({ openAtLogin: true }),
+          app.setLoginItemSettings({ openAtLogin: false })
+        ]);
 
-        await waitUntil(async () => {
-          const calls = await getCalls();
-          return calls.filter((call) => call[1] === 'RequestBackground').length === 2;
-        });
         const calls = await getCalls();
         const requestCalls = calls.filter((call) => call[1] === 'RequestBackground');
-        const options = unmarshalOptions(requestCalls[1]);
+        const options = requestCalls.map(unmarshalOptions);
 
-        expect(options.autostart).to.equal(false);
-        expect(options).to.not.have.property('commandline');
+        expect(options.map(({ autostart }) => autostart)).to.have.members([true, false]);
+        expect(options.find(({ autostart }) => !autostart)).to.not.have.property('commandline');
       });
     }
   );

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -1211,11 +1211,17 @@ describe('app module', () => {
         expect(options.commandline).to.deep.equal(['"/tmp/electron app"', '"--flag=value with spaces"', '100%%', '""']);
       });
 
-      it('requests autostart to be disabled', async () => {
+      it('applies the latest setting after an in-flight request', async () => {
+        app.setLoginItemSettings({ openAtLogin: true });
         app.setLoginItemSettings({ openAtLogin: false });
 
-        const call = await waitForPortalCall('RequestBackground');
-        const options = unmarshalOptions(call);
+        await waitUntil(async () => {
+          const calls = await getCalls();
+          return calls.filter((call) => call[1] === 'RequestBackground').length === 2;
+        });
+        const calls = await getCalls();
+        const requestCalls = calls.filter((call) => call[1] === 'RequestBackground');
+        const options = unmarshalOptions(requestCalls[1]);
 
         expect(options.autostart).to.equal(false);
         expect(options).to.not.have.property('commandline');


### PR DESCRIPTION
#### Description of Change

Adds Linux support for `app.setLoginItemSettings()` using the XDG Desktop Portal Background interface.

Closes #32388 

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added Linux support for `app.setLoginItemSettings()` using the XDG Desktop Portal.
