### PR TITLE
fix: clang-analyzer dead store in GetLoginItemSettingsHelper

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -225,12 +225,12 @@ std::vector<LaunchItem> GetLoginItemSettingsHelper(
         LONG res = RegOpenKeyEx(scope_key, StartupApprovedRun.c_str(), 0,
                                 KEY_QUERY_VALUE, &hkey);
         if (res == ERROR_SUCCESS) {
-          DWORD type, size;
+          DWORD type;
           wchar_t startup_binary[12];
+          DWORD size = sizeof(startup_binary);
           LONG result =
               RegQueryValueEx(hkey, it->Name(), nullptr, &type,
-                              reinterpret_cast<BYTE*>(&startup_binary),
-                              &(size = sizeof(startup_binary)));
+                              reinterpret_cast<BYTE*>(&startup_binary), &size);
           if (result == ERROR_SUCCESS) {
             if (type == REG_BINARY) {
               // any other binary other than this indicates that the program is


### PR DESCRIPTION
#### Description of Change

- `shell/browser/browser_win.cc` passed `&(size = sizeof(startup_binary))` to `RegQueryValueEx`; the assignment is never read back, so `clang-analyzer-deadcode.DeadStores` (enabled in #53032) fails the `windows-x64 / clang-tidy` job on `main` (e.g. https://github.com/electron/electron/actions/runs/32457633257/job/96716560580).
- Initialize `size` before the call and pass `&size`. No behavior change.

Backport targets match where #53032 landed (44-x-y merged, 43-x-y in flight).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none