### PR TITLE
fix: register the tray's StatusNotifierItem under its bus name again (43-x-y)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,6 +135,7 @@ chore_disable_protocol_handler_dcheck.patch
 fix_check_for_file_existence_before_setting_mtime.patch
 cherry-pick-3a02de271fd3.patch
 cherry-pick-726eafecc145.patch
+cherry-pick-a98778054068.patch
 fix_linux_tray_id.patch
 expose_gtk_ui_platform_field.patch
 patch_osr_control_screen_info.patch

--- a/patches/chromium/cherry-pick-a98778054068.patch
+++ b/patches/chromium/cherry-pick-a98778054068.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Thu, 20 Aug 2026 19:05:13 -0700
+Subject: [StatusIconLinuxDbus] Use separate D-Bus connections for status icons
+
+crrev.com/1678472 passed the combined service name and object path to
+RegisterStatusNotifierItem to support multiple status icons on a single
+connection. However, GNOME's AppIndicator extension interprets service
+names without a leading '/' as well-known bus names, resulting in D-Bus
+registration errors.
+
+Fix this by assigning the first status icon to the shared session bus
+and subsequent status icons to dedicated private connections.
+Standardize exported object paths to /StatusNotifierItem and
+/org/chromium/DbusMenu and pass only the well-known service name to
+RegisterStatusNotifierItem.
+
+Bug: 543471702
+Change-Id: I9e8b7fec6c6b61bb3e7d291d6597327baf8828b7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8272040
+Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1683620}
+
+Only the production status_icon_linux_dbus.cc hunks are carried; the
+upstream unittest hunks are omitted. In Chromium >= 154.0.8016.0.
+
+diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+index ddc7877f7891fcda71ddfc84db55ab0072078ad5..60a3c13471a630c36b377544e83bd5bf967c47d7 100644
+--- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
++++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
+@@ -25,6 +25,7 @@
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
++#include "base/task/single_thread_task_runner_thread_mode.h"
+ #include "base/task/thread_pool.h"
+ #include "components/dbus/menu/menu.h"
+ #include "components/dbus/properties/dbus_properties.h"
+@@ -140,11 +141,6 @@ std::string PropertyIdFromId(int service_id) {
+   return "chrome_status_icon_" + base::NumberToString(service_id);
+ }
+ 
+-dbus::ObjectPath ObjectPathFromId(const std::string& path, int service_id) {
+-  return dbus::ObjectPath(
+-      base::StrCat({path, "/", base::NumberToString(service_id)}));
+-}
+-
+ using DbusImage = std::tuple</*width=*/int32_t,
+                              /*height=*/int32_t,
+                              /*pixels=*/std::vector<uint8_t>>;
+@@ -230,10 +226,31 @@ base::FilePath WriteIconFile(size_t icon_file_id,
+   return file_path;
+ }
+ 
++bool g_shared_bus_in_use = false;
++
++scoped_refptr<dbus::Bus> CreateSessionBus() {
++  dbus::Bus::Options options;
++  options.bus_type = dbus::Bus::SESSION;
++  options.connection_type = dbus::Bus::PRIVATE;
++  options.dbus_task_runner = base::ThreadPool::CreateSingleThreadTaskRunner(
++      {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
++      base::SingleThreadTaskRunnerThreadMode::SHARED);
++  return base::MakeRefCounted<dbus::Bus>(std::move(options));
++}
++
++scoped_refptr<dbus::Bus> GetBusForNewStatusIcon() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (!g_shared_bus_in_use) {
++    g_shared_bus_in_use = true;
++    return dbus_thread_linux::GetSharedSessionBus();
++  }
++  return CreateSessionBus();
++}
++
+ }  // namespace
+ 
+ StatusIconLinuxDbus::StatusIconLinuxDbus()
+-    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus()) {}
++    : StatusIconLinuxDbus(GetBusForNewStatusIcon()) {}
+ 
+ StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus)
+     : bus_(std::move(bus)),
+@@ -322,26 +339,33 @@ StatusIconLinuxDbus::~StatusIconLinuxDbus() {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+   CleanupIconFile();
+ 
+-  if (!service_name_.empty()) {
+-    bus_->GetDBusTaskRunner()->PostTask(
+-        FROM_HERE,
+-        base::BindOnce(
+-            [](scoped_refptr<dbus::Bus> bus, const std::string& service_name) {
+-              bus->ReleaseOwnership(service_name);
+-            },
+-            bus_, service_name_));
+-  }
+-
+-  if (item_) {
+-    bus_->UnregisterExportedObject(
+-        ObjectPathFromId(kPathStatusNotifierItem, service_id_));
+-    item_ = nullptr;
+-  }
+-
+   if (menu_) {
+     menu_.reset();
+-    bus_->UnregisterExportedObject(
+-        ObjectPathFromId(kPathDbusMenu, service_id_));
++  }
++  item_ = nullptr;
++  watcher_ = nullptr;
++
++  if (bus_) {
++    if (bus_ == dbus_thread_linux::GetSharedSessionBus()) {
++      g_shared_bus_in_use = false;
++      bus_->UnregisterExportedObject(dbus::ObjectPath(kPathStatusNotifierItem));
++      bus_->UnregisterExportedObject(dbus::ObjectPath(kPathDbusMenu));
++      if (!service_name_.empty()) {
++        bus_->GetDBusTaskRunner()->PostTask(
++            FROM_HERE, base::BindOnce(
++                           [](scoped_refptr<dbus::Bus> bus,
++                              const std::string& service_name) {
++                             bus->ReleaseOwnership(service_name);
++                           },
++                           bus_, service_name_));
++      }
++    } else {
++      bus_->GetDBusTaskRunner()->PostTask(
++          FROM_HERE,
++          base::BindOnce(
++              [](scoped_refptr<dbus::Bus> bus) { bus->ShutdownAndBlock(); },
++              bus_));
++    }
+   }
+ }
+ 
+@@ -395,8 +419,7 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+                     base::NumberToString(base::Process::Current().Pid()), "-",
+                     base::NumberToString(service_id_)});
+ 
+-  item_ = bus_->GetExportedObject(
+-      ObjectPathFromId(kPathStatusNotifierItem, service_id_));
++  item_ = bus_->GetExportedObject(dbus::ObjectPath(kPathStatusNotifierItem));
+ 
+   for (const char* interface : {kInterfaceStatusNotifierItem,
+                                 kInterfaceStatusNotifierItemFreedesktop}) {
+@@ -434,7 +457,7 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+       base::DoNothing());
+ 
+   menu_ = std::make_unique<DbusMenu>(
+-      bus_->GetExportedObject(ObjectPathFromId(kPathDbusMenu, service_id_)),
++      bus_->GetExportedObject(dbus::ObjectPath(kPathDbusMenu)),
+       base::BindOnce(&StatusIconLinuxDbus::OnInitialized,
+                      weak_factory_.GetWeakPtr()));
+   UpdateMenuImpl(delegate_->GetMenuModel(), false);
+@@ -442,8 +465,7 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+   // Initialize properties map.
+   SetProperty<"b">(kPropertyItemIsMenu, false, false);
+   SetProperty<"i">(kPropertyWindowId, 0, false);
+-  SetProperty<"o">(kPropertyMenu, ObjectPathFromId(kPathDbusMenu, service_id_),
+-                   false);
++  SetProperty<"o">(kPropertyMenu, dbus::ObjectPath(kPathDbusMenu), false);
+   SetProperty<"s">(kPropertyAttentionIconName, "", false);
+   SetProperty<"s">(kPropertyAttentionMovieName, "", false);
+   SetProperty<"s">(kPropertyCategory, kPropertyValueCategory, false);
+@@ -498,9 +520,7 @@ void StatusIconLinuxDbus::RegisterStatusNotifierItem() {
+       kMethodRegisterStatusNotifierItem,
+       base::BindOnce(&StatusIconLinuxDbus::OnRegistered,
+                      weak_factory_.GetWeakPtr()),
+-      base::StrCat(
+-          {service_name_,
+-           ObjectPathFromId(kPathStatusNotifierItem, service_id_).value()}));
++      service_name_);
+ }
+ 
+ void StatusIconLinuxDbus::OnRegistered(

--- a/patches/chromium/fix_linux_tray_id.patch
+++ b/patches/chromium/fix_linux_tray_id.patch
@@ -13,10 +13,10 @@ https://github.com/electron/electron/pull/48675#issuecomment-3452781711
 for more info.
 
 diff --git a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
-index ddc7877f7891fcda71ddfc84db55ab0072078ad5..35b992eacd9ca393561a79ccc2243953c0c91be9 100644
+index 60a3c13471a630c36b377544e83bd5bf967c47d7..8169dfff20f281ebe9b489fb0449fbd09af7d0b8 100644
 --- a/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
 +++ b/chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc
-@@ -136,8 +136,9 @@ int NextServiceId() {
+@@ -137,8 +137,9 @@ int NextServiceId() {
    return ++status_icon_count;
  }
  
@@ -27,16 +27,15 @@ index ddc7877f7891fcda71ddfc84db55ab0072078ad5..35b992eacd9ca393561a79ccc2243953
 +      {app_name, "_status_icon_", base::NumberToString(service_id)});
  }
  
- dbus::ObjectPath ObjectPathFromId(const std::string& path, int service_id) {
-@@ -232,15 +233,18 @@ base::FilePath WriteIconFile(size_t icon_file_id,
+ using DbusImage = std::tuple</*width=*/int32_t,
+@@ -249,15 +250,17 @@ scoped_refptr<dbus::Bus> GetBusForNewStatusIcon() {
  
  }  // namespace
  
 -StatusIconLinuxDbus::StatusIconLinuxDbus()
--    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus()) {}
+-    : StatusIconLinuxDbus(GetBusForNewStatusIcon()) {}
 +StatusIconLinuxDbus::StatusIconLinuxDbus(const std::string_view app_name)
-+    : StatusIconLinuxDbus(dbus_thread_linux::GetSharedSessionBus(),
-+                          app_name) {}
++    : StatusIconLinuxDbus(GetBusForNewStatusIcon(), app_name) {}
  
 -StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus)
 +StatusIconLinuxDbus::StatusIconLinuxDbus(scoped_refptr<dbus::Bus> bus,
@@ -51,7 +50,7 @@ index ddc7877f7891fcda71ddfc84db55ab0072078ad5..35b992eacd9ca393561a79ccc2243953
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
    if (bus_) {
      CheckStatusNotifierWatcherHasOwner();
-@@ -447,7 +451,8 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
+@@ -469,7 +472,8 @@ void StatusIconLinuxDbus::OnHostRegisteredResponse(
    SetProperty<"s">(kPropertyAttentionIconName, "", false);
    SetProperty<"s">(kPropertyAttentionMovieName, "", false);
    SetProperty<"s">(kPropertyCategory, kPropertyValueCategory, false);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/53213

#52952 cherry-picked https://crrev.com/c/8250459, which gives each status icon its own object path and passes `"<well-known name>/StatusNotifierItem/<n>"` to `RegisterStatusNotifierItem`. GNOME's appindicator extension (and other GDBusProxy-based hosts) treat an argument that doesn't start with `/` as a bus name; resolving that string fails, the registration is refused, and the icon falls back to XEmbed on Xorg and disappears on Wayland. Upstream fixed this in https://crrev.com/c/8272040 (Chromium 154.0.8016.0, already in `main`): the first icon uses the shared session bus and later ones a private connection, the item is exported at `/StatusNotifierItem` again, and only the well-known name is registered. This picks that CL (production hunks only, as with the earlier two) directly after `cherry-pick-726eafecc145.patch`, and rebases `fix_linux_tray_id.patch` onto the resulting constructor, which now matches `main`'s copy of that patch.

Checked with a stand-in `org.kde.StatusNotifierWatcher` that resolves items the way the GNOME extension does: 43.4.1 registers `org.freedesktop.StatusNotifierItem-<pid>-1/StatusNotifierItem/1` and is refused with `NameHasNoOwner`; the 44-x-y build of the same change (#53214) registers `org.freedesktop.StatusNotifierItem-<pid>-1` and the `Id` property reads back on both the `org.kde` and `org.freedesktop` interfaces at `/StatusNotifierItem`. On Ubuntu 24.04 GNOME Wayland (arm64) the same build shows the icon in the top bar with a working menu and `RegisteredStatusNotifierItems` lists it, where 44.0.0 lists nothing.

#### Checklist

- [x] PR description included
- [x] I have built and tested this change
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Fixed the tray icon not appearing on GNOME (and disappearing entirely on Wayland) since 43.4.1.



