### PR TITLE
build: fail PGO merge on corrupt profraw input

### DIFF
--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -540,8 +540,12 @@ jobs:
           fi
           out="profiles/electron-${target}-${TIMESTAMP}-${SHORT_SHA}.profdata"
           echo "Merging $count profraw files for $target"
-          # Tolerate truncated profraw from children killed at shutdown.
-          "$PROFDATA" merge --failure-mode=all -o "$out" "$dir"*.profraw
+          # A truncated or corrupt profraw means a child process was killed
+          # mid-dump, and that child is usually the benchmark renderer - the
+          # merged profile would silently lose most of its Blink counters and
+          # pessimize the renderer in release builds. Fail the run instead so
+          # the branch keeps its last good state files.
+          "$PROFDATA" merge --failure-mode=any -o "$out" "$dir"*.profraw
           merged=$((merged+1))
         done
         if [ "$merged" -eq 0 ]; then


### PR DESCRIPTION
- `llvm-profdata merge --failure-mode=all` only fails when *every* input is unreadable. A truncated `child_pool-*.profraw` (a child killed while dumping its counters at shutdown) was skipped with a warning and the thin profile was uploaded and rolled out. That is how `42-x-y` win-x64 shipped a profile with ~16% of its usual counts from 42.8.1 onward (microsoft/vscode#331672); `main` win-arm64's latest profile is partially hit the same way.
- Switch to `--failure-mode=any` so a corrupt input fails the run and the branch keeps its previous state files until a clean collection lands.

Follow-up (separate PR): have the browser wait for children to dump their profiles at shutdown like Chrome's `browser_shutdown.cc` does, so the race stops happening in the first place.

Notes: none