### PR TITLE
ci: fix all zizmor audit findings

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -49,8 +49,11 @@ runs:
   steps:
     - name: Validate inputs
       shell: bash
+      env:
+        PUBLISH: ${{ inputs.publish }}
+        IS_RELEASE: ${{ inputs.is-release }}
       run: |
-        if [ "${{ inputs.publish }}" = "true" ] && [ "${{ inputs.is-release }}" != "true" ]; then
+        if [ "$PUBLISH" = "true" ] && [ "$IS_RELEASE" != "true" ]; then
           echo "Can only publish release builds"
           exit 1
         fi
@@ -61,8 +64,10 @@ runs:
     - name: Set GN_EXTRA_ARGS for MacOS x64 Builds
       shell: bash
       if: ${{ inputs.target-arch == 'x64' && inputs.target-platform == 'macos' }}
-      run: |
-        if [ "${{ inputs.is-release }}" = "true" ]; then
+      env:
+        IS_RELEASE: ${{ inputs.is-release }}
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
+        if [ "$IS_RELEASE" = "true" ]; then
           SNAPSHOT_TOOLCHAIN="//electron/build/toolchain/mac:clang_x64_snapshot"
         else
           SNAPSHOT_TOOLCHAIN="//build/toolchain/mac:clang_x64"
@@ -77,7 +82,9 @@ runs:
     - name: Set GN_EXTRA_ARGS for MacOS Release Builds
       shell: bash
       if: ${{ inputs.is-release == 'true' && inputs.target-platform == 'macos' }}
-      run: |
+      env:
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
         GN_APPENDED_ARGS="$GN_EXTRA_ARGS thin_lto_enable_cache=false"
         # Build mksnapshot, node_mksnapshot, v8_context_snapshot_generator
         # and the natives code-cache generator without ThinLTO/PGO/dsyms
@@ -85,15 +92,17 @@ runs:
         # they are four serialized ThinLTO links of V8/Blink/Node (~40 min
         # of link-pool time) whose outputs are optimization-independent
         # data. x64 is handled in the x64 step above.
-        if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+        if [ "$TARGET_ARCH" = "arm64" ]; then
           GN_APPENDED_ARGS="$GN_APPENDED_ARGS v8_snapshot_toolchain=\"//electron/build/toolchain/mac:clang_arm64_snapshot\""
         fi
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Set GN_EXTRA_ARGS for Windows
       shell: bash
       if: ${{ inputs.target-arch != 'x64' && inputs.target-platform == 'win' }}
-      run: |
-        GN_APPENDED_ARGS="$GN_APPENDED_ARGS target_cpu=\"${{ inputs.target-arch }}\""
+      env:
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
+        GN_APPENDED_ARGS="$GN_APPENDED_ARGS target_cpu=\"$TARGET_ARCH\""
         echo "GN_EXTRA_ARGS=$GN_APPENDED_ARGS" >> $GITHUB_ENV
     - name: Add Clang problem matcher
       shell: bash
@@ -126,6 +135,11 @@ runs:
     - name: Build Electron ${{ inputs.step-suffix }}
       if: ${{ inputs.target-platform != 'win' }}
       shell: bash
+      env:
+        PUBLISH: ${{ inputs.publish }}
+        IS_RELEASE: ${{ inputs.is-release }}
+        ARTIFACT_PLATFORM: ${{ inputs.artifact-platform }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
       run: |
         rm -rf "src/out/Default/Electron Framework.framework"
         rm -rf src/out/Default/Electron*.app
@@ -142,9 +156,9 @@ runs:
 
         export NINJA_SUMMARIZE_BUILD=1
         export NO_COLOR=1
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "$PUBLISH" = "true" ] || echo -quiet)
 
-        if [ "${{ inputs.is-release }}" = "true" ]; then
+        if [ "$IS_RELEASE" = "true" ]; then
           e build --target electron:release_build $QUIET_FLAG
         else
           e build --target electron:testing_build $QUIET_FLAG
@@ -153,7 +167,7 @@ runs:
         node electron/script/check-symlinks.js
 
         # Build stats and object checksums
-        BUILD_STATS_ARGS="out/Default/siso.INFO --out-dir out/Default --output-object-checksums object-checksums.${{ inputs.artifact-platform }}_${{ inputs.target-arch }}.json"
+        BUILD_STATS_ARGS="out/Default/siso.INFO --out-dir out/Default --output-object-checksums object-checksums.${ARTIFACT_PLATFORM}_${TARGET_ARCH}.json"
         if [ -f previous-object-checksums.json ]; then
           BUILD_STATS_ARGS="$BUILD_STATS_ARGS --input-object-checksums previous-object-checksums.json"
         fi
@@ -166,6 +180,10 @@ runs:
     - name: Build Electron (Windows) ${{ inputs.step-suffix }}
       if: ${{ inputs.target-platform == 'win' }}
       shell: powershell
+      env:
+        IS_RELEASE: ${{ inputs.is-release }}
+        ARTIFACT_PLATFORM: ${{ inputs.artifact-platform }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
       run: |
         cd src\electron
         git pack-refs
@@ -173,8 +191,8 @@ runs:
 
         $env:NINJA_SUMMARIZE_BUILD = 1
         $env:NO_COLOR = 1
-        $quietFlag = if ($env:ACTIONS_STEP_DEBUG -eq "true" -or "${{ inputs.is-release }}" -eq "true") { @() } else { @("-quiet") }
-        if ("${{ inputs.is-release }}" -eq "true") {          
+        $quietFlag = if ($env:ACTIONS_STEP_DEBUG -eq "true" -or $env:IS_RELEASE -eq "true") { @() } else { @("-quiet") }
+        if ($env:IS_RELEASE -eq "true") {          
           e build --target electron:release_build
         } else {
           e build --target electron:testing_build $quietFlag
@@ -187,7 +205,7 @@ runs:
         node electron\script\check-symlinks.js
 
         # Build stats and object checksums
-        $statsArgs = @("out\Default\siso.exe.INFO", "--out-dir", "out\Default", "--output-object-checksums", "object-checksums.${{ inputs.artifact-platform }}_${{ inputs.target-arch }}.json")
+        $statsArgs = @("out\Default\siso.exe.INFO", "--out-dir", "out\Default", "--output-object-checksums", "object-checksums.$($env:ARTIFACT_PLATFORM)_$($env:TARGET_ARCH).json")
         if (Test-Path previous-object-checksums.json) {
           $statsArgs += @("--input-object-checksums", "previous-object-checksums.json")
         }
@@ -203,14 +221,20 @@ runs:
         }
     - name: Verify dist.zip ${{ inputs.step-suffix }}
       shell: bash
+      env:
+        IS_ASAN: ${{ inputs.is-asan }}
+        IS_UBSAN: ${{ inputs.is-ubsan }}
+        TARGET_OS: ${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
+        ARTIFACT_PLATFORM: ${{ inputs.artifact-platform }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
       run: |
-        cd src        
-        if [ "${{ inputs.is-asan }}" != "true" ] && [ "${{ inputs.is-ubsan }}" != "true" ]; then
-          target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
-          if [ "${{ inputs.artifact-platform }}" = "mas" ]; then
+        cd src
+        if [ "$IS_ASAN" != "true" ] && [ "$IS_UBSAN" != "true" ]; then
+          target_os=$TARGET_OS
+          if [ "$ARTIFACT_PLATFORM" = "mas" ]; then
             target_os="${target_os}_mas"
           fi
-          electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.${{ inputs.target-arch }}.manifest
+          electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.$TARGET_ARCH.manifest
         fi
     # mksnapshot_args is consumed by both the mksnapshot tests and by
     # @electron/mksnapshot from the released mksnapshot.zip, so this is needed
@@ -218,6 +242,8 @@ runs:
     - name: Fixup Mksnapshot ${{ inputs.step-suffix }}
       shell: bash
       if: ${{ inputs.generate-test-artifacts == 'true' || inputs.is-release == 'true' }}
+      env:
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
       run: |
         cd src
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG=1 e d gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
@@ -236,7 +262,7 @@ runs:
         sed $SEDOPTION '/--warn-about-builtin-profile-data/d' out/Default/mksnapshot_args
         sed $SEDOPTION '/--abort-on-bad-builtin-profile-data/d' out/Default/mksnapshot_args
 
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           cd out/Default
           powershell Compress-Archive -update mksnapshot_args mksnapshot.zip
           powershell mkdir mktmp\\gen\\v8
@@ -264,16 +290,23 @@ runs:
     - name: Build Chromedriver ${{ inputs.step-suffix }}
       shell: bash
       if: ${{ inputs.generate-chromedriver == 'true' }}
+      env:
+        PUBLISH: ${{ inputs.publish }}
+        IS_ASAN: ${{ inputs.is-asan }}
+        IS_UBSAN: ${{ inputs.is-ubsan }}
+        TARGET_OS: ${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
+        ARTIFACT_PLATFORM: ${{ inputs.artifact-platform }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
       run: |
         cd src
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "$PUBLISH" = "true" ] || echo -quiet)
         e build --target electron:electron_chromedriver_zip $QUIET_FLAG
-        if [ "${{ inputs.is-asan }}" != "true" ] && [ "${{ inputs.is-ubsan }}" != "true" ]; then
-          target_os=${{ inputs.target-platform == 'macos' && 'mac' || inputs.target-platform }}
-          if [ "${{ inputs.artifact-platform }}" = "mas" ]; then
+        if [ "$IS_ASAN" != "true" ] && [ "$IS_UBSAN" != "true" ]; then
+          target_os=$TARGET_OS
+          if [ "$ARTIFACT_PLATFORM" = "mas" ]; then
             target_os="${target_os}_mas"
           fi
-          electron/script/zip_manifests/check-zip-manifest.py out/Default/chromedriver.zip electron/script/zip_manifests/chromedriver_zip.$target_os.${{ inputs.target-arch }}.manifest
+          electron/script/zip_manifests/check-zip-manifest.py out/Default/chromedriver.zip electron/script/zip_manifests/chromedriver_zip.$target_os.$TARGET_ARCH.manifest
         fi
     - name: Create installed_software.json ${{ inputs.step-suffix }}
       shell: powershell
@@ -300,10 +333,12 @@ runs:
     - name: Zip Symbols ${{ inputs.step-suffix }}
       shell: bash
       if: ${{ inputs.generate-symbols == 'true' }}
+      env:
+        IS_RELEASE: ${{ inputs.is-release }}
       run: |
         cd src
         export BUILD_PATH="$(pwd)/out/Default"
-        if [ "${{ inputs.is-release }}" = "true" ]; then
+        if [ "$IS_RELEASE" = "true" ]; then
           DELETE_DSYMS_AFTER_ZIP=1 electron/script/zip-symbols.py -b $BUILD_PATH
         else
           electron/script/zip-symbols.py -b $BUILD_PATH
@@ -311,9 +346,12 @@ runs:
     - name: Generate FFMpeg ${{ inputs.step-suffix }}
       shell: bash
       if: ${{ inputs.is-release == 'true' }}
+      env:
+        PUBLISH: ${{ inputs.publish }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
       run: |
-        e init -f --root=$(pwd) --out=ffmpeg fmmpeg --import ffmpeg --target-cpu ${{ inputs.target-arch }} --remote-build siso
-        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "${{ inputs.publish }}" = "true" ] || echo -quiet)
+        e init -f --root=$(pwd) --out=ffmpeg fmmpeg --import ffmpeg --target-cpu "$TARGET_ARCH" --remote-build siso
+        QUIET_FLAG=$([ "${ACTIONS_STEP_DEBUG:-}" = "true" ] || [ "$PUBLISH" = "true" ] || echo -quiet)
         e build --target electron:electron_ffmpeg_zip $QUIET_FLAG
     - name: Remove Clang problem matcher
       shell: bash
@@ -364,10 +402,12 @@ runs:
       if: ${{ inputs.publish == 'true' }}
       shell: bash
       id: github-upload
+      env:
+        UPLOAD_TO_STORAGE: ${{ inputs.upload-to-storage }}
       run: |
         rm -rf src/out/Default/obj
         cd src/electron
-        if [ "${{ inputs.upload-to-storage }}" = "1" ]; then
+        if [ "$UPLOAD_TO_STORAGE" = "1" ]; then
           echo 'Uploading Electron release distribution to Azure'
           script/release/uploaders/upload.py --verbose --upload_to_storage
         else
@@ -382,7 +422,7 @@ runs:
     - name: Generate siso report
       if: ${{ inputs.target-platform != 'win' && !cancelled() }}
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
         cd src
         e d siso report -C out/Default > siso_report.txt
         SISO_REPORT_PATH=$(grep -o '/.*siso-report-[^ ]*' siso_report.txt)
@@ -392,7 +432,7 @@ runs:
     - name: Generate siso report (Windows)
       if: ${{ inputs.target-platform == 'win' && !cancelled() }}
       shell: powershell
-      run: |
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
         cd src
         e d siso report -C out\Default > siso_report.txt
         $SISO_REPORT_PATH = Get-Content "siso_report.txt" | Select-String "report file:\s*(.+)" | ForEach-Object { 
@@ -403,16 +443,21 @@ runs:
     - name: Generate Artifact Key
       if: always() && !cancelled()
       shell: bash
-      run: |
-        if [ "${{ inputs.is-asan }}" = "true" ] && [ "${{ inputs.is-ubsan }}" = "true" ]; then
+      env:
+        IS_ASAN: ${{ inputs.is-asan }}
+        IS_UBSAN: ${{ inputs.is-ubsan }}
+        ARTIFACT_PLATFORM: ${{ inputs.artifact-platform }}
+        TARGET_ARCH: ${{ inputs.target-arch }}
+      run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
+        if [ "$IS_ASAN" = "true" ] && [ "$IS_UBSAN" = "true" ]; then
           echo "Only one sanitizer build can be enabled at a time (set either is-asan or is-ubsan)."
           exit 1
-        elif [ "${{ inputs.is-asan }}" = "true" ]; then 
-          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ inputs.target-arch }}_asan
-        elif [ "${{ inputs.is-ubsan }}" = "true" ]; then
-          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ inputs.target-arch }}_ubsan
+        elif [ "$IS_ASAN" = "true" ]; then
+          ARTIFACT_KEY=${ARTIFACT_PLATFORM}_${TARGET_ARCH}_asan
+        elif [ "$IS_UBSAN" = "true" ]; then
+          ARTIFACT_KEY=${ARTIFACT_PLATFORM}_${TARGET_ARCH}_ubsan
         else
-          ARTIFACT_KEY=${{ inputs.artifact-platform }}_${{ inputs.target-arch }}
+          ARTIFACT_KEY=${ARTIFACT_PLATFORM}_${TARGET_ARCH}
         fi
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
     # The current generated_artifacts_<< artifact.key >> name was taken from CircleCI

--- a/.github/actions/build-git-cache/action.yml
+++ b/.github/actions/build-git-cache/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
   - name: Set GIT_CACHE_PATH to make gclient to use the cache
     shell: bash
-    run: |
+    run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
       echo "GIT_CACHE_PATH=$(pwd)/git-cache" >> $GITHUB_ENV
   - name: Set Chromium Git Cookie
     uses: ./src/electron/.github/actions/set-chromium-cookie
@@ -16,8 +16,10 @@ runs:
     uses: ./src/electron/.github/actions/install-build-tools
   - name: Set up cache drive
     shell: bash
+    env:
+      TARGET_PLATFORM: ${{ inputs.target-platform }}
     run: |
-      if [ "${{ inputs.target-platform }}" = "win" ]; then
+      if [ "$TARGET_PLATFORM" = "win" ]; then
         echo "CACHE_DRIVE=/mnt/win-cache" >> $GITHUB_ENV
       else
         echo "CACHE_DRIVE=/mnt/cross-instance-cache" >> $GITHUB_ENV

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
   - name: Set GIT_CACHE_PATH to make gclient to use the cache
     shell: bash
-    run: |
+    run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
       echo "GIT_CACHE_PATH=$(pwd)/git-cache" >> $GITHUB_ENV
   - name: Install Dependencies
     uses: ./src/electron/.github/actions/install-dependencies
@@ -26,12 +26,14 @@ runs:
     uses: ./src/electron/.github/actions/install-build-tools
   - name: Generate DEPS Hash
     shell: bash
-    run: |
+    env:
+      TARGET_PLATFORM: ${{ inputs.target-platform }}
+    run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
       node src/electron/script/generate-deps-hash.js
       DEPSHASH="v2-src-cache-$(cat src/electron/.depshash)"
       echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
       echo "CACHE_FILE=$DEPSHASH.tar" >> $GITHUB_ENV
-      if [ "${{ inputs.target-platform }}" = "win" ]; then
+      if [ "$TARGET_PLATFORM" = "win" ]; then
         echo "CACHE_DRIVE=/mnt/win-cache" >> $GITHUB_ENV
       else
         echo "CACHE_DRIVE=/mnt/cross-instance-cache" >> $GITHUB_ENV
@@ -39,8 +41,10 @@ runs:
   - name: Generate SAS Key
     if: ${{ inputs.generate-sas-token == 'true' }}
     shell: bash
+    env:
+      TARGET_PLATFORM: ${{ inputs.target-platform }}
     run: |
-      curl --unix-socket /var/run/sas/sas.sock --fail "http://foo/$CACHE_FILE?platform=${{ inputs.target-platform }}&getAccountName=true" > sas-token
+      curl --unix-socket /var/run/sas/sas.sock --fail "http://foo/$CACHE_FILE?platform=$TARGET_PLATFORM&getAccountName=true" > sas-token
   - name: Save SAS Key
     if: ${{ inputs.generate-sas-token == 'true' }}
     uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -51,8 +55,10 @@ runs:
   - name: Check If Cache Exists
     id: check-cache
     shell: bash
+    env:
+      USE_CACHE: ${{ inputs.use-cache }}
     run: |
-      if [[ "${{ inputs.use-cache }}" == "false" ]]; then
+      if [[ "$USE_CACHE" == "false" ]]; then
         echo "Not using cache this time..."
         echo "cache_exists=false" >> $GITHUB_OUTPUT
       else
@@ -98,6 +104,8 @@ runs:
   - name: Gclient Sync
     if: steps.check-cache.outputs.cache_exists == 'false'
     shell: bash
+    env:
+      IS_RELEASE: ${{ inputs.is-release }}
     run: |
       e d gclient config \
         --name "src/electron" \
@@ -110,7 +118,7 @@ runs:
       fi
 
       ELECTRON_DEPOT_TOOLS_WIN_TOOLCHAIN=0 DEPOT_TOOLS_WIN_TOOLCHAIN=0 ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 e d gclient sync --with_branch_heads --with_tags
-      if [[ "${{ inputs.is-release }}" != "true" ]]; then
+      if [[ "$IS_RELEASE" != "true" ]]; then
         # Re-export all the patches to check if there were changes.
         python3 src/electron/script/export_all_patches.py src/electron/patches/config.json
         cd src/electron

--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -120,10 +120,12 @@ runs:
     - name: Fix dsymutil (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       shell: bash
+      env:
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
       run : |
         # Fix dsymutil
-        if [ "${{ inputs.target-platform }}" = "macos" ]; then
-          if  [ "${{ env.TARGET_ARCH }}" == "arm64" ]; then
+        if [ "$TARGET_PLATFORM" = "macos" ]; then
+          if  [ "$TARGET_ARCH" == "arm64" ]; then
             DSYM_SHA_FILE=src/tools/clang/dsymutil/bin/dsymutil.arm64.sha1
           else
             DSYM_SHA_FILE=src/tools/clang/dsymutil/bin/dsymutil.x64.sha1
@@ -142,7 +144,7 @@ runs:
     - name: Set ninja in path
       if: ${{ inputs.target-platform != 'linux' }}
       shell: bash
-      run : |
+      run : | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, value is build config
         echo "$(pwd)/src/third_party/ninja" >> $GITHUB_PATH
     - name: Fix siso
       uses: ./src/electron/.github/actions/cipd-install

--- a/.github/actions/generate-types/action.yml
+++ b/.github/actions/generate-types/action.yml
@@ -12,17 +12,20 @@ runs:
   steps:
   - name: Generating Types for SHA in ${{ inputs.sha-file }}
     shell: bash
+    env:
+      SHA_FILE: ${{ inputs.sha-file }}
+      FILENAME: ${{ inputs.filename }}
     run: |
       export ELECTRON_DIR=$(pwd)
-      if [ "${{ inputs.sha-file }}" == ".dig-old" ]; then
+      if [ "$SHA_FILE" == ".dig-old" ]; then
         cd /tmp
         git clone https://github.com/electron/electron.git
         cd electron
       fi
-      git checkout $(cat $ELECTRON_DIR/${{ inputs.sha-file }})
+      git checkout $(cat "$ELECTRON_DIR/$SHA_FILE")
       node script/yarn.js install --immutable
       echo "#!/usr/bin/env node\nglobal.x=1" > node_modules/typescript/bin/tsc
       node node_modules/.bin/electron-docs-parser --dir=./ --outDir=./ --moduleVersion=0.0.0-development
       node node_modules/.bin/electron-typescript-definitions --api=electron-api.json --outDir=artifacts
-      mv artifacts/electron.d.ts $ELECTRON_DIR/artifacts/${{ inputs.filename }}
+      mv artifacts/electron.d.ts "$ELECTRON_DIR/artifacts/$FILENAME"
     working-directory: ./electron

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -5,7 +5,8 @@ runs:
   steps:
   - name: Install Build Tools
     shell: bash
-    run: |
+    # zizmor: ignore[adhoc-packages] the latest @electron/build-tools CLI is installed by design; it then pins depot_tools itself
+    run: | # zizmor: ignore[github-env] composite action; only run by trusted push/pull_request pipelines, paths are fixed depot_tools locations
       if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
         git config --global core.filemode false
         git config --global core.autocrlf false

--- a/.github/actions/restore-cache-aks/action.yml
+++ b/.github/actions/restore-cache-aks/action.yml
@@ -8,8 +8,10 @@ runs:
   steps:
   - name: Restore and Ensure Src Cache
     shell: bash
+    env:
+      TARGET_PLATFORM: ${{ inputs.target-platform }}
     run: |
-      if [ "${{ inputs.target-platform }}" = "win" ]; then
+      if [ "$TARGET_PLATFORM" = "win" ]; then
         cache_path=/mnt/win-cache/$DEPSHASH.tar
       else
         cache_path=/mnt/cross-instance-cache/$DEPSHASH.tar

--- a/.github/actions/set-chromium-cookie/action.yml
+++ b/.github/actions/set-chromium-cookie/action.yml
@@ -32,7 +32,7 @@ runs:
       fi
   - name: Set the git cookie from chromium.googlesource.com (Windows)
     if: ${{ runner.os == 'Windows' }}
-    shell: cmd
+    shell: cmd # zizmor: ignore[misfeature] cmd is deliberate: the cookie string's quoting only survives under cmd, and the step expands no untrusted input
     run: |
       if "%CHROMIUM_GIT_COOKIE_WINDOWS_STRING%"=="" (
         echo CHROMIUM_GIT_COOKIE_WINDOWS_STRING is not set - cannot authenticate.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - "no-backport"
       - "semver/none"
@@ -18,6 +20,8 @@ updates:
       - /npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - "no-backport"
     open-pull-requests-limit: 2
@@ -29,6 +33,8 @@ updates:
       - /npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
@@ -40,6 +46,8 @@ updates:
       - /npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
@@ -51,6 +59,8 @@ updates:
       - /npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
@@ -62,6 +72,8 @@ updates:
       - /npm
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0

--- a/.github/workflows/archaeologist-dig.yml
+++ b/.github/workflows/archaeologist-dig.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js/npm
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:

--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -27,6 +27,7 @@ jobs:
             .
             .github
             .yarn
+          persist-credentials: false
       - run: yarn workspaces focus @electron/gha-workflows
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: audit-errors

--- a/.github/workflows/branch-created.yml
+++ b/.github/workflows/branch-created.yml
@@ -278,9 +278,10 @@ jobs:
             }
       - name: Dump Release Project Board Contents
         if: ${{ steps.check-major-version.outputs.MAJOR }}
-        run: gh project item-list ${{ steps.create-release-board.outputs.number }} --owner electron --format json | jq
+        run: gh project item-list "$BOARD_NUMBER" --owner electron --format json | jq
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BOARD_NUMBER: ${{ steps.create-release-board.outputs.number }}
       - name: Find Previous Release Project Board
         if: ${{ steps.check-major-version.outputs.MAJOR }}
         uses: dsanders11/project-actions/find-project@4b06452b0128cf601dac14399aa668a8eed2d684 # v2.0.1

--- a/.github/workflows/build-git-cache.yml
+++ b/.github/workflows/build-git-cache.yml
@@ -18,6 +18,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -41,6 +43,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Build Git Cache
       uses: ./src/electron/.github/actions/build-git-cache
       with:
@@ -66,6 +69,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Build Git Cache
       uses: ./src/electron/.github/actions/build-git-cache
       with:
@@ -91,6 +95,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Build Git Cache
       uses: ./src/electron/.github/actions/build-git-cache
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,8 @@ jobs:
     with:
       container: '{"image":"ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}","options":"--user root"}'
       skip: ${{ needs.setup.outputs.pgo-only == 'true' }}
-    secrets: inherit
+    secrets:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
 
   # Docs Only Jobs
   docs-only:
@@ -150,7 +151,6 @@ jobs:
       contents: read
     with:
       container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
-    secrets: inherit
 
   # Checkout Jobs
   checkout-macos:
@@ -295,7 +295,8 @@ jobs:
       target-platform: macos
       target-archs: x64 arm64
       check-runs-on: macos-15
-    secrets: inherit
+    secrets:
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
 
   linux-gn-check:
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -308,7 +309,8 @@ jobs:
       target-archs: x64 arm64
       check-runs-on: electron-arc-centralus-linux-amd64-8core
       check-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root","volumes":["/mnt/cross-instance-cache:/mnt/cross-instance-cache"]}'
-    secrets: inherit
+    secrets:
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
 
   windows-gn-check:
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -320,7 +322,8 @@ jobs:
       target-archs: x64 arm64
       check-runs-on: electron-arc-centralus-linux-amd64-8core
       check-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-windows.outputs.build-image-sha }}","options":"--user root --device /dev/fuse --cap-add SYS_ADMIN","volumes":["/mnt/win-cache:/mnt/win-cache"]}'
-    secrets: inherit
+    secrets:
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
 
   # Build Jobs - These cascade into testing jobs
   macos-x64:
@@ -340,7 +343,17 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
       enable-ssh: ${{ inputs.enable-ssh || false }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   
   # macos-arm64, linux-x64, and windows-x64 carry the clang-tidy legs. When a
   # change touches no native code (per setup's native filter), run-clang-tidy
@@ -366,7 +379,17 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
       enable-ssh: ${{ inputs.enable-ssh || false }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   macos-arm64-ubsan:
     permissions:
@@ -387,7 +410,17 @@ jobs:
       upload-to-storage: '0'
       enable-ssh: ${{ inputs.enable-ssh || false }}
       is-ubsan: true
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   linux-x64:
     permissions:
@@ -411,7 +444,17 @@ jobs:
       gn-build-type: testing
       generate-symbols: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   linux-x64-asan:
     permissions:
@@ -433,7 +476,17 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
       is-asan: true
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   linux-x64-ubsan:
     permissions:
@@ -455,7 +508,17 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
       is-ubsan: true
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   
   linux-arm64:
     permissions:
@@ -476,7 +539,17 @@ jobs:
       gn-build-type: testing
       generate-symbols: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
     
   test-linux-arm64-64k:
     uses: ./.github/workflows/pipeline-segment-electron-test-64k.yml
@@ -488,7 +561,6 @@ jobs:
     with:
       test-runs-on: ubuntu-22.04-arm
       test-container: '{"image":"ghcr.io/electron/test:arm64v8-${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
-    secrets: inherit
 
   windows-x64:
     permissions:
@@ -510,7 +582,17 @@ jobs:
       gn-build-type: testing
       generate-symbols: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   windows-arm64:
     permissions:
@@ -529,7 +611,17 @@ jobs:
       gn-build-type: testing
       generate-symbols: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   gha-done:
     name: GitHub Actions Completed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,7 +344,7 @@ jobs:
       upload-to-storage: '0'
       enable-ssh: ${{ inputs.enable-ssh || false }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -380,7 +380,7 @@ jobs:
       upload-to-storage: '0'
       enable-ssh: ${{ inputs.enable-ssh || false }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -411,7 +411,7 @@ jobs:
       enable-ssh: ${{ inputs.enable-ssh || false }}
       is-ubsan: true
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -445,7 +445,7 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -477,7 +477,7 @@ jobs:
       upload-to-storage: '0'
       is-asan: true
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -509,7 +509,7 @@ jobs:
       upload-to-storage: '0'
       is-ubsan: true
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -540,7 +540,7 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -583,7 +583,7 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -612,7 +612,7 @@ jobs:
       generate-symbols: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     # The filters are evaluated per-pattern and OR'd together, so the src
     # exclusions must live inside a single negated brace pattern - a second
     # negated pattern would match (and re-include) every file the first one
@@ -176,6 +177,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:
@@ -211,6 +213,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:
@@ -243,6 +246,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:

--- a/.github/workflows/clean-orphaned-cache-uploads.yml
+++ b/.github/workflows/clean-orphaned-cache-uploads.yml
@@ -22,6 +22,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha

--- a/.github/workflows/clean-src-cache.yml
+++ b/.github/workflows/clean-src-cache.yml
@@ -21,6 +21,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -80,11 +80,12 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: electron/electron
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body-file - <<'EOF'
+          gh issue comment "$ISSUE_NUMBER" --body-file - <<EOF
           <!-- blocked/need-repro -->
 
-          Hello @${{ github.event.issue.user.login }}. Thanks for reporting this and helping to make Electron better!
+          Hello @${ISSUE_AUTHOR}. Thanks for reporting this and helping to make Electron better!
 
           Would it be possible for you to make a standalone testcase with only the code necessary to reproduce the issue? For example, [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small test cases and makes it easy to publish your test case to a [gist](https://gist.github.com) that Electron maintainers can use.
 

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -44,6 +44,7 @@ jobs:
             .
             .github
             .yarn
+          persist-credentials: false
       - run: yarn workspaces focus @electron/gha-workflows
       - name: Add labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -151,11 +151,12 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: electron/electron
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body-file - <<'EOF'
+          gh issue comment "$ISSUE_NUMBER" --body-file - <<EOF
           <!-- end-of-life -->
 
-          Hello @${{ github.event.issue.user.login }}. Thanks for reporting this and helping to make Electron better!
+          Hello @${ISSUE_AUTHOR}. Thanks for reporting this and helping to make Electron better!
 
           The version of Electron reported in this issue has reached end-of-life and is [no longer supported](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#timeline). If you're still experiencing this issue on a [supported version](https://releases.electronjs.org/) of Electron, please update this issue to reflect that version of Electron.
 

--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -25,6 +25,7 @@ jobs:
             ${{ env.ISSUE_TEMPLATE_DIR }}
             .github/workflows
             .yarn
+          persist-credentials: false
       - run: yarn workspaces focus @electron/gha-workflows
       - name: Check for required sections
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -93,7 +93,17 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   publish-arm64:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
@@ -116,4 +126,14 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -30,6 +30,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -56,6 +58,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
 

--- a/.github/workflows/linux-publish.yml
+++ b/.github/workflows/linux-publish.yml
@@ -94,7 +94,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -127,7 +127,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/macos-disk-cleanup.yml
+++ b/.github/workflows/macos-disk-cleanup.yml
@@ -31,6 +31,7 @@ jobs:
           sparse-checkout: |
             .github/actions/free-space-macos
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Get Disk Space Before Cleanup
         id: disk-before

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -30,6 +30,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -56,6 +58,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -98,7 +98,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -131,7 +131,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -164,7 +164,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -197,7 +197,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/macos-publish.yml
+++ b/.github/workflows/macos-publish.yml
@@ -97,7 +97,17 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   publish-x64-mas:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
@@ -120,7 +130,17 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   publish-arm64-darwin:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
@@ -143,7 +163,17 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   publish-arm64-mas:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
@@ -166,4 +196,14 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}

--- a/.github/workflows/non-maintainer-dependency-change.yml
+++ b/.github/workflows/non-maintainer-dependency-change.yml
@@ -1,7 +1,7 @@
 name: Check for Disallowed Non-Maintainer Change
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     paths:
       - 'yarn.lock'
       - 'spec/yarn.lock'

--- a/.github/workflows/pgo-generation-schedule.yml
+++ b/.github/workflows/pgo-generation-schedule.yml
@@ -35,6 +35,7 @@ jobs:
             .
             .github
             .yarn
+          persist-credentials: false
       - run: yarn workspaces focus @electron/gha-workflows
       - name: Dispatch PGO generation on main and supported branches
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -50,6 +50,8 @@ jobs:
       build-image-sha: ${{ steps.set-output.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Get Build Image SHA
       id: set-output
       uses: ./.github/actions/build-image-sha
@@ -80,6 +82,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
 
@@ -106,6 +109,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:
@@ -136,6 +140,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:
@@ -321,6 +326,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie
@@ -340,6 +346,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Run Electron Only Hooks
       run: |
         e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
@@ -499,6 +506,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
@@ -512,6 +520,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Download llvm-profdata
       run: |
         # --output-dir is required: the default location replaces the clang install.

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -197,7 +197,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   build-linux-arm64:
     permissions:
@@ -217,7 +227,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   build-macos-x64:
     permissions:
@@ -237,7 +257,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   build-macos-arm64:
     permissions:
@@ -257,7 +287,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   build-windows-x64:
     permissions:
@@ -276,7 +316,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   build-windows-arm64:
     permissions:
@@ -295,7 +345,17 @@ jobs:
       generate-chromedriver: false
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   # ---------------------------------------------------------------------------
   # V8 builtins PGO: instrumented d8 + JetStream 2 -> block-hint profile.
@@ -415,7 +475,6 @@ jobs:
       artifact-key: linux_x64
       collect-runs-on: electron-arc-centralus-linux-amd64-8core
       collect-container: '{"image":"ghcr.io/electron/build:${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
-    secrets: inherit
 
   collect-linux-arm64:
     permissions:
@@ -429,7 +488,6 @@ jobs:
       # Instrumented arm64 crashes on GitHub-hosted arm64 runners; ARC nodes work.
       collect-runs-on: electron-arc-centralus-linux-arm64-4core
       collect-container: '{"image":"ghcr.io/electron/test:arm64v8-${{ needs.checkout-linux.outputs.build-image-sha }}","options":"--user root --privileged --init"}'
-    secrets: inherit
 
   collect-macos-x64:
     permissions:
@@ -441,7 +499,6 @@ jobs:
       target-arch: x64
       artifact-key: darwin_x64
       collect-runs-on: macos-15-large
-    secrets: inherit
 
   collect-macos-arm64:
     permissions:
@@ -453,7 +510,6 @@ jobs:
       target-arch: arm64
       artifact-key: darwin_arm64
       collect-runs-on: macos-15
-    secrets: inherit
 
   collect-windows-x64:
     permissions:
@@ -465,7 +521,6 @@ jobs:
       target-arch: x64
       artifact-key: win_x64
       collect-runs-on: windows-latest
-    secrets: inherit
 
   collect-windows-arm64:
     permissions:
@@ -477,7 +532,6 @@ jobs:
       target-arch: arm64
       artifact-key: win_arm64
       collect-runs-on: windows-11-arm
-    secrets: inherit
 
   # ---------------------------------------------------------------------------
   # Merge: .profraw sets -> named .profdata (one x64 job, in-tree clang tooling)

--- a/.github/workflows/pgo-generation.yml
+++ b/.github/workflows/pgo-generation.yml
@@ -198,7 +198,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -228,7 +228,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -258,7 +258,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -288,7 +288,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -317,7 +317,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -346,7 +346,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -54,6 +54,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 
 permissions: {}
 
@@ -75,7 +96,17 @@ jobs:
       gn-build-type: ${{ inputs.gn-build-type }}
       generate-symbols: ${{ inputs.generate-symbols }}
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml
     permissions:
@@ -88,7 +119,15 @@ jobs:
       target-platform: ${{ inputs.target-platform }}
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
   nn-test:
     uses: ./.github/workflows/pipeline-segment-node-nan-test.yml
     permissions:
@@ -100,4 +139,6 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
-    secrets: inherit
+    secrets:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}

--- a/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-test-and-nan.yml
@@ -55,7 +55,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -97,7 +99,7 @@ jobs:
       generate-symbols: ${{ inputs.generate-symbols }}
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -120,7 +122,7 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -69,6 +69,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 
 concurrency:
   group: electron-build-and-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.is-asan }}-${{ inputs.is-ubsan }}-${{ github.ref_protected == true && github.run_id || github.ref }}
@@ -94,7 +115,17 @@ jobs:
       is-asan: ${{ inputs.is-asan }}
       is-ubsan: ${{ inputs.is-ubsan }}
       enable-ssh: ${{ inputs.enable-ssh }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml
     permissions:
@@ -110,4 +141,12 @@ jobs:
       is-asan: ${{ inputs.is-asan }}
       is-ubsan: ${{ inputs.is-ubsan }}
       enable-ssh: ${{ inputs.enable-ssh }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}

--- a/.github/workflows/pipeline-electron-build-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-test.yml
@@ -70,7 +70,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -116,7 +118,7 @@ jobs:
       is-ubsan: ${{ inputs.is-ubsan }}
       enable-ssh: ${{ inputs.enable-ssh }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -142,7 +144,7 @@ jobs:
       is-ubsan: ${{ inputs.is-ubsan }}
       enable-ssh: ${{ inputs.enable-ssh }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
@@ -68,6 +68,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 
 permissions: {}
 
@@ -90,7 +111,17 @@ jobs:
       generate-symbols: ${{ inputs.generate-symbols }}
       upload-to-storage: ${{ inputs.upload-to-storage }}
       upload-out-gen-artifacts: true
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   clang-tidy:
     uses: ./.github/workflows/pipeline-segment-electron-clang-tidy.yml
     permissions:
@@ -102,7 +133,6 @@ jobs:
       clang-tidy-container: ${{ inputs.clang-tidy-container }}
       target-platform: ${{ inputs.target-platform }}
       target-arch: ${{ inputs.target-arch }}
-    secrets: inherit
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml
     permissions:
@@ -115,7 +145,15 @@ jobs:
       target-platform: ${{ inputs.target-platform }}
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
   test-wayland:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml
     permissions:
@@ -130,7 +168,15 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
       display-server: wayland
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
   nn-test:
     uses: ./.github/workflows/pipeline-segment-node-nan-test.yml
     permissions:
@@ -142,4 +188,6 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
       gn-build-type: ${{ inputs.gn-build-type }}
-    secrets: inherit
+    secrets:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}

--- a/.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
+++ b/.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
@@ -69,7 +69,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -112,7 +114,7 @@ jobs:
       upload-to-storage: ${{ inputs.upload-to-storage }}
       upload-out-gen-artifacts: true
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -146,7 +148,7 @@ jobs:
       test-runs-on: ${{ inputs.test-runs-on }}
       test-container: ${{ inputs.test-container }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -169,7 +171,7 @@ jobs:
       test-container: ${{ inputs.test-container }}
       display-server: wayland
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
@@ -73,6 +73,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 
 concurrency:
   group: electron-build-and-tidy-and-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ github.ref_protected == true && github.run_id || github.ref }}
@@ -97,7 +118,17 @@ jobs:
       is-asan: ${{ inputs.is-asan }}
       enable-ssh: ${{ inputs.enable-ssh }}
       upload-out-gen-artifacts: true
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   clang-tidy:
     uses: ./.github/workflows/pipeline-segment-electron-clang-tidy.yml
     permissions:
@@ -109,7 +140,6 @@ jobs:
       clang-tidy-container: ${{ inputs.clang-tidy-container }}
       target-platform: ${{ inputs.target-platform }}
       target-arch: ${{ inputs.target-arch }}
-    secrets: inherit
   test:
     uses: ./.github/workflows/pipeline-segment-electron-test.yml
     permissions:
@@ -124,4 +154,12 @@ jobs:
       test-container: ${{ inputs.test-container }}
       is-asan: ${{ inputs.is-asan }}
       enable-ssh: ${{ inputs.enable-ssh }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}

--- a/.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
+++ b/.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
@@ -74,7 +74,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -119,7 +121,7 @@ jobs:
       enable-ssh: ${{ inputs.enable-ssh }}
       upload-out-gen-artifacts: true
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -155,7 +157,7 @@ jobs:
       is-asan: ${{ inputs.is-asan }}
       enable-ssh: ${{ inputs.enable-ssh }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/pipeline-electron-docs-only.yml
+++ b/.github/workflows/pipeline-electron-docs-only.yml
@@ -32,6 +32,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Generate DEPS Hash
       run: |
         node src/electron/script/generate-deps-hash.js
@@ -48,6 +49,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Run TS/JS compile

--- a/.github/workflows/pipeline-electron-docs-only.yml
+++ b/.github/workflows/pipeline-electron-docs-only.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 20
-    container: ${{ fromJSON(inputs.container) }}
+    container: ${{ fromJSON(inputs.container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     steps:
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -12,6 +12,9 @@ on:
         description: 'Skip the actual lint work but still report the lint / Lint check as skipped'
         type: boolean
         default: false
+    secrets:
+      CHROMIUM_GIT_COOKIE:
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 20
-    container: ${{ fromJSON(inputs.container) }}
+    container: ${{ fromJSON(inputs.container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     steps:
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/pipeline-electron-lint.yml
+++ b/.github/workflows/pipeline-electron-lint.yml
@@ -38,6 +38,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Set Chromium Git Cookie

--- a/.github/workflows/pipeline-segment-build-siso.yml
+++ b/.github/workflows/pipeline-segment-build-siso.yml
@@ -57,6 +57,7 @@ jobs:
         sparse-checkout: |
           DEPS
           .github/siso-patches
+        persist-credentials: false
     - name: Resolve siso revision from Chromium DEPS
       id: resolve
       run: |

--- a/.github/workflows/pipeline-segment-build-siso.yml
+++ b/.github/workflows/pipeline-segment-build-siso.yml
@@ -131,9 +131,10 @@ jobs:
         CGO_ENABLED: '0'
         GOOS: ${{ steps.host.outputs.goos }}
         GOARCH: ${{ steps.host.outputs.goarch }}
+        BINARY: ${{ steps.host.outputs.binary }}
       run: |
         mkdir -p "${GITHUB_WORKSPACE}/siso-out"
-        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/${{ steps.host.outputs.binary }}" .
+        go build -trimpath -o "${GITHUB_WORKSPACE}/siso-out/${BINARY}" .
     - name: Upload siso artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -155,12 +155,15 @@ jobs:
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Set GN_EXTRA_ARGS for Linux
       if: ${{ inputs.target-platform == 'linux' }}
+      env:
+        IS_ASAN: ${{ inputs.is-asan }}
+        IS_UBSAN: ${{ inputs.is-ubsan }}
       run: |
-        if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+        if [ "$TARGET_ARCH" = "arm64" ]; then
           GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
-        elif [ "${{ inputs.is-asan }}" = true ]; then
+        elif [ "$IS_ASAN" = true ]; then
           GN_EXTRA_ARGS='is_asan=true is_lsan=true v8_enable_verify_heap=true'
-        elif [ "${{ inputs.is-ubsan }}" = true ]; then
+        elif [ "$IS_UBSAN" = true ]; then
           GN_EXTRA_ARGS='is_ubsan=true is_ubsan_no_recover=true'
         fi
         echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
@@ -211,8 +214,10 @@ jobs:
       env:
         ELECTRON_DEPOT_TOOLS_DISABLE_LOG: true
     - name: Init Build Tools
+      env:
+        GN_BUILD_TYPE: ${{ inputs.gn-build-type }}
       run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }} --remote-build siso
+        e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE" --import "$GN_BUILD_TYPE" --target-cpu "$TARGET_ARCH" --remote-build siso
     - name: Run Electron Only Hooks
       run: |
         e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -84,7 +84,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -120,7 +122,7 @@ env:
   SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   GCLIENT_EXTRA_ARGS: ${{ inputs.target-platform == 'macos' && '--custom-var=checkout_mac=True --custom-var=host_os=mac' || inputs.target-platform == 'win' && '--custom-var=checkout_win=True' || '--custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
-  ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  ACTIONS_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
   RUNNER_LABEL: ${{ inputs.build-runs-on }}
 
 jobs:

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -125,6 +125,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Setup SSH Debugging
       if: ${{ inputs.target-platform == 'macos' && (inputs.enable-ssh || env.ACTIONS_STEP_DEBUG == 'true') }}
       uses: ./src/electron/.github/actions/ssh-debug
@@ -201,6 +202,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Fix Sync
       if: ${{ inputs.target-platform != 'linux' }}
       uses: ./src/electron/.github/actions/fix-sync

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -83,6 +83,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/pipeline-segment-electron-build.yml
+++ b/.github/workflows/pipeline-segment-electron-build.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ inputs.build-runs-on }}
     permissions:
       contents: read
-    container: ${{ fromJSON(inputs.build-container) }}
+    container: ${{ fromJSON(inputs.build-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     environment: ${{ inputs.environment }}
     env:
       TARGET_ARCH: ${{ inputs.target-arch }}

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -52,6 +52,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Cleanup disk space on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       shell: bash
@@ -99,6 +100,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Fix hermetic Python (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/cipd-install

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -113,14 +113,14 @@ jobs:
     - name: Run Electron Only Hooks
       run: |
         echo "solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]" > tmpgclient
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           echo "solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False,'install_sysroot':False,'checkout_win':True},'managed':False}]" > tmpgclient
           echo "target_os=['win']" >> tmpgclient
         fi
         e d gclient runhooks --gclientfile=tmpgclient
 
         # Fix VS Toolchain
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           rm -rf src/third_party/depot_tools/win_toolchain/vs_files
           e d python3 src/build/vs_toolchain.py update --force
         fi
@@ -151,7 +151,7 @@ jobs:
 
         # For macOS use_remoteexec=false will cause GN errors, so even though we're doing no remote build, set it
         export GN_EXTRA_ARGS="use_remoteexec=true target_cpu=\"${TARGET_ARCH}\""
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
         fi
 
@@ -160,7 +160,7 @@ jobs:
         # Copy macOS framework headers so clang-tidy can find them via -F.
         # This must happen after e build since e init -f may
         # recreate the output directory.
-        if [ "${{ inputs.target-platform }}" = "macos" ]; then
+        if [ "$TARGET_PLATFORM" = "macos" ]; then
           OUT=src/out/${ELECTRON_OUT_DIR}
           SQRL=src/third_party/squirrel.mac
 

--- a/.github/workflows/pipeline-segment-electron-clang-tidy.yml
+++ b/.github/workflows/pipeline-segment-electron-clang-tidy.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.clang-tidy-runs-on }}
     permissions:
       contents: read
-    container: ${{ fromJSON(inputs.clang-tidy-container) }}
+    container: ${{ fromJSON(inputs.clang-tidy-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     env:
       BUILD_TYPE: ${{ inputs.target-platform == 'macos' && 'darwin' || inputs.target-platform }}
       TARGET_ARCH: ${{ inputs.target-arch }}

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ inputs.check-runs-on }}
     permissions:
       contents: read
-    container: ${{ fromJSON(inputs.check-container) }}
+    container: ${{ fromJSON(inputs.check-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     steps:
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -48,6 +48,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Cleanup disk space on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       shell: bash
@@ -95,6 +96,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Fix hermetic Python (macOS)
       if: ${{ inputs.target-platform == 'macos' }}
       uses: ./src/electron/.github/actions/cipd-install

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -107,16 +107,18 @@ jobs:
         target-platform: ${{ inputs.target-platform }}
         package: infra/3pp/tools/cpython3/${platform}
     - name: Run Electron Only Hooks
+      env:
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
       run: |
         echo "solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]" > tmpgclient
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           echo "solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False,'install_sysroot':False,'checkout_win':True},'managed':False}]" > tmpgclient
           echo "target_os=['win']" >> tmpgclient
         fi
         e d gclient runhooks --gclientfile=tmpgclient
 
         # Fix VS Toolchain
-        if [ "${{ inputs.target-platform }}" = "win" ]; then
+        if [ "$TARGET_PLATFORM" = "win" ]; then
           rm -rf src/third_party/depot_tools/win_toolchain/vs_files
           e d python3 src/build/vs_toolchain.py update --force
         fi
@@ -138,20 +140,23 @@ jobs:
     # needed: gn gen only read_file()s the checked-in state files in
     # build/pgo_profiles, the profiles themselves are compile-time inputs.
     - name: Run GN Check for ${{ inputs.target-archs }}
+      env:
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
+        TARGET_ARCHS: ${{ inputs.target-archs }}
       run: |
         for build_type in testing release
         do
-          for target_cpu in ${{ inputs.target-archs }}
+          for target_cpu in $TARGET_ARCHS
           do
             e init -f --root=$(pwd) --out=Default $build_type --import $build_type --target-cpu $target_cpu --remote-build none
             cd src/electron
             export GN_EXTRA_ARGS="target_cpu=\"$target_cpu\""
-            if [ "${{ inputs.target-platform }}" = "linux" ]; then
+            if [ "$TARGET_PLATFORM" = "linux" ]; then
               if [ "$target_cpu" = "arm64" ]; then
                 export GN_EXTRA_ARGS="$GN_EXTRA_ARGS fatal_linker_warnings=false enable_linux_installer=false"
               fi
             fi
-            if [ "${{ inputs.target-platform }}" = "win" ]; then
+            if [ "$TARGET_PLATFORM" = "win" ]; then
               export GN_EXTRA_ARGS="$GN_EXTRA_ARGS use_v8_context_snapshot=true target_os=\"win\""
             fi
 
@@ -161,7 +166,7 @@ jobs:
 
             # The publish matrix also builds a Mac App Store variant of every
             # macOS release, so check that graph too.
-            if [ "${{ inputs.target-platform }}" = "macos" ] && [ "$build_type" = "release" ]; then
+            if [ "$TARGET_PLATFORM" = "macos" ] && [ "$build_type" = "release" ]; then
               export GN_EXTRA_ARGS="$GN_EXTRA_ARGS is_mas_build=true"
 
               e build --gen=only

--- a/.github/workflows/pipeline-segment-electron-gn-check.yml
+++ b/.github/workflows/pipeline-segment-electron-gn-check.yml
@@ -20,6 +20,9 @@ on:
         description: 'JSON container information for aks runs-on'
         required: false
         default: '{"image":null}'
+    secrets:
+      ELECTRON_RBE_JWT:
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -2,6 +2,7 @@
 # ONLY EDIT .github/workflows/pipeline-segment-electron-build.yml
 
 name: Pipeline Segment - Electron Publish
+
 on:
   workflow_call:
     inputs:
@@ -11,78 +12,78 @@ on:
         type: string
       target-platform:
         type: string
-        description: Platform to run on, can be macos, win or linux
+        description: 'Platform to run on, can be macos, win or linux'
         required: true
       target-arch:
         type: string
-        description: Arch to build for, can be x64 or arm64
+        description: 'Arch to build for, can be x64 or arm64'
         required: true
       target-variant:
         type: string
-        description: Variant to build for, no effect on non-macOS target platforms. Can
-          be darwin, mas or all.
+        description: 'Variant to build for, no effect on non-macOS target platforms. Can
+          be darwin, mas or all.'
         default: all
       build-runs-on:
         type: string
-        description: What host to run the build
+        description: 'What host to run the build'
         required: true
       build-container:
         type: string
-        description: JSON container information for aks runs-on
+        description: 'JSON container information for aks runs-on'
         required: false
         default: '{"image":null}'
       is-release:
-        description: Whether this build job is a release job
+        description: 'Whether this build job is a release job'
         required: true
         type: boolean
         default: false
       gn-build-type:
-        description: The gn build type - testing or release
+        description: 'The gn build type - testing or release'
         required: true
         type: string
         default: testing
       generate-symbols:
-        description: Whether or not to generate symbols
+        description: 'Whether or not to generate symbols'
         required: true
         type: boolean
         default: false
       generate-chromedriver:
-        description: Whether or not to build chromedriver
+        description: 'Whether or not to build chromedriver'
         required: false
         type: boolean
         default: true
       generate-test-artifacts:
-        description: Whether or not to generate artifacts only consumed by test jobs
+        description: 'Whether or not to generate artifacts only consumed by test jobs'
         required: false
         type: boolean
         default: true
       upload-to-storage:
-        description: Whether or not to upload build artifacts to external storage
+        description: 'Whether or not to upload build artifacts to external storage'
         required: true
         type: string
-        default: "0"
+        default: '0'
       is-asan:
-        description: Building the Address Sanitizer (ASan) Linux build
+        description: 'Building the Address Sanitizer (ASan) Linux build'
         required: false
         type: boolean
         default: false
       is-ubsan:
-        description: Building the Undefined Behavior Sanitizer (UBSan) build
+        description: 'Building the Undefined Behavior Sanitizer (UBSan) build'
         required: false
         type: boolean
         default: false
       upload-out-gen-artifacts:
-        description: Whether to upload the src/gen artifacts
+        description: 'Whether to upload the src/gen artifacts'
         required: false
         type: boolean
         default: false
       publish:
-        description: Whether to publish a release
+        description: 'Whether to publish a release'
         required: false
         type: boolean
         default: false
       enable-ssh:
-        description: Enable SSH debugging
+        description: 'Enable SSH debugging'
         required: false
         type: boolean
         default: false
@@ -107,13 +108,16 @@ on:
         required: false
       SUDOWOODO_EXCHANGE_URL:
         required: false
+
 permissions: {}
+
 concurrency:
   group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch
     }}-${{ inputs.target-variant }}-${{ inputs.is-asan }}-${{ inputs.is-ubsan
     }}-${{ inputs.is-release }}-${{ github.ref_protected == true &&
     github.run_id || github.ref }}
   cancel-in-progress: ${{ github.ref_protected != true }}
+
 env:
   CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
   CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
@@ -128,6 +132,7 @@ env:
   ELECTRON_OUT_DIR: Default
   ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
   RUNNER_LABEL: ${{ inputs.build-runs-on }}
+
 jobs:
   build:
     defaults:
@@ -160,13 +165,16 @@ jobs:
           env.ACTIONS_STEP_DEBUG == 'true') }}
         uses: ./src/electron/.github/actions/ssh-debug
         with:
-          tunnel: "true"
+          tunnel: 'true'
         env:
           CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
           CLOUDFLARE_TUNNEL_HOSTNAME: ${{ vars.CLOUDFLARE_TUNNEL_HOSTNAME }}
           CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
           AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Safe to background: it only deletes preinstalled toolchains/simulators that
+      # none of the setup steps below read; the wait-all before the src cache
+      # restore (the step that needs the freed disk) is a no-op on win/linux.
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos
@@ -184,21 +192,20 @@ jobs:
         if: ${{ inputs.target-platform == 'linux' }}
         env:
           IS_ASAN: ${{ inputs.is-asan }}
-        run: >
+          IS_UBSAN: ${{ inputs.is-ubsan }}
+        run: |
           if [ "$TARGET_ARCH" = "arm64" ]; then
             GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
           elif [ "$IS_ASAN" = true ]; then
             GN_EXTRA_ARGS='is_asan=true is_lsan=true v8_enable_verify_heap=true'
-          elif [ "${{ inputs.is-ubsan }}" = true ]; then
+          elif [ "$IS_UBSAN" = true ]; then
             GN_EXTRA_ARGS='is_ubsan=true is_ubsan_no_recover=true'
           fi
-
           echo "GN_EXTRA_ARGS=$GN_EXTRA_ARGS" >> $GITHUB_ENV
       - name: Set GN_EXTRA_ARGS for macOS UBSan
         if: ${{ inputs.target-platform == 'macos' && inputs.is-ubsan }}
-        run: >
-          echo "GN_EXTRA_ARGS=is_ubsan=true is_ubsan_no_recover=true" >>
-          $GITHUB_ENV
+        run: |
+          echo "GN_EXTRA_ARGS=is_ubsan=true is_ubsan_no_recover=true" >> $GITHUB_ENV
       - name: Set Chromium Git Cookie
         uses: ./src/electron/.github/actions/set-chromium-cookie
       - name: Install Build Tools
@@ -210,10 +217,12 @@ jobs:
           echo "DEPSHASH=$DEPSHASH" >> $GITHUB_ENV
           echo "CACHE_PATH=$DEPSHASH.tar" >> $GITHUB_ENV
       - name: Wait for space cleanup to finish
-        wait-all: null
+        wait-all:
       - name: Check disk space after freeing up space
         if: ${{ inputs.target-platform == 'macos' }}
         run: df -h
+      # Must stay after the wait: free-space-macos runs brew uninstall/autoremove,
+      # which cannot overlap another brew invocation.
       - name: Install AZCopy
         if: ${{ inputs.target-platform == 'macos' }}
         run: brew install azcopy
@@ -242,43 +251,47 @@ jobs:
       - name: Init Build Tools
         env:
           GN_BUILD_TYPE: ${{ inputs.gn-build-type }}
-        run: >
-          e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE"
-          --import "$GN_BUILD_TYPE" --target-cpu "$TARGET_ARCH" --remote-build siso
+        run: |
+          e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE" --import "$GN_BUILD_TYPE" --target-cpu "$TARGET_ARCH" --remote-build siso
       - name: Run Electron Only Hooks
         run: |
           e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"
+      # Release builds consume Electron-generated PGO profiles, resolved through
+      # the state files in build/pgo_profiles. The gclient hooks that download
+      # them do not run in build jobs ("Run Electron Only Hooks" sets
+      # process_deps=False, and cross-compiled targets do not match the host's
+      # checkout_* vars), so fetch exactly this build's profile here.
       - name: Download PGO Profiles
         if: ${{ inputs.gn-build-type == 'release' }}
         env:
           PGO_TARGET: ${{ inputs.target-platform }}-${{ inputs.target-arch }}
-        run: >
-          python3 src/electron/script/pgo/download-profiles.py --targets
-          "$PGO_TARGET,v8-builtins"
+        run: |
+          python3 src/electron/script/pgo/download-profiles.py --targets "$PGO_TARGET,v8-builtins"
       - name: Regenerate DEPS Hash
-        run: >
-          (cd src/electron && git checkout .) && node
-          src/electron/script/generate-deps-hash.js
-
+        run: |
+          (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
           echo "DEPSHASH=$(cat src/electron/.depshash)" >> $GITHUB_ENV
       - name: Free up space (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
         uses: ./src/electron/.github/actions/free-space-macos
+      # siso runs on the build host, not the target, so the artifact is chosen by
+      # build-host os/arch: win -> windows-amd64, linux (any target arch) ->
+      # linux-amd64, macOS (x64 or arm64, both built on arm64 hosts) -> darwin-arm64.
       - name: Download custom siso binary (Windows)
         if: ${{ inputs.target-platform == 'win' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: siso-windows-amd64
           path: ${{ runner.temp }}/siso
       - name: Download custom siso binary (Linux)
         if: ${{ inputs.target-platform == 'linux' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: siso-linux-amd64
           path: ${{ runner.temp }}/siso
       - name: Download custom siso binary (macOS)
         if: ${{ inputs.target-platform == 'macos' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: siso-darwin-arm64
           path: ${{ runner.temp }}/siso
@@ -329,15 +342,15 @@ jobs:
           target-platform: ${{ inputs.target-platform }}
           artifact-platform: ${{ inputs.target-platform == 'macos' && 'darwin' ||
             inputs.target-platform }}
-          is-release: ${{ inputs.is-release }}
-          generate-symbols: ${{ inputs.generate-symbols }}
-          generate-chromedriver: ${{ inputs.generate-chromedriver }}
-          generate-test-artifacts: ${{ inputs.generate-test-artifacts }}
-          upload-to-storage: ${{ inputs.upload-to-storage }}
-          is-asan: ${{ inputs.is-asan }}
-          is-ubsan: ${{ inputs.is-ubsan }}
-          upload-out-gen-artifacts: ${{ inputs.upload-out-gen-artifacts }}
-          publish: ${{ inputs.publish }}
+          is-release: '${{ inputs.is-release }}'
+          generate-symbols: '${{ inputs.generate-symbols }}'
+          generate-chromedriver: '${{ inputs.generate-chromedriver }}'
+          generate-test-artifacts: '${{ inputs.generate-test-artifacts }}'
+          upload-to-storage: '${{ inputs.upload-to-storage }}'
+          is-asan: '${{ inputs.is-asan }}'
+          is-ubsan: '${{ inputs.is-ubsan }}'
+          upload-out-gen-artifacts: '${{ inputs.upload-out-gen-artifacts }}'
+          publish: '${{ inputs.publish }}'
       - name: Set GN_EXTRA_ARGS for MAS Build
         if: ${{ inputs.target-platform == 'macos' && (inputs.target-variant == 'all' ||
           inputs.target-variant == 'mas') }}
@@ -352,11 +365,11 @@ jobs:
         with:
           target-arch: ${{ inputs.target-arch }}
           target-platform: ${{ inputs.target-platform }}
-          artifact-platform: mas
-          is-release: ${{ inputs.is-release }}
-          generate-symbols: ${{ inputs.generate-symbols }}
-          generate-chromedriver: ${{ inputs.generate-chromedriver }}
-          generate-test-artifacts: ${{ inputs.generate-test-artifacts }}
-          upload-to-storage: ${{ inputs.upload-to-storage }}
-          step-suffix: (mas)
-          publish: ${{ inputs.publish }}
+          artifact-platform: 'mas'
+          is-release: '${{ inputs.is-release }}'
+          generate-symbols: '${{ inputs.generate-symbols }}'
+          generate-chromedriver: '${{ inputs.generate-chromedriver }}'
+          generate-test-artifacts: '${{ inputs.generate-test-artifacts }}'
+          upload-to-storage: '${{ inputs.upload-to-storage }}'
+          step-suffix: '(mas)'
+          publish: '${{ inputs.publish }}'

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -133,6 +133,7 @@ jobs:
           path: src/electron
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Setup SSH Debugging
         if: ${{ inputs.target-platform == 'macos' && (inputs.enable-ssh ||
           env.ACTIONS_STEP_DEBUG == 'true') }}
@@ -207,6 +208,7 @@ jobs:
           path: src/electron
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Fix Sync
         if: ${{ inputs.target-platform != 'linux' }}
         uses: ./src/electron/.github/actions/fix-sync

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -88,7 +88,9 @@ on:
         type: boolean
         default: false
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -130,7 +132,7 @@ env:
     inputs.target-platform == 'win' && '--custom-var=checkout_win=True' ||
     '--custom-var=checkout_arm64=True' }}
   ELECTRON_OUT_DIR: Default
-  ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  ACTIONS_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
   RUNNER_LABEL: ${{ inputs.build-runs-on }}
 
 jobs:

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -161,10 +161,12 @@ jobs:
         uses: ./src/electron/.github/actions/install-dependencies
       - name: Set GN_EXTRA_ARGS for Linux
         if: ${{ inputs.target-platform == 'linux' }}
+        env:
+          IS_ASAN: ${{ inputs.is-asan }}
         run: >
-          if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+          if [ "$TARGET_ARCH" = "arm64" ]; then
             GN_EXTRA_ARGS='target_cpu="arm64" fatal_linker_warnings=false enable_linux_installer=false'
-          elif [ "${{ inputs.is-asan }}" = true ]; then
+          elif [ "$IS_ASAN" = true ]; then
             GN_EXTRA_ARGS='is_asan=true is_lsan=true v8_enable_verify_heap=true'
           elif [ "${{ inputs.is-ubsan }}" = true ]; then
             GN_EXTRA_ARGS='is_ubsan=true is_ubsan_no_recover=true'
@@ -217,10 +219,11 @@ jobs:
         env:
           ELECTRON_DEPOT_TOOLS_DISABLE_LOG: true
       - name: Init Build Tools
+        env:
+          GN_BUILD_TYPE: ${{ inputs.gn-build-type }}
         run: >
-          e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }}
-          --import ${{ inputs.gn-build-type }} --target-cpu ${{
-          inputs.target-arch }} --remote-build siso
+          e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE"
+          --import "$GN_BUILD_TYPE" --target-cpu "$TARGET_ARCH" --remote-build siso
       - name: Run Electron Only Hooks
         run: |
           e d gclient runhooks --spec="solutions=[{'name':'src/electron','url':None,'deps_file':'DEPS','custom_vars':{'process_deps':False},'managed':False}]"

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -118,7 +118,7 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    container: ${{ fromJSON(inputs.build-container) }}
+    container: ${{ fromJSON(inputs.build-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     environment: ${{ inputs.environment }}
     env:
       TARGET_ARCH: ${{ inputs.target-arch }}

--- a/.github/workflows/pipeline-segment-electron-publish.yml
+++ b/.github/workflows/pipeline-segment-electron-publish.yml
@@ -86,6 +86,27 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_ARTIFACTS_BLOB_STORAGE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
+      SUDOWOODO_EXCHANGE_URL:
+        required: false
 permissions: {}
 concurrency:
   group: electron-build-${{ inputs.target-platform }}-${{ inputs.target-arch

--- a/.github/workflows/pipeline-segment-electron-test-64k.yml
+++ b/.github/workflows/pipeline-segment-electron-test-64k.yml
@@ -62,7 +62,8 @@ jobs:
         MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap
         ELECTRON_DISABLE_SECURITY_WARNINGS: 1
         DISPLAY: ':99.0'
+        TEST_CONTAINER: ${{ inputs.test-container }}
       run: |
-        container=$(echo '${{ inputs.test-container }}' | jq -r '.image')
+        container=$(echo "$TEST_CONTAINER" | jq -r '.image')
         src/electron/script/run-qemu-64k.sh --container $container --testfiles "`pwd`/src"
         

--- a/.github/workflows/pipeline-segment-electron-test-64k.yml
+++ b/.github/workflows/pipeline-segment-electron-test-64k.yml
@@ -42,6 +42,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Download Generated Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -170,13 +170,13 @@ jobs:
     - name: Load ASan specific environment variables
       if: ${{ inputs.is-asan == true }}
       run: |
-        echo "ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_asan" >> $GITHUB_ENV
+        echo "ARTIFACT_KEY=${BUILD_TYPE}_${TARGET_ARCH}_asan" >> $GITHUB_ENV
         echo "DISABLE_CRASH_REPORTER_TESTS=true" >> $GITHUB_ENV
         echo "IS_ASAN=true" >> $GITHUB_ENV
     - name: Load UBSan specific environment variables
       if: ${{ inputs.is-ubsan == true }}
       run: |
-        echo "ARTIFACT_KEY=${{ matrix.build-type }}_${{ inputs.target-arch }}_ubsan" >> $GITHUB_ENV
+        echo "ARTIFACT_KEY=${BUILD_TYPE}_${TARGET_ARCH}_ubsan" >> $GITHUB_ENV
         echo "DISABLE_CRASH_REPORTER_TESTS=true" >> $GITHUB_ENV
         echo "IS_UBSAN=true" >> $GITHUB_ENV
     # Safe to parallelize: each step writes a disjoint location (src/electron
@@ -308,12 +308,18 @@ jobs:
         ELECTRON_DISABLE_SECURITY_WARNINGS: 1
         DISPLAY: ':99.0'
         NPM_CONFIG_MSVS_VERSION: '2022'
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
+        DISPLAY_SERVER: ${{ inputs.display-server }}
+        IS_ASAN: ${{ inputs.is-asan }}
+        IS_UBSAN: ${{ inputs.is-ubsan }}
+        SHARD: ${{ matrix.shard }}
+        SHARD_COUNT: ${{ case(inputs.display-server == 'wayland', 1, inputs.target-platform == 'macos' && inputs.is-ubsan, 3, inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }}
       run: |
         cd src/electron
         export ELECTRON_TEST_RESULTS_DIR=`pwd`/junit
         # Get which tests are on this shard
-        tests_files=$(node script/split-tests ${{ matrix.shard }} ${{ case(inputs.display-server == 'wayland', 1, inputs.target-platform == 'macos' && inputs.is-ubsan, 3, inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }})
-        if [ "${{ inputs.display-server }}" = "wayland" ]; then
+        tests_files=$(node script/split-tests "$SHARD" "$SHARD_COUNT")
+        if [ "$DISPLAY_SERVER" = "wayland" ]; then
           allowlist_file=script/wayland-test-allowlist.txt
           filtered_tests=""
           for test_file in $tests_files; do
@@ -330,14 +336,14 @@ jobs:
         fi
 
         # Run tests
-        if [ "${{ inputs.target-platform }}" != "linux" ]; then
+        if [ "$TARGET_PLATFORM" != "linux" ]; then
           echo "About to start tests"
-          if [ "${{ inputs.target-platform }}" = "win" ]; then
-            if [ "${{ inputs.target-arch }}" = "arm64" ]; then
+          if [ "$TARGET_PLATFORM" = "win" ]; then
+            if [ "$TARGET_ARCH" = "arm64" ]; then
               export ELECTRON_FORCE_TEST_SUITE_EXIT="true"
             fi
           fi
-          if [ "${{ inputs.is-ubsan }}" = "true" ]; then
+          if [ "$IS_UBSAN" = "true" ]; then
             export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:external_symbolizer_path=$PWD/../third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer"
             export MOCHA_TIMEOUT=180000
             node script/yarn.js test --runners=main --trace-uncaught --enable-logging --files $tests_files
@@ -349,7 +355,7 @@ jobs:
           chown -R :builduser . && chmod -R g+w .
           chmod 4755 ../out/Default/chrome-sandbox
           runuser -u builduser -- git config --global --add safe.directory $(pwd)
-          if [ "${{ inputs.is-asan }}" == "true" ]; then
+          if [ "$IS_ASAN" == "true" ]; then
             cd ..
             ASAN_SYMBOLIZE="$PWD/tools/valgrind/asan/asan_symbolize.py --executable-path=$PWD/out/Default/electron"
             # symbolize=1 is required for leak suppressions to work: LSan can
@@ -366,14 +372,14 @@ jobs:
             echo "Piping output to ASAN_SYMBOLIZE ($ASAN_SYMBOLIZE)"
             cd electron
             runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn.js test --runners=main --trace-uncaught --enable-logging --files $tests_files | $ASAN_SYMBOLIZE
-          elif [ "${{ inputs.is-ubsan }}" == "true" ]; then
+          elif [ "$IS_UBSAN" == "true" ]; then
             cd ..
             export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:external_symbolizer_path=$PWD/third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer"
             export MOCHA_TIMEOUT=180000
             cd electron
             runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn.js test --runners=main --trace-uncaught --enable-logging --files $tests_files
           else
-            if [ "${{ inputs.display-server }}" = "wayland" ]; then
+            if [ "$DISPLAY_SERVER" = "wayland" ]; then
               runuser -u builduser -- script/actions/run-tests-wayland.sh script/yarn.js test --runners=main --enableRerun=3 --trace-uncaught --enable-logging --files $tests_files
             else
               runuser -u builduser -- xvfb-run script/actions/run-tests.sh script/yarn.js test --runners=main --enableRerun=3 --trace-uncaught --enable-logging --files $tests_files
@@ -396,13 +402,15 @@ jobs:
     - name: Take screenshot on timeout or cancellation
       if: ${{ inputs.target-platform != 'linux' && (cancelled() || failure()) }}
       shell: bash
+      env:
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
       run: |
         screenshot_dir="src/electron/spec/artifacts"
         mkdir -p "$screenshot_dir"
         screenshot_file="$screenshot_dir/screenshot-timeout-$(date +%Y%m%d%H%M%S).png"
-        if [ "${{ inputs.target-platform }}" = "macos" ]; then
+        if [ "$TARGET_PLATFORM" = "macos" ]; then
           screencapture -x "$screenshot_file" || true
-        elif [ "${{ inputs.target-platform }}" = "win" ]; then
+        elif [ "$TARGET_PLATFORM" = "win" ]; then
           powershell -command "Add-Type -AssemblyName System.Windows.Forms; \$screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds; \$bitmap = New-Object System.Drawing.Bitmap(\$screen.Width, \$screen.Height); \$graphics = [System.Drawing.Graphics]::FromImage(\$bitmap); \$graphics.CopyFromScreen(\$screen.Location, [System.Drawing.Point]::Empty, \$screen.Size); \$bitmap.Save('$screenshot_file')" || true
         fi
 

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -40,6 +40,23 @@ on:
         required: false
         type: string
         default: x11
+    secrets:
+      ACTIONS_STEP_DEBUG:
+        required: false
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING:
+        required: false
+      CLOUDFLARE_TUNNEL_CERT:
+        required: false
+      CLOUDFLARE_USER_CA_CERT:
+        required: false
+      DD_API_KEY:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
+      SSH_DEBUG_AUTHORIZED_USERS:
+        required: false
 
 concurrency:
   group: electron-test-${{ inputs.target-platform }}-${{ inputs.target-arch }}-${{ inputs.is-asan }}-${{ inputs.is-ubsan }}-${{ inputs.display-server }}-${{ github.ref_protected == true && github.run_id || github.ref }}

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -147,6 +147,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Turn off screenshot nag on macOS
       if: ${{ inputs.target-platform == 'macos' }}
       run: |

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -66,7 +66,7 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    container: ${{ fromJSON(inputs.test-container) }}
+    container: ${{ fromJSON(inputs.test-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -41,7 +41,9 @@ on:
         type: string
         default: x11
     secrets:
-      ACTIONS_STEP_DEBUG:
+      # ACTIONS_STEP_DEBUG is a reserved name for workflow_call secrets; the
+      # workflows that read it map this back to the ACTIONS_STEP_DEBUG env.
+      CI_STEP_DEBUG:
         required: false
       CHROMIUM_GIT_COOKIE:
         required: false
@@ -69,7 +71,7 @@ env:
   CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
   ELECTRON_OUT_DIR: Default
   ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
-  ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  ACTIONS_STEP_DEBUG: ${{ secrets.CI_STEP_DEBUG }}
   # @sentry/cli is only needed by release upload-symbols.py; skip the ~17MB CDN download on test jobs
   SENTRYCLI_SKIP_DOWNLOAD: 1
 

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -327,8 +327,6 @@ jobs:
         NPM_CONFIG_MSVS_VERSION: '2022'
         TARGET_PLATFORM: ${{ inputs.target-platform }}
         DISPLAY_SERVER: ${{ inputs.display-server }}
-        IS_ASAN: ${{ inputs.is-asan }}
-        IS_UBSAN: ${{ inputs.is-ubsan }}
         SHARD: ${{ matrix.shard }}
         SHARD_COUNT: ${{ case(inputs.display-server == 'wayland', 1, inputs.target-platform == 'macos' && inputs.is-ubsan, 3, inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }}
       run: |

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -49,7 +49,7 @@ jobs:
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
       BUILD_TYPE: linux
-    container: ${{ fromJSON(inputs.test-container) }}
+    container: ${{ fromJSON(inputs.test-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     steps:
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -108,7 +108,7 @@ jobs:
     env: 
       TARGET_ARCH: ${{ inputs.target-arch }}
       BUILD_TYPE: linux
-    container: ${{ fromJSON(inputs.test-container) }}
+    container: ${{ fromJSON(inputs.test-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     steps:
     - name: Checkout Electron
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -57,6 +57,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Install Build Tools
@@ -113,6 +114,7 @@ jobs:
         path: src/electron
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Set Chromium Git Cookie
       uses: ./src/electron/.github/actions/set-chromium-cookie
     - name: Install Build Tools

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -63,8 +63,10 @@ jobs:
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
+      env:
+        GN_BUILD_TYPE: ${{ inputs.gn-build-type }}
       run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }} --import ${{ inputs.gn-build-type }} --target-cpu ${{ inputs.target-arch }}
+        e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE" --import "$GN_BUILD_TYPE" --target-cpu "$TARGET_ARCH"
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Download Generated Artifacts
@@ -120,8 +122,10 @@ jobs:
     - name: Install Build Tools
       uses: ./src/electron/.github/actions/install-build-tools
     - name: Init Build Tools
+      env:
+        GN_BUILD_TYPE: ${{ inputs.gn-build-type }}
       run: |
-        e init -f --root=$(pwd) --out=Default ${{ inputs.gn-build-type }}
+        e init -f --root=$(pwd) --out=Default "$GN_BUILD_TYPE"
     - name: Install Dependencies
       uses: ./src/electron/.github/actions/install-dependencies
     - name: Download Generated Artifacts

--- a/.github/workflows/pipeline-segment-node-nan-test.yml
+++ b/.github/workflows/pipeline-segment-node-nan-test.yml
@@ -25,6 +25,11 @@ on:
         required: true
         type: string
         default: testing
+    secrets:
+      CHROMIUM_GIT_COOKIE:
+        required: false
+      ELECTRON_RBE_JWT:
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/pipeline-segment-pgo-collect.yml
+++ b/.github/workflows/pipeline-segment-pgo-collect.yml
@@ -51,6 +51,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       with:
         path: src/electron
+        persist-credentials: false
     - name: Setup Node.js/npm
       if: ${{ inputs.target-platform != 'linux' }}
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020

--- a/.github/workflows/pipeline-segment-pgo-collect.yml
+++ b/.github/workflows/pipeline-segment-pgo-collect.yml
@@ -34,7 +34,7 @@ permissions: {}
 jobs:
   collect:
     runs-on: ${{ inputs.collect-runs-on }}
-    container: ${{ fromJSON(inputs.collect-container) }}
+    container: ${{ fromJSON(inputs.collect-container) }} # zizmor: ignore[unpinned-images] the caller passes ghcr.io/electron/build tagged by the content hash computed in build.yml; there is no static digest to pin
     permissions:
       contents: read
     # Callers' defaults do not propagate into reusable workflows.

--- a/.github/workflows/pr-blocked-automation.yml
+++ b/.github/workflows/pr-blocked-automation.yml
@@ -1,7 +1,7 @@
 name: PR Blocked Automation
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
 # SECURITY: This workflow uses pull_request_target and has access to secrets.

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           sparse-checkout: .github/PULL_REQUEST_TEMPLATE.md
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Check for required sections
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,7 +1,7 @@
 name: PR Template Check
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [opened, ready_for_review]
 
 # SECURITY: This workflow uses pull_request_target and has access to secrets.

--- a/.github/workflows/pr-triage-automation.yml
+++ b/.github/workflows/pr-triage-automation.yml
@@ -1,7 +1,7 @@
 name: PR Triage Automation
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [synchronize, review_requested]
   issue_comment:
     types: [created]

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -64,13 +64,14 @@ jobs:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         GH_REPO: electron/electron
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
-        gh pr comment "$PR_NUMBER" --body-file - <<'EOF'
+        gh pr comment "$PR_NUMBER" --body-file - <<EOF
         <!-- ai-pr -->
 
         *AI PR Detected*
 
-        Hello @${{ github.event.pull_request.user.login }}. Due to the high amount of AI spam PRs we receive, if a PR is detected to be majority AI-generated without disclosure and untested, we will automatically close the PR.
+        Hello @${PR_AUTHOR}. Due to the high amount of AI spam PRs we receive, if a PR is detected to be majority AI-generated without disclosure and untested, we will automatically close the PR.
 
         We welcome the use of AI tools, as long as the PR meets our quality standards and has clearly been built and tested. If you believe your PR was closed in error, we welcome you to resubmit. However, please read our [CONTRIBUTING.md](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) and [AI Tool Policy](https://github.com/electron/governance/blob/main/policy/ai.md) carefully before reopening. Thanks for your contribution.
         EOF

--- a/.github/workflows/pull-request-labeled.yml
+++ b/.github/workflows/pull-request-labeled.yml
@@ -1,7 +1,7 @@
 name: Pull Request Labeled
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [labeled]
 
 # SECURITY: This workflow uses pull_request_target and has access to secrets.

--- a/.github/workflows/pull-request-merged.yml
+++ b/.github/workflows/pull-request-merged.yml
@@ -1,7 +1,7 @@
 name: Pull Request Merged
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [closed]
 
 # SECURITY: This workflow uses pull_request_target and has access to secrets.

--- a/.github/workflows/pull-request-opened-synchronized.yml
+++ b/.github/workflows/pull-request-opened-synchronized.yml
@@ -1,7 +1,7 @@
 name: Pull Request Opened/Synchronized
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] deliberate; only base-branch code runs, the PR head is never checked out (see SECURITY note)
     types: [opened, synchronize]
 
 # SECURITY: This workflow uses pull_request_target and has access to secrets.

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,6 +35,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -63,6 +65,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:
@@ -90,6 +93,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
 
@@ -116,6 +120,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -185,7 +185,17 @@ jobs:
       # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   linux:
     name: linux-${{ matrix.target-arch }}
@@ -210,7 +220,17 @@ jobs:
       # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   windows:
     name: windows-${{ matrix.target-arch }}
@@ -234,4 +254,14 @@ jobs:
       # No test job consumes these builds - skip src_artifacts / cross-arch snapshots.
       generate-test-artifacts: false
       upload-to-storage: '0'
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -186,7 +186,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -221,7 +221,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -255,7 +255,7 @@ jobs:
       generate-test-artifacts: false
       upload-to-storage: '0'
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -51,6 +51,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3.29.5
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -98,7 +98,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
@@ -130,7 +130,7 @@ jobs:
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
     secrets:
-      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
       CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
       CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
       CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -30,6 +30,8 @@ jobs:
       build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      with:
+        persist-credentials: false
     - name: Set Build Image SHA
       id: build-image-sha
       uses: ./.github/actions/build-image-sha
@@ -58,6 +60,7 @@ jobs:
       with:
         path: src/electron
         fetch-depth: 0
+        persist-credentials: false
     - name: Checkout & Sync & Save
       uses: ./src/electron/.github/actions/checkout
       with:

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -97,7 +97,17 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
 
   publish-arm64-win:
     uses: ./.github/workflows/pipeline-segment-electron-publish.yml
@@ -119,4 +129,14 @@ jobs:
       gn-build-type: release
       generate-symbols: true
       upload-to-storage: ${{ inputs.upload-to-storage }}
-    secrets: inherit
+    secrets:
+      ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_ARTIFACTS_BLOB_STORAGE: ${{ secrets.ELECTRON_ARTIFACTS_BLOB_STORAGE }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+      SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}

--- a/script/copy-pipeline-segment-publish.js
+++ b/script/copy-pipeline-segment-publish.js
@@ -11,21 +11,25 @@ const target = path.resolve(__dirname, '../.github/workflows/pipeline-segment-el
 
 const baseContents = fs.readFileSync(base, 'utf-8');
 
-const parsedBase = yaml.parse(baseContents);
-parsedBase.name = 'Pipeline Segment - Electron Publish';
-parsedBase.jobs.build.permissions = {
+// parseDocument (rather than parse + stringify) keeps the base workflow's
+// comments, including the zizmor ignore annotations, in the generated file.
+const doc = yaml.parseDocument(baseContents);
+doc.set('name', 'Pipeline Segment - Electron Publish');
+doc.setIn(['jobs', 'build', 'permissions'], {
   'artifact-metadata': 'write',
   attestations: 'write',
   contents: 'read',
   'id-token': 'write'
-};
+});
+
+const generated = PREFIX + doc.toString();
 
 if (process.argv.includes('--check')) {
-  if (fs.readFileSync(target, 'utf-8') !== PREFIX + yaml.stringify(parsedBase)) {
+  if (fs.readFileSync(target, 'utf-8') !== generated) {
     console.error(`${target} is out of date`);
     console.error('Please run "copy-pipeline-segment-publish.js" to update it');
     process.exit(1);
   }
 } else {
-  fs.writeFileSync(target, PREFIX + yaml.stringify(parsedBase));
+  fs.writeFileSync(target, generated);
 }


### PR DESCRIPTION
Drives the org zizmor audit (zizmor 1.29.0, `secrets-outside-env` disabled, online audits on) from 222 findings on `main` to **0**. Replaces #50654, redone from scratch on current `main`.

| audit | before | after | how |
|---|---|---|---|
| template-injection | 81 | 0 | `${{ inputs/steps/matrix/github.event }}` moved out of `run:` into step `env:` |
| artipacked | 52 | 0 | `persist-credentials: false` on every `actions/checkout` |
| secrets-inherit | 49 | 0 | each reusable workflow declares the secrets it reads; call sites pass exactly that set (`ACTIONS_STEP_DEBUG` travels as `CI_STEP_DEBUG`, a reserved name otherwise) |
| github-env | 14 | 0 | annotated: composite actions writing derived build paths in trusted pipelines |
| unpinned-images | 10 | 0 | annotated: image is `ghcr.io/electron/build` tagged by a content hash computed in `build.yml` |
| dangerous-triggers | 7 | 0 | annotated: `pull_request_target` workflows only run base-branch code |
| dependabot-cooldown | 6 | 0 | 7-day cooldown on all dependabot update groups |
| ref-version-mismatch | 1 | 0 | `upload-sarif` pin comment said v3.29.5, sha is v4.37.8 |
| adhoc-packages / misfeature | 2 | 0 | annotated: `npm i -g @electron/build-tools` and `shell: cmd` are deliberate |

One commit per category for review.

- No expanded value changes; the three `gh issue/pr comment` heredocs now take the author login from an env var (bodies contain no other `$` or backticks, so the posted text is identical).
- No job relies on persisted checkout credentials: pushes and comments go through app tokens or `GITHUB_TOKEN` env.
- Secret sets were derived from `secrets.*` references and cross-checked both ways (every referenced secret declared; every call site passes the callee's declared set). Declared `required: false` so fork PRs keep working. Call sites whose callee reads no secrets (docs-only, clang-tidy, test-64k, pgo-collect) now pass none.
- actionlint output is identical to `main`.

- Two follow-up fixes after a local review pass: the test step no longer exports `IS_ASAN=false` / `IS_UBSAN=false` (the specs test those variables for truthiness), and `copy-pipeline-segment-publish.js` now preserves comments so the generated publish workflow keeps its annotation and `--check` passes.
- Rebased over #52418 (UBSan build); its new `run:` expansions and `secrets: inherit` sites are handled the same way.

Notes: none
