### PR TITLE
build: skip linux-arm in PGO profile generation

### DIFF
--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -194,26 +194,6 @@ jobs:
       upload-to-storage: '0'
     secrets: inherit
 
-  build-linux-arm:
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-    uses: ./.github/workflows/pipeline-segment-electron-build.yml
-    needs: [checkout-linux, build-siso-linux]
-    with:
-      build-runs-on: electron-arc-centralus-linux-amd64-32core
-      build-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
-      target-platform: linux
-      target-arch: arm
-      is-release: false
-      gn-build-type: pgo-instrument
-      generate-symbols: false
-      generate-chromedriver: false
-      generate-test-artifacts: false
-      upload-to-storage: '0'
-    secrets: inherit
-
   build-linux-arm64:
     permissions:
       contents: read
@@ -449,19 +429,10 @@ jobs:
       collect-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
     secrets: inherit
 
-  collect-linux-arm:
-    permissions:
-      contents: read
-    uses: ./.github/workflows/pipeline-segment-pgo-collect.yml
-    needs: [checkout-linux, build-linux-arm]
-    with:
-      target-platform: linux
-      target-arch: arm
-      artifact-key: linux_arm
-      collect-runs-on: electron-arc-centralus-linux-arm64-4core
-      collect-container: '{"image":"ghcr.io/electron/test:arm32v7-${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init --memory=12g","volumes":["/home/runner/externals:/mnt/runner-externals"]}'
-    secrets: inherit
-
+  # linux-arm (armv7l) is deliberately not in this set: its instrumented
+  # build links the profile runtime without the -u__llvm_profile_runtime
+  # hook, so the runtime never initializes and every run produced an
+  # empty .profraw. The state file keeps the last published profile.
   collect-linux-arm64:
     permissions:
       contents: read
@@ -543,7 +514,7 @@ jobs:
   merge-profiles:
     name: Merge Profiles
     # checkout-linux provides the container image SHA and the src cache.
-    needs: [checkout-linux, collect-linux-x64, collect-linux-arm, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64]
+    needs: [checkout-linux, collect-linux-x64, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64]
     # Merge whatever was collected; repo guard because !cancelled() runs in forks.
     if: ${{ !cancelled() && github.repository == 'electron/electron' }}
     runs-on: electron-arc-centralus-linux-amd64-4core
@@ -635,7 +606,7 @@ jobs:
     # published: a partial profile set must never reach the CDN or the state
     # files. Skipped jobs (the skip-* inputs) are allowed - intentionally
     # regenerating a subset of platforms is fine; failures are not.
-    needs: [collect-linux-x64, collect-linux-arm, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64, generate-v8-builtins-profiles, merge-profiles]
+    needs: [collect-linux-x64, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64, generate-v8-builtins-profiles, merge-profiles]
     if: ${{ !cancelled() && github.repository == 'electron/electron' && needs.merge-profiles.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && inputs.upload-to-storage }}
     runs-on: ubuntu-latest
     # Holds the Azure OIDC credentials; restricted to protected branches.
@@ -764,7 +735,7 @@ jobs:
 
   # Aggregate gate so a single status reflects the whole run.
   pgo-done:
-    needs: [collect-linux-x64, collect-linux-arm, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64, generate-v8-builtins-profiles, merge-profiles, upload-profiles]
+    needs: [collect-linux-x64, collect-linux-arm64, collect-macos-x64, collect-macos-arm64, collect-windows-x64, collect-windows-x86, collect-windows-arm64, generate-v8-builtins-profiles, merge-profiles, upload-profiles]
     if: always() && !cancelled() && github.repository == 'electron/electron'
     runs-on: ubuntu-latest
     permissions: {}

--- a/script/pgo/README.md
+++ b/script/pgo/README.md
@@ -141,10 +141,12 @@ combo's instrumented build runs its own benchmarks:
 | Profile | Collection host |
 |---|---|
 | linux-x64 | x64 ARC runner (build container) |
-| linux-arm | arm64 ARC runner (arm32v7 test container) |
 | linux-arm64 | `ubuntu-22.04-arm` (arm64v8 test container) |
 | win-x64 | `windows-latest` |
 | win-x86 | `windows-latest` (WOW64) |
 | win-arm64 | `windows-11-arm` |
 | macos-x64 | `macos-15-large` |
 | macos-arm64 | `macos-15` |
+
+linux-arm (armv7l) is skipped: its instrumented build never initializes the
+profile runtime, so collection only ever produced empty profiles.


### PR DESCRIPTION
The linux-arm PGO collection has never produced a usable profile: the published `linux-arm` .profdata is 560 bytes (arm64/x64 are ~196 MB), and the latest run (https://github.com/electron/electron/actions/runs/32534410961) hung the whole workflow for 330 minutes after the arm32 renderer crashed mid-collection.

Root cause: the arm32 instrumented link passes `-noprofilelib` and lists `libclang_rt.profile.a` explicitly (`build_fix_profile_runtime_resolution_for_pgo_instrumented_builds.patch`), which drops the driver's `-u__llvm_profile_runtime`. On Linux nothing else references that symbol, so `InstrProfilingRuntime.cpp.o` is never pulled from the archive, the runtime never reads `LLVM_PROFILE_FILE`, and every process logs `LLVM Profile Error: Failed to write file : Filename not set`. The arm32 binary from that run has no `__LLVM_PROFILE_RT_INIT_ONCE` / "Set profile file path" strings at all; the x64 binary does.

- Remove the `build-linux-arm` / `collect-linux-arm` jobs and their `needs` entries
- Document the skip in `script/pgo/README.md`

`linux-arm.pgo.txt` is untouched, so release builds keep consuming the same (empty) profile as before. The real fix is `-Wl,-u,__llvm_profile_runtime` next to `-noprofilelib` in the patch, after which the jobs can come back. main and 44-x-y no longer build armv7l (#51816), so this is opened directly against 42-x-y and 43-x-y.

Notes: none
