### PR TITLE
fix: don't kill the primary instance on large second-instance messages

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1064,6 +1064,12 @@ events will be emitted for that. However when users start your app in command
 line, the system's single instance mechanism will be bypassed, and you have to
 use this method to ensure single instance.
 
+> [!NOTE]
+> On macOS and Linux, the second instance's command line arguments and
+> `additionalData` are sent to the primary instance in a single message that is
+> limited to 32 MB. Larger messages are dropped: this method still returns
+> `false`, but the primary instance does not emit `second-instance`.
+
 An example of activating the window of primary instance when a second instance
 starts:
 

--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -12,6 +12,13 @@ On the Electron side, we then expose an extra parameter to the
 app.requestSingleInstanceLock API so that users can pass in a JSON
 object for the second instance to send to the first instance.
 
+Since the payload can be large, the POSIX implementation reads the
+message into a growable buffer until the client shuts down its end of
+the socket instead of a fixed 32 KiB array, and the client waits for
+the socket to become writable rather than giving up, so an oversized
+message no longer gets truncated or causes the second instance to kill
+the primary as unresponsive.
+
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
 index f076d0f783e2c0f6b5444002f756001adf2729bd..a03d99f929e2d354cdba969567d781561656261d 100644
 --- a/chrome/browser/process_singleton.h
@@ -65,10 +72,93 @@ index f076d0f783e2c0f6b5444002f756001adf2729bd..a03d99f929e2d354cdba969567d78156
  #if BUILDFLAG(IS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d43bc42cd 100644
+index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..664f3168546880d9ebce7cace7b78a176567b8db 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
-@@ -619,6 +619,7 @@ class ProcessSingleton::LinuxWatcher
+@@ -41,6 +41,7 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
++#include <poll.h>
+ #include <signal.h>
+ #include <stddef.h>
+ #include <string.h>
+@@ -144,7 +145,9 @@ constexpr std::string_view kStartToken = "START";
+ constexpr std::string_view kACKToken = "ACK";
+ constexpr std::string_view kShutdownToken = "SHUTDOWN";
+ const char kTokenDelimiter = '\0';
+-const int kMaxMessageLength = 32 * 1024;
++// The maximum length of a message the browser will buffer. Longer messages
++// are drained from the socket and dropped.
++const size_t kMaxMessageLength = 32 * 1024 * 1024;
+ 
+ bool g_disable_prompt = false;
+ bool g_skip_is_chrome_process_check = false;
+@@ -167,15 +170,32 @@ void CloseSocket(int fd) {
+   DPCHECK(rv == 0) << "Error closing socket";
+ }
+ 
+-// Write a message to a socket fd.
+-bool WriteToSocket(int fd, std::string_view message) {
++// Wait for a socket to become writable, for up to |timeout|.
++// Returns -1 if error occurred, 0 if timeout reached, > 0 if the socket is
++// ready for write.
++int WaitSocketForWrite(int fd, const base::TimeDelta& timeout) {
++  struct pollfd pfd = {};
++  pfd.fd = fd;
++  pfd.events = POLLOUT;
++  return HANDLE_EINTR(poll(
++      &pfd, 1, base::saturated_cast<int>(timeout.InMillisecondsRoundedUp())));
++}
++
++// Write a message to a socket fd. Whenever the socket would block, wait for it
++// to become writable again; |timeout| bounds the total time spent waiting.
++bool WriteToSocket(int fd,
++                   std::string_view message,
++                   const base::TimeDelta& timeout = base::TimeDelta()) {
+   DCHECK(!message.empty());
++  const base::TimeTicks deadline = base::TimeTicks::Now() + timeout;
+   while (!message.empty()) {
+     ssize_t rv = HANDLE_EINTR(write(fd, message.data(), message.size()));
+     if (rv < 0) {
+       if (errno == EAGAIN || errno == EWOULDBLOCK) {
+-        // The socket shouldn't block, we're sending so little data.  Just give
+-        // up here, since NotifyOtherProcess() doesn't have an asynchronous api.
++        const base::TimeDelta remaining = deadline - base::TimeTicks::Now();
++        if (remaining.is_positive() && WaitSocketForWrite(fd, remaining) > 0) {
++          continue;
++        }
+         LOG(ERROR) << "ProcessSingleton would block on write(), so it gave up.";
+         return false;
+       }
+@@ -546,10 +566,7 @@ class ProcessSingleton::LinuxWatcher
+     SocketReader(ProcessSingleton::LinuxWatcher* parent,
+                  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner,
+                  int fd)
+-        : parent_(parent),
+-          ui_task_runner_(ui_task_runner),
+-          fd_(fd),
+-          bytes_read_(0) {
++        : parent_(parent), ui_task_runner_(ui_task_runner), fd_(fd) {
+       DCHECK_CURRENTLY_ON(BrowserThread::IO);
+       // Wait for reads.
+       fd_watch_controller_ = base::FileDescriptorWatcher::WatchReadable(
+@@ -593,11 +610,10 @@ class ProcessSingleton::LinuxWatcher
+     const int fd_;
+ 
+     // Store the message in this buffer.
+-    std::array<char, kMaxMessageLength> buf_;
++    std::string buf_;
+ 
+-    // Tracks the number of bytes we've read in case we're getting partial
+-    // reads.
+-    size_t bytes_read_;
++    // Whether the message exceeded kMaxMessageLength and is being dropped.
++    bool message_too_long_ = false;
+ 
+     base::OneShotTimer timer_;
+   };
+@@ -619,6 +635,7 @@ class ProcessSingleton::LinuxWatcher
    // |reader| is for sending back ACK message.
    void HandleMessage(const std::string& current_dir,
                       const std::vector<std::string>& argv,
@@ -76,7 +166,19 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
                       SocketReader* reader);
  
    // Called when the ProcessSingleton that owns this class is about to be
-@@ -678,13 +679,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
+@@ -663,8 +680,9 @@ void ProcessSingleton::LinuxWatcher::OnSocketCanReadWithoutBlocking(
+     PLOG(ERROR) << "accept() failed";
+     return;
+   }
+-  DCHECK(base::SetNonBlocking(connection_socket))
+-      << "Failed to make non-blocking socket.";
++  if (!base::SetNonBlocking(connection_socket)) {
++    PLOG(ERROR) << "Failed to make non-blocking socket.";
++  }
+   readers_.insert(
+       std::make_unique<SocketReader>(this, ui_task_runner_, connection_socket));
+ }
+@@ -678,13 +696,17 @@ void ProcessSingleton::LinuxWatcher::StartListening(int socket) {
  }
  
  void ProcessSingleton::LinuxWatcher::HandleMessage(
@@ -96,18 +198,67 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
      // Send back "ACK" message to prevent the client process from starting up.
      reader->FinishWithACK(kACKToken);
    } else {
-@@ -714,7 +719,8 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-   bytes_read_ += ReadFromSocketWithTimeout(
-       fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
+@@ -711,23 +733,58 @@ void ProcessSingleton::LinuxWatcher::RemoveSocketReader(SocketReader* reader) {
+ void ProcessSingleton::LinuxWatcher::SocketReader::
+     OnSocketCanReadWithoutBlocking() {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+-  bytes_read_ += ReadFromSocketWithTimeout(
+-      fd_, base::span(buf_).subspan(bytes_read_), base::Seconds(0));
  
 -  // Validate the message.  The shortest message is kStartToken\0x\0x
++  // The client shuts down its writing end after sending the message, so read
++  // until EOF to get the whole message.
++  std::array<char, 64 * 1024> chunk;
++  while (true) {
++    ssize_t rv = HANDLE_EINTR(read(fd_, chunk.data(), chunk.size()));
++    if (rv > 0) {
++      const size_t bytes_read = base::checked_cast<size_t>(rv);
++      if (message_too_long_) {
++        continue;
++      }
++      if (buf_.size() + bytes_read > kMaxMessageLength) {
++        LOG(ERROR) << "Socket message too long, dropping it";
++        message_too_long_ = true;
++        buf_.clear();
++        continue;
++      }
++      buf_.append(base::as_string_view(base::span(chunk).first(bytes_read)));
++      continue;
++    }
++    if (rv == 0) {  // The client has finished sending.
++      break;
++    }
++    if (errno == EAGAIN || errno == EWOULDBLOCK) {
++      return;  // Wait for the rest of the message.
++    }
++    PLOG(ERROR) << "read() failed";
++    CleanupAndDeleteSelf();
++    return;
++  }
++
++  if (message_too_long_) {
++    // Reply so the client exits instead of treating this process as hung.
++    fd_watch_controller_.reset();
++    timer_.Stop();
++    FinishWithACK(kACKToken);
++    return;
++  }
++
 +  // Validate the message.  The shortest message kStartToken\0\00
 +  // The shortest message with additional data is kStartToken\0\00\00\0.
    const size_t kMinMessageLength = kStartToken.length() + 4;
-   if (bytes_read_ < kMinMessageLength) {
-     buf_[bytes_read_] = 0;
-@@ -727,7 +733,7 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
-       base::as_string_view(base::span(buf_).first(bytes_read_));
+-  if (bytes_read_ < kMinMessageLength) {
+-    buf_[bytes_read_] = 0;
+-    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_.data();
++  if (buf_.size() < kMinMessageLength) {
++    LOG(ERROR) << "Invalid socket message (wrong length):" << buf_;
+     CleanupAndDeleteSelf();
+     return;
+   }
+ 
+-  std::string_view str =
+-      base::as_string_view(base::span(buf_).first(bytes_read_));
++  std::string_view str = buf_;
    std::vector<std::string> tokens =
        base::SplitString(str, std::string(1, kTokenDelimiter),
 -                        base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
@@ -115,7 +266,7 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
  
    if (tokens.size() < 3 || tokens[0] != kStartToken) {
      LOG(ERROR) << "Wrong message format: " << str;
-@@ -745,10 +751,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
+@@ -745,10 +802,45 @@ void ProcessSingleton::LinuxWatcher::SocketReader::
    tokens.erase(tokens.begin());
    tokens.erase(tokens.begin());
  
@@ -162,7 +313,7 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
    fd_watch_controller_.reset();
  
    // LinuxWatcher::HandleMessage() is in charge of destroying this SocketReader
-@@ -777,8 +818,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
+@@ -777,8 +869,10 @@ void ProcessSingleton::LinuxWatcher::SocketReader::FinishWithACK(
  //
  ProcessSingleton::ProcessSingleton(
      const base::FilePath& user_data_dir,
@@ -173,7 +324,7 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
        current_pid_(base::GetCurrentProcId()) {
    socket_path_ = user_data_dir.Append(chrome::kSingletonSocketFilename);
    lock_path_ = user_data_dir.Append(chrome::kSingletonLockFilename);
-@@ -899,7 +942,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -899,7 +993,8 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
               sizeof(socket_timeout));
  
    // Found another process, prepare our command line
@@ -183,7 +334,7 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
    std::string to_send(kStartToken);
    to_send.push_back(kTokenDelimiter);
  
-@@ -909,11 +953,21 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
+@@ -909,13 +1004,23 @@ ProcessSingleton::NotifyResult ProcessSingleton::NotifyOtherProcessWithTimeout(
    to_send.append(current_dir.value());
  
    const std::vector<std::string>& argv = cmd_line.argv();
@@ -203,8 +354,11 @@ index 5a88dfda5eb2c4bf5b547a76eef81b530f3ea96e..3d3cb9b717b48acb5290c6a57050401d
 +  }
 +
    // Send the message
-   if (!WriteToSocket(socket.fd(), to_send)) {
+-  if (!WriteToSocket(socket.fd(), to_send)) {
++  if (!WriteToSocket(socket.fd(), to_send, timeout)) {
      // Try to kill the other process, because it might have been dead.
+     if (!kill_unresponsive || !KillProcessByLockPath(true))
+       return PROFILE_IN_USE;
 diff --git a/chrome/browser/process_singleton_win.cc b/chrome/browser/process_singleton_win.cc
 index ae659d84a5ae2f2e87ce288477506575f8d86839..274887d62ff8d008bb86815a11205fcaa5f2c2ff 100644
 --- a/chrome/browser/process_singleton_win.cc

--- a/spec/api-app-spec.ts
+++ b/spec/api-app-spec.ts
@@ -399,6 +399,20 @@ describe('app module', () => {
       });
     });
 
+    it('sends and receives data larger than the singleton message buffer', async () => {
+      await testArgumentPassing({
+        args: ['--send-data', '--data-size=300000'],
+        expectedAdditionalData: 'x'.repeat(300000)
+      });
+    });
+
+    ifit(process.platform !== 'win32')('passes long arguments to the second-instance event', async () => {
+      await testArgumentPassing({
+        args: [`--long-arg=${'a'.repeat(50000)}`],
+        expectedAdditionalData: null
+      });
+    });
+
     it('sends and receives numerical data', async () => {
       await testArgumentPassing({
         args: ['--send-data', '--data-content=2'],

--- a/spec/fixtures/api/singleton-data/main.js
+++ b/spec/fixtures/api/singleton-data/main.js
@@ -21,13 +21,16 @@ if (app.commandLine.hasSwitch('data-content')) {
     obj = undefined;
   }
 }
+if (app.commandLine.hasSwitch('data-size')) {
+  obj = 'x'.repeat(parseInt(app.commandLine.getSwitchValue('data-size')));
+}
 
 const gotTheLock = sendAdditionalData ? app.requestSingleInstanceLock(obj) : app.requestSingleInstanceLock();
 
 app.on('second-instance', (event, args, workingDirectory, data) => {
   setImmediate(() => {
-    console.log([JSON.stringify(args), JSON.stringify(data)].join('||'));
-    app.exit(0);
+    const line = [JSON.stringify(args), JSON.stringify(data)].join('||');
+    process.stdout.write(line + '\n', () => app.exit(0));
   });
 });
 


### PR DESCRIPTION
Backport of #52628

See that PR for details.

Manual backport notes: same shape as the 43-x-y backport — the only conflict was inside `patches/chromium/feat_add_data_parameter_to_processsingleton.patch` (one differing context line in `process_singleton.h` plus `main`-only blob hashes defeat the 3-way apply); re-anchored against this branch's Chromium with the `process_singleton_posix.cc` change byte-identical to `main`. Validated locally on Linux: `e sync --3` clean, `lint --patches` clean, `e build`, the `app.requestSingleInstanceLock` spec block (14 passing, including the new long-arguments test), and a manual run of the `singleton-data` fixture with a 100 KB argv and 1–2 MB `additionalData` (primary stays alive and receives the full payload; with the previous patch the primary dies).

Notes: Fixed the primary instance being killed or receiving truncated arguments when a second instance passed a very long command line or large `additionalData` to `app.requestSingleInstanceLock()`.
