### PR TITLE
fix: avoid creating webFrameMain for transient frames

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -12,6 +12,7 @@
 #include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
+#include "content/browser/renderer_host/frame_tree_node.h"         // nogncheck
 #include "content/browser/renderer_host/render_frame_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_process_host_impl.h"  // nogncheck
 #include "content/public/browser/frame_tree_node_id.h"
@@ -634,6 +635,12 @@ WebFrameMain* WebFrameMain::From(v8::Isolate* isolate,
       // RFH is in the process of being swapped. Need to lookup by FTN to avoid
       // creating dangling WebFrameMain.
       web_frame = FromFrameTreeNodeId(rfh->GetFrameTreeNodeId());
+      if (!web_frame) {
+        // A WebFrameMain cannot be created for a transient RFH, so initialize
+        // it with the current active RFH and update it when the swap completes.
+        auto* rfh_impl = static_cast<content::RenderFrameHostImpl*>(rfh);
+        rfh = rfh_impl->frame_tree_node()->current_frame_host();
+      }
       break;
     case LifecycleState::kPrerendering:
     case LifecycleState::kActive:

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -223,6 +223,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   DCHECK(inserted);
 
   render_frame_disposed_ = false;
+  render_frame_detached_ = false;
   TeardownMojoConnection();
   MaybeSetupMojoConnection();
 }

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -15,6 +15,7 @@ import {
   session,
   systemPreferences,
   WebContents,
+  WebContentsView,
   WebFrameMain
 } from 'electron/main';
 
@@ -1167,6 +1168,52 @@ describe('BrowserWindow module', () => {
         after(() => {
           server.close();
         });
+        it('exposes a cross-origin iframe during navigation', async () => {
+          const port = (server.address() as AddressInfo).port;
+          const fixture = path.join(os.tmpdir(), `web-frame-main-navigation-${crypto.randomUUID()}.html`);
+          fs.writeFileSync(fixture, `<iframe src="${url}/iframe"></iframe>`);
+          defer(() => fs.unlinkSync(fixture));
+
+          const view = new WebContentsView({
+            webPreferences: { partition: `wfm-navigation-${crypto.randomUUID()}`, sandbox }
+          });
+          defer(() => view.webContents.destroy());
+          w.contentView.addChildView(view);
+          defer(() => w.contentView.removeChildView(view));
+
+          const { webContents } = view;
+          const didStartNavigation = new Promise<number>((resolve) => {
+            webContents.on('did-start-navigation', (details) => {
+              if (!details.isMainFrame) resolve(details.frame!.frameTreeNodeId);
+            });
+          });
+          const headersReceived = new Promise<number>((resolve) => {
+            webContents.session.webRequest.onHeadersReceived((details, callback) => {
+              const frameTreeNodeId = details.frame?.frameTreeNodeId;
+              callback({ responseHeaders: details.responseHeaders });
+              if (details.resourceType === 'subFrame' && frameTreeNodeId) resolve(frameTreeNodeId);
+            });
+          });
+          defer(() => webContents.session.webRequest.onHeadersReceived(null));
+
+          await webContents.loadFile(fixture);
+          const frameTreeNodeId = await didStartNavigation;
+          expect(await headersReceived).to.equal(frameTreeNodeId);
+
+          const iframe = webContents.mainFrame.frames[0];
+          expect(iframe.frameTreeNodeId).to.equal(frameTreeNodeId);
+          const navigated = emittedUntil(
+            webContents,
+            'did-frame-navigate',
+            (_event: Electron.Event, _url: string, _code: number, _status: string, isMainFrame: boolean) => !isMainFrame
+          );
+          iframe.executeJavaScript(`location.href = 'http://localhost:${port}/navigated'`);
+          const [, , , , , processId, routingId] = await navigated;
+          const navigatedIframe = webFrameMain.fromId(processId, routingId);
+          expect(navigatedIframe).to.equal(iframe);
+          expect(navigatedIframe!.frameTreeNodeId).to.equal(frameTreeNodeId);
+        });
+
         it('for initial navigation, event order is consistent', async () => {
           const firedEvents: string[] = [];
           const expectedEventOrder = ['did-start-navigation', 'did-frame-navigate', 'did-navigate'];

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1214,6 +1214,48 @@ describe('BrowserWindow module', () => {
           expect(navigatedIframe!.frameTreeNodeId).to.equal(frameTreeNodeId);
         });
 
+        it('recovers a frame when its renderer crashes during navigation', async () => {
+          const crossOriginUrl = url.replace('127.0.0.1', 'localhost');
+          const view = new WebContentsView({
+            webPreferences: { partition: `wfm-crash-navigation-${crypto.randomUUID()}`, sandbox }
+          });
+          defer(() => view.webContents.destroy());
+          w.contentView.addChildView(view);
+          defer(() => w.contentView.removeChildView(view));
+
+          const { webContents } = view;
+          await webContents.loadURL(`${url}/initial`);
+
+          let resumeNavigation: (() => void) | undefined;
+          const frameReceived = new Promise<WebFrameMain>((resolve) => {
+            webContents.session.webRequest.onHeadersReceived((details, callback) => {
+              if (details.resourceType === 'mainFrame' && details.frame) {
+                resumeNavigation = () => callback({ responseHeaders: details.responseHeaders });
+                resolve(details.frame);
+              } else {
+                callback({ responseHeaders: details.responseHeaders });
+              }
+            });
+          });
+          defer(() => {
+            resumeNavigation?.();
+            webContents.session.webRequest.onHeadersReceived(null);
+          });
+
+          const navigation = webContents.loadURL(`${crossOriginUrl}/navigated`);
+          const frame = await frameReceived;
+          const renderProcessGone = once(webContents, 'render-process-gone');
+          webContents.forcefullyCrashRenderer();
+          await renderProcessGone;
+          expect(frame.detached).to.be.true();
+
+          resumeNavigation!();
+          resumeNavigation = undefined;
+          await navigation;
+
+          expect(webContents.mainFrame).to.equal(frame);
+          expect(frame.detached).to.be.false();
+        });
         it('for initial navigation, event order is consistent', async () => {
           const firedEvents: string[] = [];
           const expectedEventOrder = ['did-start-navigation', 'did-frame-navigate', 'did-navigate'];


### PR DESCRIPTION
#### Description of Change
- Fixes #53068.  This issue was exposed due to the changes in #52217
This fix prevents `WebFrameMain` from being created for a speculative or pending-commit `RenderFrameHost`. If no wrapper exists during a frame swap, Electron now initializes one from the current active frame and updates it when the swap completes.

Also, added a regression test for the fixed issue.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->Fixed a crash when accessing frame details during cross-origin navigation.