### PR TITLE
fix: resolve region-qualified `--lang` values against shipped locales on macOS

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -337,6 +337,16 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   std::string locale = command_line->GetSwitchValueASCII(::switches::kLang);
 
 #if BUILDFLAG(IS_MAC)
+  // On macOS, l10n_util::GetApplicationLocale() returns the --lang value
+  // verbatim instead of resolving it against the locales that actually ship
+  // (Chromium relies on Cocoa having already done that). A tag like "de-DE"
+  // therefore fails to find de.lproj and no locale pak is loaded at all,
+  // which leaves every localized string empty. Resolve it the same way the
+  // other platforms do, and fall back to Cocoa's choice if it can't be
+  // resolved.
+  if (!locale.empty())
+    locale = l10n_util::CheckAndResolveLocale(locale).value_or(std::string());
+
   // The browser process only wants to support the language Cocoa will use,
   // so force the app locale to be overridden with that value. This must
   // happen before the ResourceBundle is loaded

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -598,6 +598,8 @@ describe('command line switches', () => {
     it('should set the locale', async () => testLocale('fr', `fr|${currentSystemLocale}|${currentPreferredLanguages}`));
     it('should set the locale with country code', async () =>
       testLocale('zh-CN', `zh-CN|${currentSystemLocale}|${currentPreferredLanguages}`));
+    it('should resolve a locale whose country code is not shipped', async () =>
+      testLocale('de-DE', `de|${currentSystemLocale}|${currentPreferredLanguages}`));
     it('should not set an invalid locale', async () =>
       testLocale('asdfkl', `${currentLocale}|${currentSystemLocale}|${currentPreferredLanguages}`));
 


### PR DESCRIPTION
- On macOS a region-qualified `--lang` such as `de-DE` (also `fr-FR`, `it-IT`, `es-ES`, `ja-JP`, `ko-KR`, …) was handed to `ResourceBundle` verbatim, which looked for `de_DE.lproj`, found nothing (the pak ships as `de.lproj`), and silently loaded **no** locale pak: every localized string in the browser process came back empty (`locale resources are not loaded`) and `app.getLocale()` reported `en-US`. `l10n_util::GetApplicationLocale()` skips resolution on macOS because Chrome relies on Cocoa having matched the locale already; Electron's `--lang` bypasses that.
- Resolve the value with `l10n_util::CheckAndResolveLocale()` the way Windows/Linux already do, and fall back to Cocoa's locale when it can't be resolved (`asdfkl` now behaves like "no `--lang`" instead of "no strings at all").
- Adds a `--lang=de-DE` → `de` case to the existing `--lang switch` specs.
- Most visible symptom was a hard crash on WebAuthn with Touch ID: the empty `IDS_WEBAUTHN_TOUCH_ID_PROMPT_REASON` reached `-[LAContext evaluateAccessControl:…]`, which raises `NSInvalidArgumentException`. #53185 guards that path independently.

Notes: Fixed region-qualified `--lang` values such as `de-DE` loading no locale resources on macOS, which left localized strings empty and could crash WebAuthn Touch ID prompts.
