### PR TITLE
fix: use-after-free when event handlers re-enter chooser, protocol stream and webauthn code

### DIFF
--- a/shell/browser/hid/hid_chooser_controller.cc
+++ b/shell/browser/hid/hid_chooser_controller.cc
@@ -161,7 +161,11 @@ void HidChooserController::OnDeviceRemoved(
                                         .Set("device", device.Clone())
                                         .Set("frame", rfh)
                                         .Build();
+    // The handler may destroy the requesting frame, which deletes |this|.
+    base::WeakPtr<HidChooserController> weak_this = weak_factory_.GetWeakPtr();
     session->Get()->Emit("hid-device-removed", details);
+    if (!weak_this)
+      return;
   }
   RemoveDeviceInfo(device);
 }
@@ -244,10 +248,14 @@ void HidChooserController::OnGotDevices(
                                         .Set("deviceList", devicesToDisplay)
                                         .Set("frame", rfh)
                                         .Build();
+    // The handler may destroy the requesting frame, which deletes |this|.
+    base::WeakPtr<HidChooserController> weak_this = weak_factory_.GetWeakPtr();
     prevent_default = session->Get()->Emit(
         "select-hid-device", details,
         base::BindRepeating(&HidChooserController::OnDeviceChosen,
                             weak_factory_.GetWeakPtr()));
+    if (!weak_this)
+      return;
   }
   if (!prevent_default) {
     RunCallback({});

--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -72,10 +72,15 @@ void BluetoothChooser::ShowDiscoveryState(DiscoveryState state) {
       break;
   }
 
+  // The handler may run the callback synchronously, which runs
+  // |event_handler_| and destroys |this|.
+  base::WeakPtr<BluetoothChooser> weak_this = weak_ptr_factory_.GetWeakPtr();
   bool prevent_default =
       api_web_contents_->Emit("select-bluetooth-device", GetDeviceList(),
                               base::BindOnce(&BluetoothChooser::OnDeviceChosen,
                                              weak_ptr_factory_.GetWeakPtr()));
+  if (!weak_this)
+    return;
   if (!prevent_default && idle_state) {
     if (device_id_to_name_map_.empty()) {
       event_handler_.Run(content::BluetoothChooserEvent::CANCELLED, "");
@@ -108,10 +113,15 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
   }
 
   if (changed) {
+    // The handler may run the callback synchronously, which runs
+    // |event_handler_| and destroys |this|.
+    base::WeakPtr<BluetoothChooser> weak_this = weak_ptr_factory_.GetWeakPtr();
     bool prevent_default = api_web_contents_->Emit(
         "select-bluetooth-device", GetDeviceList(),
         base::BindOnce(&BluetoothChooser::OnDeviceChosen,
                        weak_ptr_factory_.GetWeakPtr()));
+    if (!weak_this)
+      return;
 
     if (!prevent_default)
       event_handler_.Run(content::BluetoothChooserEvent::SELECTED, device_id);

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -34,6 +34,12 @@ NodeStreamLoader::NodeStreamLoader(
 }
 
 NodeStreamLoader::~NodeStreamLoader() {
+  // The "removeListener" and "destroy" calls below run user JS which may
+  // invoke the handlers we are unsubscribing. Invalidate weak pointers first
+  // so those handlers, which are bound weakly, become no-ops instead of
+  // re-entering NotifyComplete() on a partially destroyed object.
+  weak_factory_.InvalidateWeakPtrs();
+
   v8::Isolate::Scope isolate_scope(isolate_);
   v8::HandleScope handle_scope(isolate_);
 
@@ -75,9 +81,15 @@ void NodeStreamLoader::Start(network::mojom::URLResponseHeadPtr head) {
   client_->OnReceiveResponse(std::move(head), std::move(consumer),
                              std::nullopt);
 
+  // Subscribing runs the emitter's "on" method, which may invoke the handler
+  // synchronously and delete |this|, so check |weak| between each call.
   auto weak = weak_factory_.GetWeakPtr();
   On("end", base::BindRepeating(&NodeStreamLoader::NotifyEnd, weak));
+  if (!weak)
+    return;
   On("error", base::BindRepeating(&NodeStreamLoader::NotifyError, weak));
+  if (!weak)
+    return;
   On("readable", base::BindRepeating(&NodeStreamLoader::NotifyReadable, weak));
 }
 

--- a/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
+++ b/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
@@ -148,12 +148,19 @@ void ElectronAuthenticatorRequestClientDelegate::SelectAccount(
                                            ->GetWrapper(isolate)
                                            .ToLocalChecked();
 
+  // A listener that runs the callback synchronously completes the request,
+  // which may destroy |this| before EmitEvent returns.
+  base::WeakPtr<ElectronAuthenticatorRequestClientDelegate> weak_this =
+      weak_factory_.GetWeakPtr();
   v8::Local<v8::Value> emit_result = gin_helper::EmitEvent(
       isolate, session_wrapper, "select-webauthn-account", event_object,
       details,
       base::BindRepeating(
           &ElectronAuthenticatorRequestClientDelegate::OnAccountSelected,
           weak_factory_.GetWeakPtr()));
+  if (!weak_this) {
+    return;
+  }
 
   // EventEmitter.prototype.emit() returns true iff there was at least one
   // listener. With no listener there is no way for the app to choose an

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -656,6 +656,48 @@ describe('protocol module', () => {
         await contents.loadFile(path.join(__dirname, 'fixtures', 'pages', 'fetch.html'));
         await hasClosedPromise;
       });
+
+      it('does not crash when the stream emits end synchronously from on()', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const data: any = {
+            on(event: string, listener: () => void) {
+              if (event === 'end') listener();
+              return data;
+            },
+            removeListener() {
+              return data;
+            }
+          };
+          callback({ statusCode: 200, headers: { 'Content-Type': 'text/plain' }, data });
+        });
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal('');
+      });
+
+      it('does not crash when removeListener re-invokes a listener during teardown', async () => {
+        registerStreamProtocol(protocolName, (request, callback) => {
+          const listeners: Record<string, () => void> = {};
+          let calls = 0;
+          const data: any = {
+            on(event: string, listener: () => void) {
+              listeners[event] = listener;
+              if (event === 'readable') setImmediate(() => listeners.end());
+              return data;
+            },
+            removeListener(event: string, listener: () => void) {
+              if (event === 'end' && calls++ < 2) listener();
+              return data;
+            },
+            read: () => null,
+            destroy() {},
+            pause() {},
+            resume() {}
+          };
+          callback({ statusCode: 200, headers: { 'Content-Type': 'text/plain' }, data });
+        });
+        const r = await ajax(protocolName + '://fake-host');
+        expect(r.data).to.equal('');
+      });
     });
   }
 

--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -231,32 +231,6 @@ describe("session 'select-webauthn-account' event", () => {
     expect(result.userHandle).to.equal(bob.userHandle);
   });
 
-  it('does not crash when the listener invokes the callback and then throws', async () => {
-    await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
-    await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });
-
-    const error = new Error('boom');
-    const listeners = process.listeners('uncaughtException');
-    process.removeAllListeners('uncaughtException');
-    const thrown = new Promise<Error>((resolve) => process.once('uncaughtException', resolve));
-
-    try {
-      (w.webContents.session as NodeJS.EventEmitter).on('select-webauthn-account', (event, details, callback) => {
-        callback(details.accounts[0].credentialId);
-        throw error;
-      });
-
-      const result = await getAssertion();
-      expect(await thrown).to.equal(error);
-      expect(result.ok).to.be.true();
-    } finally {
-      process.removeAllListeners('uncaughtException');
-      for (const listener of listeners) {
-        process.on('uncaughtException', listener);
-      }
-    }
-  });
-
   it('cancels the request when the callback is invoked with an unknown credentialId', async () => {
     await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
     await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });

--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -231,6 +231,32 @@ describe("session 'select-webauthn-account' event", () => {
     expect(result.userHandle).to.equal(bob.userHandle);
   });
 
+  it('does not crash when the listener invokes the callback and then throws', async () => {
+    await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
+    await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });
+
+    const error = new Error('boom');
+    const listeners = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    const thrown = new Promise<Error>((resolve) => process.once('uncaughtException', resolve));
+
+    try {
+      (w.webContents.session as NodeJS.EventEmitter).on('select-webauthn-account', (event, details, callback) => {
+        callback(details.accounts[0].credentialId);
+        throw error;
+      });
+
+      const result = await getAssertion();
+      expect(await thrown).to.equal(error);
+      expect(result.ok).to.be.true();
+    } finally {
+      process.removeAllListeners('uncaughtException');
+      for (const listener of listeners) {
+        process.on('uncaughtException', listener);
+      }
+    }
+  });
+
   it('cancels the request when the callback is invoked with an unknown credentialId', async () => {
     await addCredential({ id: 'cred-alice', userHandle: 'uh-alice', name: 'alice@example.com', displayName: 'Alice' });
     await addCredential({ id: 'cred-bob', userHandle: 'uh-bob', name: 'bob@example.com', displayName: 'Bob' });

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -4925,6 +4925,26 @@ describe('navigator.hid', () => {
       }
     }
   });
+
+  it('does not crash when the requesting webContents is destroyed from the select-hid-device handler', async () => {
+    const guest = (webContents as typeof ElectronInternal.WebContents).create({
+      type: 'webview',
+      embedder: w.webContents
+    });
+    await guest.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+    session.defaultSession.setPermissionCheckHandler(() => true);
+    session.defaultSession.setDevicePermissionHandler(() => true);
+    const selectFired = new Promise<void>((resolve) => {
+      w.webContents.session.once('select-hid-device', () => {
+        guest.destroy();
+        resolve();
+      });
+    });
+    guest.executeJavaScript('navigator.hid.requestDevice({filters: []})', true).catch(() => {});
+    await selectFired;
+    await setTimeout();
+    expect(guest.isDestroyed()).to.be.true();
+  });
 });
 
 describe('navigator.usb', () => {

--- a/spec/fixtures/crash-cases/webauthn-select-account-listener-throws/index.js
+++ b/spec/fixtures/crash-cases/webauthn-select-account-listener-throws/index.js
@@ -1,0 +1,83 @@
+// A 'select-webauthn-account' listener that invokes the callback and then
+// throws must not crash the main process. The throw should surface as an
+// ordinary uncaughtException and the assertion should still resolve.
+const { app, BrowserWindow } = require('electron');
+
+const http = require('node:http');
+
+const expectedError = new Error('boom');
+let caught = null;
+process.on('uncaughtException', (err) => {
+  caught = err;
+});
+
+async function addCredential(w, authenticatorId, id, userHandle, name) {
+  const privateKey = await w.webContents.executeJavaScript(`
+    (async () => {
+      const k = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign']);
+      const pkcs8 = await crypto.subtle.exportKey('pkcs8', k.privateKey);
+      return btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+    })()
+  `);
+  await w.webContents.debugger.sendCommand('WebAuthn.addCredential', {
+    authenticatorId,
+    credential: {
+      credentialId: Buffer.from(id).toString('base64'),
+      isResidentCredential: true,
+      rpId: 'localhost',
+      privateKey,
+      userHandle: Buffer.from(userHandle).toString('base64'),
+      userName: name,
+      userDisplayName: name,
+      signCount: 0
+    }
+  });
+}
+
+app
+  .whenReady()
+  .then(async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader('Content-Type', 'text/html');
+      res.end('<!doctype html><title>webauthn</title>');
+    });
+    await new Promise((resolve) => server.listen(0, 'localhost', resolve));
+
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(`http://localhost:${server.address().port}/`);
+    w.webContents.debugger.attach();
+    await w.webContents.debugger.sendCommand('WebAuthn.enable');
+    const { authenticatorId } = await w.webContents.debugger.sendCommand('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true
+      }
+    });
+    await addCredential(w, authenticatorId, 'cred-alice', 'uh-alice', 'alice@example.com');
+    await addCredential(w, authenticatorId, 'cred-bob', 'uh-bob', 'bob@example.com');
+
+    w.webContents.session.on('select-webauthn-account', (event, details, callback) => {
+      callback(details.accounts[0].credentialId);
+      throw expectedError;
+    });
+
+    const result = await w.webContents.executeJavaScript(`
+    navigator.credentials.get({
+      publicKey: { challenge: new Uint8Array(32), rpId: 'localhost', userVerification: 'required' }
+    }).then(c => ({ ok: true, id: c.id }), e => ({ ok: false, name: e.name, message: e.message }))
+  `);
+
+    if (!result.ok) throw new Error(`assertion failed: ${result.name}: ${result.message}`);
+    if (caught !== expectedError) throw new Error(`expected listener error to reach uncaughtException, got: ${caught}`);
+
+    server.close();
+    app.quit();
+  })
+  .catch((err) => {
+    console.error(err);
+    app.exit(1);
+  });


### PR DESCRIPTION
Backport of #53258
Backport of #53274

See those PRs for details. The local AI handler and `isolated-world-created` commits are omitted because those features do not exist on 44-x-y.

Notes: Fixed crashes when certain app event handlers call back into Electron synchronously.
