### PR TITLE
fix: crash in gin::PerIsolateData::NotifyDisposed when a session is created during quit

### DIFF
--- a/patches/chromium/chore_restore_some_deprecated_wrapper_utility_in_gin.patch
+++ b/patches/chromium/chore_restore_some_deprecated_wrapper_utility_in_gin.patch
@@ -20,18 +20,6 @@ index c80020b2bda2af39b38295dad3c6208cb8294b88..873015289db9709c00c32080e5387d9c
      void OnDisposed() override;
  
     private:
-diff --git a/gin/isolate_holder.cc b/gin/isolate_holder.cc
-index 7c640559dc7a09730f0053be8798d10bc8ac1a1c..24127c579e149345cc9b937b17dbfe630b0d3c35 100644
---- a/gin/isolate_holder.cc
-+++ b/gin/isolate_holder.cc
-@@ -225,6 +225,7 @@ void IsolateHolder::WillCreateMicrotasksRunner() {
- 
- void IsolateHolder::WillDestroyMicrotasksRunner() {
-   DCHECK(g_initialized_microtasks_runner);
-+  isolate_data_->NotifyBeforeMicrotasksRunnerDispose();
-   g_destroyed_microtasks_runner = true;
- }
- 
 diff --git a/gin/per_isolate_data.cc b/gin/per_isolate_data.cc
 index 9670f9f904c6c864e82409617ac4c7698c6fc3ef..d1014af4b63da244820ff865a8e824ddf68433a9 100644
 --- a/gin/per_isolate_data.cc

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -22,6 +22,7 @@
 #include "electron/fuses.h"
 #include "electron/snapshot_checksum.h"
 #include "gin/array_buffer.h"
+#include "gin/per_isolate_data.h"
 #include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
 #include "shell/browser/microtasks_runner.h"
@@ -250,6 +251,9 @@ void JavascriptEnvironment::DestroyMicrotasksRunner() {
     v8::HandleScope scope{isolate()};
     gin_helper::CleanedUpAtExit::DoCleanup();
   }
+  // After DoCleanup() so that observers created by JS that ran during it (e.g.
+  // a webContents 'destroyed' handler) are notified too.
+  gin::PerIsolateData::From(isolate())->NotifyBeforeMicrotasksRunnerDispose();
   base::CurrentThread::Get()->RemoveTaskObserver(microtasks_runner_.get());
   microtasks_runner_.reset();
 }

--- a/spec/fixtures/crash-cases/dispose-observer-created-at-exit/index.js
+++ b/spec/fixtures/crash-cases/dispose-observer-created-at-exit/index.js
@@ -1,0 +1,11 @@
+const { app, globalShortcut, session, WebContentsView } = require('electron');
+
+app.whenReady().then(() => {
+  const view = new WebContentsView();
+  globalThis.view = view;
+  view.webContents.once('destroyed', () => {
+    session.fromPartition('created-at-exit');
+    globalShortcut.isRegistered('Alt+F9');
+  });
+  app.quit();
+});


### PR DESCRIPTION
Backport of #52836

See that PR for details.

Notes: Fixed a possible main process crash at quit when a session was created from JavaScript that runs during shutdown.