### PR TITLE
fix: reject redirects for CORS preflight requests

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -512,6 +512,11 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToStartRequest(
   }
 
   if (current_request_uses_header_client_ && !redirect_url_.is_empty()) {
+    if (for_cors_preflight_) {
+      // CORS preflight doesn't support redirect.
+      OnRequestError(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+      return;
+    }
     HandleBeforeRequestRedirect();
     return;
   }

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -20,7 +20,12 @@ const fixturesPath = path.resolve(__dirname, 'fixtures');
 describe('webRequest module', () => {
   const ses = session.defaultSession;
   const server = http.createServer((req, res) => {
-    if (req.url === '/serverRedirect') {
+    if (req.url === '/corsPreflight') {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Headers', 'x-trigger');
+      res.setHeader('Access-Control-Allow-Methods', 'POST');
+      res.end('ok');
+    } else if (req.url === '/serverRedirect') {
       res.statusCode = 301;
       res.setHeader('Location', 'http://' + req.rawHeaders[1]);
       res.end();
@@ -365,6 +370,36 @@ describe('webRequest module', () => {
       });
       await ajax(defaultURL + 'serverRedirect');
       await ajax(defaultURL + 'serverRedirect');
+    });
+
+    it('does not crash when redirecting a CORS preflight request', async () => {
+      const sourceServer = http.createServer((_req, res) => res.end('<html></html>'));
+      const sourceURL = (await listen(sourceServer)).url;
+      const corsContents = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true });
+      let redirectedPreflight = false;
+      ses.webRequest.onBeforeRequest((details, callback) => {
+        if (details.method === 'OPTIONS' && details.url === `${defaultURL}corsPreflight`) {
+          redirectedPreflight = true;
+          callback({ redirectURL: `${defaultURL}redirectedPreflight` });
+          return;
+        }
+        callback({});
+      });
+
+      try {
+        await corsContents.loadURL(sourceURL);
+        await expect(
+          corsContents.executeJavaScript(`fetch("${defaultURL}corsPreflight", {
+            method: "POST",
+            headers: { "X-Trigger": "1" },
+            body: "trigger"
+          })`)
+        ).to.eventually.be.rejected();
+        expect(redirectedPreflight).to.be.true();
+      } finally {
+        corsContents.destroy();
+        sourceServer.close();
+      }
     });
 
     it('works with file:// protocol', async () => {


### PR DESCRIPTION
#### Description of Change

Fixes #52592.

CORS preflight requests use a special `InProgressRequest` without a target URL-loader client. When `webRequest.onBeforeRequest` returned a `redirectURL`, `ContinueToStartRequest` entered normal redirect handling and dereferenced the missing client.

Reject these preflight redirects with `net::ERR_FAILED` before normal redirect handling. The regression uses separate HTTP source and target origins, redirects the generated `OPTIONS` request, and verifies that the fetch fails without crashing Electron.

Local validation on Windows x64:

- Incremental `out\Testing` Electron build completed successfully with Ninja `-j 10`.
- Focused `api-web-request-spec.ts` regression passed: 1 test, 1 pass.
- Removing the guard reproduced the main-process termination and left the test harness waiting without results.
- Targeted JavaScript lint, formatting check, and `git diff --check` passed.
- The full `npm test` suite was not run.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when `webRequest` redirected a CORS preflight request.
