### PR TITLE
fix: deliver macOS notifications without an icon when the attachment fails

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -160,7 +160,15 @@ void CocoaNotification::Show(const NotificationOptions& options) {
                                        URL:url
                                    options:attachment_options
                                      error:&error];
-              return (attachment && !error) ? attachment : nil;
+              if (!attachment || error) {
+                if (electron::debug_notifications) {
+                  LOG(INFO) << "Notification icon attachment failed: "
+                            << (error ? error.localizedDescription.UTF8String
+                                      : "unknown error");
+                }
+                return nil;
+              }
+              return attachment;
             },
             mac_presenter, icon),
         base::BindOnce(
@@ -168,7 +176,9 @@ void CocoaNotification::Show(const NotificationOptions& options) {
                UNMutableNotificationContent* content,
                UNNotificationAttachment* attachment) {
               if (auto* notification = weak_self.get()) {
-                content.attachments = @[ attachment ];
+                // Deliver without an icon if the attachment couldn't be made.
+                if (attachment)
+                  content.attachments = @[ attachment ];
                 auto* self = static_cast<CocoaNotification*>(notification);
                 self->ScheduleNotification(content);
               }


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/52295

Since the UserNotifications rewrite (#47817) a notification's icon is turned into a `UNNotificationAttachment` on the image task runner, and that step returns `nil` when the temporary PNG can't be written under the user data dir or `+attachmentWithIdentifier:URL:options:error:` fails. The reply on the UI thread put the result straight into `@[ attachment ]`, so a `nil` there raised `NSInvalidArgumentException` and took down the browser process.

The notification is now scheduled without attachments when the icon couldn't be attached, and the failure is logged under `--enable-logging` notification debugging.

#### Checklist

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash on macOS when a notification's icon could not be attached; the notification is now shown without the icon.
