### PR TITLE
chore: fix clang-tidy dead-store warning in browser_win.cc

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -225,12 +225,12 @@ std::vector<LaunchItem> GetLoginItemSettingsHelper(
         LONG res = RegOpenKeyEx(scope_key, StartupApprovedRun.c_str(), 0,
                                 KEY_QUERY_VALUE, &hkey);
         if (res == ERROR_SUCCESS) {
-          DWORD type, size;
+          DWORD type;
           wchar_t startup_binary[12];
+          DWORD size = sizeof(startup_binary);
           LONG result =
               RegQueryValueEx(hkey, it->Name(), nullptr, &type,
-                              reinterpret_cast<BYTE*>(&startup_binary),
-                              &(size = sizeof(startup_binary)));
+                              reinterpret_cast<BYTE*>(&startup_binary), &size);
           if (result == ERROR_SUCCESS) {
             if (type == REG_BINARY) {
               // any other binary other than this indicates that the program is


### PR DESCRIPTION
#### Description of Change

`windows-x64 / clang-tidy` is currently red on every open PR with `clang-analyzer-deadcode.DeadStores` at `shell/browser/browser_win.cc:233`: `RegQueryValueEx` was passed `&(size = sizeof(startup_binary))`, and the analyzer cannot see the value being read back through the pointer. Initialize `size` on its own line and pass `&size`; behaviour is identical.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
