### PR TITLE
docs: update `breaking-changes.md` after 44.0.0 release

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -2,6 +2,8 @@
 
 Breaking changes will be documented here, and deprecation warnings added to JS code where possible, at least [one major version](tutorial/electron-versioning.md#semver) before the change is made.
 
+Note that breaking changes listed for future releases are always subject to change.
+
 ### Types of Breaking Changes
 
 This document uses the following convention to categorize breaking changes:
@@ -12,7 +14,7 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
-## Planned Breaking API Changes (45.0)
+## Breaking API Changes (45.0)
 
 ### Behavior Changed: screen capture requests are reported as `display-capture` in `setPermissionRequestHandler`
 
@@ -57,8 +59,6 @@ its removal. The API can temporarily be restored with the
 `RequestStorageAccessFor`. See
 [Chromium's intent to remove discussion](https://groups.google.com/a/chromium.org/g/blink-dev/c/bqHGZYHWxnQ)
 for more information.
-
-## Planned Breaking API Changes (44.0)
 
 ### Behavior Changed: file descriptors for files inside ASAR archives are only usable through `fs`
 
@@ -113,6 +113,8 @@ win.webContents.setWindowOpenHandler(() => ({
 
 Setting `nodeIntegration: true` in the override also makes the child unsandboxed and has
 the same effect.
+
+## Breaking API Changes (44.0)
 
 ### Behavior Changed: `webContents` may be `null` in `select-client-certificate`
 
@@ -457,7 +459,7 @@ and the fields `openAsHidden`, `wasOpenedAsHidden` and `restoreState` from the r
 
 These only worked on macOS 12 and below. Support for macOS 12 has been dropped.
 
-## Planned Breaking API Changes (43.0)
+## Breaking API Changes (43.0)
 
 ### Behavior Changed: Rounded corners on Linux
 
@@ -534,7 +536,7 @@ It continues to work on macOS and Windows. GTK intends for this feature
 to be a user choice rather than an app choice, and has removed the API
 to do this programmatically.
 
-## Planned Breaking API Changes (42.0)
+## Breaking API Changes (42.0)
 
 ### Behavior Changed: macOS notifications now use `UNNotification` API
 
@@ -614,7 +616,7 @@ nativeImage.createFromNamedImage(imageName, {
 })
 ```
 
-## Planned Breaking API Changes (41.0)
+## Breaking API Changes (41.0)
 
 ### Behavior Changed: PDFs no longer create a separate WebContents
 
@@ -636,7 +638,7 @@ This property will still be honored on macOS and Windows, but support on Linux
 will be removed in a future version of Electron. GTK intends for this to be a user choice rather
 than an app choice and has removed the API to do this programmatically.
 
-## Planned Breaking API Changes (40.0)
+## Breaking API Changes (40.0)
 
 ### Deprecated: `clipboard` API access from renderer processes
 
@@ -649,7 +651,7 @@ your preload script and expose it using the [contextBridge](https://www.electron
 Debug symbols for MacOS (dSYM) now use xz compression in order to handle larger file sizes. `dsym.zip` files are now
 `dsym.tar.xz` files. End users using debug symbols may need to update their zip utilities.
 
-## Planned Breaking API Changes (39.0)
+## Breaking API Changes (39.0)
 
 ### Deprecated: `--host-rules` command line switch
 
@@ -696,7 +698,7 @@ When using shared texture offscreen rendering feature, the `paint` event now emi
 It moves the `sharedTextureHandle`, `planes`, `modifier` into a unified `handle` property.
 See the [OffscreenSharedTexture](./api/structures/offscreen-shared-texture.md) API structure for more details.
 
-## Planned Breaking API Changes (38.0)
+## Breaking API Changes (38.0)
 
 ### Removed: `ELECTRON_OZONE_PLATFORM_HINT` environment variable
 
@@ -733,7 +735,7 @@ The `webFrame.findFrameByRoutingId(routingId)` function will be removed.
 
 You should use `webFrame.findFrameByToken(frameToken)` instead.
 
-## Planned Breaking API Changes (37.0)
+## Breaking API Changes (37.0)
 
 ### Utility Process unhandled rejection behavior change
 
@@ -781,7 +783,7 @@ and then using it in `ProtocolResponse.session`.
 `BrowserWindow.IsVisibleOnAllWorkspaces()` will now return false on Linux if the
 window is not currently visible.
 
-## Planned Breaking API Changes (36.0)
+## Breaking API Changes (36.0)
 
 ### Behavior Changes: `app.commandLine`
 
@@ -864,7 +866,7 @@ $ electron --gtk-version=3   # or --gtk-version=2
 
 The same can be done with the [`app.commandLine.appendSwitch`](https://www.electronjs.org/docs/latest/api/command-line#commandlineappendswitchswitch-value) function.
 
-## Planned Breaking API Changes (35.0)
+## Breaking API Changes (35.0)
 
 ### Behavior Changed: Dialog API's `defaultPath` option on Linux
 
@@ -948,7 +950,7 @@ It has been always returning `true` since Electron 23, which only supports Windo
 
 https://learn.microsoft.com/en-us/windows/win32/dwm/composition-ovw#disabling-dwm-composition-windows7-and-earlier
 
-## Planned Breaking API Changes (34.0)
+## Breaking API Changes (34.0)
 
 ### Behavior Changed: menu bar will be hidden during fullscreen on Windows
 
@@ -956,7 +958,7 @@ This brings the behavior to parity with Linux. Prior behavior: Menu bar is still
 
 **Correction**: This was previously listed as a breaking change in Electron 33, but was first released in Electron 34.
 
-## Planned Breaking API Changes (33.0)
+## Breaking API Changes (33.0)
 
 ### Deprecated: `document.execCommand("paste")`
 
@@ -1061,7 +1063,7 @@ const shouldReduceTransparency = systemPreferences.accessibilityDisplayShouldRed
 const prefersReducedTransparency = nativeTheme.prefersReducedTransparency
 ```
 
-## Planned Breaking API Changes (32.0)
+## Breaking API Changes (32.0)
 
 ### Removed: `File.path`
 
@@ -1128,7 +1130,7 @@ The `databases` directory was used by WebSQL, which was removed in Electron 31.
 Chromium now performs a cleanup that deletes this directory. See
 [issue #45396](https://github.com/electron/electron/issues/45396).
 
-## Planned Breaking API Changes (31.0)
+## Breaking API Changes (31.0)
 
 ### Removed: `WebSQL` support
 
@@ -1147,7 +1149,7 @@ See [crbug.com/332584706](https://issues.chromium.org/issues/332584706) for more
 
 This brings the behavior to parity with Windows and Linux. Prior behavior: The first `flashFrame(true)` bounces the dock icon only once (using the [NSInformationalRequest](https://developer.apple.com/documentation/appkit/nsrequestuserattentiontype/nsinformationalrequest) level) and `flashFrame(false)` does nothing. New behavior: Flash continuously until `flashFrame(false)` is called. This uses the [NSCriticalRequest](https://developer.apple.com/documentation/appkit/nsrequestuserattentiontype/nscriticalrequest) level instead. To explicitly use `NSInformationalRequest` to cause a single dock icon bounce, it is still possible to use [`dock.bounce('informational')`](https://www.electronjs.org/docs/latest/api/dock#dockbouncetype-macos).
 
-## Planned Breaking API Changes (30.0)
+## Breaking API Changes (30.0)
 
 ### Behavior Changed: cross-origin iframes now use Permission Policy to access features
 
@@ -1201,7 +1203,7 @@ property instead.
 
 Chromium has removed access to this information.
 
-## Planned Breaking API Changes (29.0)
+## Breaking API Changes (29.0)
 
 ### Behavior Changed: `ipcRenderer` can no longer be sent over the `contextBridge`
 
@@ -1257,7 +1259,7 @@ app.on('gpu-process-crashed', (event, killed) => { /* ... */ })
 app.on('child-process-gone', (event, details) => { /* ... */ })
 ```
 
-## Planned Breaking API Changes (28.0)
+## Breaking API Changes (28.0)
 
 ### Behavior Changed: `WebContents.backgroundThrottling` set to false affects all `WebContents` in the host `BrowserWindow`
 
@@ -1367,7 +1369,7 @@ app.on('gpu-process-crashed', (event, killed) => { /* ... */ })
 app.on('child-process-gone', (event, details) => { /* ... */ })
 ```
 
-## Planned Breaking API Changes (27.0)
+## Breaking API Changes (27.0)
 
 ### Removed: macOS 10.13 / 10.14 support
 
@@ -1463,7 +1465,7 @@ systemPreferences.getColor('alternate-selected-control-text')
 systemPreferences.getColor('selected-content-background')
 ```
 
-## Planned Breaking API Changes (26.0)
+## Breaking API Changes (26.0)
 
 ### Deprecated: `webContents.getPrinters`
 
@@ -1516,7 +1518,7 @@ systemPreferences.getColor('alternate-selected-control-text')
 systemPreferences.getColor('selected-content-background')
 ```
 
-## Planned Breaking API Changes (25.0)
+## Breaking API Changes (25.0)
 
 ### Deprecated: `protocol.{un,}{register,intercept}{Buffer,String,Stream,File,Http}Protocol` and `protocol.isProtocol{Registered,Intercepted}`
 
@@ -1603,7 +1605,7 @@ if (ret === null) {
 }
 ```
 
-## Planned Breaking API Changes (24.0)
+## Breaking API Changes (24.0)
 
 ### API Changed: `nativeImage.createThumbnailFromPath(path, size)`
 
@@ -1640,7 +1642,7 @@ nativeImage.createThumbnailFromPath(imagePath, size).then(result => {
 })
 ```
 
-## Planned Breaking API Changes (23.0)
+## Breaking API Changes (23.0)
 
 ### Behavior Changed: Draggable Regions on macOS
 
@@ -1722,7 +1724,7 @@ w.capturePage().then(image => {
 })
 ```
 
-## Planned Breaking API Changes (22.0)
+## Breaking API Changes (22.0)
 
 ### Deprecated: `webContents.incrementCapturerCount(stayHidden, stayAwake)`
 
@@ -1839,7 +1841,7 @@ win.webContents.on('input-event', (_, event) => {
 })
 ```
 
-## Planned Breaking API Changes (21.0)
+## Breaking API Changes (21.0)
 
 ### Behavior Changed: V8 Memory Cage enabled
 
@@ -1903,7 +1905,7 @@ webContents.printToPDF({
 })
 ```
 
-## Planned Breaking API Changes (20.0)
+## Breaking API Changes (20.0)
 
 ### Removed: macOS 10.11 / 10.12 support
 
@@ -1939,14 +1941,14 @@ has a change to its arguments.  This handler no longer is passed a frame
 [`WebFrameMain`](api/web-frame-main.md), but instead is passed the `origin`, which
 is the origin that is checking for device permission.
 
-## Planned Breaking API Changes (19.0)
+## Breaking API Changes (19.0)
 
 ### Removed: IA32 Linux binaries
 
 This is a result of Chromium 102.0.4999.0 dropping support for IA32 Linux.
 This concludes the [removal of support for IA32 Linux](#removed-ia32-linux-support).
 
-## Planned Breaking API Changes (18.0)
+## Breaking API Changes (18.0)
 
 ### Removed: `nativeWindowOpen`
 
@@ -1958,7 +1960,7 @@ Since Electron 15, `nativeWindowOpen` has been enabled by default.
 See the documentation for [window.open in Electron](api/window-open.md)
 for more details.
 
-## Planned Breaking API Changes (17.0)
+## Breaking API Changes (17.0)
 
 ### Removed: `desktopCapturer.getSources` in the renderer
 
@@ -2001,7 +2003,7 @@ Since Electron 15, `nativeWindowOpen` has been enabled by default.
 See the documentation for [window.open in Electron](api/window-open.md)
 for more details.
 
-## Planned Breaking API Changes (16.0)
+## Breaking API Changes (16.0)
 
 ### Behavior Changed: `crashReporter` implementation switched to Crashpad on Linux
 
@@ -2025,7 +2027,7 @@ Electron apps.
 See [here](#removed-desktopcapturergetsources-in-the-renderer) for details on
 how to replace this API in your app.
 
-## Planned Breaking API Changes (15.0)
+## Breaking API Changes (15.0)
 
 ### Default Changed: `nativeWindowOpen` defaults to `true`
 
@@ -2049,7 +2051,7 @@ console.log(app.runningUnderRosettaTranslation)
 console.log(app.runningUnderARM64Translation)
 ```
 
-## Planned Breaking API Changes (14.0)
+## Breaking API Changes (14.0)
 
 ### Removed: `remote` module
 
@@ -2146,7 +2148,7 @@ webContents.on('did-create-window', (window, details) => {
 })
 ```
 
-## Planned Breaking API Changes (13.0)
+## Breaking API Changes (13.0)
 
 ### API Changed: `session.setPermissionCheckHandler(handler)`
 
@@ -2270,7 +2272,7 @@ webContents.setWindowOpenHandler((details) => {
 })
 ```
 
-## Planned Breaking API Changes (12.0)
+## Breaking API Changes (12.0)
 
 ### Removed: Pepper Flash support
 
@@ -2369,7 +2371,7 @@ shell.moveItemToTrash(path)
 shell.trashItem(path).then(/* ... */)
 ```
 
-## Planned Breaking API Changes (11.0)
+## Breaking API Changes (11.0)
 
 ### Removed: `BrowserView.{destroy, fromId, fromWebContents, getAllViews}` and `id` property of `BrowserView`
 
@@ -2379,7 +2381,7 @@ has also been removed.
 
 For more detailed information, see [#23578](https://github.com/electron/electron/pull/23578).
 
-## Planned Breaking API Changes (10.0)
+## Breaking API Changes (10.0)
 
 ### Deprecated: `companyName` argument to `crashReporter.start()`
 
@@ -2507,7 +2509,7 @@ const isRegistered = protocol.isProtocolRegistered(scheme)
 const isIntercepted = protocol.isProtocolIntercepted(scheme)
 ```
 
-## Planned Breaking API Changes (9.0)
+## Breaking API Changes (9.0)
 
 ### Default Changed: Loading non-context-aware native modules in the renderer process is disabled by default
 
@@ -2603,7 +2605,7 @@ error.
 The `shell.openItem` API has been replaced with an asynchronous `shell.openPath` API.
 You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/main/wg-api/spec-documents/shell-openitem.md).
 
-## Planned Breaking API Changes (8.0)
+## Breaking API Changes (8.0)
 
 ### Behavior Changed: Values sent over IPC are now serialized with Structured Clone Algorithm
 
@@ -2756,7 +2758,7 @@ systemPreferences.isHighContrastColorScheme()
 nativeTheme.shouldUseHighContrastColors
 ```
 
-## Planned Breaking API Changes (7.0)
+## Breaking API Changes (7.0)
 
 ### Deprecated: Atom.io Node Headers URL
 
@@ -2904,7 +2906,7 @@ These functions now have two forms, synchronous and Promise-based asynchronous:
 * `dialog.showOpenDialog()`/`dialog.showOpenDialogSync()` [#16973](https://github.com/electron/electron/pull/16973)
 * `dialog.showSaveDialog()`/`dialog.showSaveDialogSync()` [#17054](https://github.com/electron/electron/pull/17054)
 
-## Planned Breaking API Changes (6.0)
+## Breaking API Changes (6.0)
 
 ### API Changed: `win.setMenu(null)` is now `win.removeMenu()`
 
@@ -2986,7 +2988,7 @@ tray.setHighlightMode(mode)
 // API will be removed in v7.0 without replacement.
 ```
 
-## Planned Breaking API Changes (5.0)
+## Breaking API Changes (5.0)
 
 ### Default Changed: `nodeIntegration` and `webviewTag` default to false, `contextIsolation` defaults to true
 
@@ -3078,7 +3080,7 @@ const factor = webContents.getZoomFactor()
 console.log(factor)
 ```
 
-## Planned Breaking API Changes (4.0)
+## Breaking API Changes (4.0)
 
 The following list includes the breaking API changes made in Electron 4.0.
 


### PR DESCRIPTION
* Move two changes into the 45 section that didn't end up being
  backported into 44.

* Remove "Planned" from all section headers, and add a disclaimer about
  changes listed for future releases.

#### Checklist

- [x] I have filled out the PR description

#### Release Notes

Notes: none