### PR TITLE
fix: do not show duplicated toggle full screen menu item on macos

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -139,36 +139,49 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 
 // This class stores a base::WeakPtr<electron::ElectronMenuModel> as an
 // Objective-C object, which allows it to be stored in the representedObject
-// field of an NSMenuItem.
+// field of an NSMenuItem. It also stores the identity of the original menu item
+// so copies created by AppKit can be distinguished from ones created by us.
 @interface WeakPtrToElectronMenuModelAsNSObject : NSObject
-+ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model;
-+ (electron::ElectronMenuModel*)getFrom:(id)instance;
-- (instancetype)initWithModel:(electron::ElectronMenuModel*)model;
++ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model
+                       menuItem:(NSMenuItem*)menuItem;
++ (instancetype)metadataFromRepresentedObject:(id)representedObject;
+- (instancetype)initWithModel:(electron::ElectronMenuModel*)model
+                     menuItem:(NSMenuItem*)menuItem;
 - (electron::ElectronMenuModel*)menuModel;
+- (BOOL)isSourceMenuItem:(NSMenuItem*)menuItem;
 @end
 
 @implementation WeakPtrToElectronMenuModelAsNSObject {
   base::WeakPtr<electron::ElectronMenuModel> _model;
+  NSMenuItem* __weak _menuItem;
 }
 
-+ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model {
-  return [[WeakPtrToElectronMenuModelAsNSObject alloc] initWithModel:model];
++ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model
+                       menuItem:(NSMenuItem*)menuItem {
+  return [[WeakPtrToElectronMenuModelAsNSObject alloc] initWithModel:model
+                                                            menuItem:menuItem];
 }
 
-+ (electron::ElectronMenuModel*)getFrom:(id)instance {
-  return [base::apple::ObjCCastStrict<WeakPtrToElectronMenuModelAsNSObject>(
-      instance) menuModel];
++ (instancetype)metadataFromRepresentedObject:(id)representedObject {
+  return base::apple::ObjCCastStrict<WeakPtrToElectronMenuModelAsNSObject>(
+      representedObject);
 }
 
-- (instancetype)initWithModel:(electron::ElectronMenuModel*)model {
+- (instancetype)initWithModel:(electron::ElectronMenuModel*)model
+                     menuItem:(NSMenuItem*)menuItem {
   if ((self = [super init])) {
     _model = model->GetWeakPtr();
+    _menuItem = menuItem;
   }
   return self;
 }
 
 - (electron::ElectronMenuModel*)menuModel {
   return _model.get();
+}
+
+- (BOOL)isSourceMenuItem:(NSMenuItem*)menuItem {
+  return _menuItem == menuItem;
 }
 
 @end
@@ -434,7 +447,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     item.submenu = submenu;
     item.tag = index;
     item.representedObject =
-        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model];
+        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model
+                                                     menuItem:item];
     submenu.delegate = self;
 
     // Set submenu's role.
@@ -452,7 +466,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     // in validation of the menu items.
     item.tag = index;
     item.representedObject =
-        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model];
+        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model
+                                                     menuItem:item];
     ui::Accelerator accelerator;
     if (model->GetAcceleratorAtWithParams(index, useDefaultAccelerator_,
                                           &accelerator)) {
@@ -521,8 +536,9 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     return;
   }
 
-  electron::ElectronMenuModel* model =
-      [WeakPtrToElectronMenuModelAsNSObject getFrom:represented];
+  auto* metadata = [WeakPtrToElectronMenuModelAsNSObject
+      metadataFromRepresentedObject:represented];
+  electron::ElectronMenuModel* model = [metadata menuModel];
   if (!model)
     return;
 
@@ -535,6 +551,17 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   // if the menu item is disabled. So we only disable the menu item when the
   // menu is open. This matches behavior of |validateUserInterfaceItem|.
   item.enabled = model->IsEnabledAt(index);
+
+  // AppKit changes the source full screen item's shortcut to Function+F and
+  // creates a hidden copy to preserve Control+Command+F. The copy has the same
+  // representedObject and tag, but its presentation state is owned by AppKit.
+  // representedObject points to the same menuItem, so we can simply skip the
+  // menu item created by AppKit and not by ourselves.
+  if (![metadata isSourceMenuItem:item] &&
+      model->GetRoleAt(index) == u"togglefullscreen") {
+    return;
+  }
+
   item.hidden = !model->IsVisibleAt(index);
   item.state = model->IsItemCheckedAt(index) ? NSControlStateValueOn
                                              : NSControlStateValueOff;
@@ -607,8 +634,9 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 // item chosen.
 - (void)itemSelected:(id)sender {
   NSInteger modelIndex = [sender tag];
-  electron::ElectronMenuModel* model =
-      [WeakPtrToElectronMenuModelAsNSObject getFrom:[sender representedObject]];
+  auto* metadata = [WeakPtrToElectronMenuModelAsNSObject
+      metadataFromRepresentedObject:[sender representedObject]];
+  electron::ElectronMenuModel* model = [metadata menuModel];
   DCHECK(model);
   if (model) {
     NSEvent* event = [NSApp currentEvent];
@@ -651,13 +679,6 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 
 - (void)menuWillOpen:(NSMenu*)menu {
   isMenuOpen_ = YES;
-
-  // macOS automatically injects a duplicate "Toggle Full Screen" menu item
-  // when we set menu.delegate on submenus. Remove hidden duplicates.
-  for (NSMenuItem* item in menu.itemArray) {
-    if (item.isHidden && item.action == @selector(toggleFullScreenMode:))
-      [menu removeItem:item];
-  }
 
   if (model_)
     model_->MenuWillShow();

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -141,37 +141,37 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 // Objective-C object, which allows it to be stored in the representedObject
 // field of an NSMenuItem. It also stores the identity of the original menu item
 // so copies created by AppKit can be distinguished from ones created by us.
-@interface WeakPtrToElectronMenuModelAsNSObject : NSObject
-+ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model
-                       menuItem:(NSMenuItem*)menuItem;
+@interface ElectronMenuItemMetadata : NSObject
++ (instancetype)metadataForModel:(electron::ElectronMenuModel*)model
+                  sourceMenuItem:(NSMenuItem*)sourceMenuItem;
 + (instancetype)metadataFromRepresentedObject:(id)representedObject;
 - (instancetype)initWithModel:(electron::ElectronMenuModel*)model
-                     menuItem:(NSMenuItem*)menuItem;
+               sourceMenuItem:(NSMenuItem*)sourceMenuItem;
 - (electron::ElectronMenuModel*)menuModel;
 - (BOOL)isSourceMenuItem:(NSMenuItem*)menuItem;
 @end
 
-@implementation WeakPtrToElectronMenuModelAsNSObject {
+@implementation ElectronMenuItemMetadata {
   base::WeakPtr<electron::ElectronMenuModel> _model;
-  NSMenuItem* __weak _menuItem;
+  NSMenuItem* __weak _sourceMenuItem;
 }
 
-+ (instancetype)weakPtrForModel:(electron::ElectronMenuModel*)model
-                       menuItem:(NSMenuItem*)menuItem {
-  return [[WeakPtrToElectronMenuModelAsNSObject alloc] initWithModel:model
-                                                            menuItem:menuItem];
++ (instancetype)metadataForModel:(electron::ElectronMenuModel*)model
+                  sourceMenuItem:(NSMenuItem*)sourceMenuItem {
+  return [[ElectronMenuItemMetadata alloc] initWithModel:model
+                                          sourceMenuItem:sourceMenuItem];
 }
 
 + (instancetype)metadataFromRepresentedObject:(id)representedObject {
-  return base::apple::ObjCCastStrict<WeakPtrToElectronMenuModelAsNSObject>(
+  return base::apple::ObjCCastStrict<ElectronMenuItemMetadata>(
       representedObject);
 }
 
 - (instancetype)initWithModel:(electron::ElectronMenuModel*)model
-                     menuItem:(NSMenuItem*)menuItem {
+               sourceMenuItem:(NSMenuItem*)sourceMenuItem {
   if ((self = [super init])) {
     _model = model->GetWeakPtr();
-    _menuItem = menuItem;
+    _sourceMenuItem = sourceMenuItem;
   }
   return self;
 }
@@ -181,7 +181,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 }
 
 - (BOOL)isSourceMenuItem:(NSMenuItem*)menuItem {
-  return _menuItem == menuItem;
+  return _sourceMenuItem == menuItem;
 }
 
 @end
@@ -447,8 +447,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     item.submenu = submenu;
     item.tag = index;
     item.representedObject =
-        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model
-                                                     menuItem:item];
+        [ElectronMenuItemMetadata metadataForModel:model sourceMenuItem:item];
     submenu.delegate = self;
 
     // Set submenu's role.
@@ -466,8 +465,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     // in validation of the menu items.
     item.tag = index;
     item.representedObject =
-        [WeakPtrToElectronMenuModelAsNSObject weakPtrForModel:model
-                                                     menuItem:item];
+        [ElectronMenuItemMetadata metadataForModel:model sourceMenuItem:item];
     ui::Accelerator accelerator;
     if (model->GetAcceleratorAtWithParams(index, useDefaultAccelerator_,
                                           &accelerator)) {
@@ -531,12 +529,11 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   if (!represented)
     return;
 
-  if (![represented
-          isKindOfClass:[WeakPtrToElectronMenuModelAsNSObject class]]) {
+  if (![represented isKindOfClass:[ElectronMenuItemMetadata class]]) {
     return;
   }
 
-  auto* metadata = [WeakPtrToElectronMenuModelAsNSObject
+  auto* metadata = [ElectronMenuItemMetadata
       metadataFromRepresentedObject:represented];
   electron::ElectronMenuModel* model = [metadata menuModel];
   if (!model)
@@ -637,7 +634,7 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
 // item chosen.
 - (void)itemSelected:(id)sender {
   NSInteger modelIndex = [sender tag];
-  auto* metadata = [WeakPtrToElectronMenuModelAsNSObject
+  auto* metadata = [ElectronMenuItemMetadata
       metadataFromRepresentedObject:[sender representedObject]];
   electron::ElectronMenuModel* model = [metadata menuModel];
   DCHECK(model);

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -446,8 +446,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     submenu.title = item.title;
     item.submenu = submenu;
     item.tag = index;
-    item.representedObject =
-        [ElectronMenuItemMetadata metadataForModel:model sourceMenuItem:item];
+    item.representedObject = [ElectronMenuItemMetadata metadataForModel:model
+                                                         sourceMenuItem:item];
     submenu.delegate = self;
 
     // Set submenu's role.
@@ -464,8 +464,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     // model. Setting the target to |self| allows this class to participate
     // in validation of the menu items.
     item.tag = index;
-    item.representedObject =
-        [ElectronMenuItemMetadata metadataForModel:model sourceMenuItem:item];
+    item.representedObject = [ElectronMenuItemMetadata metadataForModel:model
+                                                         sourceMenuItem:item];
     ui::Accelerator accelerator;
     if (model->GetAcceleratorAtWithParams(index, useDefaultAccelerator_,
                                           &accelerator)) {
@@ -533,8 +533,8 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
     return;
   }
 
-  auto* metadata = [ElectronMenuItemMetadata
-      metadataFromRepresentedObject:represented];
+  auto* metadata =
+      [ElectronMenuItemMetadata metadataFromRepresentedObject:represented];
   electron::ElectronMenuModel* model = [metadata menuModel];
   if (!model)
     return;

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -559,6 +559,9 @@ NSMenuItemBadge* CreateBadge(const electron::ElectronMenuModel::Badge& badge)
   // menu item created by AppKit and not by ourselves.
   if (![metadata isSourceMenuItem:item] &&
       model->GetRoleAt(index) == u"togglefullscreen") {
+    [(id)item
+        setAllowsKeyEquivalentWhenHidden:(model->IsVisibleAt(index) ||
+                                          model->WorksWhenHiddenAt(index))];
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/52821

This PR fixes duplicated "Toggle Full Screen" menu item on macOS. From my testing, when we add it, AppKit generates another menu item with a separate shortcut and makes it hidden. Previously, we relied on that so we would remove the hidden item for toggling full screen, which was added in https://github.com/electron/electron/pull/49074. In theory this also only preserves one shortcut.

However, I think we refresh the menu and process all items (making the 2nd toggle full screen)  before we reach this check now.

Here I take a different approach -- each representedObject carries a weak pointer to the created menu item. AppKit when inserting that duplicated menu item, simply copies it, so it will no longer point to the same MenuItem*. So we skip it and just do not do anything about it, and the item will stay hidden. This also should mean that both shortcuts will work, including the hidden one.

#### Testing

Given that we adjust for the AppKit's behaviour, I didn't add any tests and it needs manual testing. I also only have access to macOS 26 Tahoe, so that's the only one I tested. I _assume_ AppKIt's behaviour is stable but would be great to confirm.

To test it, build Electron locally and run the gist with the issue: https://gist.github.com/eostrom/b120b0b6412063855bbf9b2677247368.

- [ ] only 1 toggle full screen menu item is present
- [ ] both shortcuts work

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an issue with the duplicate "Toggle Full Screen" menu item appearing in the View menu on macOS.