### PR TITLE
docs: explain process.defaultApp and open-url timing for deep links

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -43,6 +43,10 @@ if (process.defaultApp) {
 }
 ```
 
+On Windows, when running through the default Electron executable (for example, `electron .`),
+registration must include the app entry path so protocol launches load the correct application.
+Packaged apps launch their own executable and do not need these additional arguments.
+
 We will now define the function in charge of creating our browser window and load our application's `index.html` file.
 
 ```js
@@ -99,6 +103,10 @@ if (!gotTheLock) {
 ```
 
 #### macOS code:
+
+> [!IMPORTANT]
+> Register an `open-url` listener during initial startup, before waiting for `ready` or other
+> asynchronous initialization. Listeners registered later may miss a launch URL delivered by macOS.
 
 ```js @ts-type={createWindow:()=>void}
 // This method will be called when Electron has finished


### PR DESCRIPTION
#### Description of Change

The deep links tutorial shows the `process.defaultApp` branch around `app.setAsDefaultProtocolClient` and a synchronous `open-url` listener on macOS, but never explains why either is written the way it is. Cold-start `argv` handling on Windows/Linux was already documented in #49142; this fills in the two remaining gaps from #40173:

* Why `process.defaultApp` matters: in dev (`electron .`), the OS launches the generic Electron executable, so the protocol has to be registered with an explicit `execPath` and script path or there'd be no way to know which app to load.
* Why `open-url` must be registered synchronously on macOS: `Browser::OpenURL` (`shell/browser/browser.cc`) notifies observers immediately with no queueing, so a listener attached after an `await` can miss a cold-start deep link entirely.

Fixes #40173

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are changed or added <!-- N/A, docs-only change -->
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

#### Release Notes

Notes: none