### PR TITLE
fix: use-after-free when event handlers re-enter chooser, protocol stream, webauthn and local AI code

### DIFF
--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -161,7 +161,11 @@ void HidChooserController::OnDeviceRemoved(
                                         .Set("device", device.Clone())
                                         .Set("frame", rfh)
                                         .Build();
+    // The handler may destroy the requesting frame, which deletes |this|.
+    base::WeakPtr<HidChooserController> weak_this = weak_factory_.GetWeakPtr();
     session->Get()->Emit("hid-device-removed", details);
+    if (!weak_this)
+      return;
   }
   RemoveDeviceInfo(device);
 }
@@ -244,10 +248,14 @@ void HidChooserController::OnGotDevices(
                                         .Set("deviceList", devicesToDisplay)
                                         .Set("frame", rfh)
                                         .Build();
+    // The handler may destroy the requesting frame, which deletes |this|.
+    base::WeakPtr<HidChooserController> weak_this = weak_factory_.GetWeakPtr();
     prevent_default = session->Get()->Emit(
         "select-hid-device", details,
         base::BindRepeating(&HidChooserController::OnDeviceChosen,
                             weak_factory_.GetWeakPtr()));
+    if (!weak_this)
+      return;
   }
   if (!prevent_default) {
     RunCallback({});

--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -72,10 +72,15 @@ void BluetoothChooser::ShowDiscoveryState(DiscoveryState state) {
       break;
   }
 
+  // The handler may run the callback synchronously, which runs
+  // |event_handler_| and destroys |this|.
+  base::WeakPtr<BluetoothChooser> weak_this = weak_ptr_factory_.GetWeakPtr();
   bool prevent_default =
       api_web_contents_->Emit("select-bluetooth-device", GetDeviceList(),
                               base::BindOnce(&BluetoothChooser::OnDeviceChosen,
                                              weak_ptr_factory_.GetWeakPtr()));
+  if (!weak_this)
+    return;
   if (!prevent_default && idle_state) {
     if (device_id_to_name_map_.empty()) {
       event_handler_.Run(content::BluetoothChooserEvent::CANCELLED, "");
@@ -108,10 +113,15 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
   }
 
   if (changed) {
+    // The handler may run the callback synchronously, which runs
+    // |event_handler_| and destroys |this|.
+    base::WeakPtr<BluetoothChooser> weak_this = weak_ptr_factory_.GetWeakPtr();
     bool prevent_default = api_web_contents_->Emit(
         "select-bluetooth-device", GetDeviceList(),
         base::BindOnce(&BluetoothChooser::OnDeviceChosen,
                        weak_ptr_factory_.GetWeakPtr()));
+    if (!weak_this)
+      return;
 
     if (!prevent_default)
       event_handler_.Run(content::BluetoothChooserEvent::SELECTED, device_id);

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -34,6 +34,12 @@ NodeStreamLoader::NodeStreamLoader(
 }
 
 NodeStreamLoader::~NodeStreamLoader() {
+  // The "removeListener" and "destroy" calls below run user JS which may
+  // invoke the handlers we are unsubscribing. Invalidate weak pointers first
+  // so those handlers, which are bound weakly, become no-ops instead of
+  // re-entering NotifyComplete() on a partially destroyed object.
+  weak_factory_.InvalidateWeakPtrs();
+
   v8::Isolate::Scope isolate_scope(isolate_);
   v8::HandleScope handle_scope(isolate_);
 
@@ -75,9 +81,15 @@ void NodeStreamLoader::Start(network::mojom::URLResponseHeadPtr head) {
   client_->OnReceiveResponse(std::move(head), std::move(consumer),
                              std::nullopt);
 
+  // Subscribing runs the emitter's "on" method, which may invoke the handler
+  // synchronously and delete |this|, so check |weak| between each call.
   auto weak = weak_factory_.GetWeakPtr();
   On("end", base::BindRepeating(&NodeStreamLoader::NotifyEnd, weak));
+  if (!weak)
+    return;
   On("error", base::BindRepeating(&NodeStreamLoader::NotifyError, weak));
+  if (!weak)
+    return;
   On("readable", base::BindRepeating(&NodeStreamLoader::NotifyReadable, weak));
 }
 

--- a/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
+++ b/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
@@ -175,12 +175,19 @@ void ElectronAuthenticatorRequestClientDelegate::SelectAccount(
                                            ->GetWrapper(isolate)
                                            .ToLocalChecked();
 
+  // A listener that runs the callback synchronously completes the request,
+  // which may destroy |this| before EmitEvent returns.
+  base::WeakPtr<ElectronAuthenticatorRequestClientDelegate> weak_this =
+      weak_factory_.GetWeakPtr();
   v8::Local<v8::Value> emit_result = gin_helper::EmitEvent(
       isolate, session_wrapper, "select-webauthn-account", event_object,
       details,
       base::BindRepeating(
           &ElectronAuthenticatorRequestClientDelegate::OnAccountSelected,
           weak_factory_.GetWeakPtr()));
+  if (!weak_this) {
+    return;
+  }
 
   // EventEmitter.prototype.emit() returns true iff there was at least one
   // listener. With no listener there is no way for the app to choose an
@@ -334,11 +341,18 @@ void ElectronAuthenticatorRequestClientDelegate::
   dict.Set("authenticators", authenticators);
   dict.SetGetter("frame", rfh);
 
+  // A listener that runs the callback synchronously dispatches the request,
+  // which may destroy |this| before EmitEvent returns.
+  base::WeakPtr<ElectronAuthenticatorRequestClientDelegate> weak_this =
+      weak_factory_.GetWeakPtr();
   v8::Local<v8::Value> emit_result = gin_helper::EmitEvent(
       isolate, session_wrapper, "select-webauthn-authenticator", event_object,
       base::BindRepeating(
           &ElectronAuthenticatorRequestClientDelegate::OnAuthenticatorSelected,
           weak_factory_.GetWeakPtr()));
+  if (!weak_this) {
+    return;
+  }
 
   bool had_listener = false;
   if (!gin::ConvertFromV8(isolate, emit_result, &had_listener) ||

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -105,7 +105,10 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
       !electron::is_isolated_world(world_id)) {
     const auto [_, inserted] = isolated_worlds_.insert(world_id);
     if (inserted) {
-      for (const auto& callback : isolated_world_created_callbacks_) {
+      // The callbacks run JS which may register further callbacks and
+      // reallocate the vector, so iterate over a copy.
+      auto callbacks = isolated_world_created_callbacks_;
+      for (const auto& callback : callbacks) {
         if (!callback.is_null())
           callback.Run(world_id);
       }

--- a/shell/utility/ai/utility_ai_language_model.cc
+++ b/shell/utility/ai/utility_ai_language_model.cc
@@ -433,8 +433,13 @@ void UtilityAILanguageModel::OnResponderDisconnect(
   if (it != abort_controllers_.end()) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope{isolate};
-    gin_helper::CallMethod(isolate, it->second.Get(isolate), "abort");
+    // abort() runs the signal's listeners and then a microtask checkpoint,
+    // which may settle the pending append() promise and erase this entry
+    // from |abort_controllers_|. Take the controller out of the map first so
+    // we are not holding an iterator across the call.
+    v8::Local<v8::Object> abort_controller = it->second.Get(isolate);
     abort_controllers_.erase(it);
+    gin_helper::CallMethod(isolate, abort_controller, "abort");
   }
 }
 

--- a/shell/utility/ai/utility_ai_manager.cc
+++ b/shell/utility/ai/utility_ai_manager.cc
@@ -164,13 +164,17 @@ void UtilityAIManager::OnCreateLanguageModelClientDisconnect(
   if (it != abort_controllers_.end()) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
     v8::HandleScope scope{isolate};
-    if (description.empty()) {
-      gin_helper::CallMethod(isolate, it->second.Get(isolate), "abort");
-    } else {
-      gin_helper::CallMethod(isolate, it->second.Get(isolate), "abort",
-                             description);
-    }
+    // abort() runs the signal's listeners and then a microtask checkpoint,
+    // which may settle the pending create() promise and erase this entry
+    // from |abort_controllers_|. Take the controller out of the map first so
+    // we are not holding an iterator across the call.
+    v8::Local<v8::Object> abort_controller = it->second.Get(isolate);
     abort_controllers_.erase(it);
+    if (description.empty()) {
+      gin_helper::CallMethod(isolate, abort_controller, "abort");
+    } else {
+      gin_helper::CallMethod(isolate, abort_controller, "abort", description);
+    }
   }
 }
 

--- a/spec/api-local-ai-handler-spec.ts
+++ b/spec/api-local-ai-handler-spec.ts
@@ -371,6 +371,27 @@ ifdescribe(features.isPromptAPIEnabled())('localAIHandler module', () => {
       expect(message).not.null();
     });
 
+    it('does not crash the handler when several pending create() calls are aborted', async () => {
+      const aiHandler = await forkAndRegisterHandler('controllable-language-model.js');
+      await sendControllableMessage(aiHandler, { command: 'set-create', value: 'wait-for-abort' });
+      let exited = false;
+      aiHandler.once('exit', () => {
+        exited = true;
+      });
+
+      const results = await w.webContents.executeJavaScript(
+        'Promise.all([100, 200, 300].map(t => LanguageModel.create({ signal: AbortSignal.timeout(t) }).then(() => "resolved", err => err.message)))'
+      );
+      for (const result of results) {
+        expect(result).to.match(/signal timed out/);
+      }
+
+      // The handler process must still be alive and responsive.
+      await sendControllableMessage(aiHandler, { command: 'set-create', value: null });
+      expect(exited).to.be.false();
+      expect(await w.webContents.executeJavaScript('LanguageModel.create().then(() => "ok")')).to.equal('ok');
+    });
+
     it('exposes contextUsage and contextWindow on the created model', async () => {
       await forkAndRegisterHandler('basic-language-model.js');
 
@@ -814,6 +835,31 @@ ifdescribe(features.isPromptAPIEnabled())('localAIHandler module', () => {
       });
 
       expect(message).not.null();
+    });
+
+    it('does not crash the handler when one of several pending append() calls is aborted', async () => {
+      const aiHandler = await forkAndRegisterHandler('controllable-language-model.js');
+      await sendControllableMessage(aiHandler, { command: 'set-append-response', value: 'wait-for-abort' });
+      let exited = false;
+      aiHandler.once('exit', () => {
+        exited = true;
+      });
+
+      const result = await w.webContents.executeJavaScript(`
+        LanguageModel.create().then(async (model) => {
+          const controller = new AbortController();
+          const aborted = model.append("one", { signal: controller.signal }).then(() => "resolved", err => err.message);
+          model.append("two", { signal: new AbortController().signal }).catch(() => {});
+          await new Promise(r => setTimeout(r, 100));
+          controller.abort();
+          return aborted;
+        })
+      `);
+      expect(result).to.match(/aborted/);
+
+      // The handler process must still be alive and responsive.
+      await sendControllableMessage(aiHandler, { command: 'set-append-response', value: null });
+      expect(exited).to.be.false();
     });
 
     it('updates contextUsage after append', async () => {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -656,6 +656,48 @@ describe('protocol module', () => {
         await contents.loadFile(path.join(__dirname, 'fixtures', 'pages', 'fetch.html'));
         await hasClosedPromise;
       });
+
+      it('does not crash when the stream emits end synchronously from on()', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const data: any = {
+            on(event: string, listener: () => void) {
+              if (event === 'end') listener();
+              return data;
+            },
+            removeListener() {
+              return data;
+            }
+          };
+          callback({ statusCode: 200, headers: { 'Content-Type': 'text/plain' }, data });
+        });
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal('');
+      });
+
+      it('does not crash when removeListener re-invokes a listener during teardown', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const listeners: Record<string, () => void> = {};
+          let calls = 0;
+          const data: any = {
+            on(event: string, listener: () => void) {
+              listeners[event] = listener;
+              if (event === 'readable') setImmediate(() => listeners.end());
+              return data;
+            },
+            removeListener(event: string, listener: () => void) {
+              if (event === 'end' && calls++ < 2) listener();
+              return data;
+            },
+            read: () => null,
+            destroy() {},
+            pause() {},
+            resume() {}
+          };
+          callback({ statusCode: 200, headers: { 'Content-Type': 'text/plain' }, data });
+        });
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal('');
+      });
     });
   }
 

--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -454,6 +454,32 @@ describe("session 'select-webauthn-account' event", () => {
     expect(result.userHandle).to.equal(bob.userHandle);
   });
 
+  it('does not crash when the listener invokes the callback and then throws', async () => {
+    await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
+    await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });
+
+    const error = new Error('boom');
+    const listeners = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    const thrown = new Promise<Error>((resolve) => process.once('uncaughtException', resolve));
+
+    try {
+      (w.webContents.session as NodeJS.EventEmitter).on('select-webauthn-account', (event, details, callback) => {
+        callback(details.accounts[0].credentialId);
+        throw error;
+      });
+
+      const result = await getAssertion();
+      expect(await thrown).to.equal(error);
+      expect(result.ok).to.be.true();
+    } finally {
+      process.removeAllListeners('uncaughtException');
+      for (const listener of listeners) {
+        process.on('uncaughtException', listener);
+      }
+    }
+  });
+
   it('cancels the request when the callback is invoked with an unknown credentialId', async () => {
     await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
     await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });

--- a/spec/api-web-frame-spec.ts
+++ b/spec/api-web-frame-spec.ts
@@ -423,6 +423,25 @@ describe('webFrame module', () => {
         expect(worlds).to.not.include(0);
         expect(worlds).to.not.include(999);
       });
+
+      it('does not crash when a listener registers more listeners while being notified', async () => {
+        const worlds = await w.executeJavaScript(`new Promise(resolve => {
+          const mk = () => webFrame.findFrameByToken(webFrame.frameToken);
+          const seen = [];
+          const a = mk();
+          const b = mk();
+          a.once('isolated-world-created', (worldId) => {
+            seen.push(worldId);
+            for (let i = 0; i < 256; i++) mk().on('isolated-world-created', () => {});
+          });
+          b.once('isolated-world-created', (worldId) => {
+            seen.push(worldId);
+            resolve(seen);
+          });
+          webFrame.executeJavaScriptInIsolatedWorld(1107, [{ code: 'void 0' }]);
+        })`);
+        expect(worlds).to.deep.equal([1107, 1107]);
+      });
     });
   });
 });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -5110,6 +5110,26 @@ describe('navigator.hid', () => {
       }
     }
   });
+
+  it('does not crash when the requesting webContents is destroyed from the select-hid-device handler', async () => {
+    const guest = (webContents as typeof ElectronInternal.WebContents).create({
+      type: 'webview',
+      embedder: w.webContents
+    });
+    await guest.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+    session.defaultSession.setPermissionCheckHandler(() => true);
+    session.defaultSession.setDevicePermissionHandler(() => true);
+    const selectFired = new Promise<void>((resolve) => {
+      w.webContents.session.once('select-hid-device', () => {
+        guest.destroy();
+        resolve();
+      });
+    });
+    guest.executeJavaScript('navigator.hid.requestDevice({filters: []})', true).catch(() => {});
+    await selectFired;
+    await setTimeout();
+    expect(guest.isDestroyed()).to.be.true();
+  });
 });
 
 describe('navigator.usb', () => {


### PR DESCRIPTION
#### Description of Change

Fixes six re-entrancy bugs with the same shape: native code emits an event or calls user JS while still holding `this` or a live iterator, and the handler (legitimately) destroys the owner or mutates the container. All are use-after-free / iterator-invalidation crashes; per-site detail is in each commit.

- `select-bluetooth-device` callback invoked synchronously — weak-self check after emit in `BluetoothChooser`.
- `select-hid-device` / `hid-device-removed` handler destroys the requesting `webContents` — weak-self check in `HidChooserController`.
- Custom protocol stream whose `on()` / `removeListener()` fires listeners synchronously — weak-self checks in `NodeStreamLoader::Start`, invalidate weak ptrs first in the destructor.
- `select-webauthn-account` / `-authenticator` listener calls back then throws — weak-self check after emit.
- Cancelling pending local-AI `create()` / `append()` — erase the `AbortController` map entry before calling `abort()` instead of holding the iterator across it.
- `isolated-world-created` listener that registers more listeners — iterate a copy of the callback vector.

Regression specs added for all except Bluetooth (needs a real adapter).

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crashes when certain app event handlers call back into Electron synchronously.
