### PR TITLE
build: type check specs in docs-only CI

### DIFF
--- a/.github/workflows/pipeline-electron-docs-only.yml
+++ b/.github/workflows/pipeline-electron-docs-only.yml
@@ -56,6 +56,7 @@ jobs:
         cd src/electron
         node script/yarn.js create-typescript-definitions
         node script/yarn.js tsc -p tsconfig.default_app.json --noEmit
+        node script/yarn.js tsc -p tsconfig.spec.json --noEmit
         for f in build/webpack/*.js
         do
             out="${f:29}"

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -646,11 +646,13 @@ const updatesItem = new MenuItem({
   label: 'Updates',
   badge: { type: 'updates', count: 10 }
 });
+console.log(updatesItem.badge);
 
 const newItemsBadge = new MenuItem({
   label: 'New Items',
   badge: { type: 'new-items', count: 1 }
 });
+console.log(newItemsBadge.badge);
 
 // menu
 // https://github.com/electron/electron/blob/main/docs/api/menu.md

--- a/spec/ts-smoke/electron/utility.ts
+++ b/spec/ts-smoke/electron/utility.ts
@@ -83,7 +83,7 @@ localAIHandler.setPromptAPIHandler((details) => {
     }
 
     async prompt() {
-      return 'Hello World';
+      return `Hello to ${this.details.securityOrigin}`;
     }
   };
 });


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

We got burned by #53248 being a docs-only change that broke typings in our tests, and since the tests aren't run for docs-only and we also didn't type check them, there was no way to catch that in CI before merge.

This PR also includes a couple of minor changes in the smoke tests since they weren't type checking cleanly due to a few unused variables.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none
