### PR TITLE
perf: stop routing renderer requests and file loads through the main thread

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -484,6 +484,8 @@ filenames = {
     "shell/browser/net/resolve_proxy_helper.h",
     "shell/browser/net/system_network_context_manager.cc",
     "shell/browser/net/system_network_context_manager.h",
+    "shell/browser/net/url_loader_factory_gate.cc",
+    "shell/browser/net/url_loader_factory_gate.h",
     "shell/browser/net/url_loader_network_observer.cc",
     "shell/browser/net/url_loader_network_observer.h",
     "shell/browser/network_hints_handler_impl.cc",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -828,6 +828,16 @@ WebContents.prototype._init = function () {
     openDialogs.clear();
   });
 
+  this.on('newListener' as any, (eventName: string | symbol) => {
+    if (eventName === 'console-message') {
+      this._setConsoleMessageObserved(true);
+    }
+  });
+  this.on('removeListener' as any, (eventName: string | symbol) => {
+    if (eventName === 'console-message' && this.listenerCount('console-message') === 0) {
+      this._setConsoleMessageObserved(false);
+    }
+  });
   // TODO(samuelmaddock): remove deprecated 'console-message' arguments
   this.on('-console-message' as any, (event: Electron.Event<Electron.WebContentsConsoleMessageEventParams>) => {
     const hasDeprecatedListener = this.listeners('console-message').some((listener) => listener.length > 1);

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1379,7 +1379,8 @@ api::ServiceWorkerContext* Session::ServiceWorkerContext() {
 
 WebRequest* Session::WebRequest(v8::Isolate* isolate) {
   if (!web_request_)
-    web_request_ = WebRequest::Create(isolate, base::PassKey<Session>{});
+    web_request_ = WebRequest::Create(isolate, base::PassKey<Session>{},
+                                      browser_context()->GetWeakPtr());
   return web_request_;
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1313,6 +1313,8 @@ void WebContents::OnDidAddMessageToConsole(
     int32_t line_no,
     const std::u16string& source_id,
     const std::optional<std::u16string>& untrusted_stack_trace) {
+  if (!console_message_observed_)
+    return;
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
 
@@ -4948,6 +4950,8 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
       .SetMethod("clone", &WebContents::Clone)
+      .SetMethod("_setConsoleMessageObserved",
+                 &WebContents::SetConsoleMessageObserved)
       .SetMethod("_loadURL", &WebContents::LoadURL)
       .SetMethod("reload", &WebContents::Reload)
       .SetMethod("reloadIgnoringCache", &WebContents::ReloadIgnoringCache)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -428,6 +428,9 @@ class WebContents final : public ExclusiveAccessContext,
 
   // Set the window as owner window.
   void SetOwnerWindow(NativeWindow* owner_window);
+  void SetConsoleMessageObserved(bool observed) {
+    console_message_observed_ = observed;
+  }
   void SetOwnerWindow(content::WebContents* web_contents,
                       NativeWindow* owner_window);
   void SetOwnerBaseWindow(std::optional<BaseWindow*> owner_window);
@@ -838,6 +841,9 @@ class WebContents final : public ExclusiveAccessContext,
 
   // Whether background throttling is disabled.
   bool background_throttling_ = true;
+
+  // Kept by JS while 'console-message' has listeners.
+  bool console_message_observed_ = false;
 
   // Whether this WebContents currently contributes to the process-wide caret
   // browsing refcount.

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -28,6 +28,7 @@
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/login_handler.h"
+#include "shell/browser/net/url_loader_factory_gate.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
@@ -313,7 +314,9 @@ WebRequest::ResponseListenerInfo::ResponseListenerInfo(
 WebRequest::ResponseListenerInfo::ResponseListenerInfo() = default;
 WebRequest::ResponseListenerInfo::~ResponseListenerInfo() = default;
 
-WebRequest::WebRequest(base::PassKey<Session>) {}
+WebRequest::WebRequest(base::PassKey<Session>,
+                       base::WeakPtr<ElectronBrowserContext> browser_context)
+    : browser_context_{std::move(browser_context)} {}
 WebRequest::~WebRequest() = default;
 
 gin::ObjectTemplateBuilder WebRequest::GetObjectTemplateBuilder(
@@ -743,6 +746,10 @@ void WebRequest::SetListener(Event event,
     listeners->erase(event);
   else
     (*listeners)[event] = {std::move(filter), std::move(listener)};
+  if (browser_context_) {
+    browser_context_->intercept_state()->SetHasWebRequestListeners(
+        HasListener());
+  }
 }
 
 template <typename... Args>
@@ -789,10 +796,13 @@ WebRequest* WebRequest::FromOrCreate(v8::Isolate* isolate,
 }
 
 // static
-WebRequest* WebRequest::Create(v8::Isolate* isolate,
-                               base::PassKey<Session> passkey) {
+WebRequest* WebRequest::Create(
+    v8::Isolate* isolate,
+    base::PassKey<Session> passkey,
+    base::WeakPtr<ElectronBrowserContext> browser_context) {
   return cppgc::MakeGarbageCollected<WebRequest>(
-      isolate->GetCppHeap()->GetAllocationHandle(), std::move(passkey));
+      isolate->GetCppHeap()->GetAllocationHandle(), std::move(passkey),
+      std::move(browser_context));
 }
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <string>
 
+#include "base/memory/weak_ptr.h"
 #include "base/types/pass_key.h"
 #include "gin/weak_cell.h"
 #include "gin/wrappable.h"
@@ -34,6 +35,10 @@ namespace gin_helper {
 template <typename T>
 class Handle;
 }  // namespace gin_helper
+
+namespace electron {
+class ElectronBrowserContext;
+}  // namespace electron
 
 namespace electron::api {
 
@@ -70,10 +75,14 @@ class WebRequest final : public gin::Wrappable<WebRequest> {
                                   content::BrowserContext* browser_context);
 
   // Return a new WebRequest object. This can only be called by api::Session.
-  static WebRequest* Create(v8::Isolate* isolate, base::PassKey<Session>);
+  static WebRequest* Create(
+      v8::Isolate* isolate,
+      base::PassKey<Session>,
+      base::WeakPtr<ElectronBrowserContext> browser_context);
 
   // Make public for cppgc::MakeGarbageCollected.
-  explicit WebRequest(base::PassKey<Session>);
+  WebRequest(base::PassKey<Session>,
+             base::WeakPtr<ElectronBrowserContext> browser_context);
   ~WebRequest() override;
 
   // disable copy
@@ -127,6 +136,8 @@ class WebRequest final : public gin::Wrappable<WebRequest> {
   void OnRequestWillBeDestroyed(extensions::WebRequestInfo* info);
 
  private:
+  base::WeakPtr<ElectronBrowserContext> browser_context_;
+
   // Contains info about requests that are blocked waiting for a response from
   // the user.
   struct BlockedRequest;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -108,6 +108,7 @@
 #include "shell/browser/net/proxying_url_loader_factory.h"
 #include "shell/browser/net/proxying_websocket.h"
 #include "shell/browser/net/system_network_context_manager.h"
+#include "shell/browser/net/url_loader_factory_gate.h"
 #include "shell/browser/network_hints_handler_impl.h"
 #include "shell/browser/notifications/notification_presenter.h"
 #include "shell/browser/notifications/platform_notification_service.h"
@@ -1537,6 +1538,25 @@ void ElectronBrowserClient::WillCreateURLLoaderFactory(
 #endif
 
   auto [proxied_receiver, target_factory_remote] = factory_builder.Append();
+
+  // Renderer-facing factories get an IO-thread gate in front of the proxy, so
+  // requests only detour through this thread while something observes them.
+  if (frame_host && type != URLLoaderFactoryType::kNavigation) {
+    mojo::Remote<network::mojom::URLLoaderFactory> target(
+        std::move(target_factory_remote));
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> gate_to_network;
+    target->Clone(gate_to_network.InitWithNewPipeAndPassReceiver());
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> gate_to_proxy;
+    mojo::PendingReceiver<network::mojom::URLLoaderFactory> proxy_receiver =
+        gate_to_proxy.InitWithNewPipeAndPassReceiver();
+    CreateURLLoaderFactoryGate(
+        static_cast<ElectronBrowserContext*>(browser_context)
+            ->intercept_state(),
+        std::move(proxied_receiver), std::move(gate_to_network),
+        std::move(gate_to_proxy));
+    proxied_receiver = std::move(proxy_receiver);
+    target_factory_remote = target.Unbind();
+  }
 
   // Required by WebRequestInfoInitParams.
   //

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -17,6 +17,7 @@
 #include "base/path_service.h"
 #include "base/strings/escape.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"
@@ -52,6 +53,7 @@
 #include "shell/browser/file_system_access/file_system_access_permission_context_factory.h"
 #include "shell/browser/media/media_device_id_salt.h"
 #include "shell/browser/net/resolve_proxy_helper.h"
+#include "shell/browser/net/url_loader_factory_gate.h"
 #include "shell/browser/protocol_registry.h"
 #include "shell/browser/serial/serial_chooser_context.h"
 #include "shell/browser/special_storage_policy.h"
@@ -392,6 +394,11 @@ ElectronBrowserContext::ElectronBrowserContext(
   }
 
   BrowserContextDependencyManager::GetInstance()->MarkBrowserContextLive(this);
+  intercept_state_ = base::MakeRefCounted<InterceptState>();
+  intercept_state_->SetIgnoreConnectionsLimitDomains(base::SplitString(
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+          switches::kIgnoreConnectionsLimit),
+      ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY));
 
   // Initialize Pref Registry.
   InitPrefs();
@@ -630,6 +637,13 @@ ElectronBrowserContext::GetURLLoaderFactory() {
       std::move(factory_builder)
           .Finish(storage_partition->GetNetworkContext(), std::move(params));
   return url_loader_factory_;
+}
+
+void ElectronBrowserContext::InterceptedProtocolsChanged() {
+  std::vector<std::string> schemes;
+  for (const auto& [scheme, handler] : protocol_registry_->intercept_handlers())
+    schemes.push_back(scheme);
+  intercept_state_->SetInterceptedSchemes(std::move(schemes));
 }
 
 scoped_refptr<network::SharedURLLoaderFactory>

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -49,6 +49,7 @@ class ElectronDownloadManagerDelegate;
 class ElectronPermissionManager;
 class ElectronPreconnectManagerDelegate;
 class MediaDeviceIDSalt;
+class InterceptState;
 class ProtocolRegistry;
 class ResolveProxyHelper;
 class WebViewManager;
@@ -94,6 +95,11 @@ class ElectronBrowserContext : public content::BrowserContext {
   ResolveProxyHelper* GetResolveProxyHelper();
   content::PreconnectManager* GetPreconnectManager();
   scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactory() override;
+
+  // What the IO-thread URLLoaderFactoryGates route to the UI thread; kept in
+  // sync by api::WebRequest and ProtocolRegistry.
+  InterceptState* intercept_state() const { return intercept_state_.get(); }
+  void InterceptedProtocolsChanged();
   scoped_refptr<network::SharedURLLoaderFactory> InterceptURLLoaderFactory(
       scoped_refptr<network::SharedURLLoaderFactory> factory);
 
@@ -222,6 +228,7 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // Shared URLLoaderFactory.
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  scoped_refptr<InterceptState> intercept_state_;
 
   // Subscription to Network Service process gone notifications.
   base::CallbackListSubscription network_service_gone_subscription_;

--- a/shell/browser/net/asar/asar_url_loader_factory.cc
+++ b/shell/browser/net/asar/asar_url_loader_factory.cc
@@ -6,22 +6,35 @@
 
 #include <utility>
 
+#include "base/functional/bind.h"
 #include "base/memory/self_deleting.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
 #include "shell/browser/net/asar/asar_url_loader.h"
 
 namespace electron {
+
+namespace {
+
+void BindOnIOThread(
+    mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver) {
+  // Deletes itself with its last receiver.
+  base::MakeSelfDeleting<AsarURLLoaderFactory>(std::move(receiver));
+}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+}  // namespace
 
 // static
 mojo::PendingRemote<network::mojom::URLLoaderFactory>
 AsarURLLoaderFactory::Create() {
   mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote;
-
-  // The AsarURLLoaderFactory will delete itself when there are no more
-  // receivers - see the SelfDeletingURLLoaderFactory::OnDisconnect method.
-  base::MakeSelfDeleting<AsarURLLoaderFactory>(
-      pending_remote.InitWithNewPipeAndPassReceiver());
-
-  return pending_remote;  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+  // Bound on the IO thread rather than the UI thread it is created from: all
+  // it does is post loaders to the thread pool.
+  content::GetIOThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(&BindOnIOThread,
+                     pending_remote.InitWithNewPipeAndPassReceiver()));
+  return pending_remote;
 }
 
 AsarURLLoaderFactory::AsarURLLoaderFactory(

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -84,10 +84,11 @@ ProxyingURLLoaderFactory::InProgressRequest::InProgressRequest(
       proxied_loader_receiver_(this, std::move(loader_receiver)),
       target_client_(std::move(client)),
       current_response_(network::mojom::URLResponseHead::New()),
-      // Always use "extraHeaders" mode to be compatible with old APIs.
-      // A non-zero request ID is required to use the TrustedHeaderClient path
-      // which allows webRequest to modify headers like Proxy-Authorization.
-      has_any_extra_headers_listeners_(network_service_request_id != 0) {
+      // "extraHeaders" mode (two round trips per request) only while
+      // webRequest has listeners; see has_any_extra_headers_listeners_.
+      has_any_extra_headers_listeners_(network_service_request_id != 0 &&
+                                       factory->web_request_ &&
+                                       factory->web_request_->HasListener()) {
   // If there is a client error, clean up the request.
   target_client_.set_disconnect_handler(base::BindOnce(
       &ProxyingURLLoaderFactory::InProgressRequest::OnRequestError,

--- a/shell/browser/net/url_loader_factory_gate.cc
+++ b/shell/browser/net/url_loader_factory_gate.cc
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/net/url_loader_factory_gate.h"
+
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "base/memory/self_deleting.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/self_deleting_url_loader_factory.h"
+#include "services/network/public/mojom/url_loader_factory.mojom.h"
+#include "url/gurl.h"
+
+namespace electron {
+
+InterceptState::InterceptState() = default;
+InterceptState::~InterceptState() = default;
+
+void InterceptState::SetHasWebRequestListeners(bool has_listeners) {
+  base::AutoLock lock(lock_);
+  has_web_request_listeners_ = has_listeners;
+}
+
+void InterceptState::SetInterceptedSchemes(
+    base::flat_set<std::string> schemes) {
+  base::AutoLock lock(lock_);
+  intercepted_schemes_ = std::move(schemes);
+}
+
+void InterceptState::SetIgnoreConnectionsLimitDomains(
+    std::vector<std::string> domains) {
+  base::AutoLock lock(lock_);
+  ignore_connections_limit_domains_ = std::move(domains);
+}
+
+bool InterceptState::WantsRequest(const GURL& url) const {
+  base::AutoLock lock(lock_);
+  if (has_web_request_listeners_ || intercepted_schemes_.contains(url.scheme()))
+    return true;
+  for (const auto& domain : ignore_connections_limit_domains_) {
+    if (url.DomainIs(domain))
+      return true;
+  }
+  return false;
+}
+
+namespace {
+
+class URLLoaderFactoryGate : public network::SelfDeletingURLLoaderFactory {
+ public:
+  URLLoaderFactoryGate(
+      scoped_refptr<InterceptState> state,
+      mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor,
+      base::SelfDeletingPassKey key)
+      : network::SelfDeletingURLLoaderFactory(std::move(receiver), key),
+        state_(std::move(state)),
+        target_(std::move(target)),
+        interceptor_(std::move(interceptor)) {
+    target_.set_disconnect_handler(
+        base::BindOnce(&URLLoaderFactoryGate::DisconnectReceiversAndDestroy,
+                       base::Unretained(this)));
+    interceptor_.set_disconnect_handler(
+        base::BindOnce(&URLLoaderFactoryGate::DisconnectReceiversAndDestroy,
+                       base::Unretained(this)));
+  }
+
+  // network::mojom::URLLoaderFactory:
+  void CreateLoaderAndStart(
+      mojo::PendingReceiver<network::mojom::URLLoader> loader,
+      int32_t request_id,
+      uint32_t options,
+      const network::ResourceRequest& request,
+      mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation)
+      override {
+    auto& factory = state_->WantsRequest(request.url) ? interceptor_ : target_;
+    factory->CreateLoaderAndStart(std::move(loader), request_id, options,
+                                  request, std::move(client),
+                                  traffic_annotation);
+  }
+
+ private:
+  ~URLLoaderFactoryGate() override = default;
+
+  const scoped_refptr<InterceptState> state_;
+  mojo::Remote<network::mojom::URLLoaderFactory> target_;
+  mojo::Remote<network::mojom::URLLoaderFactory> interceptor_;
+};
+
+}  // namespace
+
+void CreateURLLoaderFactoryGate(
+    scoped_refptr<InterceptState> state,
+    mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor) {
+  content::GetIOThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](scoped_refptr<InterceptState> state,
+             mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
+             mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
+             mojo::PendingRemote<network::mojom::URLLoaderFactory>
+                 interceptor) {
+            base::MakeSelfDeleting<URLLoaderFactoryGate>(
+                std::move(state), std::move(receiver), std::move(target),
+                std::move(interceptor));
+          },
+          std::move(state), std::move(receiver), std::move(target),
+          std::move(interceptor)));
+}
+
+}  // namespace electron

--- a/shell/browser/net/url_loader_factory_gate.h
+++ b/shell/browser/net/url_loader_factory_gate.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_NET_URL_LOADER_FACTORY_GATE_H_
+#define ELECTRON_SHELL_BROWSER_NET_URL_LOADER_FACTORY_GATE_H_
+
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_set.h"
+#include "base/memory/ref_counted.h"
+#include "base/synchronization/lock.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "services/network/public/mojom/url_loader_factory.mojom-forward.h"
+
+class GURL;
+
+namespace electron {
+
+// What makes a session's requests take the ProxyingURLLoaderFactory path: any
+// webRequest listener (they re-run on redirects, so URL filters cannot be
+// applied here), an intercepted scheme, or an --ignore-connections-limit
+// domain. Written on the UI thread, read on the IO thread.
+class InterceptState : public base::RefCountedThreadSafe<InterceptState> {
+ public:
+  InterceptState();
+
+  void SetHasWebRequestListeners(bool has_listeners);
+  void SetInterceptedSchemes(base::flat_set<std::string> schemes);
+  void SetIgnoreConnectionsLimitDomains(std::vector<std::string> domains);
+
+  // True when a request for `url` has to go through ProxyingURLLoaderFactory.
+  bool WantsRequest(const GURL& url) const;
+
+ private:
+  friend class base::RefCountedThreadSafe<InterceptState>;
+  ~InterceptState();
+
+  mutable base::Lock lock_;
+  bool has_web_request_listeners_ GUARDED_BY(lock_) = false;
+  base::flat_set<std::string> intercepted_schemes_ GUARDED_BY(lock_);
+  std::vector<std::string> ignore_connections_limit_domains_ GUARDED_BY(lock_);
+};
+
+// Bound on the IO thread between a renderer's factory pipe and the network:
+// requests go straight to `target` unless `state` wants them on the UI thread,
+// in which case `interceptor` (a ProxyingURLLoaderFactory) gets them. Lives as
+// long as its receivers and both remotes do.
+void CreateURLLoaderFactoryGate(
+    scoped_refptr<InterceptState> state,
+    mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor);
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_NET_URL_LOADER_FACTORY_GATE_H_

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -86,11 +86,18 @@ const HandlersMap::mapped_type* ProtocolRegistry::FindRegistered(
 bool ProtocolRegistry::InterceptProtocol(ProtocolType type,
                                          const std::string& scheme,
                                          const ProtocolHandler& handler) {
-  return intercept_handlers_.try_emplace(scheme, type, handler).second;
+  const bool added =
+      intercept_handlers_.try_emplace(scheme, type, handler).second;
+  if (added)
+    browser_context_->InterceptedProtocolsChanged();
+  return added;
 }
 
 bool ProtocolRegistry::UninterceptProtocol(const std::string& scheme) {
-  return intercept_handlers_.erase(scheme) != 0;
+  const bool removed = intercept_handlers_.erase(scheme) != 0;
+  if (removed)
+    browser_context_->InterceptedProtocolsChanged();
+  return removed;
 }
 
 const HandlersMap::mapped_type* ProtocolRegistry::FindIntercepted(

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -98,6 +98,7 @@ declare namespace Electron {
   interface WebContents {
     _awaitNextLoad(expectedUrl: string): Promise<void>;
     _loadURL(url: string, options: ElectronInternal.LoadURLOptions): void;
+    _setConsoleMessageObserved(observed: boolean): void;
     getOwnerBrowserWindow(): Electron.BrowserWindow | null;
     getLastWebPreferences(): Electron.WebPreferences | null;
     _getProcessMemoryInfo(): Electron.ProcessMemoryInfo;


### PR DESCRIPTION
#### Description of Change

**A renderer's network requests and file:// loads no longer wait for the main process's JavaScript.** Today every `URLLoaderFactory` Electron hands a renderer is fronted by objects bound on the browser UI thread, so each `<script>`, stylesheet, `fetch()` or image request is dispatched by the main thread and sits in its queue while app code runs. Measured on Linux x64 release builds, medians of 3 warm loads, with the main process either idle or running 100 ms of JavaScript right after the navigation commits (which is what app startup looks like from the window's side):

| | idle main process | main process busy 100 ms |
|---|---|---|
| page with 150 small subresources from a local server, no `webRequest` listeners | 51 -> 46 ms | 152 -> 51 ms |
| same page, session has a `protocol.handle()` for another scheme | 48 -> 49 ms | 152 -> 50 ms |
| same page, any `webRequest` listener registered (matching or not) | 54 -> 54 ms | 152 -> 155 ms (unchanged: still via the main thread) |
| page with 60 small stylesheets from disk (`loadFile`) | 30 -> 28 ms | 130 -> 30 ms (200 ms busy: 230 -> 31) |
| renderer `fetch()` round trip, no listeners / with a `webRequest` listener | 0.43 -> 0.39 ms / 0.66 -> 0.65 ms | |
| main-process CPU per renderer request, no listeners / with a listener | 145 -> 130 us / 330 -> 335 us | |
| main-process CPU per renderer `console.log`, no `console-message` listener | 22.6 -> 13.4 us | |

Four commits, each independent:

1. **Keep renderer network requests off the main thread unless they are observed.** `WillCreateURLLoaderFactory` wrapped every factory in a `ProxyingURLLoaderFactory` on the UI thread, listeners or not. Renderer-facing factories now get a small `URLLoaderFactoryGate` on the IO thread in front of the proxy: it forwards straight to the network service unless the session has a `webRequest` listener, an intercepted scheme matching the request, or an `--ignore-connections-limit` domain, in which case the request goes to the proxy exactly as before. That state is a few words under a lock that `api::WebRequest` and `ProtocolRegistry` update, so a listener added at any time applies to the next request without recreating factories (listeners re-run on redirects, which is why their URL filters are not applied at the gate). With a listener registered nothing changes, within noise.
2. **Bind the file:// URL loader factory off the main thread.** `AsarURLLoaderFactory` only posts loaders to the thread pool, so it is now bound on the IO thread; file:// subresources stop queueing behind main-process work.
3. **Skip the trusted-header round trips for requests proxied without webRequest listeners.** The proxy put every request in "extraHeaders" mode (two `TrustedHeaderClient` round trips per request); that is what lets listeners see and modify network-owned headers, so it stays whenever the session has any `webRequest` listener, and requests that reach the proxy only for an intercepted protocol or an `--ignore-connections-limit` domain skip it.
4. **Don't build `console-message` events while nothing listens for them.** `OnDidAddMessageToConsole` created an event object and emitted into JS for every renderer console call; `WebContents` now keeps a flag from `newListener`/`removeListener` and returns early without it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes (webRequest, protocol, session, net, BrowserWindow, webContents, asar, webview, subframe, service worker, extensions and chromium specs locally on Linux)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Page resources, `fetch()` calls and file:// loads in renderers no longer wait for the main process to be idle when no `webRequest` listeners or protocol interceptors are registered.
