### PR TITLE
fix: clear device metrics overrides when a DevTools client disconnects

### DIFF
--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -12,8 +12,10 @@
 #include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
+#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/devtools_agent_host.h"
+#include "content/public/browser/devtools_agent_host_client_channel.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/devtools_socket_factory.h"
 #include "content/public/browser/favicon_status.h"
@@ -82,6 +84,10 @@ std::unique_ptr<content::DevToolsSocketFactory> CreateSocketFactory() {
 }
 
 const char kBrowserCloseMethod[] = "Browser.close";
+const char kSetDeviceMetricsOverrideMethod[] =
+    "Emulation.setDeviceMetricsOverride";
+const char kClearDeviceMetricsOverrideMethod[] =
+    "Emulation.clearDeviceMetricsOverride";
 
 }  // namespace
 
@@ -107,6 +113,14 @@ void DevToolsManagerDelegate::HandleCommand(
     NotHandledCallback callback) {
   crdtp::Dispatchable dispatchable(crdtp::SpanFrom(message));
   DCHECK(dispatchable.ok());
+  if (crdtp::SpanEquals(crdtp::SpanFrom(kSetDeviceMetricsOverrideMethod),
+                        dispatchable.Method())) {
+    channels_with_device_overrides_.insert(channel);
+  } else if (crdtp::SpanEquals(
+                 crdtp::SpanFrom(kClearDeviceMetricsOverrideMethod),
+                 dispatchable.Method())) {
+    channels_with_device_overrides_.erase(channel);
+  }
   if (crdtp::SpanEquals(crdtp::SpanFrom(kBrowserCloseMethod),
                         dispatchable.Method())) {
     // In theory, we should respond over the protocol saying that the
@@ -120,6 +134,40 @@ void DevToolsManagerDelegate::HandleCommand(
     return;
   }
   std::move(callback).Run(message);
+}
+
+void DevToolsManagerDelegate::ClientAttached(
+    content::DevToolsAgentHostClientChannel* channel) {
+  // Drop stale bookkeeping in case the channel's address was reused.
+  channels_with_device_overrides_.erase(channel);
+}
+
+void DevToolsManagerDelegate::ClientDetached(
+    content::DevToolsAgentHostClientChannel* channel) {
+  if (channels_with_device_overrides_.erase(channel) == 0)
+    return;
+
+  // Session teardown (EmulationHandler::Disable()) does not undo the view
+  // resize done by Emulation.setDeviceMetricsOverride, so a client that
+  // detaches without clearing its overrides leaves the view pinned at the
+  // emulated size forever. Restore it here until that is fixed upstream.
+  // This applies to every kind of client (remote debugging, the bundled
+  // frontend, webContents.debugger) since they all detach the same way.
+  content::WebContents* web_contents =
+      channel->GetAgentHost()->GetWebContents();
+  if (!web_contents || web_contents->IsBeingDestroyed())
+    return;
+
+  // Leave the size alone if another client still holds an override on the
+  // same WebContents; it is cleared when that client clears it or detaches.
+  for (content::DevToolsAgentHostClientChannel* other :
+       channels_with_device_overrides_) {
+    if (other->GetAgentHost()->GetWebContents() == web_contents)
+      return;
+  }
+
+  static_cast<content::WebContentsImpl*>(web_contents)
+      ->ClearDeviceEmulationSize();
 }
 
 scoped_refptr<content::DevToolsAgentHost>

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/containers/flat_set.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 
 namespace content {
@@ -31,6 +32,10 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
   void HandleCommand(content::DevToolsAgentHostClientChannel* channel,
                      base::span<const uint8_t> message,
                      NotHandledCallback callback) override;
+  void ClientAttached(
+      content::DevToolsAgentHostClientChannel* channel) override;
+  void ClientDetached(
+      content::DevToolsAgentHostClientChannel* channel) override;
   scoped_refptr<content::DevToolsAgentHost> CreateNewTarget(
       const GURL& url,
       TargetType target_type,
@@ -39,6 +44,11 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
   bool HasBundledFrontendResources() override;
   bool ShouldUseBundledFrontendResources() override;
   content::BrowserContext* GetDefaultBrowserContext() override;
+
+ private:
+  // Channels with an uncleared Emulation.setDeviceMetricsOverride.
+  base::flat_set<content::DevToolsAgentHostClientChannel*>
+      channels_with_device_overrides_;
 };
 
 }  // namespace electron

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -7,7 +7,7 @@ import * as http from 'node:http';
 import * as path from 'node:path';
 
 import { emittedUntil } from './lib/events-helpers';
-import { listen } from './lib/spec-helpers';
+import { listen, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('debugger module', () => {
@@ -64,6 +64,25 @@ describe('debugger module', () => {
       await detach;
       expect(w.webContents.debugger.isAttached()).to.be.false();
       expect(w.devToolsWebContents.isDestroyed()).to.be.false();
+    });
+
+    it('clears device metrics overrides left behind by the session', async () => {
+      await w.webContents.loadURL('about:blank');
+      const innerSize = () => w.webContents.executeJavaScript('window.innerWidth + "x" + window.innerHeight');
+
+      w.webContents.debugger.attach();
+      await w.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
+        width: 200,
+        height: 150,
+        deviceScaleFactor: 0,
+        mobile: false
+      });
+      expect(await innerSize()).to.equal('200x150');
+
+      // Detaching without Emulation.clearDeviceMetricsOverride used to leave
+      // the view pinned at the emulated size.
+      w.webContents.debugger.detach();
+      await waitUntil(async () => (await innerSize()) !== '200x150');
     });
   });
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -14,7 +14,7 @@ import {
 } from 'electron/main';
 
 import { expect } from 'chai';
-import * as ws from 'ws';
+import WebSocketClient = require('ws');
 
 import * as ChildProcess from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
@@ -772,6 +772,107 @@ describe('command line switches', () => {
           'devtoolsFrontendUrl should not point to the remote CDN'
         );
       }
+    });
+
+    it('clears device metrics overrides when a client disconnects without detaching', async function () {
+      // A client dying without clearing its overrides used to leave the page
+      // pinned at the emulated size forever.
+      const appPath = path.join(fixturesPath, 'apps', 'remote-debugging-emulation');
+      appProcess = ChildProcess.spawn(process.execPath, [appPath, '--remote-debugging-port=0']);
+
+      let stderr = '';
+      const browserWsUrl = await new Promise<string>((resolve, reject) => {
+        appProcess!.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+          const m = /DevTools listening on (ws:\/\/\S+)/.exec(stderr);
+          if (m) {
+            appProcess!.stderr.removeAllListeners('data');
+            resolve(m[1]);
+          }
+        });
+        appProcess!.on('exit', () =>
+          reject(new Error(`Process exited before DevTools URL was found. stderr: ${stderr}`))
+        );
+      });
+
+      type Client = {
+        socket: WebSocketClient;
+        send(method: string, params?: unknown, sessionId?: string): Promise<any>;
+        attachToPage(): Promise<string>;
+      };
+      const connectClient = async (): Promise<Client> => {
+        const socket = new WebSocketClient(browserWsUrl);
+        await once(socket, 'open');
+        let nextId = 1;
+        const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>();
+        socket.on('message', (data: WebSocketClient.Data) => {
+          const message = JSON.parse(data.toString());
+          const handler = message.id && pending.get(message.id);
+          if (handler) {
+            pending.delete(message.id);
+            if (message.error) handler.reject(new Error(message.error.message));
+            else handler.resolve(message.result);
+          }
+        });
+        const failPending = (why: string) => {
+          for (const handler of pending.values()) handler.reject(new Error(why));
+          pending.clear();
+        };
+        socket.on('error', (error: Error) => failPending(`websocket error: ${error.message}`));
+        socket.on('close', () => failPending('websocket closed'));
+        const send = (method: string, params: unknown = {}, sessionId?: string) =>
+          new Promise<any>((resolve, reject) => {
+            const id = nextId++;
+            pending.set(id, { resolve, reject });
+            socket.send(JSON.stringify({ id, method, params, sessionId }));
+          });
+        const attachToPage = async () => {
+          // The window may not exist yet when the DevTools server comes up.
+          let page: any;
+          await waitUntil(async () => {
+            const { targetInfos } = await send('Target.getTargets');
+            page = targetInfos.find((target: any) => target.type === 'page');
+            return page !== undefined;
+          });
+          const { sessionId } = await send('Target.attachToTarget', { targetId: page.targetId, flatten: true });
+          return sessionId;
+        };
+        return { socket, send, attachToPage };
+      };
+      const innerSize = async (client: Client, sessionId: string) => {
+        const { result } = await client.send(
+          'Runtime.evaluate',
+          {
+            expression: 'window.innerWidth + "x" + window.innerHeight',
+            returnByValue: true
+          },
+          sessionId
+        );
+        return result.value;
+      };
+
+      const clientA = await connectClient();
+      const sessionA = await clientA.attachToPage();
+      const originalSize = await innerSize(clientA, sessionA);
+      await clientA.send(
+        'Emulation.setDeviceMetricsOverride',
+        {
+          width: 800,
+          height: 450,
+          deviceScaleFactor: 0,
+          mobile: false
+        },
+        sessionA
+      );
+      expect(await innerSize(clientA, sessionA)).to.equal('800x450');
+
+      // Drop the TCP connection like a killed client process would.
+      (clientA.socket as any)._socket.destroy();
+
+      const clientB = await connectClient();
+      const sessionB = await clientB.attachToPage();
+      await waitUntil(async () => (await innerSize(clientB, sessionB)) === originalSize);
+      clientB.socket.close();
     });
   });
 
@@ -3474,7 +3575,7 @@ describe('chromium features', () => {
       const server = http.createServer();
       defer(() => server.close());
       const { port } = await listen(server);
-      const wss = new ws.Server({ server });
+      const wss = new WebSocketClient.Server({ server });
       const finished = new Promise<string | undefined>((resolve, reject) => {
         wss.on('error', reject);
         wss.on('connection', (ws, upgradeReq) => {

--- a/spec/fixtures/apps/remote-debugging-emulation/main.js
+++ b/spec/fixtures/apps/remote-debugging-emulation/main.js
@@ -1,0 +1,10 @@
+const { app, BrowserWindow, Menu } = require('electron');
+
+app.whenReady().then(() => {
+  // No menu bar, so the web contents size is a stable test baseline.
+  Menu.setApplicationMenu(null);
+  const win = new BrowserWindow({ width: 600, height: 400, show: true });
+  win.loadURL('data:text/html,<title>remote-debugging-emulation</title>');
+});
+
+app.on('window-all-closed', () => app.quit());

--- a/spec/fixtures/apps/remote-debugging-emulation/package.json
+++ b/spec/fixtures/apps/remote-debugging-emulation/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "remote-debugging-emulation",
+  "main": "main.js"
+}


### PR DESCRIPTION
Backport of #52254

See that PR for details.

Notes: Fixed DevTools device metrics overrides persisting indefinitely when a remote debugging client disconnected without clearing them.