### PR TITLE
fix: terminate utility processes immediately on Windows instead of running CRT exit

### DIFF
--- a/shell/app/electron_main_win.cc
+++ b/shell/app/electron_main_win.cc
@@ -19,6 +19,7 @@
 #include "base/i18n/icu_util.h"
 #include "base/memory/raw_ptr_exclusion.h"
 #include "base/process/launch.h"
+#include "base/process/process.h"
 #include "base/strings/cstring_view.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/atl.h"  // ensures that ATL statics like `_AtlWinModule` are initialized (it's an issue in static debug build)
@@ -44,6 +45,9 @@ namespace {
 // from //electron:electron_app
 const char kUserDataDir[] = "user-data-dir";
 const char kProcessType[] = "type";
+const char kUtilityProcess[] = "utility";
+const char kUtilitySubType[] = "utility-sub-type";
+const char kNodeService[] = "node.mojom.NodeService";
 
 [[nodiscard]] bool IsEnvSet(const base::cstring_view name) {
   size_t required_size = 0;
@@ -231,5 +235,13 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   content::ContentMainParams params(&delegate);
   params.instance = instance;
   params.sandbox_info = &sandbox_info;
-  return content::ContentMain(std::move(params));
+  int rc = content::ContentMain(std::move(params));
+  // System DLLs loaded into utility processes crash in their DLL_PROCESS_DETACH
+  // handlers during CRT exit, so leave the way Chrome does: without running it.
+  // Node utility processes keep the normal exit for their addons' handlers.
+  if (process_type == kUtilityProcess &&
+      command_line->GetSwitchValueASCII(kUtilitySubType) != kNodeService) {
+    base::Process::TerminateCurrentProcessImmediately(rc);
+  }
+  return rc;
 }


### PR DESCRIPTION
Backport of #53038

See that PR for details.

Notes: Fixed utility process crashes at exit on Windows 11 24H2 and later.