### PR TITLE
docs: note that MenuItem badges are not displayed in Dock menus

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -66,7 +66,7 @@ See [`Menu`](menu.md) for examples.
     with the specified id.
   * `badge` [MenuItemBadge](structures/menu-item-badge.md) (optional) _macOS_ - A badge shown alongside
     the label, either a system-styled count (`alerts`, `updates`, `new-items`) or a custom string.
-    Only available on macOS 14 and up.
+    Only available on macOS 14 and up. Not displayed in [Dock menus](dock.md#docksetmenumenu-macos).
 
 > [!NOTE]
 > `acceleratorWorksWhenHidden` is specified as being macOS-only because accelerators always work when items are hidden on Windows and Linux. The option is exposed to users to give them the option to turn it off, as this is possible in native macOS development.
@@ -198,3 +198,6 @@ A [`MenuItemBadge`](structures/menu-item-badge.md) (optional) indicating the bad
 
 This property can be dynamically changed; setting it to `undefined` removes the badge. Only available on
 macOS 14 and up.
+
+Badges are not displayed in [Dock menus](dock.md#docksetmenumenu-macos), though the same item
+shows its badge in an application menu.

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -30,6 +30,10 @@ hide the app, and switch between different open windows.
 To set an app-defined custom Dock menu, pass any [Menu](../api/menu.md) instance into the
 [`dock.setMenu`](../api/dock.md#docksetmenumenu-macos) API.
 
+> [!NOTE]
+> A [`badge`](../api/menu-item.md#menuitembadge-macos) on a `MenuItem` is not displayed in a Dock
+> menu, though the same item shows it in an application menu.
+
 > [!TIP]
 > For best practices to make your Dock menu feel more native, see Apple's
 > [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/dock-menus)


### PR DESCRIPTION
#### Description of Change

A `badge` set on a menu item is silently ignored when the item is part of a Dock menu
(`app.dock.setMenu()`). The same item shows its badge normally in an application menu, so nothing
signals that anything is wrong – the badge simply never appears. The `badge` docs say only "Only
available on macOS 14 and up", so on macOS 14+ it is reasonable to expect one to show.

Verified on macOS 26 with Electron 44, passing the same items to both menus:

```js
const items = () => [
  { label: 'Custom badge', badge: { content: '7' } },
  { label: 'Count badge', badge: { type: 'new-items', count: 3 } }
]

Menu.setApplicationMenu(Menu.buildFromTemplate([
  { role: 'appMenu' },
  { label: 'Badges', submenu: items() }
]))
app.dock.setMenu(Menu.buildFromTemplate(items()))
```

The application menu renders both badges, the system-styled count even localizing to "3 neu" on a
German system. The Dock menu renders neither, for `normal` and `radio` items alike.

This looks like a platform limitation rather than something Electron can address. A Dock menu is
built by the same `ElectronMenuController` as an application menu
(`-[ElectronApplicationDelegate setApplicationDockMenu:]`), so `item.badge` is assigned either way
in `makeMenuItemForIndex:`, and `applicationDockMenu:` re-applies item state through
`refreshMenuTree:` -> `applyStateToMenuItem:` before the menu is shown. The badge reaches the
`NSMenuItem` and macOS does not render it. Apple documents a comparable restriction for custom
menu item views ("menu item views are not supported in the Dock menu" –
[Views in Menu Items](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MenuList/Articles/ViewsInMenuItems.html)).

The docs state only the behavior, in case the cause ever changes.

Disclosure: I developed this with Claude (Claude Code), and reviewed and verified it locally.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
