### PR TITLE
docs: type webContents as nullable in app 'login' and 'select-client-certificate'

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -326,7 +326,7 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
 Returns:
 
 * `event` Event
-* `webContents` [WebContents](web-contents.md) (optional)
+* `webContents` [WebContents](web-contents.md) | null
 * `url` URL
 * `certificateList` [Certificate[]](structures/certificate.md)
 * `callback` Function
@@ -361,7 +361,7 @@ app.on('select-client-certificate', (event, webContents, url, list, callback) =>
 Returns:
 
 * `event` Event
-* `webContents` [WebContents](web-contents.md) (optional)
+* `webContents` [WebContents](web-contents.md) | null
 * `authenticationResponseDetails` Object
   * `url` URL
   * `pid` number


### PR DESCRIPTION
#### Description of Change

`app`'s `login` and `select-client-certificate` events fire with `webContents === null` for requests that don't originate from a renderer (`net.fetch`/`net.request`, utility processes; #52162 added the latter case for `select-client-certificate` in 44). The prose and `breaking-changes.md` say so, but the parameter lines were marked `(optional)`, which the definitions generator drops for a non-trailing event argument, so `electron.d.ts` typed both listeners as `webContents: WebContents` and TypeScript consumers got no prompt to null-check. Writing the type as `WebContents | null` makes the generated listener signature `webContents: WebContents | null` for both events.

#### Checklist

- [x] PR description included
- [x] `npm run create-typescript-definitions` shows the listener param becoming nullable
- [x] PR title follows semantic commit guidelines

#### Release Notes

Notes: Fixed the TypeScript type of the `webContents` argument to `app`'s `login` and `select-client-certificate` events, which is `null` for `net` and utility-process requests.
