### PR TITLE
Docs/fix register accelerator platform availability

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -173,8 +173,8 @@ You can add a `click` function for additional behavior.
 
 #### `menuItem.registerAccelerator`
 
-A `boolean` indicating if the accelerator should be registered with the
-system or just displayed.
+A `boolean` indicating if the accelerator should be registered with the 
+system or just displayed. This property is available on Linux and Windows.
 
 This property can be dynamically changed.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -171,10 +171,10 @@ will turn off that property for all adjacent items in the same menu.
 
 You can add a `click` function for additional behavior.
 
-#### `menuItem.registerAccelerator`
+#### `menuItem.registerAccelerator` Linux Windows
 
 A `boolean` indicating if the accelerator should be registered with the 
-system or just displayed. This property is available on Linux and Windows.
+system or just displayed.
 
 This property can be dynamically changed.
 


### PR DESCRIPTION
The registerAccelerator property is marked as available on Linux and Windows in the MenuItem constructor options, but the corresponding menuItem.registerAccelerator property documentation does not specify the same platform availability.

This creates an inconsistency between the two references and may cause confusion about the platforms supported by the property.

Changes

* Added the Linux Windows platform indicators to the menuItem.registerAccelerator property documentation.
* Kept the platform availability consistent with the existing registerAccelerator documentation.

Testing

Documentation-only change. No functional code was modified.