### PR TITLE
ci: move macOS ubsan build to a weekly scheduled run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,27 +364,6 @@ jobs:
       enable-ssh: ${{ inputs.enable-ssh || false }}
     secrets: inherit
 
-  macos-arm64-ubsan:
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-    uses: ./.github/workflows/pipeline-electron-build-and-test.yml
-    needs: [checkout-macos, build-siso-macos]
-    with:
-      build-runs-on: macos-15-xlarge
-      test-runs-on: macos-15
-      target-platform: macos
-      target-arch: arm64
-      target-variant: darwin
-      is-release: false
-      gn-build-type: testing
-      generate-symbols: false
-      upload-to-storage: '0'
-      enable-ssh: ${{ inputs.enable-ssh || false }}
-      is-ubsan: true
-    secrets: inherit
-
   linux-x64:
     permissions:
       contents: read
@@ -532,7 +511,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [docs-only, checkout-macos, checkout-linux, checkout-windows, macos-x64, macos-arm64, macos-arm64-ubsan, linux-x64, linux-x64-asan, linux-x64-ubsan, linux-arm64, build-siso-macos, build-siso-linux, build-siso-windows, windows-x64, windows-arm64]
+    needs: [docs-only, checkout-macos, checkout-linux, checkout-windows, macos-x64, macos-arm64, linux-x64, linux-x64-asan, linux-x64-ubsan, linux-arm64, build-siso-macos, build-siso-linux, build-siso-windows, windows-x64, windows-arm64]
     if: always() && github.repository == 'electron/electron'
     steps:
     - name: Fail if any needed job failed or was cancelled

--- a/.github/workflows/macos-ubsan-schedule.yml
+++ b/.github/workflows/macos-ubsan-schedule.yml
@@ -1,0 +1,98 @@
+name: macOS UBSan Build
+
+# Runs the macOS UBSan build and test suite on main once a week. This lives
+# outside the per-PR CI matrix in build.yml because macOS runners are
+# expensive and running the UBSan build on every CI job saturates them.
+# The linux-x64-ubsan job in build.yml still runs on every CI job.
+
+on:
+  workflow_dispatch:
+    inputs:
+      enable-ssh:
+        description: 'Enable SSH debugging'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # 15:00 UTC every Friday (8am Pacific) - runs on main.
+    - cron: '0 15 * * 5'
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  setup:
+    if: github.repository == 'electron/electron'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      build-image-sha: ${{ steps.build-image-sha.outputs.build-image-sha }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Set Build Image SHA
+      id: build-image-sha
+      uses: ./.github/actions/build-image-sha
+
+  checkout-macos:
+    needs: setup
+    runs-on: electron-arc-centralus-linux-amd64-32core
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/electron/build:${{ needs.setup.outputs.build-image-sha }}
+      options: --user root
+      volumes:
+        - /mnt/cross-instance-cache:/mnt/cross-instance-cache
+        - /var/run/sas:/var/run/sas
+    env:
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
+    outputs:
+      build-image-sha: ${{ needs.setup.outputs.build-image-sha }}
+    steps:
+    - name: Checkout Electron
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        path: src/electron
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Checkout & Sync & Save
+      uses: ./src/electron/.github/actions/checkout
+      with:
+        generate-sas-token: 'true'
+        target-platform: macos
+
+  build-siso-macos:
+    needs: setup
+    uses: ./.github/workflows/pipeline-segment-build-siso.yml
+    permissions:
+      contents: read
+    with:
+      host: darwin-arm64
+
+  macos-arm64-ubsan:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    uses: ./.github/workflows/pipeline-electron-build-and-test.yml
+    needs: [checkout-macos, build-siso-macos]
+    with:
+      build-runs-on: macos-15-xlarge
+      test-runs-on: macos-15
+      target-platform: macos
+      target-arch: arm64
+      target-variant: darwin
+      is-release: false
+      gn-build-type: testing
+      generate-symbols: false
+      upload-to-storage: '0'
+      enable-ssh: ${{ inputs.enable-ssh || false }}
+      is-ubsan: true
+    secrets: inherit


### PR DESCRIPTION
Backport of #53277

See that PR for details. The new scheduled workflow uses `secrets: inherit` here because 45-x-y's reusable pipeline workflows do not declare named secrets yet.

Notes: none
