### PR TITLE
docs: clarify registerAccelerator platform availability

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -173,8 +173,8 @@ You can add a `click` function for additional behavior.
 
 #### `menuItem.registerAccelerator`
 
-A `boolean` indicating if the accelerator should be registered with the
-system or just displayed.
+A `boolean` indicating if the accelerator should be registered with the 
+system or just displayed. This property is available on Linux and Windows.
 
 This property can be dynamically changed.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -171,10 +171,10 @@ will turn off that property for all adjacent items in the same menu.
 
 You can add a `click` function for additional behavior.
 
-#### `menuItem.registerAccelerator`
+#### `menuItem.registerAccelerator` Linux Windows
 
 A `boolean` indicating if the accelerator should be registered with the 
-system or just displayed. This property is available on Linux and Windows.
+system or just displayed.
 
 This property can be dynamically changed.
 


### PR DESCRIPTION
The registerAccelerator property is documented as available on Linux and Windows in the MenuItem constructor options, but the corresponding menuItem.registerAccelerator property documentation did not specify the same platform availability.

This inconsistency could cause confusion about the platforms supported by the property.

This change updates the menuItem.registerAccelerator documentation to make its Linux and Windows availability explicit and consistent with the existing documentation.

Checklist

* Documentation has been updated.
* The platform availability is consistent with the existing registerAccelerator documentation.
* No functional code was modified.

Release Notes

Notes: No release notes required for this documentation-only change.