### PR TITLE
build: add electron_xcache host tool for cross-target V8 code caches

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -258,6 +258,7 @@ jobs:
         Set-ExecutionPolicy Bypass -Scope Process -Force
         cd src/out/Default
         Expand-Archive -Force dist.zip -DestinationPath ./
+        if (Test-Path xcache.zip) { Expand-Archive -Force xcache.zip -DestinationPath ./ }
     - name: Unzip Dist (unix)
       if: ${{ inputs.target-platform != 'win' }}
       run: |

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -263,6 +263,7 @@ jobs:
       run: |
         cd src/out/Default
         unzip -:o dist.zip
+        if [ -f xcache.zip ]; then unzip -:o xcache.zip electron_xcache; fi
     - name: Import & Trust Self-Signed Codesigning Cert on MacOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: |

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -906,6 +906,23 @@ source_set("electron_lib") {
   }
 }
 
+# Host tool that emits a V8 code cache for a JS file, keyed to whichever V8
+# startup snapshot blob it is given -- including one from another OS/CPU's
+# build of the same Electron version. See shell/common/electron_xcache_main.cc.
+if (current_toolchain == default_toolchain) {
+  executable("electron_xcache") {
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    include_dirs = [ "//" ]
+    sources = [ "shell/common/electron_xcache_main.cc" ]
+    deps = [
+      "//third_party/zlib",
+      "//v8",
+      "//v8:v8_libplatform",
+    ]
+  }
+}
+
 # Build-time host tool emitting V8 code caches for the electron/js2c/* framework
 # bundles. Built in v8_snapshot_toolchain (like node_mksnapshot) so it links V8
 # with V8_TARGET_ARCH set to the target and reads the target's snapshot blob --

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -909,7 +909,7 @@ source_set("electron_lib") {
 # Host tool that emits a V8 code cache for a JS file, keyed to whichever V8
 # startup snapshot blob it is given -- including one from another OS/CPU's
 # build of the same Electron version. See shell/common/electron_xcache_main.cc.
-if (current_toolchain == default_toolchain) {
+if (!is_win && current_toolchain == default_toolchain) {
   executable("electron_xcache") {
     configs += [ "//build/config/compiler:no_chromium_code" ]
     configs -= [ "//build/config/compiler:chromium_code" ]
@@ -1959,6 +1959,20 @@ dist_zip("hunspell_dictionaries_zip") {
   outputs = [ "$root_build_dir/hunspell_dictionaries.zip" ]
 }
 
+if (is_linux) {
+  dist_zip("electron_xcache_zip") {
+    data_deps = [
+      ":electron_xcache",
+      ":licenses",
+    ]
+    if (is_official_build) {
+      data_deps += [ ":strip_electron_xcache_binary" ]
+    }
+    deps = data_deps
+    outputs = [ "$root_build_dir/xcache.zip" ]
+  }
+}
+
 copy("libcxx_headers") {
   sources = libcxx_headers + libcxx_licenses + [
               "//buildtools/third_party/libc++/__assertion_handler",
@@ -2075,6 +2089,9 @@ group("testing_build") {
     ":electron_mksnapshot_zip",
     ":node_headers",
   ]
+  if (is_linux) {
+    public_deps += [ ":electron_xcache_zip" ]
+  }
 }
 
 group("release_build") {
@@ -2112,6 +2129,13 @@ if (is_linux && is_official_build) {
     symbol_output = "$root_out_dir/debug/chrome-sandbox.debug"
     compress_debug_sections = true
     deps = [ "//sandbox/linux:chrome_sandbox" ]
+  }
+
+  strip_binary("strip_electron_xcache_binary") {
+    binary_input = "$root_out_dir/electron_xcache"
+    symbol_output = "$root_out_dir/debug/electron_xcache.debug"
+    compress_debug_sections = true
+    deps = [ ":electron_xcache" ]
   }
 
   strip_binary("strip_libffmpeg_shlib") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -909,7 +909,7 @@ source_set("electron_lib") {
 # Host tool that emits a V8 code cache for a JS file, keyed to whichever V8
 # startup snapshot blob it is given -- including one from another OS/CPU's
 # build of the same Electron version. See shell/common/electron_xcache_main.cc.
-if (!is_win && current_toolchain == default_toolchain) {
+if (current_toolchain == default_toolchain) {
   executable("electron_xcache") {
     configs += [ "//build/config/compiler:no_chromium_code" ]
     configs -= [ "//build/config/compiler:chromium_code" ]
@@ -1959,18 +1959,16 @@ dist_zip("hunspell_dictionaries_zip") {
   outputs = [ "$root_build_dir/hunspell_dictionaries.zip" ]
 }
 
-if (is_linux) {
-  dist_zip("electron_xcache_zip") {
-    data_deps = [
-      ":electron_xcache",
-      ":licenses",
-    ]
-    if (is_official_build) {
-      data_deps += [ ":strip_electron_xcache_binary" ]
-    }
-    deps = data_deps
-    outputs = [ "$root_build_dir/xcache.zip" ]
+dist_zip("electron_xcache_zip") {
+  data_deps = [
+    ":electron_xcache",
+    ":licenses",
+  ]
+  if (is_linux && is_official_build) {
+    data_deps += [ ":strip_electron_xcache_binary" ]
   }
+  deps = data_deps
+  outputs = [ "$root_build_dir/xcache.zip" ]
 }
 
 copy("libcxx_headers") {
@@ -2089,7 +2087,7 @@ group("testing_build") {
     ":electron_mksnapshot_zip",
     ":node_headers",
   ]
-  if (is_linux) {
+  if (!is_mas_build) {
     public_deps += [ ":electron_xcache_zip" ]
   }
 }

--- a/build/zip.py
+++ b/build/zip.py
@@ -76,7 +76,9 @@ def skip_path(dep, dist_zip, target_cpu):
       "arm" in target_cpu
       and dist_zip == "mksnapshot.zip"
       and "snapshot_blob.bin" in candidates
-    )
+    ) or
+    # electron_xcache links V8 but is always handed the target's blob.
+    (dist_zip == "xcache.zip" and "snapshot_blob.bin" in candidates)
   )
   if should_skip and os.environ.get('ELECTRON_DEBUG_ZIP_SKIP') == '1':
     print("Skipping {}".format(dep))

--- a/script/actions/move-artifacts.sh
+++ b/script/actions/move-artifacts.sh
@@ -110,6 +110,7 @@ mv_if_exist src/out/Default/mksnapshot.zip
 mv_if_exist src/out/Default/chromedriver.zip
 mv_if_exist src/out/ffmpeg/ffmpeg.zip
 mv_if_exist src/out/Default/hunspell_dictionaries.zip
+mv_if_exist src/out/Default/xcache.zip
 mv_if_exist src/cross-arch-snapshots
 cp_if_exist src/out/electron_ninja_log
 cp_if_exist src/out/Default/.ninja_log

--- a/script/actions/restore-artifacts.sh
+++ b/script/actions/restore-artifacts.sh
@@ -32,6 +32,7 @@ mv_if_exist mksnapshot.zip src/out/Default
 mv_if_exist chromedriver.zip src/out/Default
 mv_if_exist ffmpeg.zip src/out/ffmpeg
 mv_if_exist hunspell_dictionaries.zip src/out/Default
+mv_if_exist xcache.zip src/out/Default
 mv_if_exist cross-arch-snapshots src
 
 echo Restoring artifacts from $SRC_ARTIFACTS

--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -168,7 +168,9 @@ function assetsForVersion(version: string, validatingRelease: boolean) {
     `mksnapshot-${version}-win32-x64.zip`,
     `mksnapshot-${version}-win32-arm64-x64.zip`,
     `electron-${version}-win32-x64-toolchain-profile.zip`,
-    `electron-${version}-win32-arm64-toolchain-profile.zip`
+    `electron-${version}-win32-arm64-toolchain-profile.zip`,
+    `xcache-${version}-linux-arm64.zip`,
+    `xcache-${version}-linux-x64.zip`
   ];
   if (!validatingRelease) {
     patterns.push('SHASUMS256.txt');

--- a/script/release/release.ts
+++ b/script/release/release.ts
@@ -169,8 +169,12 @@ function assetsForVersion(version: string, validatingRelease: boolean) {
     `mksnapshot-${version}-win32-arm64-x64.zip`,
     `electron-${version}-win32-x64-toolchain-profile.zip`,
     `electron-${version}-win32-arm64-toolchain-profile.zip`,
+    `xcache-${version}-darwin-arm64.zip`,
+    `xcache-${version}-darwin-x64.zip`,
     `xcache-${version}-linux-arm64.zip`,
-    `xcache-${version}-linux-x64.zip`
+    `xcache-${version}-linux-x64.zip`,
+    `xcache-${version}-win32-arm64.zip`,
+    `xcache-${version}-win32-x64.zip`
   ];
   if (!validatingRelease) {
     patterns.push('SHASUMS256.txt');

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -111,6 +111,10 @@ def main():
         libcxx_objects_zip)
     upload_electron(release, libcxx_objects_zip, args)
 
+    xcache_zip = os.path.join(OUT_DIR, get_zip_name('xcache', ELECTRON_VERSION))
+    shutil.copy2(os.path.join(OUT_DIR, 'xcache.zip'), xcache_zip)
+    upload_electron(release, xcache_zip, args)
+
     # Upload headers.zip and abi_headers.zip as non-platform specific
     if get_target_arch() == "x64":
       cxx_headers_zip = os.path.join(OUT_DIR, 'libcxx_headers.zip')

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -111,10 +111,6 @@ def main():
         libcxx_objects_zip)
     upload_electron(release, libcxx_objects_zip, args)
 
-    xcache_zip = os.path.join(OUT_DIR, get_zip_name('xcache', ELECTRON_VERSION))
-    shutil.copy2(os.path.join(OUT_DIR, 'xcache.zip'), xcache_zip)
-    upload_electron(release, xcache_zip, args)
-
     # Upload headers.zip and abi_headers.zip as non-platform specific
     if get_target_arch() == "x64":
       cxx_headers_zip = os.path.join(OUT_DIR, 'libcxx_headers.zip')
@@ -129,6 +125,11 @@ def main():
   ffmpeg_build_path = os.path.join(SRC_DIR, 'out', 'ffmpeg', 'ffmpeg.zip')
   shutil.copy2(ffmpeg_build_path, ffmpeg_zip)
   upload_electron(release, ffmpeg_zip, args)
+
+  if get_platform_key() != 'mas':
+    xcache_zip = os.path.join(OUT_DIR, get_zip_name('xcache', ELECTRON_VERSION))
+    shutil.copy2(os.path.join(OUT_DIR, 'xcache.zip'), xcache_zip)
+    upload_electron(release, xcache_zip, args)
 
   chromedriver = get_zip_name('chromedriver', ELECTRON_VERSION)
   chromedriver_zip = os.path.join(OUT_DIR, chromedriver)

--- a/shell/common/electron_xcache_main.cc
+++ b/shell/common/electron_xcache_main.cc
@@ -1,0 +1,585 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+//
+// electron_xcache: host tool that compiles a JavaScript file and emits a V8
+// code cache (v8::ScriptCompiler::CachedData) that a target Electron build of
+// the same version -- any OS / CPU -- accepts in the process created from the
+// supplied V8 startup snapshot blob.
+//
+// A code cache is arch-neutral except for its header (version hash, flag hash,
+// read-only-snapshot checksum) and ReadOnlyHeapRef back-references into the
+// read-only heap, all of which are properties of the snapshot blob the
+// consuming isolate was created from. The tool therefore creates its isolate
+// from the target's blob, with JavaScript execution disallowed (the blob's
+// builtin metadata does not describe this binary's builtins), and serializes.
+// Build it from the target version's checkout in a release configuration.
+
+#ifdef UNSAFE_BUFFERS_BUILD
+#pragma allow_unsafe_buffers
+#endif
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "libplatform/libplatform.h"
+#include "third_party/zlib/zlib.h"
+#include "v8.h"
+
+namespace {
+
+// Non-default V8 flags of the Electron main process; FlagList::Hash() over
+// them is part of the code-cache key. Keep in sync with the browser flavor of
+// electron_natives_codecache in BUILD.gn.
+constexpr char kDefaultV8Flags[] =
+    "--rehash-snapshot --no-freeze-flags-after-init";
+
+// v8/src/snapshot/snapshot.cc, SnapshotImpl.
+constexpr uint32_t kSnapNumContextsOffset = 0;
+constexpr uint32_t kSnapRehashabilityOffset = 4;
+constexpr uint32_t kSnapChecksumOffset = 8;
+constexpr uint32_t kSnapRoChecksumOffset = 12;
+constexpr uint32_t kSnapVersionStringOffset = 16;
+constexpr uint32_t kSnapVersionStringLength = 64;
+constexpr uint32_t kSnapStartupOffsetOffset =
+    kSnapVersionStringOffset + kSnapVersionStringLength;
+constexpr uint32_t kSnapFirstContextOffsetOffset =
+    kSnapStartupOffsetOffset + 2 * 4;
+// v8/src/snapshot/snapshot-data.h, SnapshotData: magic, payload length.
+constexpr uint32_t kSnapshotDataHeaderSize = 8;
+
+// v8/src/snapshot/code-serializer.h, SerializedCodeData (64-bit).
+constexpr uint32_t kCacheMagicOffset = 0;
+constexpr uint32_t kCacheVersionHashOffset = 4;
+constexpr uint32_t kCacheSourceHashOffset = 8;
+constexpr uint32_t kCacheFlagHashOffset = 12;
+constexpr uint32_t kCacheRoChecksumOffset = 16;
+constexpr uint32_t kCachePayloadLengthOffset = 20;
+constexpr uint32_t kCacheHeaderSize = 32;
+
+uint32_t ReadU32(const char* p) {
+  uint32_t v;
+  std::memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+std::string Hex(uint32_t v) {
+  char buf[16];
+  std::snprintf(buf, sizeof(buf), "0x%08x", v);
+  return buf;
+}
+
+class MappedFile {
+ public:
+  bool Open(const std::string& path) {
+    fd_ = open(path.c_str(), O_RDONLY);
+    if (fd_ < 0)
+      return false;
+    struct stat st;
+    if (fstat(fd_, &st) != 0 || st.st_size == 0)
+      return false;
+    size_ = static_cast<size_t>(st.st_size);
+    void* m = mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+    if (m == MAP_FAILED)
+      return false;
+    data_ = static_cast<const char*>(m);
+    return true;
+  }
+  ~MappedFile() {
+    if (data_)
+      munmap(const_cast<char*>(data_), size_);
+    if (fd_ >= 0)
+      close(fd_);
+  }
+  std::string_view view() const { return {data_, size_}; }
+
+ private:
+  int fd_ = -1;
+  const char* data_ = nullptr;
+  size_t size_ = 0;
+};
+
+bool ReadFile(const std::string& path, std::string* out) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in)
+    return false;
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  *out = ss.str();
+  return true;
+}
+
+struct BlobInfo {
+  size_t offset = 0;
+  size_t size = 0;
+  uint32_t num_contexts = 0;
+  uint32_t ro_checksum = 0;
+  std::string version;
+  bool checksum_ok = false;
+};
+
+// Parses a SnapshotImpl header at data[offset]; the blob's length is derived
+// from its last context's SnapshotData header.
+bool ParseBlobAt(std::string_view data, size_t offset, BlobInfo* info) {
+  if (offset + kSnapFirstContextOffsetOffset + 4 > data.size())
+    return false;
+  const char* p = data.data() + offset;
+  BlobInfo b;
+  b.offset = offset;
+  b.num_contexts = ReadU32(p + kSnapNumContextsOffset);
+  const uint32_t rehashability = ReadU32(p + kSnapRehashabilityOffset);
+  if (b.num_contexts == 0 || b.num_contexts > 32 || rehashability > 1)
+    return false;
+  b.version.assign(
+      p + kSnapVersionStringOffset,
+      strnlen(p + kSnapVersionStringOffset, kSnapVersionStringLength));
+  const size_t ctx_table_end =
+      kSnapFirstContextOffsetOffset + 4 * static_cast<size_t>(b.num_contexts);
+  if (offset + ctx_table_end > data.size())
+    return false;
+  const uint32_t startup_off = ReadU32(p + kSnapStartupOffsetOffset);
+  const uint32_t last_ctx_off =
+      ReadU32(p + kSnapFirstContextOffsetOffset + 4 * (b.num_contexts - 1));
+  if (startup_off < ctx_table_end || last_ctx_off < startup_off ||
+      offset + last_ctx_off + kSnapshotDataHeaderSize > data.size())
+    return false;
+  b.size = static_cast<size_t>(last_ctx_off) + kSnapshotDataHeaderSize +
+           ReadU32(p + last_ctx_off + 4);
+  if (offset + b.size > data.size())
+    return false;
+  // Covers [ro checksum field, end); V8 seeds adler32 with 0.
+  const uLong a =
+      adler32(0L, reinterpret_cast<const Bytef*>(p + kSnapRoChecksumOffset),
+              static_cast<uInt>(b.size - kSnapRoChecksumOffset));
+  b.checksum_ok = static_cast<uint32_t>(a) == ReadU32(p + kSnapChecksumOffset);
+  b.ro_checksum = ReadU32(p + kSnapRoChecksumOffset);
+  *info = b;
+  return true;
+}
+
+// Every V8 snapshot blob for `version` in `data`: a bare blob file, or a
+// binary that embeds one (the Node startup snapshot in electron / electron.exe
+// / "Electron Framework").
+std::vector<BlobInfo> FindBlobs(std::string_view data,
+                                const std::string& version) {
+  std::vector<BlobInfo> out;
+  const std::string needle = version + '\0';
+  size_t pos = 0;
+  while ((pos = data.find(needle, pos)) != std::string_view::npos) {
+    BlobInfo b;
+    if (pos >= kSnapVersionStringOffset &&
+        ParseBlobAt(data, pos - kSnapVersionStringOffset, &b)) {
+      out.push_back(b);
+    }
+    ++pos;
+  }
+  return out;
+}
+
+const char* KindOf(const BlobInfo& b) {
+  if (b.num_contexts >= 4)
+    return "node-startup-snapshot";
+  if (b.num_contexts == 3)
+    return "v8_context_snapshot";
+  if (b.num_contexts == 1)
+    return "bare-v8-snapshot";
+  return "unknown";
+}
+
+void PrintBlob(std::ostream& os, const BlobInfo& b, size_t index) {
+  os << "  [" << index << "] offset=" << b.offset << " size=" << b.size
+     << " contexts=" << b.num_contexts << " kind=" << KindOf(b)
+     << " ro_checksum=" << Hex(b.ro_checksum)
+     << " checksum=" << (b.checksum_ok ? "ok" : "MISMATCH") << " version=\""
+     << b.version << "\"\n";
+}
+
+std::vector<std::string> Split(const std::string& s, char sep) {
+  std::vector<std::string> out;
+  std::string cur;
+  for (char c : s) {
+    if (c == sep) {
+      if (!cur.empty())
+        out.push_back(cur);
+      cur.clear();
+    } else {
+      cur.push_back(c);
+    }
+  }
+  if (!cur.empty())
+    out.push_back(cur);
+  return out;
+}
+
+// The blob refers to its embedder's external references (Node's or Blink's C++
+// callbacks and external string resources) by index into a table only that
+// embedder has. Callbacks are never invoked here, but external strings are
+// wired to their resource during deserialization, so every index must resolve
+// to a string-resource-shaped object; nothing reads those strings. One-byte
+// and two-byte resources declare data()/length() at the same vtable positions.
+class InertStringResource final
+    : public v8::String::ExternalOneByteStringResource {
+ public:
+  const char* data() const override { return kEmpty; }
+  size_t length() const override { return 0; }
+  bool IsCacheable() const override { return false; }
+
+ protected:
+  void Dispose() override {}
+
+ private:
+  static constexpr char kEmpty[1] = {0};
+};
+
+std::vector<intptr_t> MakeInertExternalReferences() {
+  static InertStringResource resource;
+  std::vector<intptr_t> refs(1 << 18, reinterpret_cast<intptr_t>(&resource));
+  refs.push_back(0);
+  return refs;
+}
+
+void Usage() {
+  std::cerr
+      << "usage: electron_xcache --snapshot <blob-or-binary> --in <file.js> "
+         "--out <file> [options]\n"
+         "       electron_xcache --snapshot <blob-or-binary> --list\n\n"
+         "  --snapshot <file>   V8 startup snapshot the TARGET process is "
+         "created "
+         "from: a bare blob\n"
+         "                      (v8_context_snapshot[.<arch>].bin) or a binary "
+         "embedding one\n"
+         "                      (electron, electron.exe, 'Electron Framework' "
+         "-> "
+         "its Node startup\n"
+         "                      snapshot). Any OS/arch; must match this tool's "
+         "V8 "
+         "version.\n"
+         "  --blob-index <n>    which blob when --snapshot holds several (see "
+         "--list)\n"
+         "  --list              print the blobs found in --snapshot and exit\n"
+         "  --in <file.js>      source to compile\n"
+         "  --out <file>        cache output path\n"
+         "  --mode script|function|module   (default script)\n"
+         "  --params a,b,c      parameters for --mode function\n"
+         "                      (default exports,require,module,__filename,"
+         "__dirname)\n"
+         "  --eager             eagerly compile all inner functions\n"
+         "  --filename <name>   script origin name (default: basename of "
+         "--in)\n"
+         "  --v8-flags \"...\"    non-default V8 flags of the consuming "
+         "process\n"
+         "                      (default \""
+      << kDefaultV8Flags
+      << "\")\n"
+         "  --expect-flag-hash 0x..  fail unless the produced flag hash "
+         "matches\n"
+         "  --icu-data <file>   icudtl.dat (default: next to this binary)\n"
+         "  --json              print a JSON summary to stdout\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  std::string snapshot_path, in_path, out_path, filename, icu_data;
+  std::string mode = "script";
+  std::string v8_flags = kDefaultV8Flags;
+  std::string params_csv = "exports,require,module,__filename,__dirname";
+  int blob_index = -1;
+  bool list = false, eager = false, json = false;
+  int64_t expect_flag_hash = -1;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view a = argv[i];
+    auto value = [&](std::string* dst) {
+      if (i + 1 >= argc) {
+        std::cerr << "missing value for " << a << "\n";
+        exit(2);
+      }
+      *dst = argv[++i];
+    };
+    std::string tmp;
+    if (a == "--snapshot") {
+      value(&snapshot_path);
+    } else if (a == "--in") {
+      value(&in_path);
+    } else if (a == "--out") {
+      value(&out_path);
+    } else if (a == "--mode") {
+      value(&mode);
+    } else if (a == "--params") {
+      value(&params_csv);
+    } else if (a == "--filename") {
+      value(&filename);
+    } else if (a == "--v8-flags") {
+      value(&v8_flags);
+    } else if (a == "--icu-data") {
+      value(&icu_data);
+    } else if (a == "--blob-index") {
+      value(&tmp);
+      blob_index = std::stoi(tmp);
+    } else if (a == "--expect-flag-hash") {
+      value(&tmp);
+      expect_flag_hash = static_cast<int64_t>(std::stoul(tmp, nullptr, 0));
+    } else if (a == "--list") {
+      list = true;
+    } else if (a == "--eager") {
+      eager = true;
+    } else if (a == "--json") {
+      json = true;
+    } else if (a == "--help" || a == "-h") {
+      Usage();
+      return 0;
+    } else {
+      std::cerr << "unknown argument: " << a << "\n";
+      Usage();
+      return 2;
+    }
+  }
+  if (snapshot_path.empty() ||
+      (!list && (in_path.empty() || out_path.empty()))) {
+    Usage();
+    return 2;
+  }
+  if (mode != "script" && mode != "function" && mode != "module") {
+    std::cerr << "--mode must be script, function or module\n";
+    return 2;
+  }
+
+  const std::string version = v8::V8::GetVersion();
+
+  MappedFile container_file;
+  if (!container_file.Open(snapshot_path)) {
+    std::cerr << "cannot read " << snapshot_path << "\n";
+    return 1;
+  }
+  const std::string_view container = container_file.view();
+  const std::vector<BlobInfo> blobs = FindBlobs(container, version);
+  if (list) {
+    std::cout << "V8 " << version << "; snapshot blobs in " << snapshot_path
+              << ":\n";
+    for (size_t i = 0; i < blobs.size(); ++i)
+      PrintBlob(std::cout, blobs[i], i);
+  }
+  if (blobs.empty()) {
+    BlobInfo other;
+    if (ParseBlobAt(container, 0, &other)) {
+      std::cerr << snapshot_path << " is a snapshot for V8 \"" << other.version
+                << "\"; this tool is V8 \"" << version << "\"\n";
+    } else {
+      std::cerr << "no V8 " << version << " snapshot blob found in "
+                << snapshot_path << "\n";
+    }
+    return 1;
+  }
+  if (list)
+    return 0;
+
+  const BlobInfo* chosen = nullptr;
+  if (blob_index >= 0) {
+    if (static_cast<size_t>(blob_index) >= blobs.size()) {
+      std::cerr << "--blob-index out of range (" << blobs.size() << " found)\n";
+      return 1;
+    }
+    chosen = &blobs[blob_index];
+  } else {
+    // Default: the only Node startup snapshot if present, else the only blob.
+    size_t node_count = 0;
+    for (const BlobInfo& b : blobs) {
+      if (b.num_contexts >= 4) {
+        chosen = &b;
+        ++node_count;
+      }
+    }
+    if (node_count != 1)
+      chosen = blobs.size() == 1 ? &blobs[0] : nullptr;
+    if (!chosen) {
+      std::cerr << "several candidate blobs; pick one with --blob-index:\n";
+      for (size_t i = 0; i < blobs.size(); ++i)
+        PrintBlob(std::cerr, blobs[i], i);
+      return 1;
+    }
+  }
+  if (!chosen->checksum_ok)
+    std::cerr << "warning: blob checksum mismatch -- continuing\n";
+  const BlobInfo chosen_info = *chosen;
+  std::vector<uint64_t> blob_storage((chosen_info.size + 7) / 8);
+  std::memcpy(blob_storage.data(), container.data() + chosen_info.offset,
+              chosen_info.size);
+  v8::StartupData blob{reinterpret_cast<const char*>(blob_storage.data()),
+                       static_cast<int>(chosen_info.size)};
+
+  std::string source;
+  if (!ReadFile(in_path, &source)) {
+    std::cerr << "cannot read " << in_path << "\n";
+    return 1;
+  }
+  if (filename.empty()) {
+    const size_t slash = in_path.find_last_of("/\\");
+    filename = slash == std::string::npos ? in_path : in_path.substr(slash + 1);
+  }
+
+  if (!v8::V8::InitializeICUDefaultLocation(
+          argv[0], icu_data.empty() ? nullptr : icu_data.c_str())) {
+    std::cerr << "warning: ICU data not loaded; pass --icu-data <icudtl.dat> "
+                 "if non-ASCII identifiers fail to parse\n";
+  }
+  if (!v8_flags.empty())
+    v8::V8::SetFlagsFromString(v8_flags.c_str(), v8_flags.size());
+  // Deterministic output; --random-seed is excluded from FlagList::Hash().
+  v8::V8::SetFlagsFromString("--random-seed=314159265");
+  std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
+  v8::V8::InitializePlatform(platform.get());
+  v8::V8::SetSnapshotDataBlob(&blob);
+  v8::V8::Initialize();
+
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+  create_params.snapshot_blob = &blob;
+  std::vector<intptr_t> external_references = MakeInertExternalReferences();
+  create_params.external_references = external_references.data();
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+
+  std::vector<uint8_t> cache;
+  int rc = 0;
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Isolate::DisallowJavascriptExecutionScope no_js(
+        isolate,
+        v8::Isolate::DisallowJavascriptExecutionScope::CRASH_ON_FAILURE);
+    // Index 0 is a plain Context::New() in both the Node startup snapshot and
+    // Blink's v8_context_snapshot.
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
+    v8::TryCatch try_catch(isolate);
+
+    v8::Local<v8::String> code;
+    if (!v8::String::NewFromUtf8(isolate, source.data(),
+                                 v8::NewStringType::kNormal,
+                                 static_cast<int>(source.size()))
+             .ToLocal(&code)) {
+      std::cerr << "source is not valid UTF-8 or too large\n";
+      return 1;
+    }
+    v8::Local<v8::String> name =
+        v8::String::NewFromUtf8(isolate, filename.c_str()).ToLocalChecked();
+    const bool is_module = mode == "module";
+    v8::ScriptOrigin origin(name, 0, 0, false, -1, v8::Local<v8::Value>(),
+                            false, false, is_module);
+    const auto options = eager ? v8::ScriptCompiler::kEagerCompile
+                               : v8::ScriptCompiler::kNoCompileOptions;
+    v8::ScriptCompiler::Source src(code, origin);
+    std::unique_ptr<v8::ScriptCompiler::CachedData> cd;
+    if (mode == "script") {
+      v8::Local<v8::UnboundScript> script;
+      if (v8::ScriptCompiler::CompileUnboundScript(isolate, &src, options)
+              .ToLocal(&script)) {
+        cd.reset(v8::ScriptCompiler::CreateCodeCache(script));
+      }
+    } else if (mode == "function") {
+      v8::LocalVector<v8::String> params(isolate);
+      for (const std::string& p : Split(params_csv, ','))
+        params.push_back(
+            v8::String::NewFromUtf8(isolate, p.c_str()).ToLocalChecked());
+      v8::Local<v8::Function> fn;
+      if (v8::ScriptCompiler::CompileFunction(
+              context, &src, params.size(), params.data(), 0, nullptr, options)
+              .ToLocal(&fn)) {
+        cd.reset(v8::ScriptCompiler::CreateCodeCacheForFunction(fn));
+      }
+    } else {
+      v8::Local<v8::Module> module;
+      if (v8::ScriptCompiler::CompileModule(isolate, &src, options)
+              .ToLocal(&module)) {
+        cd.reset(v8::ScriptCompiler::CreateCodeCache(
+            module->GetUnboundModuleScript()));
+      }
+    }
+
+    if (try_catch.HasCaught()) {
+      v8::String::Utf8Value msg(isolate, try_catch.Exception());
+      v8::Local<v8::Message> m = try_catch.Message();
+      std::cerr << "compile error: " << (*msg ? *msg : "?");
+      if (!m.IsEmpty())
+        std::cerr << " (" << filename << ":"
+                  << m->GetLineNumber(context).FromMaybe(0) << ")";
+      std::cerr << "\n";
+      rc = 3;
+    } else if (!cd || cd->length < static_cast<int>(kCacheHeaderSize)) {
+      std::cerr << "V8 produced no code cache\n";
+      rc = 4;
+    } else {
+      cache.assign(cd->data, cd->data + cd->length);
+    }
+  }
+  isolate->Dispose();
+  v8::V8::Dispose();
+  v8::V8::DisposePlatform();
+  delete create_params.array_buffer_allocator;
+  if (rc)
+    return rc;
+
+  const char* h = reinterpret_cast<const char*>(cache.data());
+  const uint32_t flag_hash = ReadU32(h + kCacheFlagHashOffset);
+  const uint32_t ro_checksum = ReadU32(h + kCacheRoChecksumOffset);
+  if (ro_checksum != chosen_info.ro_checksum) {
+    std::cerr << "internal error: cache ro checksum " << Hex(ro_checksum)
+              << " != blob's " << Hex(chosen_info.ro_checksum) << "\n";
+    return 5;
+  }
+  if (expect_flag_hash >= 0 &&
+      static_cast<uint32_t>(expect_flag_hash) != flag_hash) {
+    std::cerr << "flag hash " << Hex(flag_hash) << " != expected "
+              << Hex(static_cast<uint32_t>(expect_flag_hash))
+              << "; the consuming process runs with different non-default "
+                 "V8 flags (see --v8-flags)\n";
+    return 6;
+  }
+  {
+    std::ofstream out(out_path, std::ios::binary | std::ios::trunc);
+    if (!out || !out.write(h, static_cast<std::streamsize>(cache.size()))) {
+      std::cerr << "cannot write " << out_path << "\n";
+      return 1;
+    }
+  }
+  if (json) {
+    std::cout << "{\"v8\":\"" << version << "\",\"mode\":\"" << mode
+              << "\",\"eager\":" << (eager ? "true" : "false")
+              << ",\"flags\":\"" << v8_flags << "\",\"size\":" << cache.size()
+              << ",\"header\":{\"magic\":\""
+              << Hex(ReadU32(h + kCacheMagicOffset)) << "\",\"versionHash\":\""
+              << Hex(ReadU32(h + kCacheVersionHashOffset))
+              << "\",\"sourceHash\":\""
+              << Hex(ReadU32(h + kCacheSourceHashOffset))
+              << "\",\"flagHash\":\"" << Hex(flag_hash)
+              << "\",\"roSnapshotChecksum\":\"" << Hex(ro_checksum)
+              << "\",\"payloadLength\":"
+              << ReadU32(h + kCachePayloadLengthOffset)
+              << "},\"snapshot\":{\"file\":\"" << snapshot_path
+              << "\",\"offset\":" << chosen_info.offset
+              << ",\"size\":" << chosen_info.size
+              << ",\"contexts\":" << chosen_info.num_contexts << ",\"kind\":\""
+              << KindOf(chosen_info) << "\"},\"out\":\"" << out_path << "\"}\n";
+  } else {
+    std::cerr << "electron_xcache: " << out_path << " (" << cache.size()
+              << " B, " << mode << (eager ? ", eager" : "")
+              << ") v8=" << version << " flagHash=" << Hex(flag_hash)
+              << " ro=" << Hex(ro_checksum) << " from " << KindOf(chosen_info)
+              << "@" << snapshot_path << "+" << chosen_info.offset << "\n";
+  }
+  return 0;
+}

--- a/shell/common/electron_xcache_main.cc
+++ b/shell/common/electron_xcache_main.cc
@@ -87,6 +87,39 @@ std::string Hex(uint32_t v) {
   return buf;
 }
 
+// JSON string literal, quotes included.
+std::string Json(std::string_view v) {
+  std::string out = "\"";
+  for (char c : v) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          out += buf;
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out + '"';
+}
+
 class MappedFile {
  public:
   bool Open(const std::string& path) {
@@ -599,9 +632,9 @@ int main(int argc, char* argv[]) {
     }
   }
   if (json) {
-    std::cout << "{\"v8\":\"" << version << "\",\"mode\":\"" << mode
-              << "\",\"eager\":" << (eager ? "true" : "false")
-              << ",\"flags\":\"" << v8_flags << "\",\"size\":" << cache.size()
+    std::cout << "{\"v8\":" << Json(version) << ",\"mode\":" << Json(mode)
+              << ",\"eager\":" << (eager ? "true" : "false")
+              << ",\"flags\":" << Json(v8_flags) << ",\"size\":" << cache.size()
               << ",\"header\":{\"magic\":\""
               << Hex(ReadU32(h + kCacheMagicOffset)) << "\",\"versionHash\":\""
               << Hex(ReadU32(h + kCacheVersionHashOffset))
@@ -611,11 +644,12 @@ int main(int argc, char* argv[]) {
               << "\",\"roSnapshotChecksum\":\"" << Hex(ro_checksum)
               << "\",\"payloadLength\":"
               << ReadU32(h + kCachePayloadLengthOffset)
-              << "},\"snapshot\":{\"file\":\"" << snapshot_path
-              << "\",\"offset\":" << chosen_info.offset
+              << "},\"snapshot\":{\"file\":" << Json(snapshot_path)
+              << ",\"offset\":" << chosen_info.offset
               << ",\"size\":" << chosen_info.size
-              << ",\"contexts\":" << chosen_info.num_contexts << ",\"kind\":\""
-              << KindOf(chosen_info) << "\"},\"out\":\"" << out_path << "\"}\n";
+              << ",\"contexts\":" << chosen_info.num_contexts
+              << ",\"kind\":" << Json(KindOf(chosen_info))
+              << "},\"out\":" << Json(out_path) << "}\n";
   } else {
     std::cerr << "electron_xcache: " << out_path << " (" << cache.size()
               << " B, " << mode << (eager ? ", eager" : "")

--- a/shell/common/electron_xcache_main.cc
+++ b/shell/common/electron_xcache_main.cc
@@ -20,10 +20,14 @@
 #pragma allow_unsafe_buffers
 #endif
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 #include <cstdint>
 #include <cstdio>
@@ -86,6 +90,22 @@ std::string Hex(uint32_t v) {
 class MappedFile {
  public:
   bool Open(const std::string& path) {
+#if defined(_WIN32)
+    file_ = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE)
+      return false;
+    LARGE_INTEGER size;
+    if (!GetFileSizeEx(file_, &size) || size.QuadPart == 0)
+      return false;
+    size_ = static_cast<size_t>(size.QuadPart);
+    mapping_ = CreateFileMappingA(file_, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (!mapping_)
+      return false;
+    data_ = static_cast<const char*>(
+        MapViewOfFile(mapping_, FILE_MAP_READ, 0, 0, 0));
+    return data_ != nullptr;
+#else
     fd_ = open(path.c_str(), O_RDONLY);
     if (fd_ < 0)
       return false;
@@ -98,17 +118,32 @@ class MappedFile {
       return false;
     data_ = static_cast<const char*>(m);
     return true;
+#endif
   }
   ~MappedFile() {
+#if defined(_WIN32)
+    if (data_)
+      UnmapViewOfFile(data_);
+    if (mapping_)
+      CloseHandle(mapping_);
+    if (file_ != INVALID_HANDLE_VALUE)
+      CloseHandle(file_);
+#else
     if (data_)
       munmap(const_cast<char*>(data_), size_);
     if (fd_ >= 0)
       close(fd_);
+#endif
   }
   std::string_view view() const { return {data_, size_}; }
 
  private:
+#if defined(_WIN32)
+  HANDLE file_ = INVALID_HANDLE_VALUE;
+  HANDLE mapping_ = nullptr;
+#else
   int fd_ = -1;
+#endif
   const char* data_ = nullptr;
   size_t size_ = 0;
 };

--- a/shell/common/electron_xcache_main.cc
+++ b/shell/common/electron_xcache_main.cc
@@ -11,9 +11,10 @@
 // read-only-snapshot checksum) and ReadOnlyHeapRef back-references into the
 // read-only heap, all of which are properties of the snapshot blob the
 // consuming isolate was created from. The tool therefore creates its isolate
-// from the target's blob, with JavaScript execution disallowed (the blob's
-// builtin metadata does not describe this binary's builtins), and serializes.
-// Build it from the target version's checkout in a release configuration.
+// from the target's blob, runs no JavaScript in it beyond context setup (the
+// blob's builtin metadata does not describe this binary's builtins), and
+// serializes. Build it from the target version's checkout in a release
+// configuration.
 
 #ifdef UNSAFE_BUFFERS_BUILD
 #pragma allow_unsafe_buffers
@@ -296,6 +297,7 @@ int main(int argc, char* argv[]) {
   std::string snapshot_path, in_path, out_path, filename, icu_data;
   std::string mode = "script";
   std::string v8_flags = kDefaultV8Flags;
+  std::string extra_v8_flags;
   std::string params_csv = "exports,require,module,__filename,__dirname";
   int blob_index = -1;
   bool list = false, eager = false, json = false;
@@ -325,6 +327,8 @@ int main(int argc, char* argv[]) {
       value(&filename);
     } else if (a == "--v8-flags") {
       value(&v8_flags);
+    } else if (a == "--extra-v8-flags") {
+      value(&extra_v8_flags);
     } else if (a == "--icu-data") {
       value(&icu_data);
     } else if (a == "--blob-index") {
@@ -436,6 +440,8 @@ int main(int argc, char* argv[]) {
     std::cerr << "warning: ICU data not loaded; pass --icu-data <icudtl.dat> "
                  "if non-ASCII identifiers fail to parse\n";
   }
+  if (!extra_v8_flags.empty())
+    v8_flags += " " + extra_v8_flags;
   if (!v8_flags.empty())
     v8::V8::SetFlagsFromString(v8_flags.c_str(), v8_flags.size());
   // Deterministic output; --random-seed is excluded from FlagList::Hash().
@@ -458,13 +464,14 @@ int main(int argc, char* argv[]) {
   {
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
+    // Index 0 is a plain Context::New() in both the Node startup snapshot and
+    // Blink's v8_context_snapshot. Flags that install extensions (--expose-gc)
+    // run their setup script here; nothing may run after this point.
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    v8::Context::Scope context_scope(context);
     v8::Isolate::DisallowJavascriptExecutionScope no_js(
         isolate,
         v8::Isolate::DisallowJavascriptExecutionScope::CRASH_ON_FAILURE);
-    // Index 0 is a plain Context::New() in both the Node startup snapshot and
-    // Blink's v8_context_snapshot.
-    v8::Local<v8::Context> context = v8::Context::New(isolate);
-    v8::Context::Scope context_scope(context);
     v8::TryCatch try_catch(isolate);
 
     v8::Local<v8::String> code;

--- a/spec/xcache-spec.ts
+++ b/spec/xcache-spec.ts
@@ -10,11 +10,18 @@ import * as vm from 'node:vm';
 
 import { ifdescribe } from './lib/spec-helpers';
 
-// electron_xcache ships in xcache.zip next to dist.zip on Linux; CI unzips it
-// beside the electron binary.
-const xcache = path.resolve(process.execPath, '..', 'electron_xcache');
+// electron_xcache ships in xcache.zip next to dist.zip; CI unzips it into the
+// same directory (on macOS that is the directory holding Electron.app).
+const outDir =
+  process.platform === 'darwin' ? path.resolve(process.execPath, '../../../..') : path.dirname(process.execPath);
+const xcache = path.join(outDir, process.platform === 'win32' ? 'electron_xcache.exe' : 'electron_xcache');
+// The binary that embeds this process's Node startup snapshot.
+const snapshotHolder =
+  process.platform === 'darwin'
+    ? path.resolve(process.execPath, '../../Frameworks/Electron Framework.framework/Versions/A/Electron Framework')
+    : process.execPath;
 
-ifdescribe(process.platform === 'linux' && fs.existsSync(xcache))('electron_xcache', () => {
+ifdescribe(fs.existsSync(xcache))('electron_xcache', () => {
   let tmp: string;
   before(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-xcache-'));
@@ -33,7 +40,7 @@ ifdescribe(process.platform === 'linux' && fs.existsSync(xcache))('electron_xcac
       xcache,
       [
         '--snapshot',
-        process.execPath,
+        snapshotHolder,
         '--in',
         input,
         '--out',

--- a/spec/xcache-spec.ts
+++ b/spec/xcache-spec.ts
@@ -1,0 +1,81 @@
+import { app } from 'electron/main';
+
+import { expect } from 'chai';
+
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+import { ifdescribe } from './lib/spec-helpers';
+
+// electron_xcache ships in xcache.zip next to dist.zip on Linux; CI unzips it
+// beside the electron binary.
+const xcache = path.resolve(process.execPath, '..', 'electron_xcache');
+
+ifdescribe(process.platform === 'linux' && fs.existsSync(xcache))('electron_xcache', () => {
+  let tmp: string;
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-xcache-'));
+  });
+  after(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const generate = (source: string, ...args: string[]) => {
+    const input = path.join(tmp, 'input.js');
+    const output = path.join(tmp, 'output.cache');
+    fs.writeFileSync(input, source);
+    // The tool defaults to a plain main process's flags; the spec runner adds
+    // its own --js-flags (spec/index.js), which are part of the cache key too.
+    const result = childProcess.spawnSync(
+      xcache,
+      [
+        '--snapshot',
+        process.execPath,
+        '--in',
+        input,
+        '--out',
+        output,
+        '--json',
+        '--extra-v8-flags',
+        app.commandLine.getSwitchValue('js-flags'),
+        ...args
+      ],
+      { encoding: 'utf8' }
+    );
+    expect(result.status, result.stderr).to.equal(0);
+    return { info: JSON.parse(result.stdout), cache: fs.readFileSync(output) };
+  };
+
+  it('finds the Node startup snapshot this process was created from', () => {
+    const { info } = generate('1');
+    expect(info.snapshot.kind).to.equal('node-startup-snapshot');
+    const own = new vm.Script('1', { filename: 'probe' }).createCachedData();
+    // SerializedCodeData header: [12] FlagList::Hash, [16] read-only snapshot checksum.
+    expect(info.header.flagHash).to.equal('0x' + own.readUInt32LE(12).toString(16).padStart(8, '0'));
+    expect(info.header.roSnapshotChecksum).to.equal('0x' + own.readUInt32LE(16).toString(16).padStart(8, '0'));
+  });
+
+  it('produces a script cache the main process accepts', () => {
+    const source = 'function f (n) { return n * 7; } [f(6), typeof f];';
+    const { cache } = generate(source, '--eager');
+    const script = new vm.Script(source, { filename: 'xcache-script', cachedData: cache });
+    expect(script.cachedDataRejected).to.equal(false);
+    expect(script.runInThisContext()).to.deep.equal([42, 'function']);
+  });
+
+  it('produces a function cache the main process accepts', () => {
+    const source = 'module.exports = { answer: exports.seed * 2, self: typeof require };';
+    const { cache } = generate(source, '--mode', 'function');
+    const fn = vm.compileFunction(source, ['exports', 'require', 'module', '__filename', '__dirname'], {
+      filename: 'xcache-function',
+      cachedData: cache
+    }) as any;
+    expect(fn.cachedDataRejected).to.equal(false);
+    const mod = { exports: {} as any };
+    fn({ seed: 21 }, require, mod, 'xcache-function', tmp);
+    expect(mod.exports).to.deep.equal({ answer: 42, self: 'function' });
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> This tool is intentionally left undocumented until it's usage is validated and tested at scale. The intention is to allow folks to generate code caches for their scripts _without_ having to run builds on all three platforms. 

#### Description of Change

Adds `electron_xcache`, a standalone host tool (`//electron:electron_xcache`) that compiles a JS file and emits a V8 code cache for the main process of a *target* Electron build of the same version — any OS/arch — given that build's V8 startup snapshot blob (or the binary embedding its Node startup snapshot: `electron`, `electron.exe`, `Electron Framework`).

- A code cache's only build-specific content is its header (version/flag hashes, RO-snapshot checksum) and `ReadOnlyHeapRef` offsets, all properties of the snapshot the consuming isolate was created from — so the tool creates its isolate from the target's blob, runs no JS beyond context setup, uses an inert external-reference table, and serializes.
- `--mode script|function|module`, `--eager`, `--v8-flags` / `--extra-v8-flags` (defaults to the main process's non-default set), `--expect-flag-hash`, `--list` to show the blobs found in a binary.
- Links only `//v8`, `//v8:v8_libplatform`, `//third_party/zlib`: one compile + one link on top of an existing build (~15 s incremental in a ThinLTO release dir).
- `xcache.zip` (binary + `icudtl.dat` + licenses; stripped on Linux official builds) is part of `testing_build`/`release_build` on every non-MAS build, staged with the other generated artifacts, and uploaded on publish as `xcache-<version>-{darwin,linux,win32}-{x64,arm64}.zip`. Any of them can target any platform; they differ only in which host they run on.
- `spec/xcache-spec.ts` (when the binary is present next to the build) checks the tool finds the running build's Node snapshot and that its script/function caches are accepted and execute correctly in the main process — guards the default flag set against drift.

Validated against 45.0.0-nightly.20260821: boots from all six desktop targets' embedded Node snapshots; output accepted and behaviourally identical to an uncached compile in the linux-x64, darwin-arm64 and darwin-x64 main processes (32/32 test scripts each, incl. lodash and typescript.js).

#### Checklist

- [x] PR description included
- [x] `npm test` passes

#### Release Notes

Notes: none
