### PR TITLE
fix: don't abort the process when a JS accessor throws during value conversion

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1239,7 +1239,8 @@ v8::Local<v8::Value> App::GetAccessibilitySupportFeatures() {
 
   v8::Local<v8::Array> arr = v8::Array::New(isolate, features.size());
   for (uint32_t i = 0; i < features.size(); ++i) {
-    arr->Set(isolate->GetCurrentContext(), i, features[i]).Check();
+    arr->CreateDataProperty(isolate->GetCurrentContext(), i, features[i])
+        .Check();
   }
   return handle_scope.Escape(arr);
 }

--- a/shell/browser/api/electron_api_auto_updater.cc
+++ b/shell/browser/api/electron_api_auto_updater.cc
@@ -75,12 +75,12 @@ void AutoUpdater::OnError(const std::string& message,
 
     // add two new params for better error handling
     errorObject
-        ->Set(context, gin::StringToV8(isolate, "code"),
-              v8::Integer::New(isolate, code))
+        ->CreateDataProperty(context, gin::StringToV8(isolate, "code"),
+                             v8::Integer::New(isolate, code))
         .Check();
     errorObject
-        ->Set(context, gin::StringToV8(isolate, "domain"),
-              gin::StringToV8(isolate, domain))
+        ->CreateDataProperty(context, gin::StringToV8(isolate, "domain"),
+                             gin::StringToV8(isolate, domain))
         .Check();
 
     gin_helper::EmitEvent(isolate, wrapper, "error", errorObject, message);

--- a/shell/browser/api/electron_api_clipboard.cc
+++ b/shell/browser/api/electron_api_clipboard.cc
@@ -313,7 +313,7 @@ v8::Local<v8::Promise> Clipboard::Read(ui::ClipboardBuffer buffer,
                       return;
                     }
                     v8::Local<v8::Array> array = v8::Array::New(iso, 1);
-                    array->Set(ctx, 0, wrapper).Check();
+                    array->CreateDataProperty(ctx, 0, wrapper).Check();
                     promise.Resolve(array);
                   },
                   std::move(promise), buffer));

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -450,8 +450,8 @@ v8::Local<v8::Promise> Notification::GetHistory(v8::Isolate* isolate) {
 
           auto handle = gin_helper::CreateHandle(isolate, notif);
           result
-              ->Set(isolate->GetCurrentContext(), static_cast<uint32_t>(i),
-                    handle.ToV8())
+              ->CreateDataProperty(isolate->GetCurrentContext(),
+                                   static_cast<uint32_t>(i), handle.ToV8())
               .Check();
         }
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -347,9 +347,9 @@ class ClearDataTask : public gin_helper::CleanedUpAtExit {
       auto error = v8::Exception::Error(
           gin::StringToV8(isolate, "Failed to clear data"));
       error.As<v8::Object>()
-          ->Set(promise_.GetContext(),
-                gin::StringToV8(isolate, "failedDataTypes"),
-                failed_data_types_array)
+          ->CreateDataProperty(promise_.GetContext(),
+                               gin::StringToV8(isolate, "failedDataTypes"),
+                               failed_data_types_array)
           .Check();
 
       promise_.Reject(error);

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -665,8 +665,12 @@ struct Converter<ImportSharedTextureInfo> {
       if (v8_native_pixmap.Get("planes", &v8_planes)) {
         out->planes.clear();
         for (uint32_t i = 0; i < v8_planes->Length(); ++i) {
-          v8::Local<v8::Value> v8_item =
-              v8_planes->Get(isolate->GetCurrentContext(), i).ToLocalChecked();
+          v8::Local<v8::Value> v8_item;
+          if (!v8_planes->Get(isolate->GetCurrentContext(), i)
+                   .ToLocal(&v8_item) ||
+              !v8_item->IsObject()) {
+            return false;
+          }
           gin::Dictionary v8_plane(isolate, v8_item.As<v8::Object>());
           ImportSharedTextureInfoPlane plane;
           v8_plane.Get("stride", &plane.stride);

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -223,7 +223,10 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
 
   auto context = isolate->GetCurrentContext();
   auto headers = val.As<v8::Object>();
-  auto keys = headers->GetOwnPropertyNames(context).ToLocalChecked();
+  v8::Local<v8::Array> keys;
+  if (!headers->GetOwnPropertyNames(context).ToLocal(&keys)) {
+    return false;
+  }
   for (uint32_t i = 0; i < keys->Length(); i++) {
     v8::Local<v8::Value> keyVal;
     if (!keys->Get(context, i).ToLocal(&keyVal)) {
@@ -232,12 +235,16 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
     std::string key;
     gin::ConvertFromV8(isolate, keyVal, &key);
 
-    auto localVal = headers->Get(context, keyVal).ToLocalChecked();
+    v8::Local<v8::Value> localVal;
+    if (!headers->Get(context, keyVal).ToLocal(&localVal)) {
+      return false;
+    }
     if (localVal->IsArray()) {
       auto values = localVal.As<v8::Array>();
       for (uint32_t j = 0; j < values->Length(); j++) {
-        if (!addHeaderFromValue(key,
-                                values->Get(context, j).ToLocalChecked())) {
+        v8::Local<v8::Value> item;
+        if (!values->Get(context, j).ToLocal(&item) ||
+            !addHeaderFromValue(key, item)) {
           return false;
         }
       }

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -160,7 +160,9 @@ struct Converter<std::vector<std::pair<K, V>>> {
     out->clear();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
     v8::Local<v8::Object> obj = value.As<v8::Object>();
-    v8::Local<v8::Array> keys = obj->GetPropertyNames(context).ToLocalChecked();
+    v8::Local<v8::Array> keys;
+    if (!obj->GetPropertyNames(context).ToLocal(&keys))
+      return false;
     const uint32_t length = keys->Length();
     out->reserve(length);
     for (uint32_t i = 0; i < length; ++i) {

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -145,9 +145,11 @@ struct Converter<std::set<T>> {
     v8::Local<v8::Array> array = val.As<v8::Array>();
     uint32_t length = array->Length();
     for (uint32_t i = 0; i < length; ++i) {
+      v8::Local<v8::Value> v8_item;
+      if (!array->Get(context, i).ToLocal(&v8_item))
+        return false;
       T item;
-      if (!Converter<T>::FromV8(isolate,
-                                array->Get(context, i).ToLocalChecked(), &item))
+      if (!Converter<T>::FromV8(isolate, v8_item, &item))
         return false;
       result.insert(std::move(item));
     }
@@ -167,7 +169,9 @@ struct Converter<std::map<K, V, Compare>> {
     out->clear();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
     v8::Local<v8::Object> obj = value.As<v8::Object>();
-    v8::Local<v8::Array> keys = obj->GetPropertyNames(context).ToLocalChecked();
+    v8::Local<v8::Array> keys;
+    if (!obj->GetPropertyNames(context).ToLocal(&keys))
+      return false;
     const uint32_t length = keys->Length();
     for (uint32_t i = 0; i < length; ++i) {
       v8::MaybeLocal<v8::Value> maybe_v8key = keys->Get(context, i);

--- a/shell/common/gin_helper/dictionary.h
+++ b/shell/common/gin_helper/dictionary.h
@@ -211,8 +211,9 @@ class Dictionary : public gin::Dictionary {
       return true;
 
     v8::Local<v8::Context> context = isolate()->GetCurrentContext();
-    v8::Local<v8::Array> props =
-        GetHandle()->GetOwnPropertyNames(context).ToLocalChecked();
+    v8::Local<v8::Array> props;
+    if (!GetHandle()->GetOwnPropertyNames(context).ToLocal(&props))
+      return false;
     return props->Length() == 0;
   }
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -75,12 +75,18 @@ bool DeepFreeze(const v8::Local<v8::Object>& object,
     return true;
   frozen.insert(hash);
 
-  v8::Local<v8::Array> property_names =
-      object->GetOwnPropertyNames(context).ToLocalChecked();
+  v8::Local<v8::Array> property_names;
+  if (!object->GetOwnPropertyNames(context).ToLocal(&property_names))
+    return false;
   for (uint32_t i = 0; i < property_names->Length(); ++i) {
-    v8::Local<v8::Value> child =
-        object->Get(context, property_names->Get(context, i).ToLocalChecked())
-            .ToLocalChecked();
+    v8::Local<v8::Value> name;
+    if (!property_names->Get(context, i).ToLocal(&name))
+      return false;
+    // The property may be an accessor that throws (e.g. a DOM element the page
+    // has decorated), so the read must be checked.
+    v8::Local<v8::Value> child;
+    if (!object->Get(context, name).ToLocal(&child))
+      return false;
     if (child->IsObject() && !child->IsTypedArray()) {
       if (!DeepFreeze(child.As<v8::Object>(), context, frozen))
         return false;

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -865,8 +865,9 @@ void OverrideGlobalValueFromIsolatedWorld(
     v8::MaybeLocal<v8::Value> maybe_proxy = PassValueToOtherContext(
         isolate, source_context, main_context, value, source_context->Global(),
         support_dynamic_properties, BridgeErrorTarget::kSource);
-    DCHECK(!maybe_proxy.IsEmpty());
-    auto proxy = maybe_proxy.ToLocalChecked();
+    v8::Local<v8::Value> proxy;
+    if (!maybe_proxy.ToLocal(&proxy))
+      return;
 
     target_object.Set(final_key, proxy);
   }
@@ -902,8 +903,8 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
       v8::MaybeLocal<v8::Value> maybe_getter_proxy = PassValueToOtherContext(
           isolate, source_context, main_context, getter,
           source_context->Global(), false, BridgeErrorTarget::kSource);
-      DCHECK(!maybe_getter_proxy.IsEmpty());
-      getter_proxy = maybe_getter_proxy.ToLocalChecked();
+      if (!maybe_getter_proxy.ToLocal(&getter_proxy))
+        return false;
     }
     if (!setter->IsNullOrUndefined() && setter->IsObject()) {
       v8::Local<v8::Context> source_context =
@@ -911,8 +912,8 @@ bool OverrideGlobalPropertyFromIsolatedWorld(
       v8::MaybeLocal<v8::Value> maybe_setter_proxy = PassValueToOtherContext(
           isolate, source_context, main_context, setter,
           source_context->Global(), false, BridgeErrorTarget::kSource);
-      DCHECK(!maybe_setter_proxy.IsEmpty());
-      setter_proxy = maybe_setter_proxy.ToLocalChecked();
+      if (!maybe_setter_proxy.ToLocal(&setter_proxy))
+        return false;
     }
 
     v8::PropertyDescriptor desc(getter_proxy, setter_proxy);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -374,11 +374,17 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     v8::LocalVector<v8::Value> cloned(isolate);
     cloned.reserve(length);
     for (size_t i = 0; i < length; i++) {
+      // Reading an index can run a user-defined accessor which may throw, so
+      // this must not be ToLocalChecked(). If it throws, bail out and let the
+      // pending exception propagate to the caller like any other conversion
+      // failure.
+      v8::Local<v8::Value> element;
+      if (!arr->Get(source_context, i).ToLocal(&element))
+        return {};
       auto value_for_array = PassValueToOtherContextInner(
           isolate, source_context, source_execution_context,
-          destination_context, arr->Get(source_context, i).ToLocalChecked(),
-          value, object_cache, support_dynamic_properties, recursion_depth + 1,
-          error_target);
+          destination_context, element, value, object_cache,
+          support_dynamic_properties, recursion_depth + 1, error_target);
       if (value_for_array.IsEmpty())
         return {};
       cloned.push_back(value_for_array.ToLocalChecked());

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -569,7 +569,7 @@ class WebFrameRenderer final
                              v8::Local<v8::Object> provider) {
     auto context = isolate->GetCurrentContext();
     if (!provider->Has(context, gin::StringToV8(isolate, "spellCheck"))
-             .ToChecked()) {
+             .FromMaybe(false)) {
       thrower.ThrowError("\"spellCheck\" has to be defined");
       return;
     }

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -157,15 +157,23 @@ void WebWorkerObserver::ShareEnvironmentWithContext(
   v8::Local<v8::Object> original_global = original_context->Global();
   v8::Local<v8::Object> new_global = worker_context->Global();
 
+  // Script in the original context can redefine these globals with accessors
+  // that throw, so read them defensively and fall back to the environment's
+  // own process object / undefined rather than crashing the worker.
+  v8::TryCatch try_catch(isolate);
   v8::Local<v8::Value> process_value;
-  CHECK(original_global
-            ->Get(original_context, gin::StringToV8(isolate, "process"))
-            .ToLocal(&process_value));
+  if (!original_global
+           ->Get(original_context, gin::StringToV8(isolate, "process"))
+           .ToLocal(&process_value)) {
+    process_value = env->process_object();
+  }
 
   v8::Local<v8::Value> require_value;
-  CHECK(original_global
-            ->Get(original_context, gin::StringToV8(isolate, "require"))
-            .ToLocal(&require_value));
+  if (!original_global
+           ->Get(original_context, gin::StringToV8(isolate, "require"))
+           .ToLocal(&require_value)) {
+    require_value = v8::Undefined(isolate);
+  }
 
   // Set up 'global' as an alias for globalThis. Node.js bootstrapping normally
   // does this during LoadEnvironment, but we skip full bootstrap for shared

--- a/shell/utility/ai/utility_ai_language_model.cc
+++ b/shell/utility/ai/utility_ai_language_model.cc
@@ -31,15 +31,21 @@ struct Converter<on_device_model::mojom::ResponseConstraintPtr> {
     if (val.is_null())
       return v8::Undefined(isolate);
 
+    v8::Local<v8::Value> result;
     if (val->is_json_schema()) {
-      return v8::JSON::Parse(isolate->GetCurrentContext(),
-                             StringToV8(isolate, val->get_json_schema()))
-          .ToLocalChecked();
+      if (v8::JSON::Parse(isolate->GetCurrentContext(),
+                          StringToV8(isolate, val->get_json_schema()))
+              .ToLocal(&result)) {
+        return result;
+      }
     } else if (val->is_regex()) {
-      return v8::RegExp::New(isolate->GetCurrentContext(),
-                             StringToV8(isolate, val->get_regex()),
-                             v8::RegExp::kNone)
-          .ToLocalChecked();
+      v8::Local<v8::RegExp> regexp;
+      if (v8::RegExp::New(isolate->GetCurrentContext(),
+                          StringToV8(isolate, val->get_regex()),
+                          v8::RegExp::kNone)
+              .ToLocal(&regexp)) {
+        return regexp;
+      }
     }
 
     return v8::Undefined(isolate);
@@ -168,10 +174,12 @@ bool IsReadableStream(v8::Isolate* isolate, v8::Local<v8::Value> val) {
   }
 
   v8::Local<v8::Value> args[] = {val};
-  v8::Local<v8::Value> result =
-      is_readable_stream->Get(isolate)
-          ->Call(context, v8::Null(isolate), std::size(args), args)
-          .ToLocalChecked();
+  v8::Local<v8::Value> result;
+  if (!is_readable_stream->Get(isolate)
+           ->Call(context, v8::Null(isolate), std::size(args), args)
+           .ToLocal(&result)) {
+    return false;
+  }
 
   return result->IsBoolean() && result.As<v8::Boolean>()->Value();
 }
@@ -179,9 +187,11 @@ bool IsReadableStream(v8::Isolate* isolate, v8::Local<v8::Value> val) {
 uint64_t GetContextUsage(v8::Isolate* isolate,
                          v8::Local<v8::Object> language_model) {
   auto context = isolate->GetCurrentContext();
-  v8::Local<v8::Value> val =
-      language_model->Get(context, gin::StringToV8(isolate, "contextUsage"))
-          .ToLocalChecked();
+  v8::Local<v8::Value> val;
+  if (!language_model->Get(context, gin::StringToV8(isolate, "contextUsage"))
+           .ToLocal(&val)) {
+    return 0;
+  }
   uint64_t token_count = 0;
   if (val->IsNumber()) {
     gin::ConvertFromV8(isolate, val, &token_count);
@@ -295,14 +305,19 @@ class PromptResponder {
         [](base::WeakPtr<PromptResponder> weak_ptr, v8::Isolate* isolate,
            v8::Local<v8::Value> result) {
           if (weak_ptr) {
-            CHECK(result->IsObject());
-
-            v8::Local<v8::Value> done =
-                result.As<v8::Object>()
-                    ->Get(isolate->GetCurrentContext(),
-                          gin::StringToV8(isolate, "done"))
-                    .ToLocalChecked();
-            CHECK(done->IsBoolean());
+            // The stream is app-provided JS, so the chunk can be anything;
+            // bail out with an error instead of crashing the process.
+            v8::Local<v8::Value> done;
+            if (!result->IsObject() ||
+                !result.As<v8::Object>()
+                     ->Get(isolate->GetCurrentContext(),
+                           gin::StringToV8(isolate, "done"))
+                     .ToLocal(&done) ||
+                !done->IsBoolean()) {
+              weak_ptr->SendError();
+              weak_ptr->DeleteThis();
+              return;
+            }
 
             if (done.As<v8::Boolean>()->Value()) {
               uint64_t token_count = GetContextUsage(
@@ -312,11 +327,15 @@ class PromptResponder {
               weak_ptr->completed_ = true;
               weak_ptr->DeleteThis();
             } else {
-              v8::Local<v8::Value> val =
-                  result.As<v8::Object>()
-                      ->Get(isolate->GetCurrentContext(),
-                            gin::StringToV8(isolate, "value"))
-                      .ToLocalChecked();
+              v8::Local<v8::Value> val;
+              if (!result.As<v8::Object>()
+                       ->Get(isolate->GetCurrentContext(),
+                             gin::StringToV8(isolate, "value"))
+                       .ToLocal(&val)) {
+                weak_ptr->SendError();
+                weak_ptr->DeleteThis();
+                return;
+              }
 
               std::string value;
 
@@ -437,10 +456,12 @@ bool UtilityAILanguageModel::IsLanguageModel(v8::Isolate* isolate,
   }
 
   v8::Local<v8::Value> args[] = {val};
-  v8::Local<v8::Value> result =
-      is_language_model->Get(isolate)
-          ->Call(context, v8::Null(isolate), std::size(args), args)
-          .ToLocalChecked();
+  v8::Local<v8::Value> result;
+  if (!is_language_model->Get(isolate)
+           ->Call(context, v8::Null(isolate), std::size(args), args)
+           .ToLocal(&result)) {
+    return false;
+  }
 
   return result->IsBoolean() && result.As<v8::Boolean>()->Value();
 }
@@ -458,10 +479,12 @@ bool UtilityAILanguageModel::IsLanguageModelClass(v8::Isolate* isolate,
   }
 
   v8::Local<v8::Value> args[] = {val};
-  v8::Local<v8::Value> result =
-      is_language_model_class->Get(isolate)
-          ->Call(context, v8::Null(isolate), std::size(args), args)
-          .ToLocalChecked();
+  v8::Local<v8::Value> result;
+  if (!is_language_model_class->Get(isolate)
+           ->Call(context, v8::Null(isolate), std::size(args), args)
+           .ToLocal(&result)) {
+    return false;
+  }
 
   return result->IsBoolean() && result.As<v8::Boolean>()->Value();
 }

--- a/spec/api-context-bridge-spec.ts
+++ b/spec/api-context-bridge-spec.ts
@@ -474,6 +474,73 @@ describe('contextBridge', () => {
         expect(result).equal('oh no');
       });
 
+      it('should throw instead of crashing when an array argument has a throwing getter', async () => {
+        await makeBindingWindow(() => {
+          contextBridge.exposeInMainWorld('example', {
+            echo: (arr: any) => arr.length
+          });
+        });
+        const result = await callWithBindings((root: any) => {
+          const poisoned = [1, 2, 3];
+          Object.defineProperty(poisoned, 0, {
+            get() {
+              throw new Error('boom');
+            },
+            enumerable: true,
+            configurable: true
+          });
+          const nested = { a: [1, [2, 3]] };
+          Object.defineProperty(nested.a[1], 1, {
+            get() {
+              throw new Error('nested boom');
+            },
+            enumerable: true,
+            configurable: true
+          });
+          const getError = (fn: Function) => {
+            try {
+              fn();
+            } catch (e) {
+              return (e as Error).message;
+            }
+            return null;
+          };
+          return [
+            getError(() => root.example.echo(poisoned)),
+            getError(() => root.example.echo(nested)),
+            root.example.echo([1, 2, 3])
+          ];
+        });
+        expect(result).to.deep.equal(['boom', 'nested boom', 3]);
+      });
+
+      it('should throw instead of crashing when a returned array has a throwing getter', async () => {
+        await makeBindingWindow(() => {
+          contextBridge.exposeInMainWorld('example', {
+            getPoisoned: () => {
+              const poisoned = [1, 2, 3];
+              Object.defineProperty(poisoned, 0, {
+                get() {
+                  throw new Error('boom');
+                },
+                enumerable: true,
+                configurable: true
+              });
+              return poisoned;
+            }
+          });
+        });
+        const result = await callWithBindings((root: any) => {
+          try {
+            root.example.getPoisoned();
+          } catch (e) {
+            return (e as Error).message;
+          }
+          return null;
+        });
+        expect(result).to.equal('Uncaught Error: boom');
+      });
+
       it('should proxy methods that are callable multiple times', async () => {
         await makeBindingWindow(() => {
           contextBridge.exposeInMainWorld('example', {


### PR DESCRIPTION
#### Description of Change

A number of places unwrap a `v8::MaybeLocal` with `ToLocalChecked()` (or a `v8::Maybe` with `Check()` / `ToChecked()`) on a value that JavaScript controls. If the read runs a user accessor or Proxy trap that throws, the `MaybeLocal` is empty and the process aborts instead of raising a catchable error. One commit per site:

- `contextBridge` array copy: a renderer crash reachable from sandboxed web content by passing an array with a throwing index getter (or any nested such array) to an exposed function, or returning one from it. Spec added for both directions.
- `contextBridge` `DeepFreeze`: throwing accessors on page-controlled objects reached by the freeze walk.
- `contextBridge` `internalContextBridge.override*` helpers: failed conversions were `ToLocalChecked()`'d.
- `HttpResponseHeaders` converter (`webRequest.onHeadersReceived` result): throwing header getters / `ownKeys` traps.
- `std::set` / `std::map` converters (`webRequest` filters, `session.downloadURL` headers, `utilityProcess.fork` env): throwing index accessors / `ownKeys` traps.
- header-pair converter (`net.request` / `WebSocket` headers): throwing `ownKeys` trap.
- `gin_helper::Dictionary::IsEmptyObject` (`webContents.print` options): throwing `ownKeys` trap.
- `webFrame.setSpellCheckProvider`: throwing `has` trap.
- `sharedTexture` `nativePixmap.planes`: throwing index accessor, plus a missing object check.
- pooled worker contexts (`nodeIntegrationInWorker`): `CHECK` on reading a redefined `process` / `require` global.
- utility-process `LanguageModel` bridge: malformed stream chunks / throwing getters now report an error instead of `CHECK`ing.
- `Set().Check()` on freshly created arrays and error objects → `CreateDataProperty`, so a throwing setter installed on `Array.prototype` / `Error.prototype` cannot abort.

Verified locally: each case crashes the pre-fix build with `Fatal error in V8: v8::ToLocalChecked Empty MaybeLocal` and surfaces as a normal JS error on the fixed build.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Fixed a renderer crash when an array with a throwing property getter is passed across `contextBridge`, and several main/utility-process crashes when option objects passed to Electron APIs contain throwing accessors or Proxy traps.