### PR TITLE
fix: reject non-integer worldId in executeJavaScriptInIsolatedWorld

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -170,9 +170,6 @@ WebContents.prototype.executeJavaScript = async function (code, hasUserGesture) 
   );
 };
 WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (worldId, code, hasUserGesture) {
-  if (!Number.isInteger(worldId)) {
-    throw new TypeError('worldId must be an integer');
-  }
   await waitTillCanExecuteJavaScript(this);
   return ipcMainUtils.invokeInWebContents(
     this,

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -170,6 +170,9 @@ WebContents.prototype.executeJavaScript = async function (code, hasUserGesture) 
   );
 };
 WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (worldId, code, hasUserGesture) {
+  if (!Number.isInteger(worldId)) {
+    throw new TypeError('worldId must be an integer');
+  }
   await waitTillCanExecuteJavaScript(this);
   return ipcMainUtils.invokeInWebContents(
     this,

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -704,11 +704,20 @@ class WebFrameRenderer final
   //   worldId, scripts[, userGesture][, callback])
   v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
       gin::Arguments* const args,
-      const int world_id,
+      v8::Local<v8::Value> world_id_value,
       const std::vector<gin_helper::Dictionary>& scripts) {
     v8::Isolate* const isolate = args->isolate();
     gin_helper::Promise<v8::Local<v8::Value>> promise{isolate};
     v8::Local<v8::Promise> handle = promise.GetHandle();
+
+    // Take the raw value: gin's int converter never entered this method, so a
+    // non-integer worldId resolved undefined instead of rejecting.
+    if (!world_id_value->IsInt32()) {
+      promise.Reject(v8::Exception::TypeError(v8::String::NewFromUtf8Literal(
+          isolate, "worldId must be an integer")));
+      return handle;
+    }
+    const int world_id = world_id_value.As<v8::Int32>()->Value();
 
     content::RenderFrame* render_frame;
     std::string error_msg;

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -508,6 +508,12 @@ describe('webContents module', () => {
       expect(isolatedResult).to.equal(123);
       expect(mainWorldResult).to.equal(undefined);
     });
+
+    it('rejects when worldId is not an integer', async () => {
+      await expect(
+        w.webContents.executeJavaScriptInIsolatedWorld('1234' as any, [{ code: '1+1' }])
+      ).to.eventually.be.rejectedWith(TypeError, 'worldId must be an integer');
+    });
   });
 
   describe('loadURL() promise API', () => {

--- a/spec/api-web-frame-spec.ts
+++ b/spec/api-web-frame-spec.ts
@@ -369,6 +369,18 @@ describe('webFrame module', () => {
           2
         );
       });
+
+      it('executeJavaScriptInIsolatedWorld() rejects when worldId is not an integer', async () => {
+        const result = await w.executeJavaScript(`
+          webFrame.executeJavaScriptInIsolatedWorld('1234', [{code: '1 + 1'}]).then(
+            () => ({ rejected: false }),
+            (error) => ({ rejected: true, name: error.name, message: error.message })
+          )
+        `);
+        expect(result.rejected).to.be.true();
+        expect(result.name).to.equal('TypeError');
+        expect(result.message).to.equal('worldId must be an integer');
+      });
     });
 
     describe('isolated world discovery', () => {


### PR DESCRIPTION
## Description of Change

`webContents.executeJavaScriptInIsolatedWorld` forwarded `worldId` to the renderer with no integer check.

- Integer `worldId` (e.g. `1234`) evaluates the script and resolves with the result.
- String `worldId` (e.g. `'1234'`) resolved the promise with `undefined` and did not reject.

The docs describe `worldId` as an Integer. This change throws `TypeError: worldId must be an integer` for non-integer values, matching other Electron APIs that reject bad argument types instead of succeeding silently.

## Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples)

## Test plan

- Official: `yarn test -match=executeJavaScriptInIsolatedWorld`
- Existing isolated-world result test still passes with integer `999`
- New test: string `'1234'` is rejected with `TypeError`

## Release Notes

Notes: Fixed `webContents.executeJavaScriptInIsolatedWorld` resolving with `undefined` when `worldId` was not an integer.
