### PR TITLE
feat: support extraSize in setAspectRatio on Windows

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -682,7 +682,7 @@ Returns `boolean` - Whether the window is in normal state (not maximized, not mi
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
-* `extraSize` [Size](structures/size.md) (optional) _macOS_ - The extra size not to be included while
+* `extraSize` [Size](structures/size.md) (optional) _macOS_ _Windows_ - The extra size not to be included while
 maintaining the aspect ratio.
 
 This will make a window maintain an aspect ratio. The extra size allows a
@@ -701,6 +701,9 @@ height areas you have within the overall content view.
 
 The aspect ratio is not respected when window is resized programmatically with
 APIs like `win.setSize`.
+
+On Linux the aspect ratio is enforced by the window manager, which has no way
+to express `extraSize`, so it is ignored there.
 
 To reset an aspect ratio, pass 0 as the `aspectRatio` value: `win.setAspectRatio(0)`.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -769,7 +769,7 @@ Returns `boolean` - Whether the window is in normal state (not maximized, not mi
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
-* `extraSize` [Size](structures/size.md) (optional) _macOS_ - The extra size not to be included while
+* `extraSize` [Size](structures/size.md) (optional) _macOS_ _Windows_ - The extra size not to be included while
 maintaining the aspect ratio.
 
 This will make a window maintain an aspect ratio. The extra size allows a
@@ -788,6 +788,9 @@ height areas you have within the overall content view.
 
 The aspect ratio is not respected when window is resized programmatically with
 APIs like `win.setSize`.
+
+On Linux the aspect ratio is enforced by the window manager, which has no way
+to express `extraSize`, so it is ignored there.
 
 To reset an aspect ratio, pass 0 as the `aspectRatio` value: `win.setAspectRatio(0)`.
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -285,6 +285,11 @@ class NativeWindow : public views::WidgetDelegate {
   }
   virtual void SetAspectRatio(double aspect_ratio, const gfx::Size& extra_size);
 
+  // Called when the difference between the window size and the content size
+  // changes, e.g. the menu bar being shown or hidden, for platforms whose
+  // aspect ratio has to account for it.
+  virtual void UpdateAspectRatio() {}
+
   // File preview APIs.
   virtual void PreviewFile(const std::string& path,
                            const std::string& display_name) {}

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1084,12 +1084,57 @@ bool NativeWindowViews::IsResizable() const {
   return CanResize();
 }
 
+#if BUILDFLAG(IS_WIN)
+void NativeWindowViews::UpdateAspectRatio() {
+  if (aspect_ratio() > 0.0)
+    SetAspectRatio(aspect_ratio(), aspect_ratio_extra_size());
+}
+#endif
+
 void NativeWindowViews::SetAspectRatio(double aspect_ratio,
                                        const gfx::Size& extra_size) {
   NativeWindow::SetAspectRatio(aspect_ratio, extra_size);
   gfx::SizeF aspect(aspect_ratio, 1.0);
   // Scale up because SetAspectRatio() truncates aspect value to int
   aspect.Scale(100);
+
+#if BUILDFLAG(IS_WIN)
+  // Windows sizes the whole window rect to |aspect|, so everything that isn't
+  // part of the content view has to be excluded from it: |extra_size| plus the
+  // window/content difference. views::Widget::SetAspectRatio() derives that
+  // difference from the non-client view, which is empty for the native frame
+  // Electron uses, so compute it the way the macOS delegate does and hand it
+  // to the host directly.
+  //
+  // The content size is only correct once a pending layout has run: the menu
+  // bar merely invalidates the layout when it is added or removed.
+  widget()->LayoutRootViewIfNecessary();
+
+  gfx::Size excluded_margin = extra_size;
+  const gfx::Size window_size = GetSize();
+  const gfx::Size content_size = GetContentSize();
+  excluded_margin.Enlarge(window_size.width() - content_size.width(),
+                          window_size.height() - content_size.height());
+
+  // A margin larger than the window is ever allowed to grow to is
+  // unsatisfiable, and Chromium CHECKs rather than sorting it out, so keep it
+  // within the maximum size. Either axis may be unconstrained (zero).
+  const gfx::Size max_size = GetMaximumSize();
+  if (max_size.width() > 0) {
+    excluded_margin.set_width(
+        std::min(excluded_margin.width(), max_size.width()));
+  }
+  if (max_size.height() > 0) {
+    excluded_margin.set_height(
+        std::min(excluded_margin.height(), max_size.height()));
+  }
+
+  if (auto* host = static_cast<ElectronDesktopWindowTreeHostWin*>(
+          GetNativeWindow()->GetHost())) {
+    host->SetAspectRatio(aspect, excluded_margin);
+    return;
+  }
+#endif
 
   widget()->SetAspectRatio(aspect);
 }
@@ -1527,6 +1572,12 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
     // Resize the window to make sure content size is not changed.
     SetContentSize(content_size);
   }
+
+#if BUILDFLAG(IS_WIN)
+  // Adding or removing the menu bar changes the content size, and with it the
+  // margin excluded from the aspect ratio.
+  UpdateAspectRatio();
+#endif
 }
 
 void NativeWindowViews::SetParentWindow(NativeWindow* parent) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -245,6 +245,8 @@ class NativeWindowViews : public NativeWindow,
   void OnWidgetMove() override;
 
 #if BUILDFLAG(IS_WIN)
+  void UpdateAspectRatio() override;
+
   bool ExecuteWindowsCommand(int command_id) override;
   void HandleSizeEvent(WPARAM w_param, LPARAM l_param);
   void ResetWindowControls();

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -91,6 +91,11 @@ void RootView::SetMenuBarVisibility(bool visible) {
   }
 
   InvalidateLayout();
+
+  // The menu bar is part of the content area, so showing or hiding it changes
+  // the window/content difference an aspect ratio may depend on. This covers
+  // the auto-hide path too, which does not go through NativeWindow.
+  window_->UpdateAspectRatio();
 }
 
 void RootView::HandleKeyEvent(const input::NativeWebKeyboardEvent& event) {

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -30,6 +30,12 @@ class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
   ElectronDesktopWindowTreeHostWin& operator=(
       const ElectronDesktopWindowTreeHostWin&) = delete;
 
+  // views::DesktopWindowTreeHostWin::SetAspectRatio() is protected, but
+  // NativeWindowViews needs to call it directly: views::Widget only derives
+  // the excluded margin from the window frame, whereas Electron also has to
+  // exclude the extra size passed to win.setAspectRatio().
+  using views::DesktopWindowTreeHostWin::SetAspectRatio;
+
  protected:
   // views::DesktopWindowTreeHostWin:
   void OnWidgetInitDone() override;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6,6 +6,7 @@ import {
   BrowserView,
   dialog,
   ipcMain,
+  Menu,
   OnBeforeSendHeadersListenerDetails,
   net,
   protocol,
@@ -2050,7 +2051,60 @@ describe('BrowserWindow module', () => {
         // There would be also DCHECK in resize_utils.cc on
         // debug build.
         w.setAspectRatio(1.0);
-        expectBoundsEqual(w.getSize(), [400, 400]);
+        if (process.platform === 'win32') {
+          // Windows applies the ratio to the content area, so a framed window
+          // narrows to keep the content square. It must still stay within the
+          // maximum size, which is what this test guards.
+          const [width, height] = w.getSize();
+          expect(width).to.be.at.most(400);
+          expect(height).to.be.at.most(400);
+          const [contentWidth, contentHeight] = w.getContentSize();
+          expect(contentWidth - contentHeight).to.be.closeTo(0, 1);
+        } else {
+          expectBoundsEqual(w.getSize(), [400, 400]);
+        }
+      });
+
+      // Windows applies the aspect ratio to the window as soon as it is set,
+      // so the effect of |extraSize| is observable without an interactive
+      // resize. macOS only consults it from windowWillResize:, which a test
+      // cannot drive.
+      describe('extraSize', () => {
+        let aspectWindow: BrowserWindow;
+
+        afterEach(async () => {
+          await closeWindow(aspectWindow, { assertNotWindows: false });
+          aspectWindow = null as unknown as BrowserWindow;
+        });
+
+        ifit(process.platform === 'win32')('is not excluded when omitted', () => {
+          aspectWindow = new BrowserWindow({ show: false, frame: false, width: 600, height: 400 });
+          aspectWindow.setAspectRatio(1.0);
+          expectBoundsEqual(aspectWindow.getSize(), [400, 400]);
+        });
+
+        ifit(process.platform === 'win32')('is excluded from the aspect ratio calculation', () => {
+          // 600x400 minus 200px of extra width is already 1:1, so the window
+          // should keep its size instead of being squared off to 400x400.
+          aspectWindow = new BrowserWindow({ show: false, frame: false, width: 600, height: 400 });
+          aspectWindow.setAspectRatio(1.0, { width: 200, height: 0 });
+          expectBoundsEqual(aspectWindow.getSize(), [600, 400]);
+        });
+
+        ifit(process.platform === 'win32')('survives the menu bar being hidden', () => {
+          // The margin excluded on Windows covers the menu bar too, so hiding
+          // it has to recompute the margin rather than leave a stale one.
+          aspectWindow = new BrowserWindow({ show: false, width: 600, height: 400 });
+          aspectWindow.setMenu(Menu.buildFromTemplate([{ label: 'File', submenu: [{ role: 'quit' }] }]));
+          aspectWindow.setAspectRatio(1.0, { width: 200, height: 0 });
+
+          const [beforeWidth, beforeHeight] = aspectWindow.getContentSize();
+          expect(beforeWidth - beforeHeight).to.be.closeTo(200, 2);
+
+          aspectWindow.setMenuBarVisibility(false);
+          const [afterWidth, afterHeight] = aspectWindow.getContentSize();
+          expect(afterWidth - afterHeight).to.be.closeTo(200, 2);
+        });
       });
     });
 


### PR DESCRIPTION
#### Description of Change

`win.setAspectRatio(ratio, extraSize)` documented `extraSize` as macOS-only. This
implements it on Windows.

Chromium already has the concept — `HWNDMessageHandler` keeps an `excluded_margin_dip_` and `SizeWindowToAspectRatio()` passes it to `gfx::SizeRectToAspectRatioWithExcludedMargin()`, which subtracts the margin before applying the ratio and adds it back afterwards. That is exactly the semantics of `extraSize`, and it applies on both sizing paths: the immediate resize `SetAspectRatio()` performs, and `WM_SIZING` during an interactive drag.

The margin never reached it, for two reasons:

1. `views::Widget::SetAspectRatio()` takes only a ratio and derives the margin itself, so there is no way to pass `extraSize` through it.
2. The margin it derives is `non_client_view()->bounds()` minus `frame_view()->GetBoundsForClientView()`. That assumes Chrome's custom frame, drawn _inside_ the HWND client area. Electron's framed windows use the native DWM caption, which is not in the Views hierarchy at all, so the subtraction is always zero.

Because of (2), **no margin at all was being excluded on Windows** — not `extraSize`, and not the title bar or menu bar either. A frameless window kept a square outer rect while its content stayed non-square.

So `NativeWindowViews::SetAspectRatio()` now computes the margin the way the macOS delegate does — window size minus content size, plus `extraSize` — and hands it to the host directly. `DesktopWindowTreeHostWin::SetAspectRatio()` is `protected`, so `ElectronDesktopWindowTreeHostWin` re-exports it with a `using` declaration; no new Chromium patch is needed.

Three details that turned up while testing:

- **The content size needs a layout first.** `RootView::SetMenuBarVisibility()`
  only calls `InvalidateLayout()`, so reading `GetContentSize()` straight after
  it returns the pre-toggle size. `widget()->LayoutRootViewIfNecessary()` before
  measuring fixes that, and also fixes a race where a `setAspectRatio()` call
  made before the menu bar had laid out captured a margin 26px short.

- **The margin has to be recomputed when the menu bar changes.** macOS reads
  `GetSize()`/`GetContentSize()` live inside `windowWillResize:`; Windows caches
  the margin in `HWNDMessageHandler`. Hiding the menu bar changed the
  window/content difference and left the cached margin stale — a window asked
  for 200px of extra width was holding 173. `NativeWindow::UpdateAspectRatio()`
  re-pushes it, called from `RootView::SetMenuBarVisibility()` so the auto-hide
  path (toggling the menu bar with Alt), which never goes through
  `NativeWindow`, is covered too, plus from `NativeWindowViews::SetMenu()`.

- **The margin must fit inside the maximum size.**
  `SizeRectToAspectRatioWithExcludedMargin()` `CHECK`s that
  `max_window_size >= excluded_margin`. That was unreachable while the margin
  was always `0x0`; with a real margin, a window whose maximum size is narrower
  than frame + `extraSize` would hit it. The margin is clamped per axis (either
  axis may be unconstrained).

Linux is left as-is and documented as unsupported:
`DesktopWindowTreeHostPlatform::SetAspectRatio()` drops the margin with a
`NOTIMPLEMENTED_LOG_ONCE()` (crbug.com/408879446), and `WaylandWindow` does not
implement aspect ratio at all.

#### Behaviour change on Windows

Because the frame was never excluded before, `setAspectRatio()` used to size the whole window rect to the ratio on Windows. It now sizes the _content_ area, which is what the documentation describes ("This API already takes into account the difference between a window's size and its content size") and what macOS has always done. A framed 400x400 window with a 1:1 ratio now settles at 377x400, with a 363x363 content area, instead of staying 400x400 with a non-square content area.

The existing spec `doesn't change bounds when maximum size is set` asserted the old behaviour, so it now checks the invariant it was actually guarding on Windows -- the window stays within its maximum size and the content is square -- and keeps the exact bounds assertion elsewhere.

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [ ] `npm test` passes
  - The specs were verified individually against a build; the full suite has not
    been run.
- [x] tests are changed or added

#### Suggested labels

- `semver/minor` — new functionality on a platform that did not have it
- No backport labels; features are main-only by default

#### Release Notes

Notes: Added Windows support for the `extraSize` argument of `win.setAspectRatio(ratio, extraSize)`, and fixed the window frame and menu bar not being excluded from aspect ratio calculations on Windows, which means the ratio now applies to the content area rather than the whole window.
