### PR TITLE
fix: set bounds on detached `WebContentsView`

### DIFF
--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -269,9 +269,23 @@ void InspectableWebContentsView::ShowDevToolsContextMenu(
   context_menu_->RunMenuAt(widget);
 }
 
+void InspectableWebContentsView::SetContentsViewBounds(
+    const gfx::Rect& bounds) {
+  GetContentsView()->SetBoundsRect(bounds);
+
+  // If the view isn't currently in a Widget, we need to propagate the new
+  // bounds to the WebContents manually or the page won't see the correct
+  // dimensions.
+  if (!GetWidget() && contents_web_view_) {
+    if (auto* web_contents = inspectable_web_contents_->GetWebContents()) {
+      web_contents->Resize(gfx::Rect(bounds.size()));
+    }
+  }
+}
+
 void InspectableWebContentsView::Layout(PassKey) {
   if (!devtools_web_view_->GetVisible()) {
-    GetContentsView()->SetBoundsRect(GetContentsBounds());
+    SetContentsViewBounds(GetContentsBounds());
     // Propagate layout call to all children, for example browser views.
     LayoutSuperclass<View>(this);
     return;
@@ -289,7 +303,7 @@ void InspectableWebContentsView::Layout(PassKey) {
   new_contents_bounds.set_x(GetMirroredXForRect(new_contents_bounds));
 
   devtools_web_view_->SetBoundsRect(new_devtools_bounds);
-  GetContentsView()->SetBoundsRect(new_contents_bounds);
+  SetContentsViewBounds(new_contents_bounds);
 
   // Propagate layout call to all children, for example browser views.
   LayoutSuperclass<View>(this);

--- a/shell/browser/ui/inspectable_web_contents_view.h
+++ b/shell/browser/ui/inspectable_web_contents_view.h
@@ -11,6 +11,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"
+#include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/native_ui_types.h"
 #include "ui/views/view.h"
 
@@ -76,6 +77,8 @@ class InspectableWebContentsView : public views::View {
   views::View* GetContentsView() const;
 
  private:
+  void SetContentsViewBounds(const gfx::Rect& bounds);
+
   // Owns us.
   raw_ptr<InspectableWebContents> inspectable_web_contents_;
 

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -419,6 +419,45 @@ describe('WebContentsView', () => {
     });
   });
 
+  describe('setBounds', () => {
+    it('sizes the page when the view is not attached to a window', async () => {
+      const v = new WebContentsView();
+      v.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+      await v.webContents.loadURL('data:text/html,<script>initialSize = [innerWidth, innerHeight]</script>');
+      expect(await v.webContents.executeJavaScript('initialSize')).to.deep.equal([400, 300]);
+      expect(await v.webContents.executeJavaScript('[innerWidth, innerHeight]')).to.deep.equal([400, 300]);
+    });
+
+    it('resizes the page when bounds are set after loading', async () => {
+      const v = new WebContentsView();
+      v.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+      await v.webContents.loadURL('about:blank');
+      v.setBounds({ x: 0, y: 0, width: 500, height: 400 });
+      await expect(
+        waitUntil(async () => {
+          const size = await v.webContents.executeJavaScript('[innerWidth, innerHeight]');
+          return size[0] === 500 && size[1] === 400;
+        })
+      ).to.eventually.be.fulfilled();
+    });
+
+    it('resizes the page after the view is removed from a window', async () => {
+      const w = new BaseWindow({ width: 400, height: 300 });
+      const v = new WebContentsView();
+      w.contentView.addChildView(v);
+      v.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+      await v.webContents.loadURL('about:blank');
+      w.contentView.removeChildView(v);
+      v.setBounds({ x: 0, y: 0, width: 500, height: 400 });
+      await expect(
+        waitUntil(async () => {
+          const size = await v.webContents.executeJavaScript('[innerWidth, innerHeight]');
+          return size[0] === 500 && size[1] === 400;
+        })
+      ).to.eventually.be.fulfilled();
+    });
+  });
+
   describe('setBorderRadius', () => {
     ifdescribe(hasCapturableScreen())('capture', () => {
       let w: Electron.BaseWindow;


### PR DESCRIPTION
Backport of #53031.

See that PR for details.

Notes: Fixed an issue where pages loaded in a detached `WebContentsView` wouldn't see the correct window size.