### PR TITLE
fix: don't kill the primary instance on large second-instance messages

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1081,6 +1081,12 @@ events will be emitted for that. However when users start your app in command
 line, the system's single instance mechanism will be bypassed, and you have to
 use this method to ensure single instance.
 
+> [!NOTE]
+> On macOS and Linux, the second instance's command line arguments and
+> `additionalData` are sent to the primary instance in a single message that is
+> limited to 32 MB. Larger messages are dropped: this method still returns
+> `false`, but the primary instance does not emit `second-instance`.
+
 An example of activating the window of primary instance when a second instance
 starts:
 

--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -12,6 +12,13 @@ On the Electron side, we then expose an extra parameter to the
 app.requestSingleInstanceLock API so that users can pass in a JSON
 object for the second instance to send to the first instance.
 
+Since the payload can be large, the POSIX implementation reads the
+message into a growable buffer until the client shuts down its end of
+the socket instead of a fixed 32 KiB array, and the client waits for
+the socket to become writable rather than giving up, so an oversized
+message no longer gets truncated or causes the second instance to kill
+the primary as unresponsive.
+
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
 index f076d0f783e2c0f6b5444002f756001adf2729bd..a03d99f929e2d354cdba969567d781561656261d 100644
 --- a/chrome/browser/process_singleton.h
@@ -65,10 +72,93 @@ index f076d0f783e2c0f6b5444002f756001adf2729bd..a03d99f929e2d354cdba969567d78156
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0df993b22 100644
+index 55f935f38bf05586650e7a83a689347bb41a45a4..10bb34477b9a42e78a87536f6f26de60039558b6 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -621,6 +621,7 @@ class ProcessSingleton::LinuxWatcher
+@@ -41,6 +41,7 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
++#include <poll.h>
+ #include <signal.h>
+ #include <stddef.h>
+ #include <string.h>
+@@ -144,7 +145,9 @@ constexpr std::string_view kStartToken = "START";
+ constexpr std::string_view kACKToken = "ACK";
+ constexpr std::string_view kShutdownToken = "SHUTDOWN";
+ const char kTokenDelimiter = '\0';
+-const int kMaxMessageLength = 32 * 1024;
++// The maximum length of a message the browser will buffer. Longer messages
++// are drained from the socket and dropped.
++const size_t kMaxMessageLength = 32 * 1024 * 1024;
+ 
+ bool g_disable_prompt = false;
+ bool g_skip_is_chrome_process_check = false;
+@@ -167,15 +170,32 @@ void CloseSocket(int fd) {
+   DPCHECK(rv == 0) << "Error closing socket";
+ }
+ 
+-// Write a message to a socket fd.
+-bool WriteToSocket(int fd, std::string_view message) {
++// Wait for a socket to become writable, for up to |timeout|.
++// Returns -1 if error occurred, 0 if timeout reached, > 0 if the socket is
++// ready for write.
++int WaitSocketForWrite(int fd, const base::TimeDelta& timeout) {
++  struct pollfd pfd = {};
++  pfd.fd = fd;
++  pfd.events = POLLOUT;
++  return HANDLE_EINTR(poll(
++      &pfd, 1, base::saturated_cast<int>(timeout.InMillisecondsRoundedUp())));
++}
++
++// Write a message to a socket fd. Whenever the socket would block, wait for it
++// to become writable again; |timeout| bounds the total time spent waiting.
++bool WriteToSocket(int fd,
++                   std::string_view message,
++                   const base::TimeDelta& timeout = base::TimeDelta()) {
+   DCHECK(!message.empty());
++  const base::TimeTicks deadline = base::TimeTicks::Now() + timeout;
+   while (!message.empty()) {
+     ssize_t rv = HANDLE_EINTR(write(fd, message.data(), message.size()));
+     if (rv < 0) {
+       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+-        // The socket shouldn't block, we're sending so little data.  Just give
+-        // up here, since NotifyOtherProcess() doesn't have an asynchronous api.
++        const base::TimeDelta remaining = deadline - base::TimeTicks::Now();
++        if (remaining.is_positive() && WaitSocketForWrite(fd, remaining) > 0) {
++          continue;
++        }
+         LOG(ERROR) << "ProcessSingleton would block on write(), so it gave up.";
+         return false;
+       }
+@@ -548,10 +568,7 @@ class ProcessSingleton::LinuxWatcher
+     SocketReader(ProcessSingleton::LinuxWatcher* parent,
+                  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner,
+                  int fd)
+-        : parent_(parent),
+-          ui_task_runner_(ui_task_runner),
+-          fd_(fd),
+-          bytes_read_(0) {
++        : parent_(parent), ui_task_runner_(ui_task_runner), fd_(fd) {
+       DCHECK_CURRENTLY_ON(BrowserThread::IO);
+       // Wait for reads.
+       fd_watch_controller_ = base::FileDescriptorWatcher::WatchReadable(
+@@ -595,11 +612,10 @@ class ProcessSingleton::LinuxWatcher
+     const int fd_;
+ 
+     // Store the message in this buffer.
+-    std::array<char, kMaxMessageLength> buf_;
++    std::string buf_;
+ 
+-    // Tracks the number of bytes we've read in case we're getting partial
+-    // reads.
+-    size_t bytes_read_;
++    // Whether the message exceeded kMaxMessageLength and is being dropped.
++    bool message_too_long_ = false;
+ 
+     base::OneShotTimer timer_;
+   };
+@@ -621,6 +637,7 @@ class ProcessSingleton::LinuxWatcher
    // |reader| is for sending back ACK message.
    void HandleMessage(const std::string& current_dir,
                       const std::vector<std::string>& argv,
@@ -76,7 +166,19 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
                       SocketReader* reader);
  
    // Called when the ProcessSingleton that owns this class is about to be
-@@ -680,13 +681,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
+@@ -665,8 +682,9 @@ void ProcessSingleton::LinuxWatcher::OnSocketCanReadWithoutBlocking(
+     PLOG(ERROR) << "accept() failed";
+     return;
+   }
+-  DCHECK(base::SetNonBlocking(connection_socket))
+-      << "Failed to make non-blocking socket.";
++  if (!base::SetNonBlocking(connection_socket)) {
++    PLOG(ERROR) << "Failed to make non-blocking socket.";
++  }
+   readers_.insert(
+       std::make_unique<SocketReader>(this, ui_task_runner_, connection_socket));
+ }
+@@ -680,13 +698,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
  }
  
  void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -96,18 +198,67 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
      // Send back "ACK" message to prevent the client process from starting up.
      reader->FinishWithACK(kACKToken);
    } else {
-@@ -716,7 +721,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-   bytes_read_ += ReadFromSocketWithTimeout(
-       fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
+@@ -713,23 +735,58 @@ void ProcessSingleton::LinuxWatcher::RemoveSocketReader(SocketReader* reader) {
+ void ProcessSingleton::LinuxWatcher::SocketReader::
+     OnSocketCanReadWithoutBlocking() {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  bytes_read_ += ReadFromSocketWithTimeout(
+-      fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
  
 -  // Validate the message.  The shortest message is kStartToken\0x\0x
++  // The client shuts down its writing end after sending the message, so read
++  // until EOF to get the whole message.
++  std::array<char, 64 * 1024> chunk;
++  while (true) {
++    ssize_t rv = HANDLE_EINTR(read(fd_, chunk.data(), chunk.size()));
++    if (rv > 0) {
++      const size_t bytes_read = base::checked_cast<size_t>(rv);
++      if (message_too_long_) {
++        continue;
++      }
++      if (buf_.size() + bytes_read > kMaxMessageLength) {
++        LOG(ERROR) << "Socket message too long, dropping it";
++        message_too_long_ = true;
++        buf_.clear();
++        continue;
++      }
++      buf_.append(base::as_string_view(base::span(chunk).first(bytes_read)));
++      continue;
++    }
++    if (rv == 0) {  // The client has finished sending.
++      break;
++    }
++    if (errno == EAGAIN || errno == EWOULDBLOCK) {
++      return;  // Wait for the rest of the message.
++    }
++    PLOG(ERROR) << "read() failed";
++    CleanupAndDeleteSelf();
++    return;
++  }
++
++  if (message_too_long_) {
++    // Reply so the client exits instead of treating this process as hung.
++    fd_watch_controller_.reset();
++    timer_.Stop();
++    FinishWithACK(kACKToken);
++    return;
++  }
++
 +  // Validate the message.  The shortest message kStartToken\0\00
 +  // The shortest message with additional data is kStartToken\0\00\00\0.
    const size_t kMinMessageLength = kStartToken.length() + 4;
-   if (bytes_read_ < kMinMessageLength) {
-     buf_[bytes_read_] = 0;
-@@ -729,7 +735,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-       base::as_string_view(base::span(buf_).first(bytes_read_));
+-  if (bytes_read_ < kMinMessageLength) {
+-    buf_[bytes_read_] = 0;
+-    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_.data();
++  if (buf_.size() < kMinMessageLength) {
++    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_;
+     CleanupAndDeleteSelf();
+     return;
+   }
+ 
+-  std::string_view str =
+-      base::as_string_view(base::span(buf_).first(bytes_read_));
++  std::string_view str = buf_;
    std::vector<std::string> tokens =
        base::SplitString(str, std::string(1, kTokenDelimiter),
 -                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
@@ -115,7 +266,7 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
  
    if (tokens.size() < 3 || tokens[0] != kStartToken) {
      LOG(ERROR) << "Wrong message format: " << str;
-@@ -747,10 +753,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -747,10 +804,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());
  
@@ -162,7 +313,7 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
    fd_watch_controller_.reset();
  
    // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
-@@ -779,8 +820,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
+@@ -779,8 +871,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
  //
  ProcessSingleton::ProcessSingleton(
      const base::FilePath& user_data_dir,
@@ -173,7 +324,7 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
        current_pid_(base::GetCurrentProcId()) {
    socket_path_ = user_data_dir.Append(chrome::kSingletonSocketFilename);
    lock_path_ = user_data_dir.Append(chrome::kSingletonLockFilename);
-@@ -901,7 +944,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -901,7 +995,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
               sizeof(socket_timeout));
  
    // Found another process, prepare our command line
@@ -183,7 +334,7 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
    std::string to_send(kStartToken);
    to_send.push_back(kTokenDelimiter);
  
-@@ -911,11 +955,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -911,13 +1006,23 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
    to_send.append(current_dir.value());
  
    const std::vector<std::string>& argv = cmd_line.argv();
@@ -203,8 +354,11 @@ index 55f935f38bf05586650e7a83a689347bb41a45a4..b1d84a3c235cb4688b46e3bf36ec3cc0
 +  }
 +
    // Send the message
-   if (!WriteToSocket(socket.fd(), to_send)) {
+-  if (!WriteToSocket(socket.fd(), to_send)) {
++  if (!WriteToSocket(socket.fd(), to_send, timeout)) {
      // Try to kill the other process, because it might have been dead.
+     if (!kill_unresponsive || !KillProcessByLockPath(true))
+       return PROFILE_IN_USE;
 diff --git a/chrome/browser/process_singleton_win.cc b/chrome/browser/process_singleton_win.cc
 index 6687bcd53ab8dca1bc7b96446fdd673ed9d1a5da..a469ebd214407114784e06b7a8687d2de5943864 100644
 --- a/chrome/browser/process_singleton_win.cc

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -399,6 +399,20 @@ describe('app module', () => {
       });
     });
 
+    it('sends and receives data larger than the singleton message buffer', async () => {
+      await testArgumentPassing({
+        args: ['--send-data', '--data-size=300000'],
+        expectedAdditionalData: 'x'.repeat(300000)
+      });
+    });
+
+    ifit(process.platform !== 'win32')('passes long arguments to the second-instance event', async () => {
+      await testArgumentPassing({
+        args: [`--long-arg=${'a'.repeat(50000)}`],
+        expectedAdditionalData: null
+      });
+    });
+
     it('sends and receives numerical data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=2'],

--- a/spec/fixtures/api/singleton-data/main.js
+++ b/spec/fixtures/api/singleton-data/main.js
@@ -21,13 +21,16 @@ if (app.commandLine.hasSwitch('data-content')) {
     obj = undefined;
   }
 }
+if (app.commandLine.hasSwitch('data-size')) {
+  obj = 'x'.repeat(parseInt(app.commandLine.getSwitchValue('data-size')));
+}
 
 const gotTheLock = sendAdditionalData ? app.requestSingleInstanceLock(obj) : app.requestSingleInstanceLock();
 
 app.on('second-instance', (event, args, workingDirectory, data) => {
   setImmediate(() => {
-    console.log([JSON.stringify(args), JSON.stringify(data)].join('||'));
-    app.exit(0);
+    const line = [JSON.stringify(args), JSON.stringify(data)].join('||');
+    process.stdout.write(line + '\n', () => app.exit(0));
   });
 });
 


### PR DESCRIPTION
Backport of #52628

See that PR for details.

Manual backport notes: the only conflict was inside `patches/chromium/feat_add_data_parameter_to_processsingleton.patch` — this branch's copy differs from `main`'s pre-#52628 copy by one context line (`base/functional/callback.h` vs `callback_helpers.h` in `process_singleton.h`), which together with `main`-only blob hashes defeats the 3-way apply. Re-anchored the patch against this branch's Chromium; the `process_singleton_posix.cc` change is byte-identical to `main`. `e sync --3` applies the full series cleanly and `lint --patches` passes. Not built locally for 43-x-y (no RBE auth on this machine); the identical change was built and exercised on the 42-x-y backport.

Notes: Fixed the primary instance being killed or receiving truncated arguments when a second instance passed a very long command line or large `additionalData` to `app.requestSingleInstanceLock()`.
