### PR TITLE
fix: dangling WebContents/NativeWindow pointers in debugger, devtools, login, modal and process-reuse paths

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -31,7 +31,7 @@ gin::WrapperInfo Debugger::kWrapperInfo =
     electron::MakeWrapperInfo(electron::kElectronDebugger);
 
 Debugger::Debugger(content::WebContents* web_contents)
-    : content::WebContentsObserver{web_contents}, web_contents_{web_contents} {}
+    : content::WebContentsObserver{web_contents} {}
 
 Debugger::~Debugger() = default;
 
@@ -125,7 +125,14 @@ void Debugger::Attach(gin::Arguments* args) {
     return;
   }
 
-  agent_host_ = DevToolsAgentHost::GetOrCreateFor(web_contents_);
+  // web_contents() is reset to null by WebContentsObserver once the
+  // observed WebContents has been destroyed.
+  if (!web_contents()) {
+    args->ThrowTypeError("No target available");
+    return;
+  }
+
+  agent_host_ = DevToolsAgentHost::GetOrCreateFor(web_contents());
   if (!agent_host_) {
     args->ThrowTypeError("No target available");
     return;

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -7,7 +7,6 @@
 
 #include <map>
 
-#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/devtools_agent_host_client.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -74,7 +73,6 @@ class Debugger final : public gin::Wrappable<Debugger>,
   v8::Local<v8::Promise> SendCommand(gin::Arguments* args);
   void ClearPendingRequests();
 
-  raw_ptr<content::WebContents> web_contents_;  // Weak Reference.
   scoped_refptr<content::DevToolsAgentHost> agent_host_;
 
   PendingRequestMap pending_requests_;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -424,10 +424,14 @@ ElectronBrowserClient::~ElectronBrowserClient() {
 content::WebContents* ElectronBrowserClient::GetWebContentsFromProcessID(
     content::ChildProcessId process_id) {
   // If the process is a pending process, we should use the web contents
-  // for the frame host passed into RegisterPendingProcess.
+  // for the frame host passed into RegisterPendingProcess. The entry can
+  // outlive that WebContents when the process is shared, so it is held weakly.
   const auto iter = pending_processes_.find(process_id);
-  if (iter != std::end(pending_processes_))
-    return iter->second;
+  if (iter != std::end(pending_processes_)) {
+    if (content::WebContents* web_contents = iter->second.get())
+      return web_contents;
+    pending_processes_.erase(iter);
+  }
 
   // Certain render process will be created with no associated render view,
   // for example: ServiceWorker.
@@ -540,7 +544,7 @@ void ElectronBrowserClient::RegisterPendingSiteInstance(
       prefs ? prefs->CanUseSpareRenderer() : spare_renderer_compatible_;
   base::AutoReset<bool> reset(&spare_renderer_compatible_, compatible);
   const auto pending_process_id = pending_site_instance->GetProcess()->GetID();
-  pending_processes_[pending_process_id] = web_contents;
+  pending_processes_[pending_process_id] = web_contents->GetWeakPtr();
 
   if (rfh->GetParent())
     renderer_is_subframe_.insert(pending_process_id);

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -13,6 +13,7 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/render_process_host_observer.h"
@@ -394,7 +395,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   bool spare_renderer_compatible_ = false;
 
   // pending_render_process => web contents.
-  base::flat_map<content::ChildProcessId, content::WebContents*>
+  base::flat_map<content::ChildProcessId, base::WeakPtr<content::WebContents>>
       pending_processes_;
 
   base::flat_set<content::ChildProcessId> renderer_is_subframe_;

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -8,6 +8,7 @@
 
 #include "base/task/sequenced_task_runner.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/web_contents.h"
 #include "gin/arguments.h"
 #include "gin/dictionary.h"
 #include "net/http/http_response_headers.h"
@@ -36,12 +37,18 @@ LoginHandler::LoginHandler(
     : auth_required_callback_(std::move(auth_required_callback)) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
+  // The WebContents may be destroyed before the posted task runs, so only
+  // carry a weak reference to it across the hop.
+  base::WeakPtr<content::WebContents> weak_web_contents;
+  if (web_contents)
+    weak_web_contents = web_contents->GetWeakPtr();
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
-      base::BindOnce(&LoginHandler::EmitEvent, weak_factory_.GetWeakPtr(),
-                     auth_info, web_contents, is_request_for_primary_main_frame,
-                     is_request_for_navigation, process_id, url,
-                     response_headers, first_auth_attempt));
+      base::BindOnce(
+          &LoginHandler::EmitEvent, weak_factory_.GetWeakPtr(), auth_info,
+          web_contents != nullptr, std::move(weak_web_contents),
+          is_request_for_primary_main_frame, is_request_for_navigation,
+          process_id, url, response_headers, first_auth_attempt));
 }
 
 LoginHandler::LoginHandler(
@@ -63,7 +70,8 @@ LoginHandler::LoginHandler(
 
 void LoginHandler::EmitEvent(
     net::AuthChallengeInfo auth_info,
-    content::WebContents* web_contents,
+    bool has_web_contents,
+    base::WeakPtr<content::WebContents> web_contents,
     bool is_request_for_primary_main_frame,
     bool is_request_for_navigation,
     base::ProcessId process_id,
@@ -74,8 +82,11 @@ void LoginHandler::EmitEvent(
   v8::HandleScope scope(isolate);
 
   raw_ptr<api::WebContents> api_web_contents = nullptr;
-  if (web_contents) {
-    api_web_contents = api::WebContents::From(web_contents);
+  if (has_web_contents) {
+    // Cancel the request if the WebContents (or its JS wrapper) that issued
+    // it has since been destroyed.
+    if (web_contents)
+      api_web_contents = api::WebContents::From(web_contents.get());
     if (!api_web_contents) {
       std::move(auth_required_callback_).Run(std::nullopt);
       return;

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -5,6 +5,7 @@
 #ifndef ELECTRON_SHELL_BROWSER_LOGIN_HANDLER_H_
 #define ELECTRON_SHELL_BROWSER_LOGIN_HANDLER_H_
 
+#include "base/memory/weak_ptr.h"
 #include "base/process/process_handle.h"
 #include "content/public/browser/login_delegate.h"
 
@@ -50,7 +51,8 @@ class LoginHandler : public content::LoginDelegate {
 
  private:
   void EmitEvent(net::AuthChallengeInfo auth_info,
-                 content::WebContents* web_contents,
+                 bool has_web_contents,
+                 base::WeakPtr<content::WebContents> web_contents,
                  bool is_request_for_primary_main_frame,
                  bool is_request_for_navigation,
                  base::ProcessId process_id,

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -100,9 +100,10 @@ NativeWindow::NativeWindow(const int32_t base_window_id,
       is_modal_{parent != nullptr &&
                 options.ValueOrDefault(options::kModal, false)},
       has_frame_{options.ValueOrDefault(options::kFrame, true) &&
-                 title_bar_style_ == TitleBarStyle::kNormal},
-      parent_{parent} {
+                 title_bar_style_ == TitleBarStyle::kNormal} {
   DCHECK_NE(base_window_id_, 0);
+  if (parent)
+    parent_ = parent->GetWeakPtr();
 
 #if BUILDFLAG(IS_WIN)
   options.Get(options::kBackgroundMaterial, &background_material_);
@@ -484,7 +485,10 @@ bool NativeWindow::IsFocusable() const {
 }
 
 void NativeWindow::SetParentWindow(NativeWindow* parent) {
-  parent_ = parent;
+  if (parent)
+    parent_ = parent->GetWeakPtr();
+  else
+    parent_.reset();
 }
 
 bool NativeWindow::AddTabbedWindow(NativeWindow* window) {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -407,7 +407,7 @@ class NativeWindow : public views::WidgetDelegate {
 
   [[nodiscard]] bool has_frame() const { return has_frame_; }
 
-  NativeWindow* parent() const { return parent_; }
+  NativeWindow* parent() const { return parent_.get(); }
 
   [[nodiscard]] bool is_modal() const { return is_modal_; }
 
@@ -570,8 +570,9 @@ class NativeWindow : public views::WidgetDelegate {
   double aspect_ratio_ = 0.0;
   gfx::Size aspect_ratio_extraSize_;
 
-  // The parent window, it is guaranteed to be valid during this window's life.
-  raw_ptr<NativeWindow> parent_ = nullptr;
+  // The parent window. Held weakly because the parent may be destroyed
+  // before this window (e.g. a modal child whose parent is destroy()ed).
+  base::WeakPtr<NativeWindow> parent_;
 
   bool is_transitioning_fullscreen_ = false;
 

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -371,7 +371,7 @@ content::WebContents* InspectableWebContents::GetWebContents() const {
 
 content::WebContents* InspectableWebContents::GetDevToolsWebContents() const {
   if (external_devtools_web_contents_)
-    return external_devtools_web_contents_;
+    return external_devtools_web_contents_.get();
   else
     return managed_devtools_web_contents_.get();
 }
@@ -412,8 +412,12 @@ void InspectableWebContents::SetDevToolsTitle(const std::u16string& title) {
 
 void InspectableWebContents::SetDevToolsWebContents(
     content::WebContents* devtools) {
-  if (!managed_devtools_web_contents_)
-    external_devtools_web_contents_ = devtools;
+  if (managed_devtools_web_contents_)
+    return;
+  if (devtools)
+    external_devtools_web_contents_ = devtools->GetWeakPtr();
+  else
+    external_devtools_web_contents_.reset();
 }
 
 void InspectableWebContents::ShowDevTools(bool activate) {

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -282,8 +282,10 @@ class InspectableWebContents
   // The default devtools created by this class when we don't have an external
   // one assigned by SetDevToolsWebContents.
   std::unique_ptr<content::WebContents> managed_devtools_web_contents_;
-  // The external devtools assigned by SetDevToolsWebContents.
-  raw_ptr<content::WebContents> external_devtools_web_contents_ = nullptr;
+  // The external devtools assigned by SetDevToolsWebContents. Not owned by
+  // us and only observed once ShowDevTools() runs, so hold it weakly in case
+  // it is destroyed before then.
+  base::WeakPtr<content::WebContents> external_devtools_web_contents_;
 
   bool is_guest_;
   std::unique_ptr<InspectableWebContentsView> view_;

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6099,6 +6099,21 @@ describe('BrowserWindow module', () => {
         await createTwo();
       });
 
+      it('does not crash when the parent is destroyed before the modal child', async () => {
+        const parent = new BrowserWindow({ show: false });
+        const child = new BrowserWindow({ parent, modal: true, show: false });
+        parent.destroy();
+        await setTimeout(300);
+        // On Windows the child is owned by the parent HWND and is destroyed
+        // with it; elsewhere it survives and must not touch the freed parent.
+        if (!child.isDestroyed()) {
+          child.hide();
+          child.show();
+          child.hide();
+          child.destroy();
+        }
+      });
+
       ifdescribe(process.platform !== 'darwin' && !isWayland)('disabling parent windows', () => {
         it('can disable and enable a window', () => {
           const w = new BrowserWindow({ show: false });

--- a/spec/api-debugger-spec.ts
+++ b/spec/api-debugger-spec.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { once } from 'node:events';
 import * as http from 'node:http';
 import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 
 import { emittedUntil } from './lib/events-helpers';
 import { listen, waitUntil } from './lib/spec-helpers';
@@ -40,6 +41,15 @@ describe('debugger module', () => {
     it('attaches when no protocol version is specified', () => {
       w.webContents.debugger.attach();
       expect(w.webContents.debugger.isAttached()).to.be.true();
+    });
+
+    it('throws when the webContents has been destroyed', async () => {
+      const { debugger: dbg } = w.webContents;
+      w.webContents.destroy();
+      await once(w.webContents, 'destroyed');
+      await setTimeout(50);
+      expect(() => dbg.attach()).to.throw('No target available');
+      expect(dbg.isAttached()).to.be.false();
     });
   });
 

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -1334,6 +1334,20 @@ describe('webContents module', () => {
       expect(result).to.equal('InspectorFrontendHostImpl');
       devtools.destroy();
     });
+
+    it('falls back to the built-in devtools when the assigned webContents has been destroyed', async () => {
+      const w = new BrowserWindow({ show: false });
+      const devtools = new BrowserWindow({ show: false });
+      w.webContents.setDevToolsWebContents(devtools.webContents);
+      devtools.webContents.destroy();
+      await once(devtools.webContents, 'destroyed');
+      await setTimeout(50);
+      const opened = once(w.webContents, 'devtools-opened');
+      w.webContents.openDevTools({ mode: 'detach' });
+      await opened;
+      expect(w.webContents.isDevToolsOpened()).to.be.true();
+      expect(w.webContents.devToolsWebContents).to.not.be.null();
+    });
   });
 
   describe('isFocused() API', () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -4820,6 +4820,36 @@ describe('webContents module', () => {
       const body = await w.webContents.executeJavaScript('document.documentElement.textContent');
       expect(body).to.equal('401');
     });
+
+    it('does not crash when the webContents is destroyed while an auth request is in flight', async () => {
+      const w = new BrowserWindow({ show: false });
+      const wc = w.webContents;
+      const dbg = wc.debugger;
+      dbg.attach('1.3');
+      const destroyed = once(wc, 'destroyed');
+      dbg.on('message', (_e, method, params) => {
+        if (method === 'Fetch.requestPaused') {
+          dbg.sendCommand('Fetch.continueRequest', { requestId: params.requestId }).catch(() => {});
+        } else if (method === 'Fetch.authRequired') {
+          // Destroying here queues the WebContents deletion right before the
+          // task that emits 'login' for the resumed auth challenge.
+          wc.destroy();
+          dbg
+            .sendCommand('Fetch.continueWithAuth', {
+              requestId: params.requestId,
+              authChallengeResponse: { response: 'Default' }
+            })
+            .catch(() => {});
+        }
+      });
+      await dbg.sendCommand('Fetch.enable', {
+        patterns: [{ urlPattern: '*', requestStage: 'Request' }],
+        handleAuthRequests: true
+      });
+      wc.loadURL(serverUrl).catch(() => {});
+      await destroyed;
+      await setTimeout(100);
+    });
   });
 
   describe('page-title-updated event', () => {

--- a/spec/fixtures/crash-cases/webcontents-destroy-shared-process/index.js
+++ b/spec/fixtures/crash-cases/webcontents-destroy-shared-process/index.js
@@ -1,0 +1,78 @@
+// Regression test: destroying a webContents that shares its renderer process
+// with another webContents used to leave a dangling pointer that was read the
+// next time that process was (re)launched, e.g. for a service worker.
+
+const { app, BrowserWindow, session } = require('electron');
+
+const http = require('node:http');
+const { once } = require('node:events');
+const { setTimeout } = require('node:timers/promises');
+
+// Make window.open() children share the opener's process deterministically.
+app.commandLine.appendSwitch('disable-features', 'SpareRendererForSitePerProcess');
+
+const pages = {
+  '/index.html': `<!DOCTYPE html><script>
+    window.swReady = navigator.serviceWorker.register('/sw.js', { scope: '/' })
+      .then(() => navigator.serviceWorker.ready).then(() => true);
+  </script>`,
+  '/child.html': '<!DOCTYPE html><h1>child</h1>',
+  '/sw.js': `self.addEventListener('install', () => self.skipWaiting());
+    self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
+    self.addEventListener('fetch', () => {});`
+};
+
+const server = http.createServer((req, res) => {
+  const { pathname } = new URL(req.url, 'http://localhost');
+  const body = pages[pathname];
+  if (!body) {
+    res.statusCode = 404;
+    res.end();
+    return;
+  }
+  res.setHeader('Content-Type', pathname.endsWith('.js') ? 'application/javascript' : 'text/html');
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(body);
+});
+
+app.whenReady().then(async () => {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const base = `http://localhost:${server.address().port}`;
+
+  const w1 = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  w1.webContents.setWindowOpenHandler(() => ({
+    action: 'allow',
+    outlivesOpener: true,
+    overrideBrowserWindowOptions: { show: false, webPreferences: { sandbox: true } }
+  }));
+  await w1.loadURL(`${base}/index.html`);
+  await w1.webContents.executeJavaScript('window.swReady');
+
+  const created = once(w1.webContents, 'did-create-window');
+  w1.webContents.executeJavaScript(`window.open('${base}/child.html'); true`);
+  const [w2] = await created;
+  if (w2.webContents.isLoading()) await once(w2.webContents, 'did-stop-loading');
+  await setTimeout(300);
+  if (w1.webContents.getOSProcessId() !== w2.webContents.getOSProcessId()) {
+    throw new Error('expected the opener and the popup to share a renderer process');
+  }
+
+  // Make w1 the most recent registrant for the shared process, then destroy it
+  // while w2 keeps the process host alive.
+  await w1.loadURL(`${base}/index.html?again=1`);
+  w1.webContents.destroy();
+  await setTimeout(500);
+
+  // Kill the shared renderer and have the service worker relaunch it.
+  const gone = once(w2.webContents, 'render-process-gone');
+  w2.webContents.forcefullyCrashRenderer();
+  await gone;
+  await setTimeout(300);
+  await session.defaultSession.serviceWorkers.startWorkerForScope(`${base}/`).catch(() => {});
+  await setTimeout(300);
+
+  server.close();
+  app.quit();
+});
+
+app.on('window-all-closed', () => {});


### PR DESCRIPTION
#### Description of Change

Fixes five places where `shell/` kept a raw pointer to a `content::WebContents` / `NativeWindow` that JS can destroy first. Each was a main-process use-after-free reachable from public API; details in the individual commits.

- `webContents.debugger.attach()` after `webContents.destroy()` — use `WebContentsObserver::web_contents()` instead of a cached pointer; now throws `No target available`.
- `openDevTools()` after the `setDevToolsWebContents()` target was destroyed — hold it as a `WeakPtr`, fall back to the built-in DevTools.
- Re-initialising a renderer process whose registering `webContents` was destroyed (process sharing) — `pending_processes_` stores `WeakPtr<WebContents>`.
- `webContents.destroy()` while an HTTP auth `login` event is queued — bind a `WeakPtr` into the posted task and cancel the auth request if it's gone.
- `hide()`/`show()` on a modal child after `parent.destroy()` — `NativeWindow::parent_` becomes `WeakPtr<NativeWindow>`.

Each has a regression spec (debugger, webContents ×2, BrowserWindow modal) or crash-case fixture (`webcontents-destroy-shared-process`).

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crashes when a webContents or parent window is destroyed while other APIs still reference it.
