### PR TITLE
ci: fix running clang-tidy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,7 +349,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
-    needs: [checkout-macos, build-siso-macos]
+    needs: [setup, checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
       clang-tidy-runs-on: macos-15-xlarge
@@ -370,7 +370,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
-    needs: [checkout-linux, build-siso-linux]
+    needs: [setup, checkout-linux, build-siso-linux]
     if: ${{ needs.setup.outputs.src == 'true' }}
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
@@ -449,7 +449,7 @@ jobs:
       issues: read
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
-    needs: [checkout-windows, build-siso-windows]
+    needs: [setup, checkout-windows, build-siso-windows]
     if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
     with:
       build-runs-on: garm-windows-x64-32core


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#52719 actually broke clang-tidy running in CI all together, rather than gating it to only native code. It looks like there's some buggy behavior with GHA and the top-level `if` can get `needs.setup` transitively, but inside the `with` block it needs it fails to transitively resolve it and it needs to be listed explicitly as in the `needs` for the job.

CI job that validates it works: https://github.com/electron/electron/actions/runs/32447767296

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
