### PR TITLE
refactor: deliver additionalArguments to sandboxed preloads with the preload data

### DIFF
--- a/lib/preload_realm/init.ts
+++ b/lib/preload_realm/init.ts
@@ -41,6 +41,10 @@ const preloadProcess = createPreloadProcessObject();
 Object.assign(preloadProcess, binding.process);
 Object.assign(preloadProcess, processProps);
 
+if (preloadProcess.argv.includes('--unsafely-expose-electron-internals-for-testing')) {
+  preloadProcess._linkedBinding = process._linkedBinding;
+}
+
 Object.assign(process, processProps);
 
 require('@electron/internal/renderer/ipc-native-setup');

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -50,6 +50,12 @@ v8Util.setHiddenValue(global, 'emit-process-event', (event: string) => {
 Object.assign(preloadProcess, binding.process);
 Object.assign(preloadProcess, processProps);
 
+// Similar to nodes --expose-internals flag, this exposes _linkedBinding so
+// that tests can call it to get access to some test only bindings
+if (preloadProcess.argv.includes('--unsafely-expose-electron-internals-for-testing')) {
+  preloadProcess._linkedBinding = process._linkedBinding;
+}
+
 // Test-only (DCHECK builds): expose the js2c code-cache status on the
 // sandboxed preload's process shim for the code-cache spec.
 if ((v8Util as any).getJs2cCodeCacheStatus) {

--- a/lib/sandboxed_renderer/preload.ts
+++ b/lib/sandboxed_renderer/preload.ts
@@ -41,14 +41,6 @@ export function createPreloadProcessObject(): NodeJS.Process {
     }
   });
 
-  const { hasSwitch } = process._linkedBinding('electron_common_command_line');
-
-  // Similar to nodes --expose-internals flag, this exposes _linkedBinding so
-  // that tests can call it to get access to some test only bindings
-  if (hasSwitch('unsafely-expose-electron-internals-for-testing')) {
-    preloadProcess._linkedBinding = process._linkedBinding;
-  }
-
   return preloadProcess;
 }
 

--- a/shell/browser/renderer_startup_data.cc
+++ b/shell/browser/renderer_startup_data.cc
@@ -133,8 +133,10 @@ mojom::RendererStartupDataPtr BuildForFrame(content::RenderFrameHost* rfh) {
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
   auto* web_prefs = WebContentsPreferences::From(web_contents);
   std::optional<base::FilePath> preload;
-  if (web_prefs)
+  if (web_prefs) {
     preload = web_prefs->GetPreloadPath();
+    data->additional_arguments = web_prefs->additional_arguments();
+  }
   if (preload && preload->IsAbsolute()) {
     data->preload_scripts.push_back(ReadPreloadScript(
         preload_code_cache::IdForWebPreferencesPreload(*preload), *preload,

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -205,6 +205,7 @@ void WebContentsPreferences::SetFromDictionary(
   if (web_preferences.Get("defaultEncoding", &encoding))
     default_encoding_ = encoding;
   web_preferences.Get(options::kCustomArgs, &custom_args_);
+  std::erase(custom_args_, std::string());
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
@@ -364,10 +365,12 @@ void WebContentsPreferences::AppendCommandLineSwitches(
     command_line->AppendSwitch(switches::kScrollBounce);
 #endif
 
-  // Custom args for renderer process
-  for (const auto& arg : custom_args_)
-    if (!arg.empty())
+  // Sandboxed renderers get these with the preload data instead, see
+  // renderer_startup_data::BuildForFrame().
+  if (!command_line->HasSwitch(switches::kEnableSandbox)) {
+    for (const auto& arg : custom_args_)
       command_line->AppendArg(arg);
+  }
 
   if (enable_blink_features_)
     command_line->AppendSwitchASCII(::switches::kEnableBlinkFeatures,

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -90,6 +90,9 @@ class WebContentsPreferences
   bool ShouldDisablePopups() const { return disable_popups_; }
   bool IsWebSecurityEnabled() const { return web_security_; }
   std::optional<base::FilePath> GetPreloadPath() const { return preload_path_; }
+  const std::vector<std::string>& additional_arguments() const {
+    return custom_args_;
+  }
   bool ShouldFocusOnNavigation() const { return focus_on_navigation_; }
   bool IsSandboxed() const;
 

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -30,6 +30,8 @@ struct RendererStartupData {
   // Browser process.env, captured fresh per push.
   map<string, string> environment;
   string helper_exec_path;
+  // webPreferences.additionalArguments, appended to the preload's process.argv.
+  array<string> additional_arguments;
 };
 
 // A value serialized with electron::SerializeV8Value(), in the buffer it is

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -7,7 +7,9 @@
 #include <iterator>
 
 #include "base/command_line.h"
+#include "base/containers/to_vector.h"
 #include "base/process/process_metrics.h"
+#include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_frame.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -88,7 +90,6 @@ void ElectronSandboxedRendererClient::InitializeBindings(
   BindProcess(isolate, &process, render_frame);
 
   process.SetMethod("uptime", preload_utils::Uptime);
-  process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.SetReadOnly("pid", base::GetCurrentProcId());
   process.SetReadOnly("sandboxed", true);
   process.SetReadOnly("type", "renderer");
@@ -100,12 +101,23 @@ void ElectronSandboxedRendererClient::InitializeBindings(
   // ShouldLoadPreload() filters out (initial empty doc, webview frames), so
   // the bundle never observes a null startupData in practice.
   auto* api_service = ElectronApiServiceImpl::Get(render_frame);
+  const auto& process_argv = base::CommandLine::ForCurrentProcess()->argv();
+#if BUILDFLAG(IS_WIN)
+  std::vector<std::string> argv = base::ToVector(
+      process_argv, [](const auto& arg) { return base::WideToUTF8(arg); });
+#else
+  std::vector<std::string> argv = process_argv;
+#endif
   v8::Local<v8::Value> startup_data;
   if (!api_service ||
       !preload_utils::BuildStartupData(isolate, api_service->startup_data())
            .ToLocal(&startup_data)) {
     startup_data = v8::Null(isolate);
+  } else {
+    const auto& extra = api_service->startup_data()->additional_arguments;
+    argv.insert(argv.end(), extra.begin(), extra.end());
   }
+  process.Set("argv", argv);
   b.Set("startupData", startup_data);
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4165,6 +4165,25 @@ describe('BrowserWindow module', () => {
         const [, argv] = await once(ipcMain, 'answer');
         expect(argv).to.include('--my-magic-arg=foo');
       });
+
+      it('adds extra args to process.argv of a sandboxed preload, per window', async () => {
+        const preload = path.join(fixtures, 'module', 'check-arguments.js');
+        const open = async (args: string[]) => {
+          const w = new BrowserWindow({
+            show: false,
+            webPreferences: { sandbox: true, preload, additionalArguments: args }
+          });
+          const answer = once(ipcMain, 'answer');
+          w.loadFile(path.join(fixtures, 'api', 'blank.html'));
+          const [, argv] = await answer;
+          return argv as string[];
+        };
+        const first = await open(['--first-window', 'plain value']);
+        const second = await open(['--second-window']);
+        expect(first.slice(-2)).to.deep.equal(['--first-window', 'plain value']);
+        expect(second[second.length - 1]).to.equal('--second-window');
+        expect(second).to.not.include('--first-window');
+      });
     });
 
     describe('preload code cache', () => {


### PR DESCRIPTION
#### Description of Change

`webPreferences.additionalArguments` reach a preload's `process.argv` by being appended to the renderer process's command line. For sandboxed renderers the browser already pushes everything a preload needs ahead of the navigation (`RendererStartupData`, #51602), so this sends the arguments there instead and appends them to the preload's `process.argv` in the renderer. Renderers that are not sandboxed keep receiving them on the command line, where Node picks them up as before.

Why: it removes one of the per-window differences between sandboxed renderer command lines. That is what lets a window that uses `additionalArguments` start in a renderer that was launched before the window existed (#53116), and generally keeps app data out of the process's argv.

`process.argv` in preloads is unchanged (same strings, appended at the end, per window). The observable difference is that the strings are no longer on a sandboxed renderer's actual command line, so they are not seen by Chromium's switch parsing in that process or by anything else that inspects the process's argv from outside. The sandbox bundle's own check for `--unsafely-expose-electron-internals-for-testing` now reads `process.argv` for the same reason.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes (BrowserWindow, webContents, contextBridge, logging, ipc, webview, subframe, service worker specs locally on Linux; new spec for per-window arguments in sandboxed preloads)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: `webPreferences.additionalArguments` are now delivered to sandboxed preload scripts directly instead of through the renderer's command line; `process.argv` in preloads is unchanged.
