### PR TITLE
docs: clarify debugger.sendCommand timing and empty-result behavior

### DIFF
--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -94,11 +94,11 @@ or is rejected indicating the failure of the command.
 
 Send given command to the debugging target.
 
-**Notes:**
-
-* If `sendCommand` is called before the target has navigated (e.g.
-  immediately after `attach()`), the returned promise may not resolve until
-  navigation occurs.
-* If the command's response has no `result` data, as defined by that
-  command's entry in the remote debugging protocol, the promise resolves
-  with an empty object (`{}`), not `null` or `undefined`.
+> [!NOTE]
+<!-- markdownlint-disable-next-line MD032 -->
+> * If `sendCommand` is called before the target has navigated (e.g.
+>   immediately after `attach()`), the returned promise may not resolve
+>   until navigation occurs.
+> * If the command's response has no `result` data, as defined by that
+>   command's entry in the remote debugging protocol, the promise
+>   resolves with an empty object (`{}`), not `null` or `undefined`.

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -95,7 +95,7 @@ or is rejected indicating the failure of the command.
 Send given command to the debugging target.
 
 > [!NOTE]
-<!-- markdownlint-disable-next-line MD032 -->
+> <!-- markdownlint-disable-next-line MD032 -->
 > * If `sendCommand` is called before the target has navigated (e.g.
 >   immediately after `attach()`), the returned promise may not resolve
 >   until navigation occurs.

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -93,3 +93,12 @@ the 'returns' attribute of the command description in the remote debugging proto
 or is rejected indicating the failure of the command.
 
 Send given command to the debugging target.
+
+**Notes:**
+
+* If `sendCommand` is called before the target has navigated (e.g.
+  immediately after `attach()`), the returned promise may not resolve until
+  navigation occurs.
+* If the command's response has no `result` data, as defined by that
+  command's entry in the remote debugging protocol, the promise resolves
+  with an empty object (`{}`), not `null` or `undefined`.


### PR DESCRIPTION
#### Description of Change

This documents two behaviors of `debugger.sendCommand()` reported years
ago (#14810, #14811) but only ever tracked as a documentation gap
(#14822) - never reflected in `docs/api/debugger.md`. Both underlying
reports were closed as working-as-intended; the behavior itself hasn't
changed, it was just never written down. I re-verified both against
current Electron (Promise-based API, not the callback API from 2018)
before writing this.

### Evidence

**1. Delay before navigation** - `sendCommand('Page.enable')` called
immediately after `attach()`, before `loadFile()`:
```
Log 1 1787383009851
Log 3 1787383010245  // loadFile() called ~394ms later
Log 2 1787383010690  // sendCommand resolved ~445ms after loadFile was called
```

Control run - same command sent after the page had already loaded once:
```
Log 2 1787383542866  // page finished loading
Log 3 1787383542885  // sendCommand resolved ~19ms later
```

~445ms vs ~19ms: pending navigation measurably delays resolution.

**2. Empty object on success**:
```
Network.enable resolved with: {}
Page.getNavigationHistory resolved with: {"currentIndex":0,"entries":[...]}
Not.ARealMethod rejected with: 'Not.ARealMethod' wasn't found
```

Matches `DispatchProtocolMessage` in
`shell/browser/api/electron_api_debugger.cc:81`, which resolves with an
empty `DictValue` when the protocol response has no `result` field.

Fixes #14822

#### Checklist

- [ ] I have built and tested this change _(docs-only change; no build needed)_
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes _(docs-only change; verified instead via `npm run lint:markdown`, `lint:docs-relative-links`, and `lint:api-history` - all clean)_
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md) _(not applicable - documentation only)_
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
