### PR TITLE
test: move throwing select-webauthn-account listener case to a crash fixture

### DIFF
--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -454,32 +454,6 @@ describe("session 'select-webauthn-account' event", () => {
     expect(result.userHandle).to.equal(bob.userHandle);
   });
 
-  it('does not crash when the listener invokes the callback and then throws', async () => {
-    await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
-    await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });
-
-    const error = new Error('boom');
-    const listeners = process.listeners('uncaughtException');
-    process.removeAllListeners('uncaughtException');
-    const thrown = new Promise<Error>((resolve) => process.once('uncaughtException', resolve));
-
-    try {
-      (w.webContents.session as NodeJS.EventEmitter).on('select-webauthn-account', (event, details, callback) => {
-        callback(details.accounts[0].credentialId);
-        throw error;
-      });
-
-      const result = await getAssertion();
-      expect(await thrown).to.equal(error);
-      expect(result.ok).to.be.true();
-    } finally {
-      process.removeAllListeners('uncaughtException');
-      for (const listener of listeners) {
-        process.on('uncaughtException', listener);
-      }
-    }
-  });
-
   it('cancels the request when the callback is invoked with an unknown credentialId', async () => {
     await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
     await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });

--- a/spec/fixtures/crash-cases/webauthn-select-account-listener-throws/index.js
+++ b/spec/fixtures/crash-cases/webauthn-select-account-listener-throws/index.js
@@ -1,0 +1,83 @@
+// A 'select-webauthn-account' listener that invokes the callback and then
+// throws must not crash the main process. The throw should surface as an
+// ordinary uncaughtException and the assertion should still resolve.
+const { app, BrowserWindow } = require('electron');
+
+const http = require('node:http');
+
+const expectedError = new Error('boom');
+let caught = null;
+process.on('uncaughtException', (err) => {
+  caught = err;
+});
+
+async function addCredential(w, authenticatorId, id, userHandle, name) {
+  const privateKey = await w.webContents.executeJavaScript(`
+    (async () => {
+      const k = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign']);
+      const pkcs8 = await crypto.subtle.exportKey('pkcs8', k.privateKey);
+      return btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+    })()
+  `);
+  await w.webContents.debugger.sendCommand('WebAuthn.addCredential', {
+    authenticatorId,
+    credential: {
+      credentialId: Buffer.from(id).toString('base64'),
+      isResidentCredential: true,
+      rpId: 'localhost',
+      privateKey,
+      userHandle: Buffer.from(userHandle).toString('base64'),
+      userName: name,
+      userDisplayName: name,
+      signCount: 0
+    }
+  });
+}
+
+app
+  .whenReady()
+  .then(async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader('Content-Type', 'text/html');
+      res.end('<!doctype html><title>webauthn</title>');
+    });
+    await new Promise((resolve) => server.listen(0, 'localhost', resolve));
+
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(`http://localhost:${server.address().port}/`);
+    w.webContents.debugger.attach();
+    await w.webContents.debugger.sendCommand('WebAuthn.enable');
+    const { authenticatorId } = await w.webContents.debugger.sendCommand('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true
+      }
+    });
+    await addCredential(w, authenticatorId, 'cred-alice', 'uh-alice', 'alice@example.com');
+    await addCredential(w, authenticatorId, 'cred-bob', 'uh-bob', 'bob@example.com');
+
+    w.webContents.session.on('select-webauthn-account', (event, details, callback) => {
+      callback(details.accounts[0].credentialId);
+      throw expectedError;
+    });
+
+    const result = await w.webContents.executeJavaScript(`
+    navigator.credentials.get({
+      publicKey: { challenge: new Uint8Array(32), rpId: 'localhost', userVerification: 'required' }
+    }).then(c => ({ ok: true, id: c.id }), e => ({ ok: false, name: e.name, message: e.message }))
+  `);
+
+    if (!result.ok) throw new Error(`assertion failed: ${result.name}: ${result.message}`);
+    if (caught !== expectedError) throw new Error(`expected listener error to reach uncaughtException, got: ${caught}`);
+
+    server.close();
+    app.quit();
+  })
+  .catch((err) => {
+    console.error(err);
+    app.exit(1);
+  });


### PR DESCRIPTION
#### Description of Change

Follow-up to #53258: moves the "listener invokes the callback and then throws" case into a crash-case fixture so the spec runner's `uncaughtException` handlers are left untouched.

#### Release Notes

Notes: none
