### PR TITLE
fix: wait for child processes to dump PGO profiles before shutdown

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -611,6 +611,7 @@ source_set("electron_lib") {
   public_deps = [
     "//base",
     "//base:i18n",
+    "//build/config/compiler:compiler_buildflags",
     "//content/public/app",
     "//ui/base/unowned_user_data",
   ]

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -8,12 +8,15 @@
 #include <string>
 #include <utility>
 
+#include "base/clang_profiling_buildflags.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/path_service.h"
+#include "base/run_loop.h"
 #include "base/strings/string_util.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/threading/thread_restrictions.h"
+#include "build/config/compiler/compiler_buildflags.h"
 #include "chrome/common/chrome_paths.h"
 #include "gin/arguments.h"
 #include "shell/browser/browser_observer.h"
@@ -25,6 +28,10 @@
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/thread_restrictions.h"
+
+#if BUILDFLAG(CLANG_PROFILING_INSIDE_SANDBOX) && BUILDFLAG(CLANG_PGO_PROFILING)
+#include "content/public/browser/profiling_utils.h"
+#endif
 
 namespace electron {
 
@@ -164,6 +171,21 @@ void Browser::Shutdown() {
   is_quitting_ = true;
 
   observers_.Notify(&BrowserObserver::OnQuit);
+
+#if BUILDFLAG(CLANG_PROFILING_INSIDE_SANDBOX) && BUILDFLAG(CLANG_PGO_PROFILING)
+  // In PGO-instrumented builds, sandboxed child processes write their
+  // profile counters through a file handle the browser gave them, and they
+  // only do so when asked or when they exit cleanly. Once the browser quits
+  // its message loop the sandbox job object kills any child still writing,
+  // which truncates the profraw and loses the renderer's counters. Mirror
+  // chrome/browser/lifetime/browser_shutdown.cc: ask every child to dump now
+  // and wait for all of them before continuing with shutdown.
+  if (base::SingleThreadTaskRunner::HasCurrentDefault()) {
+    base::RunLoop nested_run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+    content::AskAllChildrenToDumpProfilingData(nested_run_loop.QuitClosure());
+    nested_run_loop.Run();
+  }
+#endif
 
   if (quit_main_message_loop_) {
     RunQuitClosure(std::move(quit_main_message_loop_));


### PR DESCRIPTION
Root-cause fix for the corrupt profraw files behind microsoft/vscode#331672 (see #53064 for the 42-x-y profile restore and #53065 for the merge gate).

- In `chrome_pgo_phase = 1` builds, sandboxed children write their counters through a file handle the browser hands them (`CLANG_PROFILING_INSIDE_SANDBOX`), and only do so when asked or on clean exit. Electron never asked: `app.quit()` quit the main loop, the sandbox job object killed any child still writing, and the truncated `child_pool-*.profraw` was dropped at merge. The loser is usually the benchmark renderer, so Blink ends up cold in the published profile. 42-x-y win-x64 lost this race 3/3 runs since 2026-08-02; `main` win-arm64's latest profile is partially hit.
- Mirror `chrome/browser/lifetime/browser_shutdown.cc`: at the start of `Browser::Shutdown()` call `content::AskAllChildrenToDumpProfilingData()` and run a nested loop until every child has flushed. Guarded by `CLANG_PROFILING_INSIDE_SANDBOX && CLANG_PGO_PROFILING`, so it compiles out of every shipping build.
- Verified the TU compiles with the current tree both with the flags off and with them forced on (object then references `AskAllChildrenToDumpProfilingData`). End-to-end check: a `pgo-generation` dispatch on this branch should yield 4 valid `child_pool` files for win-x64 with no `file header is corrupt` warnings in the Merge Profiles job.

Notes: none