### PR TITLE
docs: update documentation for menuItem.registerAccelerator

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -171,7 +171,7 @@ will turn off that property for all adjacent items in the same menu.
 
 You can add a `click` function for additional behavior.
 
-#### `menuItem.registerAccelerator`
+#### `menuItem.registerAccelerator` _Linux_ _Windows_
 
 A `boolean` indicating if the accelerator should be registered with the
 system or just displayed.


### PR DESCRIPTION
#### Description of Change

Added the platform availability badge (`_Linux_ _Windows_`) to the
`menuItem.registerAccelerator` instance property documentation in
`docs/api/menu-item.md`.

This change aligns the instance property documentation with the
constructor options section, where `registerAccelerator` is already
documented as being available only on Linux and Windows.

The update resolves an inconsistency that could cause confusion about
whether `menuItem.registerAccelerator` is supported on macOS.

Fixes #53123

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] `npm test` passes
- [ ] tests are changed or added
- [x] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: none