### PR TITLE
refactor: align observed webRequest loads with network semantics

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -207,6 +207,15 @@ CalculateOnBeforeSendHeadersDelta(const net::HttpRequestHeaders* old_headers,
   return std::make_pair(modified_request_headers, deleted_request_headers);
 }
 
+WebRequest* ForObservedRequest(
+    const base::WeakPtr<ElectronBrowserContext>& browser_context) {
+  if (!browser_context)
+    return nullptr;
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+  return WebRequest::FromOrCreate(isolate, browser_context.get());
+}
+
 }  // namespace
 
 const gin::WrapperInfo WebRequest::kWrapperInfo =
@@ -798,26 +807,12 @@ struct WebRequest::ObservedRequest {
   std::unique_ptr<extensions::WebRequestInfo> info;
 };
 
-namespace {
-
-WebRequest* ForObservedRequest(
-    const base::WeakPtr<ElectronBrowserContext>& browser_context) {
-  if (!browser_context)
-    return nullptr;
-  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-  v8::HandleScope scope(isolate);
-  return WebRequest::FromOrCreate(isolate, browser_context.get());
-}
-
-}  // namespace
-
 // static
 void WebRequest::ObservedRequestStarted(
     base::WeakPtr<ElectronBrowserContext> browser_context,
     uint64_t key,
     int render_process_id,
     int frame_routing_id,
-    int32_t request_id,
     const network::ResourceRequest& request) {
   auto* self = ForObservedRequest(browser_context);
   if (!self)
@@ -847,13 +842,22 @@ void WebRequest::ObservedRequestRedirected(
   observed.info->AddResponseInfoFromResourceResponse(*head);
   self->OnBeforeRedirect(observed.info.get(), observed.request,
                          redirect_info.new_url);
-  observed.request.url = redirect_info.new_url;
-  observed.request.method = redirect_info.new_method;
-  observed.request.site_for_cookies = redirect_info.new_site_for_cookies;
-  observed.request.referrer = GURL(redirect_info.new_referrer);
+}
+
+// static
+void WebRequest::ObservedRequestFollowedRedirect(
+    base::WeakPtr<ElectronBrowserContext> browser_context,
+    uint64_t key,
+    const network::ResourceRequest& request) {
+  auto* self = ForObservedRequest(browser_context);
+  if (!self)
+    return;
+  auto it = self->observed_requests_.find(key);
+  if (it == self->observed_requests_.end())
+    return;
+  ObservedRequest& observed = *it->second;
+  observed.request = request;
   observed.RebuildInfo();
-  // The renderer follows the redirect on its own; report the next leg's send
-  // like ProxyingURLLoaderFactory does after FollowRedirect().
   self->OnSendHeaders(observed.info.get(), observed.request,
                       observed.request.headers);
 }

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -151,13 +151,16 @@ class WebRequest final : public gin::Wrappable<WebRequest> {
       uint64_t key,
       int render_process_id,
       int frame_routing_id,
-      int32_t request_id,
       const network::ResourceRequest& request);
   static void ObservedRequestRedirected(
       base::WeakPtr<ElectronBrowserContext> browser_context,
       uint64_t key,
       const net::RedirectInfo& redirect_info,
       network::mojom::URLResponseHeadPtr head);
+  static void ObservedRequestFollowedRedirect(
+      base::WeakPtr<ElectronBrowserContext> browser_context,
+      uint64_t key,
+      const network::ResourceRequest& request);
   static void ObservedRequestResponded(
       base::WeakPtr<ElectronBrowserContext> browser_context,
       uint64_t key,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1548,16 +1548,11 @@ void ElectronBrowserClient::WillCreateURLLoaderFactory(
     mojo::PendingRemote<network::mojom::URLLoaderFactory> gate_to_proxy;
     mojo::PendingReceiver<network::mojom::URLLoaderFactory> proxy_receiver =
         gate_to_proxy.InitWithNewPipeAndPassReceiver();
-    RequestObserverTarget observer_target;
-    observer_target.render_process_id = render_process_id;
-    observer_target.frame_routing_id = frame_host->GetRoutingID();
-    observer_target.browser_context =
-        static_cast<ElectronBrowserContext*>(browser_context)->GetWeakPtr();
     CreateURLLoaderFactoryGate(
-        static_cast<ElectronBrowserContext*>(browser_context)
-            ->intercept_state(),
-        std::move(observer_target), std::move(proxied_receiver),
-        std::move(gate_to_network), std::move(gate_to_proxy));
+        static_cast<ElectronBrowserContext*>(browser_context),
+        render_process_id, frame_host->GetRoutingID(),
+        std::move(proxied_receiver), std::move(gate_to_network),
+        std::move(gate_to_proxy));
     proxied_receiver = std::move(proxy_receiver);
     target_factory_remote = target.Unbind();
   }

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -21,6 +21,7 @@
 #include "net/http/http_status_code.h"
 #include "net/http/http_util.h"
 #include "net/url_request/redirect_info.h"
+#include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/features.h"
 #include "services/network/public/mojom/early_hints.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
@@ -724,15 +725,14 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToBeforeRedirect(
   factory_->web_request_->OnBeforeRedirect(&info_.value(), request_,
                                            redirect_info.new_url);
   target_client_->OnReceiveRedirect(redirect_info, current_response_.Clone());
-  request_.url = redirect_info.new_url;
-  request_.method = redirect_info.new_method;
-  request_.site_for_cookies = redirect_info.new_site_for_cookies;
-  request_.referrer = GURL(redirect_info.new_referrer);
-  request_.referrer_policy = redirect_info.new_referrer_policy;
+  bool should_clear_upload = false;
+  net::RedirectUtil::UpdateHttpRequest(
+      request_.url, request_.method, redirect_info,
+      /*removed_headers=*/std::nullopt, /*modified_headers=*/std::nullopt,
+      &request_.headers, &should_clear_upload);
+  request_.UpdateOnRedirect(redirect_info);
 
-  // The request method can be changed to "GET". In this case we need to
-  // reset the request body manually.
-  if (request_.method == net::HttpRequestHeaders::kGetMethod)
+  if (should_clear_upload)
     request_.request_body = nullptr;
 }
 
@@ -874,16 +874,18 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
       browser_context_ ? browser_context_->intercept_state()->RouteFor(request)
                        : InterceptState::Route::kProxy;
   if (route != InterceptState::Route::kProxy || !web_request_->HasListener()) {
-    if (route == InterceptState::Route::kObserve) {
-      RequestObserverTarget target;
-      target.render_process_id = render_process_id_;
-      target.frame_routing_id = frame_routing_id_;
-      target.browser_context = browser_context_;
-      client = ObserveRequest(target, request_id, request, std::move(client));
-    }
     auto& target_factory = override_target_factory.is_bound()
                                ? override_target_factory
                                : target_factory_;
+    if (route == InterceptState::Route::kObserve) {
+      mojo::PendingRemote<network::mojom::URLLoaderFactory> observed_target;
+      target_factory->Clone(observed_target.InitWithNewPipeAndPassReceiver());
+      CreateObservedLoaderAndStartOnIO(
+          browser_context_, render_process_id_, frame_routing_id_,
+          std::move(loader), request_id, options, request, std::move(client),
+          traffic_annotation, std::move(observed_target));
+      return;
+    }
     target_factory->CreateLoaderAndStart(std::move(loader), request_id, options,
                                          request, std::move(client),
                                          traffic_annotation);

--- a/shell/browser/net/url_loader_factory_gate.cc
+++ b/shell/browser/net/url_loader_factory_gate.cc
@@ -16,6 +16,8 @@
 #include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "net/url_request/redirect_util.h"
+#include "services/network/public/cpp/http_request_headers_update_params.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/self_deleting_url_loader_factory.h"
 #include "services/network/public/cpp/url_loader_completion_status.h"
@@ -124,11 +126,6 @@ InterceptState::Route InterceptState::RouteFor(
   return Route::kDirect;
 }
 
-RequestObserverTarget::RequestObserverTarget() = default;
-RequestObserverTarget::RequestObserverTarget(const RequestObserverTarget&) =
-    default;
-RequestObserverTarget::~RequestObserverTarget() = default;
-
 namespace {
 
 base::AtomicSequenceNumber g_observed_request_key;
@@ -137,43 +134,91 @@ scoped_refptr<base::SequencedTaskRunner> UIThread() {
   return content::GetUIThreadTaskRunner({});
 }
 
-// Sits on a request's URLLoaderClient pipe on the IO thread, passing every
-// message straight to the renderer and telling api::WebRequest afterwards.
-class ObservedLoad : public network::mojom::URLLoaderClient {
+// Proxies both sides of an observed request on the IO thread.
+class ObservedURLLoader : public network::mojom::URLLoader,
+                          public network::mojom::URLLoaderClient {
  public:
-  ObservedLoad(const RequestObserverTarget& target,
-               int32_t request_id,
-               const network::ResourceRequest& request,
-               mojo::PendingReceiver<network::mojom::URLLoaderClient> receiver,
-               mojo::PendingRemote<network::mojom::URLLoaderClient> renderer)
-      : browser_context_(target.browser_context),
+  ObservedURLLoader(
+      base::WeakPtr<ElectronBrowserContext> browser_context,
+      int render_process_id,
+      int frame_routing_id,
+      const network::ResourceRequest& request,
+      mojo::PendingReceiver<network::mojom::URLLoader> renderer_loader,
+      mojo::PendingRemote<network::mojom::URLLoaderClient> renderer_client,
+      network::mojom::URLLoaderClientEndpointsPtr network_endpoints)
+      : browser_context_(std::move(browser_context)),
+        render_process_id_(render_process_id),
+        frame_routing_id_(frame_routing_id),
         key_(g_observed_request_key.GetNext()),
-        receiver_(this, std::move(receiver)),
-        renderer_(std::move(renderer)) {
-    receiver_.set_disconnect_handler(base::BindOnce(
-        &ObservedLoad::Finish, base::Unretained(this), std::nullopt));
-    renderer_.set_disconnect_handler(base::BindOnce(
-        &ObservedLoad::Finish, base::Unretained(this), std::nullopt));
+        request_(request),
+        renderer_loader_receiver_(this, std::move(renderer_loader)),
+        renderer_client_(std::move(renderer_client)),
+        network_loader_(std::move(network_endpoints->url_loader)),
+        network_client_receiver_(
+            this,
+            std::move(network_endpoints->url_loader_client)) {
+    auto on_disconnect = base::BindOnce(
+        &ObservedURLLoader::Finish, weak_factory_.GetWeakPtr(), std::nullopt);
+    renderer_loader_receiver_.set_disconnect_handler(base::BindOnce(
+        &ObservedURLLoader::Finish, weak_factory_.GetWeakPtr(), std::nullopt));
+    renderer_client_.set_disconnect_handler(std::move(on_disconnect));
+    network_client_receiver_.set_disconnect_handler(base::BindOnce(
+        &ObservedURLLoader::Finish, weak_factory_.GetWeakPtr(), std::nullopt));
     UIThread()->PostTask(
-        FROM_HERE,
-        base::BindOnce(&api::WebRequest::ObservedRequestStarted,
-                       browser_context_, key_, target.render_process_id,
-                       target.frame_routing_id, request_id, request));
+        FROM_HERE, base::BindOnce(&api::WebRequest::ObservedRequestStarted,
+                                  browser_context_, key_, render_process_id_,
+                                  frame_routing_id_, request_));
   }
-  ~ObservedLoad() override = default;
+  ~ObservedURLLoader() override = default;
 
  private:
+  // network::mojom::URLLoader:
+  void FollowRedirect(
+      network::HttpRequestHeadersUpdateParams headers_update_params,
+      const std::optional<GURL>& new_url) override {
+    DCHECK(pending_redirect_);
+    if (pending_redirect_) {
+      bool should_clear_upload = false;
+      net::RedirectUtil::UpdateHttpRequest(
+          request_.url, request_.method, *pending_redirect_,
+          headers_update_params.removed_headers,
+          headers_update_params.modified_headers, &request_.headers,
+          &should_clear_upload);
+      request_.cors_exempt_headers.MergeFrom(
+          headers_update_params.modified_cors_exempt_headers);
+      for (const auto& removed_header : headers_update_params.removed_headers) {
+        request_.cors_exempt_headers.RemoveHeader(removed_header);
+      }
+      request_.UpdateOnRedirect(*pending_redirect_);
+      if (new_url)
+        request_.url = *new_url;
+      if (should_clear_upload)
+        request_.request_body = nullptr;
+      pending_redirect_.reset();
+      UIThread()->PostTask(
+          FROM_HERE,
+          base::BindOnce(&api::WebRequest::ObservedRequestFollowedRedirect,
+                         browser_context_, key_, request_));
+    }
+    network_loader_->FollowRedirect(std::move(headers_update_params), new_url);
+  }
+
+  void SetPriority(net::RequestPriority priority,
+                   int32_t intra_priority_value) override {
+    network_loader_->SetPriority(priority, intra_priority_value);
+  }
+
   // network::mojom::URLLoaderClient:
   void OnReceiveEarlyHints(network::mojom::EarlyHintsPtr early_hints) override {
-    renderer_->OnReceiveEarlyHints(std::move(early_hints));
+    renderer_client_->OnReceiveEarlyHints(std::move(early_hints));
   }
   void OnReceiveResponse(
       network::mojom::URLResponseHeadPtr head,
       mojo::ScopedDataPipeConsumerHandle body,
       std::optional<mojo_base::BigBuffer> cached_metadata) override {
     auto head_for_ui = head.Clone();
-    renderer_->OnReceiveResponse(std::move(head), std::move(body),
-                                 std::move(cached_metadata));
+    renderer_client_->OnReceiveResponse(std::move(head), std::move(body),
+                                        std::move(cached_metadata));
     UIThread()->PostTask(
         FROM_HERE,
         base::BindOnce(&api::WebRequest::ObservedRequestResponded,
@@ -181,8 +226,10 @@ class ObservedLoad : public network::mojom::URLLoaderClient {
   }
   void OnReceiveRedirect(const net::RedirectInfo& redirect_info,
                          network::mojom::URLResponseHeadPtr head) override {
+    DCHECK(!pending_redirect_);
+    pending_redirect_ = redirect_info;
     auto head_for_ui = head.Clone();
-    renderer_->OnReceiveRedirect(redirect_info, std::move(head));
+    renderer_client_->OnReceiveRedirect(redirect_info, std::move(head));
     UIThread()->PostTask(
         FROM_HERE, base::BindOnce(&api::WebRequest::ObservedRequestRedirected,
                                   browser_context_, key_, redirect_info,
@@ -191,14 +238,14 @@ class ObservedLoad : public network::mojom::URLLoaderClient {
   void OnUploadProgress(int64_t current_position,
                         int64_t total_size,
                         OnUploadProgressCallback callback) override {
-    renderer_->OnUploadProgress(current_position, total_size,
-                                std::move(callback));
+    renderer_client_->OnUploadProgress(current_position, total_size,
+                                       std::move(callback));
   }
   void OnTransferSizeUpdated(int32_t transfer_size_diff) override {
-    renderer_->OnTransferSizeUpdated(transfer_size_diff);
+    renderer_client_->OnTransferSizeUpdated(transfer_size_diff);
   }
   void OnComplete(const network::URLLoaderCompletionStatus& status) override {
-    renderer_->OnComplete(status);
+    renderer_client_->OnComplete(status);
     Finish(status);
   }
 
@@ -213,23 +260,60 @@ class ObservedLoad : public network::mojom::URLLoaderClient {
   }
 
   const base::WeakPtr<ElectronBrowserContext> browser_context_;
+  const int render_process_id_;
+  const int frame_routing_id_;
   const uint64_t key_;
-  mojo::Receiver<network::mojom::URLLoaderClient> receiver_;
-  mojo::Remote<network::mojom::URLLoaderClient> renderer_;
+  network::ResourceRequest request_;
+  std::optional<net::RedirectInfo> pending_redirect_;
+  mojo::Receiver<network::mojom::URLLoader> renderer_loader_receiver_;
+  mojo::Remote<network::mojom::URLLoaderClient> renderer_client_;
+  mojo::Remote<network::mojom::URLLoader> network_loader_;
+  mojo::Receiver<network::mojom::URLLoaderClient> network_client_receiver_;
+  base::WeakPtrFactory<ObservedURLLoader> weak_factory_{this};
 };
+
+void CreateObservedLoaderAndStart(
+    base::WeakPtr<ElectronBrowserContext> browser_context,
+    int render_process_id,
+    int frame_routing_id,
+    mojo::PendingReceiver<network::mojom::URLLoader> loader,
+    int32_t request_id,
+    uint32_t options,
+    const network::ResourceRequest& request,
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+    network::mojom::URLLoaderFactory* target) {
+  mojo::PendingRemote<network::mojom::URLLoader> network_loader;
+  auto network_loader_receiver =
+      network_loader.InitWithNewPipeAndPassReceiver();
+  mojo::PendingRemote<network::mojom::URLLoaderClient> network_client;
+  auto network_endpoints = network::mojom::URLLoaderClientEndpoints::New(
+      std::move(network_loader),
+      network_client.InitWithNewPipeAndPassReceiver());
+  new ObservedURLLoader(std::move(browser_context), render_process_id,
+                        frame_routing_id, request, std::move(loader),
+                        std::move(client), std::move(network_endpoints));
+  target->CreateLoaderAndStart(std::move(network_loader_receiver), request_id,
+                               options, request, std::move(network_client),
+                               traffic_annotation);
+}
 
 class URLLoaderFactoryGate : public network::SelfDeletingURLLoaderFactory {
  public:
   URLLoaderFactoryGate(
       scoped_refptr<InterceptState> state,
-      RequestObserverTarget observer_target,
+      base::WeakPtr<ElectronBrowserContext> browser_context,
+      int render_process_id,
+      int frame_routing_id,
       mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
       mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
       mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor,
       base::SelfDeletingPassKey key)
       : network::SelfDeletingURLLoaderFactory(std::move(receiver), key),
         state_(std::move(state)),
-        observer_target_(std::move(observer_target)),
+        browser_context_(std::move(browser_context)),
+        render_process_id_(render_process_id),
+        frame_routing_id_(frame_routing_id),
         target_(std::move(target)),
         interceptor_(std::move(interceptor)) {
     target_.set_disconnect_handler(
@@ -256,9 +340,11 @@ class URLLoaderFactoryGate : public network::SelfDeletingURLLoaderFactory {
                                            traffic_annotation);
         return;
       case InterceptState::Route::kObserve:
-        client = ObserveRequest(observer_target_, request_id, request,
-                                std::move(client));
-        [[fallthrough]];
+        CreateObservedLoaderAndStart(
+            browser_context_, render_process_id_, frame_routing_id_,
+            std::move(loader), request_id, options, request, std::move(client),
+            traffic_annotation, target_.get());
+        return;
       case InterceptState::Route::kDirect:
         target_->CreateLoaderAndStart(std::move(loader), request_id, options,
                                       request, std::move(client),
@@ -271,60 +357,77 @@ class URLLoaderFactoryGate : public network::SelfDeletingURLLoaderFactory {
   ~URLLoaderFactoryGate() override = default;
 
   const scoped_refptr<InterceptState> state_;
-  const RequestObserverTarget observer_target_;
+  const base::WeakPtr<ElectronBrowserContext> browser_context_;
+  const int render_process_id_;
+  const int frame_routing_id_;
   mojo::Remote<network::mojom::URLLoaderFactory> target_;
   mojo::Remote<network::mojom::URLLoaderFactory> interceptor_;
 };
 
 }  // namespace
 
-mojo::PendingRemote<network::mojom::URLLoaderClient> ObserveRequest(
-    const RequestObserverTarget& target,
+void CreateObservedLoaderAndStartOnIO(
+    base::WeakPtr<ElectronBrowserContext> browser_context,
+    int render_process_id,
+    int frame_routing_id,
+    mojo::PendingReceiver<network::mojom::URLLoader> loader,
     int32_t request_id,
+    uint32_t options,
     const network::ResourceRequest& request,
-    mojo::PendingRemote<network::mojom::URLLoaderClient> client) {
-  mojo::PendingRemote<network::mojom::URLLoaderClient> observer;
-  auto receiver = observer.InitWithNewPipeAndPassReceiver();
-  auto create =
-      [](RequestObserverTarget target, int32_t request_id,
-         network::ResourceRequest request,
-         mojo::PendingReceiver<network::mojom::URLLoaderClient> receiver,
-         mojo::PendingRemote<network::mojom::URLLoaderClient> client) {
-        // Deletes itself when the request completes or either side goes away.
-        new ObservedLoad(target, request_id, request, std::move(receiver),
-                         std::move(client));
-      };
-  if (content::BrowserThread::CurrentlyOn(content::BrowserThread::IO)) {
-    create(target, request_id, request, std::move(receiver), std::move(client));
-  } else {
-    content::GetIOThreadTaskRunner({})->PostTask(
-        FROM_HERE, base::BindOnce(create, target, request_id, request,
-                                  std::move(receiver), std::move(client)));
-  }
-  return observer;
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> target) {
+  content::GetIOThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](base::WeakPtr<ElectronBrowserContext> browser_context,
+             int render_process_id, int frame_routing_id,
+             mojo::PendingReceiver<network::mojom::URLLoader> loader,
+             int32_t request_id, uint32_t options,
+             network::ResourceRequest request,
+             mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+             net::MutableNetworkTrafficAnnotationTag traffic_annotation,
+             mojo::PendingRemote<network::mojom::URLLoaderFactory> target) {
+            mojo::Remote<network::mojom::URLLoaderFactory> target_remote(
+                std::move(target));
+            CreateObservedLoaderAndStart(
+                std::move(browser_context), render_process_id, frame_routing_id,
+                std::move(loader), request_id, options, request,
+                std::move(client), traffic_annotation, target_remote.get());
+          },
+          std::move(browser_context), render_process_id, frame_routing_id,
+          std::move(loader), request_id, options, request, std::move(client),
+          traffic_annotation, std::move(target)));
 }
 
 void CreateURLLoaderFactoryGate(
-    scoped_refptr<InterceptState> state,
-    RequestObserverTarget observer_target,
+    ElectronBrowserContext* browser_context,
+    int render_process_id,
+    int frame_routing_id,
     mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
     mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
     mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  scoped_refptr<InterceptState> state(browser_context->intercept_state());
+  auto weak_browser_context = browser_context->GetWeakPtr();
   content::GetIOThreadTaskRunner({})->PostTask(
       FROM_HERE,
       base::BindOnce(
           [](scoped_refptr<InterceptState> state,
-             RequestObserverTarget observer,
+             base::WeakPtr<ElectronBrowserContext> browser_context,
+             int render_process_id, int frame_routing_id,
              mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
              mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
              mojo::PendingRemote<network::mojom::URLLoaderFactory>
                  interceptor) {
             base::MakeSelfDeleting<URLLoaderFactoryGate>(
-                std::move(state), std::move(observer), std::move(receiver),
-                std::move(target), std::move(interceptor));
+                std::move(state), std::move(browser_context), render_process_id,
+                frame_routing_id, std::move(receiver), std::move(target),
+                std::move(interceptor));
           },
-          std::move(state), std::move(observer_target), std::move(receiver),
-          std::move(target), std::move(interceptor)));
+          std::move(state), std::move(weak_browser_context), render_process_id,
+          frame_routing_id, std::move(receiver), std::move(target),
+          std::move(interceptor)));
 }
 
 }  // namespace electron

--- a/shell/browser/net/url_loader_factory_gate.h
+++ b/shell/browser/net/url_loader_factory_gate.h
@@ -29,6 +29,10 @@ namespace network {
 struct ResourceRequest;
 }
 
+namespace net {
+struct MutableNetworkTrafficAnnotationTag;
+}
+
 namespace electron {
 
 class ElectronBrowserContext;
@@ -71,33 +75,28 @@ class InterceptState : public base::RefCountedThreadSafe<InterceptState> {
   std::vector<std::string> ignore_connections_limit_domains_ GUARDED_BY(lock_);
 };
 
-// Where observed requests are reported: the frame's ids and the session whose
-// api::WebRequest hears about them, dereferenced on the UI thread only.
-struct RequestObserverTarget {
-  RequestObserverTarget();
-  RequestObserverTarget(const RequestObserverTarget&);
-  ~RequestObserverTarget();
-  int render_process_id = 0;
-  int frame_routing_id = 0;
-  base::WeakPtr<ElectronBrowserContext> browser_context;
-};
-
-// Wraps `client` so that the redirect, response and completion of the request
-// it belongs to are reported to `target`'s webRequest observers from the IO
-// thread; the returned client is the one to hand to the network factory.
-mojo::PendingRemote<network::mojom::URLLoaderClient> ObserveRequest(
-    const RequestObserverTarget& target,
+// Starts a request on the IO thread with both URLLoader endpoints proxied so
+// observer only webRequest events can be reported without blocking the load.
+void CreateObservedLoaderAndStartOnIO(
+    base::WeakPtr<ElectronBrowserContext> browser_context,
+    int render_process_id,
+    int frame_routing_id,
+    mojo::PendingReceiver<network::mojom::URLLoader> loader,
     int32_t request_id,
+    uint32_t options,
     const network::ResourceRequest& request,
-    mojo::PendingRemote<network::mojom::URLLoaderClient> client);
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> target);
 
 // Bound on the IO thread between a renderer's factory pipe and the network:
 // requests go straight to `target` unless `state` wants them on the UI thread,
 // in which case `interceptor` (a ProxyingURLLoaderFactory) gets them. Lives as
 // long as its receivers and both remotes do.
 void CreateURLLoaderFactoryGate(
-    scoped_refptr<InterceptState> state,
-    RequestObserverTarget observer_target,
+    ElectronBrowserContext* browser_context,
+    int render_process_id,
+    int frame_routing_id,
     mojo::PendingReceiver<network::mojom::URLLoaderFactory> receiver,
     mojo::PendingRemote<network::mojom::URLLoaderFactory> target,
     mojo::PendingRemote<network::mojom::URLLoaderFactory> interceptor);

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -842,6 +842,7 @@ describe('webRequest module', () => {
       ses.webRequest.onHeadersReceived(null);
       ses.webRequest.onSendHeaders(null);
       ses.webRequest.onBeforeRedirect(null);
+      ses.webRequest.onResponseStarted(null);
       ses.webRequest.onCompleted(null);
       ses.webRequest.onErrorOccurred(null);
     });
@@ -888,12 +889,21 @@ describe('webRequest module', () => {
       expect(calls).to.equal(0);
     });
 
-    it('still wait for a blocking listener whose type filter matches', async () => {
+    it('let a matching blocking listener take precedence over observers', async () => {
+      const completed: string[] = [];
+      ses.webRequest.onCompleted((details) => {
+        completed.push(new URL(details.url).pathname);
+      });
       ses.webRequest.onBeforeRequest({ urls: ['<all_urls>'], types: ['xhr'] }, (details, callback) => {
         callback({});
       });
       const elapsed = await fetchWhileMainIsBusy(`${serverURL}/blocked`);
       expect(elapsed).to.be.greaterThan(400);
+
+      ses.webRequest.onBeforeRequest(null);
+      const directElapsed = await fetchWhileMainIsBusy(`${serverURL}/observed-after-blocking`);
+      expect(directElapsed).to.be.lessThan(300);
+      expect(completed).to.include.members(['/blocked', '/observed-after-blocking']);
     });
 
     it('report redirect, response and completion details to observers', async () => {
@@ -904,6 +914,9 @@ describe('webRequest module', () => {
       ses.webRequest.onBeforeRedirect((d) => {
         events.push(`redirect ${new URL(d.url).pathname} -> ${new URL(d.redirectURL).pathname} ${d.statusCode}`);
       });
+      ses.webRequest.onResponseStarted((d) => {
+        events.push(`response ${new URL(d.url).pathname} ${d.statusCode}`);
+      });
       ses.webRequest.onCompleted((d) => {
         events.push(`completed ${new URL(d.url).pathname} ${d.statusCode} ${d.resourceType}`);
       });
@@ -913,8 +926,122 @@ describe('webRequest module', () => {
         'send /redirect',
         'redirect /redirect -> /landed 301',
         'send /landed',
+        'response /landed 200',
         'completed /landed 200 xhr'
       ]);
+    });
+
+    it('does not report a redirected branch until the renderer follows it', async () => {
+      const events: string[] = [];
+      ses.webRequest.onSendHeaders((details) => {
+        events.push(`send ${new URL(details.url).pathname}`);
+      });
+      ses.webRequest.onBeforeRedirect((details) => {
+        events.push(`redirect ${new URL(details.url).pathname} -> ${new URL(details.redirectURL).pathname}`);
+      });
+      const failed = new Promise<void>((resolve) => {
+        ses.webRequest.onErrorOccurred((details) => {
+          if (new URL(details.url).pathname === '/redirect') {
+            events.push(`error ${new URL(details.url).pathname}`);
+            resolve();
+          }
+        });
+      });
+      await contents.executeJavaScript(`fetch(${JSON.stringify(`${serverURL}/redirect`)}, { redirect: 'manual' })`);
+      await failed;
+      expect(events).to.deep.equal(['send /redirect', 'redirect /redirect -> /landed', 'error /redirect']);
+    });
+
+    it('reports the redirected method, headers and referrer when followed', async () => {
+      const temporaryContents = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true });
+      defer(() => {
+        if (!temporaryContents.isDestroyed()) temporaryContents.destroy();
+      });
+      await temporaryContents.loadURL(`${serverURL}/page`);
+      const sent: Array<{
+        method: string;
+        path: string;
+        referrer: string;
+        accept: string | undefined;
+        hasContentType: boolean;
+      }> = [];
+      ses.webRequest.onSendHeaders((details) => {
+        const header = (name: string) => {
+          const key = Object.keys(details.requestHeaders).find((key) => key.toLowerCase() === name);
+          return key ? details.requestHeaders[key] : undefined;
+        };
+        sent.push({
+          method: details.method,
+          path: new URL(details.url).pathname,
+          referrer: details.referrer,
+          accept: header('accept'),
+          hasContentType: header('content-type') !== undefined
+        });
+      });
+      const referrer = `${serverURL}/source`;
+      const requestURL = `${serverURL}/redirect-post`;
+      const options = {
+        method: 'POST',
+        body: 'discarded',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'text/plain'
+        },
+        referrer,
+        referrerPolicy: 'unsafe-url'
+      };
+      const data = await temporaryContents.executeJavaScript(
+        `fetch(${JSON.stringify(requestURL)}, ${JSON.stringify(options)}).then(response => response.text())`
+      );
+      temporaryContents.destroy();
+      expect(data).to.equal('GET /landed-method 0');
+      expect(sent).to.deep.equal([
+        {
+          method: 'POST',
+          path: '/redirect-post',
+          referrer,
+          accept: 'application/json',
+          hasContentType: true
+        },
+        {
+          method: 'GET',
+          path: '/landed-method',
+          referrer,
+          accept: 'application/json',
+          hasContentType: false
+        }
+      ]);
+    });
+
+    it('reports one aborted request when renderer endpoints disconnect together', async () => {
+      const requestURL = `${serverURL}/slow`;
+      const filter = { urls: [requestURL] };
+      const errors: string[] = [];
+      const sent = new Promise<void>((resolve) => {
+        ses.webRequest.onSendHeaders(filter, () => resolve());
+      });
+      const failed = new Promise<void>((resolve) => {
+        ses.webRequest.onErrorOccurred(filter, (details) => {
+          errors.push(details.error);
+          resolve();
+        });
+      });
+      const temporaryContents = (webContents as typeof ElectronInternal.WebContents).create({ sandbox: true });
+      defer(() => {
+        if (!temporaryContents.isDestroyed()) temporaryContents.destroy();
+      });
+      await temporaryContents.loadFile(path.join(fixturesPath, 'pages', 'fetch.html'));
+      await temporaryContents.executeJavaScript(`
+        window.abortObservedRequest = new AbortController();
+        fetch(${JSON.stringify(requestURL)}, { signal: window.abortObservedRequest.signal }).catch(() => {});
+        true;
+      `);
+      await sent;
+      await temporaryContents.executeJavaScript('window.abortObservedRequest.abort(); true');
+      temporaryContents.destroy();
+      await failed;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(errors).to.deep.equal(['net::ERR_ABORTED']);
     });
 
     it('report failures to onErrorOccurred', async () => {

--- a/spec/fixtures/api/web-request/server.js
+++ b/spec/fixtures/api/web-request/server.js
@@ -3,9 +3,35 @@
 const http = require('node:http');
 
 const server = http.createServer((req, res) => {
+  if (req.url === '/slow') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    const timer = setTimeout(() => res.end(req.url), 1000);
+    res.on('close', () => clearTimeout(timer));
+    return;
+  }
+  if (req.url === '/page') {
+    res.end('<!doctype html><title>webRequest observer test</title>');
+    return;
+  }
+  if (req.url === '/redirect-post') {
+    res.writeHead(301, { Location: '/landed-method' });
+    res.end();
+    return;
+  }
   if (req.url.startsWith('/redirect')) {
     res.writeHead(301, { Location: '/landed' });
     res.end();
+    return;
+  }
+  if (req.url === '/landed-method') {
+    let bodyLength = 0;
+    req.on('data', (chunk) => {
+      bodyLength += chunk.length;
+    });
+    req.on('end', () => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.end(`${req.method} ${req.url} ${bodyLength}`);
+    });
     return;
   }
   res.setHeader('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
#### Description of Change

Simplify `URLLoaderFactoryGate` construction and drop some unnecessary types. Looks good to me otherwise.

#### Release Notes

Notes: none