### PR TITLE
build: stop requesting the removed 32-bit PGO profiles during sync

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -223,14 +223,14 @@ hooks = [
     'pattern': 'src/electron/build/pgo_profiles',
     'condition': 'checkout_linux and process_deps',
     'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
-               '--targets', 'linux-x64,linux-arm,linux-arm64'],
+               '--targets', 'linux-x64,linux-arm64'],
   },
   {
     'name': 'electron_pgo_profiles_win',
     'pattern': 'src/electron/build/pgo_profiles',
     'condition': 'checkout_win and process_deps',
     'action': ['python3', 'src/electron/script/pgo/download-profiles.py',
-               '--targets', 'win-x64,win-x86,win-arm64'],
+               '--targets', 'win-x64,win-arm64'],
   },
   {
     'name': 'electron_pgo_profiles_mac',

--- a/script/pgo/README.md
+++ b/script/pgo/README.md
@@ -143,7 +143,6 @@ combo's instrumented build runs its own benchmarks:
 | linux-x64 | x64 ARC runner (build container) |
 | linux-arm64 | `ubuntu-22.04-arm` (arm64v8 test container) |
 | win-x64 | `windows-latest` |
-| win-x86 | `windows-latest` (WOW64) |
 | win-arm64 | `windows-11-arm` |
 | macos-x64 | `macos-15-large` |
 | macos-arm64 | `macos-15` |


### PR DESCRIPTION
#### Description of Change

#53163 removed the `linux-arm` and `win-x86` PGO state files, but the `electron_pgo_profiles_linux` / `_win` hooks in DEPS still ask `download-profiles.py` for those targets, so `gclient sync` currently fails on Linux and Windows ("no state file for target linux-arm"). This drops the two targets from the hooks and the stale `win-x86` row from the PGO README.

#### Release Notes

Notes: none
