### PR TITLE
fix: object lifetime bugs in sharedTexture, service-worker ipcRenderer and utilityProcess.fork()

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_utility_process.h"
 
+#include <array>
 #include <map>
 #include <unordered_map>
 #include <utility>
@@ -573,17 +574,23 @@ UtilityProcessWrapper* UtilityProcessWrapper::Create(
     opts.Get("cwd", &current_working_directory);
     opts.Get("respondToAuthRequestsFromMainProcess", &create_network_observer);
 
-    std::vector<std::string> stdio_arr{"ignore", "inherit", "inherit"};
+    constexpr std::array default_stdio{
+        IOType::IO_IGNORE,
+        IOType::IO_INHERIT,
+        IOType::IO_INHERIT,
+    };
+    std::vector<std::string> stdio_arr;
     opts.Get("stdio", &stdio_arr);
-    for (size_t i = 0; i < 3; i++) {
-      IOType type;
-      if (stdio_arr[i] == "ignore")
-        type = IOType::IO_IGNORE;
-      else if (stdio_arr[i] == "inherit")
-        type = IOType::IO_INHERIT;
-      else if (stdio_arr[i] == "pipe")
-        type = IOType::IO_PIPE;
-
+    for (size_t i = 0; i < default_stdio.size(); ++i) {
+      IOType type = default_stdio[i];
+      if (i < stdio_arr.size()) {
+        if (stdio_arr[i] == "ignore")
+          type = IOType::IO_IGNORE;
+        else if (stdio_arr[i] == "inherit")
+          type = IOType::IO_INHERIT;
+        else if (stdio_arr[i] == "pipe")
+          type = IOType::IO_PIPE;
+      }
       stdio.emplace(static_cast<IOHandle>(i), type);
     }
 

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -430,6 +430,11 @@ void ImportedTextureRelease(const v8::FunctionCallbackInfo<v8::Value>& info) {
       info.Data().As<v8::External>()->Value(
           v8::kExternalPointerTypeTagDefault));
 
+  if (wrapper->IsReferenceReleased()) {
+    LOG(WARNING) << "This imported shared texture is already released.";
+    return;
+  }
+
   auto cb = info[0];
   if (cb->IsFunction()) {
     auto* isolate = info.GetIsolate();
@@ -500,8 +505,16 @@ v8::Local<v8::Value> CreateImportedSharedTextureFromSharedImage(
   auto* wrapper = new ImportedSharedTextureWrapper();
   wrapper->ist = base::WrapRefCounted(imported);
 
+  // Every method below carries |imported_wrapped| as its [[Data]], so the
+  // external stays alive for as long as any of them is reachable. Tie the
+  // lifetime of |wrapper| to the external rather than to the returned
+  // dictionary so that a retained method can never observe a freed wrapper.
   auto imported_wrapped =
       v8::External::New(isolate, wrapper, v8::kExternalPointerTypeTagDefault);
+  auto* persistent = wrapper->CreatePersistent(isolate, imported_wrapped);
+  persistent->SetWeak(wrapper, PersistentCallbackPass1,
+                      v8::WeakCallbackType::kParameter);
+
   gin::Dictionary root(isolate, v8::Object::New(isolate));
 
   auto releaser = v8::Function::New(isolate->GetCurrentContext(),
@@ -536,13 +549,7 @@ v8::Local<v8::Value> CreateImportedSharedTextureFromSharedImage(
   root.Set("getFrameCreationSyncToken", get_frame_creation_sync_token);
   root.Set("setReleaseSyncToken", set_release_sync_token);
 
-  auto root_local = gin::ConvertToV8(isolate, root);
-  auto* persistent = wrapper->CreatePersistent(isolate, root_local);
-
-  persistent->SetWeak(wrapper, PersistentCallbackPass1,
-                      v8::WeakCallbackType::kParameter);
-
-  return root_local;
+  return gin::ConvertToV8(isolate, root);
 }
 
 struct ImportSharedTextureInfoPlane {

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -259,10 +259,13 @@ gin::WrapperInfo IPCBase<IPCRenderFrame>::kWrapperInfo =
 
 class IPCServiceWorker final : public IPCBase<IPCServiceWorker>,
                                public content::WorkerThread::Observer {
+  CPPGC_USING_PRE_FINALIZER(IPCServiceWorker, Dispose);
+
  public:
   explicit IPCServiceWorker(v8::Isolate* isolate) {
     DCHECK(IsWorkerThread());
     content::WorkerThread::AddObserver(this);
+    observing_worker_thread_ = true;
 
     electron::ServiceWorkerData* service_worker_data =
         electron::preload_realm::GetServiceWorkerData(
@@ -272,11 +275,28 @@ class IPCServiceWorker final : public IPCBase<IPCServiceWorker>,
         electron_ipc_remote_.BindNewEndpointAndPassReceiver());
   }
 
-  void WillStopCurrentWorkerThread() override { electron_ipc_remote_.reset(); }
+  // Deregister from the worker thread's observer list before cppgc reclaims
+  // this object, otherwise thread shutdown would notify a swept observer.
+  void Dispose() {
+    if (observing_worker_thread_) {
+      observing_worker_thread_ = false;
+      content::WorkerThread::RemoveObserver(this);
+    }
+  }
+
+  void WillStopCurrentWorkerThread() override {
+    // The per-thread observer list is destroyed right after this returns, so
+    // there is nothing left to deregister from in Dispose().
+    observing_worker_thread_ = false;
+    electron_ipc_remote_.reset();
+  }
 
   const char* GetHumanReadableName() const override {
     return "Electron / IPCServiceWorker";
   }
+
+ private:
+  bool observing_worker_thread_ = false;
 };
 
 template <>

--- a/spec/api-shared-texture-spec.ts
+++ b/spec/api-shared-texture-spec.ts
@@ -270,6 +270,55 @@ ifdescribe(!skip)('sharedTexture module', () => {
       return runSharedTextureManagedTest(false);
     }).timeout(debugSpec ? 100000 : 10000);
 
+    it('keeps subtle methods usable after the imported object is garbage collected', async function () {
+      this.timeout(debugSpec ? 100000 : 10000);
+      const v8Util = process._linkedBinding('electron_common_v8_util');
+      const setTimeoutAsync = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+      const osr = new BrowserWindow({
+        width: 128,
+        height: 128,
+        show: debugSpec,
+        webPreferences: {
+          offscreen: {
+            useSharedTexture: true
+          }
+        }
+      });
+      osr.webContents.setFrameRate(1);
+
+      const texture = await new Promise<Electron.OffscreenSharedTexture | null>((resolve) => {
+        osr.webContents.once('paint', (event: any) => resolve(event.texture ?? null));
+        osr.loadFile(osrPath);
+      });
+      if (!texture) {
+        console.error('No texture, GPU may be unavailable, skipping.');
+        return;
+      }
+
+      // Retain only the method closures and let the returned object become unreachable.
+      const retained = (() => {
+        const imported = sharedTexture.subtle.importSharedTexture(texture.textureInfo);
+        return {
+          getFrameCreationSyncToken: imported.getFrameCreationSyncToken,
+          release: imported.release
+        };
+      })();
+
+      for (let i = 0; i < 3; i++) {
+        await setTimeoutAsync(10);
+        v8Util.requestGarbageCollectionForTesting();
+      }
+      await setTimeoutAsync(10);
+
+      expect(retained.getFrameCreationSyncToken()).to.have.property('syncToken').that.is.a('string');
+      retained.release();
+      // A second release must be a no-op rather than a crash.
+      expect(() => retained.release()).to.not.throw();
+      expect(() => retained.getFrameCreationSyncToken()).to.throw(/released/);
+      texture.release();
+    });
+
     it('successfully imported and rendered with managed api, with iframe', async () => {
       return runSharedTextureManagedTest(true);
     }).timeout(debugSpec ? 100000 : 10000);

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -52,6 +52,25 @@ describe('utilityProcess module', () => {
         });
       }).to.throw(/stdin value other than ignore is not supported/);
     });
+
+    it('does not crash when options.stdio shrinks while being read', async () => {
+      const stdio: any = ['ignore', 'inherit', 'inherit'];
+      let reads = 0;
+      Object.defineProperty(stdio, 2, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          if (reads++ === 0) {
+            delete stdio[2];
+            stdio.length = 2;
+          }
+          return 'pipe';
+        }
+      });
+      const child = utilityProcess.fork(path.join(fixturesPath, 'empty.js'), [], { stdio });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+    });
   });
 
   describe('lifecycle events', () => {


### PR DESCRIPTION
#### Description of Change

Three ownership/lifetime fixes; each commit message has the specifics.

- `sharedTexture.subtle.importSharedTexture()` — the native wrapper was freed with the returned object while its method functions still pointed at it; tie its lifetime to the shared `v8::External` every method holds, and make `release()` idempotent.
- Service-worker `ipcRenderer` (`IPCServiceWorker`) — cppgc object registered as a `WorkerThread` observer and never unregistered; add a prefinalizer that removes it.
- `utilityProcess.fork({ stdio })` — native side indexed three entries unconditionally and left `IOType` uninitialised for unknown strings; clamp to the array size and default the rest.

Specs added for shared texture and utilityProcess.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed crashes in sharedTexture, service-worker ipcRenderer and utilityProcess.fork() caused by object lifetime bugs.
