### PR TITLE
fix: exit cleanly when the D-Bus session bus goes away on Linux

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -190,6 +190,8 @@ cherry-pick-e480c72d3627.patch
 cherry-pick-4e17fa56c471.patch
 cherry-pick-7cf589757eab.patch
 cherry-pick-0c2b2640e6fb.patch
+dbus_let_embedders_exit_cleanly_when_the_bus_connection_is_lost.patch
+chore_let_the_embedder_handle_shared_d-bus_disconnects.patch
 remove_cr_xcode_build_define_from_build_gn.patch
 cherry-pick-2c2d4b9fc5f2.patch
 cherry-pick-cf1e39ed8884.patch

--- a/patches/chromium/chore_let_the_embedder_handle_shared_d-bus_disconnects.patch
+++ b/patches/chromium/chore_let_the_embedder_handle_shared_d-bus_disconnects.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 19 Aug 2026 10:50:09 +0000
+Subject: chore: let the embedder handle shared D-Bus disconnects
+
+The shared session and system buses from dbus_thread_linux are created
+with fixed Bus::Options, so an embedder cannot pass
+Bus::Options::disconnected_callback to them. Add
+dbus_thread_linux::SetDisconnectedCallback() for the embedder to install
+one process-wide handler; when none is set the buses keep their FATAL.
+
+Downstream only: upstream is replacing these lazy statics
+(https://chromium-review.googlesource.com/c/chromium/src/+/8009126) and
+the callback will be passed at creation once that lands.
+
+diff --git a/components/dbus/thread_linux/dbus_thread_linux.cc b/components/dbus/thread_linux/dbus_thread_linux.cc
+index 40385642ae3bee53df29142ef600443d68486391..fc83a4b0261bcbc2e9f06b8ada344c3176932955 100644
+--- a/components/dbus/thread_linux/dbus_thread_linux.cc
++++ b/components/dbus/thread_linux/dbus_thread_linux.cc
+@@ -6,6 +6,9 @@
+ 
+ #include <utility>
+ 
++#include "base/functional/bind.h"
++#include "base/functional/callback.h"
++#include "base/logging.h"
+ #include "base/no_destructor.h"
+ #include "base/synchronization/lock.h"
+ #include "base/task/lazy_thread_pool_task_runner.h"
+@@ -32,6 +35,19 @@ scoped_refptr<dbus::Bus>& GetSharedSystemBusRefPtrInstance() {
+   return *bus;
+ }
+ 
++base::RepeatingClosure& GetDisconnectedCallbackInstance() {
++  static base::NoDestructor<base::RepeatingClosure> callback;
++  return *callback;
++}
++
++void OnSharedBusDisconnected() {
++  auto& callback = GetDisconnectedCallbackInstance();
++  if (!callback) {
++    LOG(FATAL) << "D-Bus connection was disconnected. Aborting.";
++  }
++  callback.Run();
++}
++
+ // Use TaskPriority::USER_BLOCKING, because there is a client
+ // (NotificationPlatformBridgeLinuxImpl) which needs to run user-blocking tasks
+ // on this thread. Use SingleThreadTaskRunnerThreadMode::SHARED, because DBus
+@@ -47,6 +63,7 @@ scoped_refptr<dbus::Bus> CreateSharedBus(dbus::Bus::BusType bus_type) {
+   options.bus_type = bus_type;
+   options.connection_type = dbus::Bus::PRIVATE;
+   options.dbus_task_runner = g_dbus_thread_task_runner.Get();
++  options.disconnected_callback = base::BindOnce(&OnSharedBusDisconnected);
+   return base::MakeRefCounted<dbus::Bus>(std::move(options));
+ }
+ 
+@@ -72,6 +89,10 @@ scoped_refptr<dbus::Bus> GetSharedSystemBus() {
+   return system_bus;
+ }
+ 
++void SetDisconnectedCallback(base::RepeatingClosure callback) {
++  GetDisconnectedCallbackInstance() = std::move(callback);
++}
++
+ void ShutdownOnDBusThreadAndBlock() {
+   if (auto& session_bus = GetSharedSessionBusRefPtrInstance()) {
+     session_bus->ShutdownOnDBusThreadAndBlock();
+diff --git a/components/dbus/thread_linux/dbus_thread_linux.h b/components/dbus/thread_linux/dbus_thread_linux.h
+index 9edf96b4a5399b20cf9f2f9343d81a900c20ea5d..bf7465ad705279e5af234d51c549c0a06051085a 100644
+--- a/components/dbus/thread_linux/dbus_thread_linux.h
++++ b/components/dbus/thread_linux/dbus_thread_linux.h
+@@ -6,6 +6,7 @@
+ #define COMPONENTS_DBUS_THREAD_LINUX_DBUS_THREAD_LINUX_H_
+ 
+ #include "base/component_export.h"
++#include "base/functional/callback_forward.h"
+ #include "base/memory/scoped_refptr.h"
+ #include "build/build_config.h"
+ 
+@@ -29,6 +30,13 @@ scoped_refptr<dbus::Bus> GetSharedSessionBus();
+ COMPONENT_EXPORT(COMPONENTS_DBUS)
+ scoped_refptr<dbus::Bus> GetSharedSystemBus();
+ 
++// Sets |callback| to run on the UI thread when a shared bus loses its
++// connection, e.g. because the desktop session is ending. The process cannot
++// keep using the bus after that, so |callback| should exit; if none is set,
++// losing the connection is fatal. Must be called on the UI thread.
++COMPONENT_EXPORT(COMPONENTS_DBUS)
++void SetDisconnectedCallback(base::RepeatingClosure callback);
++
+ // Shuts down the shared session and system buses. Must be called on the UI
+ // thread. This is intended to be called late in browser shutdown, or
+ // in tests before task environments are destroyed.

--- a/patches/chromium/dbus_let_embedders_exit_cleanly_when_the_bus_connection_is_lost.patch
+++ b/patches/chromium/dbus_let_embedders_exit_cleanly_when_the_bus_connection_is_lost.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 19 Aug 2026 10:48:38 +0000
+Subject: dbus: Let embedders exit cleanly when the bus connection is lost
+
+Since https://crrev.com/307419 (https://crbug.com/432980) Bus aborts
+with LOG(FATAL) when libdbus delivers the local Disconnected signal.
+That fits Chrome OS, where a dbus-daemon crash takes the device down
+anyway, but on desktop Linux the session bus routinely goes away under
+a running browser: at logout, on `systemctl --user restart dbus`, or
+when dbus-broker is restarted by a package upgrade. Each of those
+currently ends in a browser crash report rather than an exit.
+
+Add Bus::Options::disconnected_callback, posted to the origin thread
+when the connection is lost. When it is unset the behaviour is
+unchanged (FATAL, same message), so Chrome OS and every existing
+caller keep today's semantics. dbus_thread_linux sets it for the
+shared session and system buses and exposes SetDisconnectedCallback()
+so the embedder can treat a lost bus like a lost display server
+connection (compare the Ozone shutdown callback that
+chrome_browser_main_extra_parts_ozone.cc wires to
+chrome::SessionEnding()). Chrome's wiring follows separately.
+
+The process still cannot keep using the bus after a disconnect; the
+callback exists so it can exit without a crash report, not so it can
+carry on.
+
+Bug: none
+Test: dbus_unittests.BusTest.DisconnectedCallback
+
+Backport of https://chromium-review.googlesource.com/c/chromium/src/+/8261571
+
+diff --git a/dbus/bus.cc b/dbus/bus.cc
+index 06ce79c788f786880eeddce3cca53c2564f3eb82..64ab2caf4ece3070e69ee032ef58aa9f1289b644 100644
+--- a/dbus/bus.cc
++++ b/dbus/bus.cc
+@@ -177,7 +177,8 @@ Bus::Bus(Options options)
+       shutdown_completed_(false),
+       num_pending_watches_(0),
+       num_pending_timeouts_(0),
+-      address_(options.address) {
++      address_(options.address),
++      on_disconnected_(std::move(options.disconnected_callback)) {
+   // This is safe to call multiple times.
+   dbus_threads_init_default();
+   // The origin message loop is unnecessary if the client uses synchronous
+@@ -1151,6 +1152,14 @@ void Bus::OnDispatchStatusChanged(DBusConnection* connection,
+       FROM_HERE, base::BindOnce(&Bus::ProcessAllIncomingDataIfAny, this));
+ }
+ 
++void Bus::OnConnectionDisconnected() {
++  AssertOnDBusThread();
++  if (!on_disconnected_) {
++    LOG(FATAL) << "D-Bus connection was disconnected. Aborting.";
++  }
++  GetOriginTaskRunner()->PostTask(FROM_HERE, std::move(on_disconnected_));
++}
++
+ void Bus::OnServiceOwnerChanged(DBusMessage* message) {
+   DCHECK(message);
+   AssertOnDBusThread();
+@@ -1238,11 +1247,9 @@ DBusHandlerResult Bus::OnConnectionDisconnectedFilter(
+     DBusConnection* connection,
+     DBusMessage* message,
+     void* data) {
+-  if (dbus_message_is_signal(message,
+-                             DBUS_INTERFACE_LOCAL,
++  if (dbus_message_is_signal(message, DBUS_INTERFACE_LOCAL,
+                              kDisconnectedSignal)) {
+-    // Abort when the connection is lost.
+-    LOG(FATAL) << "D-Bus connection was disconnected. Aborting.";
++    static_cast<Bus*>(data)->OnConnectionDisconnected();
+   }
+   return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+ }
+diff --git a/dbus/bus.h b/dbus/bus.h
+index a3f4fdcb0db87c9502e5d31ea680fda5edd1319e..d3160b2d916ef5fcbebf153e725d4561fe3cd811 100644
+--- a/dbus/bus.h
++++ b/dbus/bus.h
+@@ -222,6 +222,11 @@ class CHROME_DBUS_EXPORT Bus : public base::RefCountedThreadSafe<Bus> {
+     //   // Do something.
+     //
+     std::string address;
++
++    // Called on the origin thread when the connection to the bus is lost. The
++    // process cannot meaningfully use this Bus afterwards, so the callback is
++    // expected to shut down; when it is null, losing the connection is fatal.
++    base::OnceClosure disconnected_callback;
+   };
+ 
+   // Creates a Bus object. The actual connection will be established when
+@@ -715,6 +720,9 @@ class CHROME_DBUS_EXPORT Bus : public base::RefCountedThreadSafe<Bus> {
+   void OnDispatchStatusChanged(DBusConnection* connection,
+                                DBusDispatchStatus status);
+ 
++  // Called when the connection to the bus is lost.
++  void OnConnectionDisconnected();
++
+   // Called when a service owner change occurs.
+   void OnServiceOwnerChanged(DBusMessage* message);
+ 
+@@ -802,6 +810,7 @@ class CHROME_DBUS_EXPORT Bus : public base::RefCountedThreadSafe<Bus> {
+   int num_pending_timeouts_;
+ 
+   std::string address_;
++  base::OnceClosure on_disconnected_;
+ };
+ 
+ }  // namespace dbus

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -84,6 +84,7 @@
 #if BUILDFLAG(IS_LINUX)
 #include "base/environment.h"
 #include "chrome/browser/ui/views/dark_mode_manager_linux.h"
+#include "components/dbus/thread_linux/dbus_thread_linux.h"
 #include "device/bluetooth/bluetooth_adapter_factory.h"
 #include "device/bluetooth/dbus/bluez_dbus_manager.h"
 #include "device/bluetooth/dbus/dbus_bluez_manager_wrapper_linux.h"
@@ -139,6 +140,23 @@ namespace electron {
 namespace {
 
 #if BUILDFLAG(IS_LINUX)
+// The display server connection or the session bus is gone: exit like
+// Chrome's SessionEnding(), with an off-thread watchdog that crashes us if
+// exiting hangs on the dead connection.
+void ExitOnSessionLoss() {
+  class ShutdownWatchdogDelegate : public base::Watchdog::Delegate {
+   public:
+    void Alarm() override { LOG(FATAL) << "Failed to shutdown."; }
+  };
+  static base::NoDestructor<ShutdownWatchdogDelegate> delegate;
+  static base::NoDestructor<base::Watchdog> watchdog(
+      base::Seconds(10), "SessionLossShutdown", /*enabled=*/true,
+      delegate.get());
+  watchdog->Arm();
+  if (Browser* browser = Browser::Get())
+    browser->ExitWithCode(content::RESULT_CODE_NORMAL_EXIT);
+}
+
 class LinuxUiGetterImpl : public ui::LinuxUiGetter {
  public:
   LinuxUiGetterImpl() = default;
@@ -526,24 +544,11 @@ void ElectronBrowserMainParts::PostCreateMainMessageLoop() {
   std::string app_name = electron::Browser::Get()->GetName();
 #endif
 #if BUILDFLAG(IS_LINUX)
-  // The display server connection is gone (X IO error / compositor lost):
-  // exit like Chrome's SessionEnding(), with an off-thread watchdog that
-  // crashes us if exiting hangs on the dead display connection.
-  auto shutdown_cb = base::BindOnce([] {
-    class ShutdownWatchdogDelegate : public base::Watchdog::Delegate {
-     public:
-      void Alarm() override { LOG(FATAL) << "Failed to shutdown."; }
-    };
-    static base::NoDestructor<ShutdownWatchdogDelegate> delegate;
-    static base::NoDestructor<base::Watchdog> watchdog(
-        base::Seconds(10), "OzoneShutdown", /*enabled=*/true, delegate.get());
-    watchdog->Arm();
-    if (Browser* browser = Browser::Get())
-      browser->ExitWithCode(content::RESULT_CODE_NORMAL_EXIT);
-  });
   ui::OzonePlatform::GetInstance()->PostCreateMainMessageLoop(
-      std::move(shutdown_cb),
+      base::BindOnce(&ExitOnSessionLoss),
       content::GetUIThreadTaskRunner({content::BrowserTaskType::kUserInput}));
+  dbus_thread_linux::SetDisconnectedCallback(
+      base::BindRepeating(&ExitOnSessionLoss));
 
   if (!bluez::BluezDBusManager::IsInitialized())
     bluez::DBusBluezManagerWrapperLinux::Initialize();

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -199,6 +199,39 @@ describe('app module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'linux' && fs.existsSync('/usr/bin/dbus-daemon'))(
+    'when a D-Bus bus goes away',
+    () => {
+      it('exits cleanly instead of crashing', async () => {
+        const daemon = cp.spawn('dbus-daemon', ['--session', '--nofork', '--print-address']);
+        defer(() => daemon.kill());
+        const [address] = await once(daemon.stdout, 'data');
+        const bus = address.toString().trim();
+        const env = { ...process.env, DBUS_SESSION_BUS_ADDRESS: bus, DBUS_SYSTEM_BUS_ADDRESS: bus };
+
+        const appProcess = cp.spawn(process.execPath, [path.join(fixturesPath, 'api', 'session-bus-lost')], { env });
+        defer(() => appProcess.kill());
+        const exited = once(appProcess, 'exit');
+        await once(appProcess.stdout, 'data');
+        await waitUntil(() => {
+          const names = cp
+            .spawnSync(
+              'dbus-send',
+              ['--session', '--dest=org.freedesktop.DBus', '--print-reply', '/', 'org.freedesktop.DBus.ListNames'],
+              { env }
+            )
+            .stdout.toString();
+          return (names.match(/string ":1\./g) ?? []).length >= 2;
+        });
+
+        daemon.kill();
+        const [code, signal] = await exited;
+        expect(signal).to.be.null();
+        expect(code).to.equal(0);
+      });
+    }
+  );
+
   describe('app.exit(exitCode)', () => {
     let appProcess: cp.ChildProcess | null = null;
 

--- a/spec/fixtures/api/session-bus-lost/main.js
+++ b/spec/fixtures/api/session-bus-lost/main.js
@@ -1,0 +1,5 @@
+const { app } = require('electron');
+
+app.whenReady().then(() => {
+  process.stdout.write('ready\n');
+});

--- a/spec/fixtures/api/session-bus-lost/package.json
+++ b/spec/fixtures/api/session-bus-lost/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "session-bus-lost",
+  "main": "main.js"
+}


### PR DESCRIPTION
Backport of #53022

See that PR for details.

Notes: Fixed a crash on Linux when the D-Bus session bus disconnected while the app was running, such as at logout or when dbus is restarted.