### PR TITLE
fix: apply zoom level set before the first navigation in persistent zoom modes

### DIFF
--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -67,11 +67,24 @@ void WebContentsZoomController::SetEmbedderZoomController(
 
 bool WebContentsZoomController::SetZoomLevel(double level) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  // Cannot zoom in disabled mode. Also, don't allow changing zoom level on
-  // a crashed tab, an error page or an interstitial page.
-  if (zoom_mode_ == ZOOM_MODE_DISABLED ||
-      !web_contents()->GetPrimaryMainFrame()->IsRenderFrameLive())
+  // Cannot zoom in disabled mode.
+  if (zoom_mode_ == ZOOM_MODE_DISABLED)
     return false;
+
+  // Without a live frame (before the first navigation, or on a crashed tab)
+  // there is nothing to zoom yet. In a persistent isolated/manual mode, record
+  // the level for the next navigation to apply, as the `zoomFactor` +
+  // `zoomMode` web preferences already do. Otherwise - an error page, or a mode
+  // set without the persist flag - reject it.
+  if (!web_contents()->GetPrimaryMainFrame()->IsRenderFrameLive()) {
+    if (persist_zoom_mode_ &&
+        (zoom_mode_ == ZOOM_MODE_ISOLATED || zoom_mode_ == ZOOM_MODE_MANUAL)) {
+      zoom_level_ = level;
+      has_pending_zoom_level_ = true;
+      return true;
+    }
+    return false;
+  }
 
   // Do not actually rescale the page in manual mode.
   if (zoom_mode_ == ZOOM_MODE_MANUAL) {
@@ -120,15 +133,25 @@ bool WebContentsZoomController::SetZoomLevel(double level) {
     zoom_map->SetZoomLevelForHost(host, level);
   }
 
+  has_pending_zoom_level_ = false;
+
   DCHECK(!event_data_);
   return true;
 }
 
 double WebContentsZoomController::GetZoomLevel() const {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  return zoom_mode_ == ZOOM_MODE_MANUAL
-             ? zoom_level_
-             : content::HostZoomMap::GetZoomLevel(web_contents());
+  if (zoom_mode_ == ZOOM_MODE_MANUAL)
+    return zoom_level_;
+
+  // A level recorded while no frame was live has not reached HostZoomMap yet,
+  // so report the level that the next navigation will apply. The frame goes
+  // live when the navigation request is created, long before it commits, so
+  // this cannot key off IsRenderFrameLive().
+  if (has_pending_zoom_level_)
+    return zoom_level_;
+
+  return content::HostZoomMap::GetZoomLevel(web_contents());
 }
 
 void WebContentsZoomController::SetDefaultZoomFactor(double factor) {
@@ -169,6 +192,11 @@ void WebContentsZoomController::SetZoomMode(ZoomMode new_mode) {
   DCHECK(!event_data_);
   event_data_.emplace(web_contents(), original_zoom_level, original_zoom_level,
                       false /* temporary */, new_mode);
+
+  // When entering a mode that persists, track the level the page is at, so
+  // that a later navigation cannot re-apply a stale one.
+  if (new_mode == ZOOM_MODE_ISOLATED || new_mode == ZOOM_MODE_MANUAL)
+    zoom_level_ = original_zoom_level;
 
   switch (new_mode) {
     case ZOOM_MODE_DEFAULT: {
@@ -219,7 +247,6 @@ void WebContentsZoomController::SetZoomMode(ZoomMode new_mode) {
       // the zoom level is handled independently.
       if (zoom_mode_ != ZOOM_MODE_DISABLED) {
         zoom_map->SetTemporaryZoomLevel(rfh_id, GetDefaultZoomLevel());
-        zoom_level_ = original_zoom_level;
       } else {
         // When we don't call any HostZoomMap set functions, we send the event
         // manually.
@@ -240,6 +267,7 @@ void WebContentsZoomController::SetZoomMode(ZoomMode new_mode) {
   // Any event data we've stored should have been consumed by this point.
   DCHECK(!event_data_);
 
+  has_pending_zoom_level_ = false;
   zoom_mode_ = new_mode;
 }
 
@@ -253,6 +281,13 @@ void WebContentsZoomController::ResetZoomModeOnNavigationIfNeeded(
   // the temporary zoom level for the new RenderFrameHost (which changes on
   // cross-origin navigation).
   if (persist_zoom_mode_) {
+    has_pending_zoom_level_ = false;
+
+    // Manual mode tracks the level without ever rescaling the page, so it must
+    // not reach HostZoomMap here either.
+    if (zoom_mode_ == ZOOM_MODE_MANUAL)
+      return;
+
     content::HostZoomMap* zoom_map =
         content::HostZoomMap::GetForWebContents(web_contents());
     content::GlobalRenderFrameHostId rfh_id =

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -156,6 +156,10 @@ class WebContentsZoomController
   // The current zoom level.
   double zoom_level_;
 
+  // Whether `zoom_level_` was set while no frame was live and still has to be
+  // applied by the next navigation.
+  bool has_pending_zoom_level_ = false;
+
   // The current default zoom factor.
   double default_zoom_factor_;
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -3097,6 +3097,19 @@ describe('webContents module', () => {
   describe('zoom mode', () => {
     afterEach(closeAllWindows);
 
+    const devicePixelRatio = (w: BrowserWindow) => w.webContents.executeJavaScript('window.devicePixelRatio');
+
+    // A zoom level reaches the renderer in the widget's visual properties, which
+    // the page can apply after a plain read of it has already answered. Resizing
+    // the window and waiting for the page to see it closes that gap: the size
+    // travels in the same visual properties, so it cannot overtake the level
+    const settleVisualProperties = async (w: BrowserWindow) => {
+      const width = await w.webContents.executeJavaScript('window.innerWidth');
+      const [contentWidth, contentHeight] = w.getContentSize();
+      w.setContentSize(contentWidth - 10, contentHeight);
+      await waitUntil(async () => (await w.webContents.executeJavaScript('window.innerWidth')) !== width);
+    };
+
     it('defaults to "default" zoom mode', async () => {
       const w = new BrowserWindow({ show: false });
       await w.loadURL('about:blank');
@@ -3403,6 +3416,201 @@ describe('webContents module', () => {
       await w.loadURL(crossSiteUrl);
 
       expect(w.webContents.getZoomMode()).to.equal('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('applies a zoom level set before the first navigation in isolated mode', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      w.webContents.setZoomLevel(2.0);
+
+      // Reported before the level has reached HostZoomMap, and applied after
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      await w.loadURL('about:blank');
+
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('applies a zoom level set before the first navigation in manual mode', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'manual'
+        }
+      });
+      w.webContents.setZoomLevel(2.0);
+
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      await w.loadURL('about:blank');
+
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('reports a pending zoom level while the first navigation is in flight', async () => {
+      // Answer slowly, so that the level can be sampled between the frame
+      // going live (when the navigation request is created) and the commit
+      // that puts the level into HostZoomMap
+      const server = http.createServer(async (req, res) => {
+        await setTimeout(200);
+        res.end('hello');
+      });
+      const { url: serverUrl } = await listen(server);
+      defer(() => server.close());
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      w.webContents.setZoomLevel(2.0);
+
+      const samples: number[] = [];
+      const sampler = setInterval(() => samples.push(w.webContents.getZoomLevel()), 1);
+      defer(() => clearInterval(sampler));
+
+      await w.loadURL(serverUrl);
+      clearInterval(sampler);
+
+      expect(samples).to.not.be.empty();
+      expect(
+        samples.every((sample) => sample === 2.0),
+        'zoom level dipped mid-navigation'
+      ).to.be.true();
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+    });
+
+    it('does not zoom the page in manual mode when the level is set before the first navigation', async () => {
+      const control = new BrowserWindow({ show: false });
+      await control.loadURL('about:blank');
+      const unzoomed = await devicePixelRatio(control);
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'manual'
+        }
+      });
+      w.webContents.setZoomLevel(2.0);
+      await w.loadURL('about:blank');
+      await settleVisualProperties(w);
+
+      // Manual mode tracks the level without ever rescaling the page
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      expect(await devicePixelRatio(w)).to.equal(unzoomed);
+    });
+
+    it('does not zoom the page in manual mode when webPreferences.zoomFactor is set', async () => {
+      const control = new BrowserWindow({ show: false });
+      await control.loadURL('about:blank');
+      const unzoomed = await devicePixelRatio(control);
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'manual',
+          zoomFactor: 1.5
+        }
+      });
+      await w.loadURL('about:blank');
+      await settleVisualProperties(w);
+
+      // The factor is tracked, but manual mode still must not rescale the page
+      expect(w.webContents.getZoomFactor()).to.be.closeTo(1.5, 0.0001);
+      expect(await devicePixelRatio(w)).to.equal(unzoomed);
+    });
+
+    it('zooms the page in isolated mode when the level is set before the first navigation', async () => {
+      const control = new BrowserWindow({ show: false });
+      await control.loadURL('about:blank');
+      const unzoomed = await devicePixelRatio(control);
+
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      w.webContents.setZoomLevel(2.0);
+      await w.loadURL('about:blank');
+      await settleVisualProperties(w);
+
+      // Unlike manual mode, isolated mode does rescale the page - a zoom level
+      // of 2 is a factor of 1.2^2
+      expect(await devicePixelRatio(w)).to.be.closeTo(unzoomed * 1.44, 0.01);
+    });
+
+    it('does not zoom the page in manual mode after a cross-document navigation', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+      const unzoomed = await devicePixelRatio(w);
+
+      w.webContents.setZoomMode('manual');
+      w.webContents.setZoomLevel(2.0);
+
+      await w.loadURL('about:blank');
+      await settleVisualProperties(w);
+
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+      expect(await devicePixelRatio(w)).to.equal(unzoomed);
+    });
+
+    it('does not restore a pre-disabled zoom level on navigation after returning to isolated mode', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+
+      w.webContents.setZoomMode('disabled');
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+
+      w.webContents.setZoomMode('isolated');
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+
+      // The disabled mode reset the level, so navigating must not bring it back
+      await w.loadURL('about:blank');
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+    });
+
+    it('tracks the current level when switching from disabled to manual mode', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+
+      w.webContents.setZoomMode('isolated');
+      w.webContents.setZoomLevel(2.0);
+
+      w.webContents.setZoomMode('disabled');
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+
+      // Manual mode tracks the level the page is actually at on entry
+      w.webContents.setZoomMode('manual');
+      expect(w.webContents.getZoomLevel()).to.equal(0);
+    });
+
+    it('applies a zoom level set on a crashed tab when it next loads', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          zoomMode: 'isolated'
+        }
+      });
+      await w.loadURL('about:blank');
+
+      const crashed = once(w.webContents, 'render-process-gone');
+      w.webContents.forcefullyCrashRenderer();
+      await crashed;
+
+      // No live frame, so the level is recorded for the next navigation
+      w.webContents.setZoomLevel(2.0);
+      expect(w.webContents.getZoomLevel()).to.equal(2.0);
+
+      await w.loadURL('about:blank');
       expect(w.webContents.getZoomLevel()).to.equal(2.0);
     });
 


### PR DESCRIPTION
#### Description of Change

Fixes #53225.

`webContents.setZoomLevel()` / `setZoomFactor()` is silently dropped when called before the first
navigation commits, in the zoom modes that are meant to persist (`isolated` and `manual`):

```js
const w = new BrowserWindow({ webPreferences: { zoomMode: 'isolated' } })
w.webContents.setZoomFactor(1.5)        // silently dropped
await w.loadURL('https://example.com')
w.webContents.getZoomFactor()           // 1 (expected 1.5)
```

`WebContentsZoomController::SetZoomLevel()` bails out on `!IsRenderFrameLive()`, and the JS
binding discards its `bool` result, so nothing surfaces to the app. Expressing the same intent
through web preferences – `webPreferences: { zoomMode: 'isolated', zoomFactor: 1.5 }` – does work,
because that path seeds the controller directly.

This records the level when no frame is live in a persistent zoom mode and lets
`ResetZoomModeOnNavigationIfNeeded()` apply it on the next commit – the mechanism that already
re-applies the level across navigations in those modes.

The `persist_zoom_mode_` guard keeps the extensions path unchanged: the extensions API
deliberately sets zoom modes without that flag to preserve Chromium's stock behavior, so a set
without a live frame is still rejected there.

`GetZoomLevel()` needs a matching fallback, since outside manual mode it reads `HostZoomMap`,
which a level recorded this way has not reached yet. A `has_pending_zoom_level_` flag carries
that: set when the level is recorded, cleared once the level reaches `HostZoomMap` (at commit, on
a successful `SetZoomLevel()`, or on a mode change). Frame liveness cannot serve here – the frame
goes live when the navigation request is created, long before it commits, so the reported level
would dip back to the default in between.

Review turned up two further defects in the same two functions:

* Manual mode must never rescale the page – `setZoomMode()` documents that "the page will not
  actually be zoomed" – but `ResetZoomModeOnNavigationIfNeeded()` pushed the tracked level into
  `HostZoomMap` on every navigation, which does rescale it. It now returns before that write in
  manual mode. Two pre-existing cases on `main` are fixed with it: a manual-mode `setZoomLevel()`
  followed by a cross-document navigation, and `webPreferences: { zoomMode: 'manual', zoomFactor }`,
  which rescaled the page on the first load (`devicePixelRatio` 2 -> 3 for a factor of 1.5).
* `SetZoomMode()` now records `zoom_level_` whenever a mode that persists is entered, rather than
  only in the non-disabled branch of the manual case. On `main`, `isolated` -> `disabled` ->
  `isolated` restores the pre-disabled level on the next navigation (`getZoomLevel()` reads 0, then
  2 after navigating), and `disabled` -> `manual` reports it immediately.

**Behavior changes worth calling out:**

* A zoom level can now be recorded on a *crashed* tab in `isolated` / `manual`, where it was
  rejected before – it is applied when the tab next loads. A crashed tab in `default` mode still
  rejects it, and `disabled` mode still rejects everything.
* `manual` mode no longer rescales the page on navigation.
* `isolated` -> `disabled` -> `isolated` no longer restores the pre-disabled level.

No documentation change is needed. The documented behavior of `isolated` / `manual` never carved
out a pre-navigation exception, and manual mode's "the page will not actually be zoomed" now
holds across navigations too.

**Verification.** Built and tested locally on macOS arm64. The full suite is left to CI.

| mode | set before first load | set after load | persists across navigation | rescales the page |
| --- | --- | --- | --- | --- |
| `default` | dropped (unchanged) | applied | no (unchanged) | yes |
| `isolated` | applied | applied | yes | yes |
| `manual` | applied | applied | yes | no (as documented) |
| `disabled` | rejected (unchanged) | rejected | – | – |

"Applied" means the level takes effect for the API and persists. Whether the page itself
rescales is the last column.

All 57 `zoom` specs pass (47 before, 10 added), as do the `chrome.tabs` zoom and `webFrame` specs,
which cover the extensions path where the mode is set without the persist flag. The surrounding
`webContents` (305) and `<webview>` (118) specs pass as well – the latter because the guest
delegate is the one consumer of the zoom controller's observers.

All ten added specs were confirmed to fail without the corresponding fix, by reverting it and
rebuilding:

| spec | without the fix |
| --- | --- |
| pre-load level, `isolated` | `expected +0 to equal 2` |
| pre-load level, `manual` | `expected +0 to equal 2` |
| level reported while the navigation is in flight | `zoom level dipped mid-navigation: expected false to be true` |
| `manual` does not rescale (level set pre-load) | `expected +0 to equal 2` |
| `manual` does not rescale (`zoomFactor` preference) | `expected 3 to equal 2` |
| `manual` does not rescale (after a cross-document navigation) | `expected 2.880000114440918 to equal 2` |
| `isolated` does rescale the page | `expected 2 to be close to 2.88` |
| level set on a crashed tab | `expected +0 to equal 2` |
| pre-disabled level not restored on navigation | `expected 2 to equal +0` |
| `disabled` -> `manual` tracks the current level | `expected 2 to equal +0` |

Page zoom is measured as `devicePixelRatio` against an unzoomed window, since `getZoomLevel()`
reports the tracked level and cannot see whether the page itself scaled. Each measurement first
waits for a resize the page has acknowledged: size and zoom level are fields of the same
`VisualProperties`, so the resize cannot overtake a level the read would otherwise miss.

Disclosure: I developed this with Claude (Claude Code), and reviewed, built, and tested it
locally.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes:
* Fixed `webContents.setZoomLevel()` and `setZoomFactor()` being ignored when called before a page had loaded in the `isolated` and `manual` zoom modes.
* Fixed the `manual` zoom mode rescaling the page on navigation.


