### PR TITLE
fix: crash when calling utilityProcess.postMessage() after the process has exited

### DIFF
--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -352,7 +352,7 @@ void UtilityProcessWrapper::Shutdown(uint32_t exit_code) {
 }
 
 void UtilityProcessWrapper::PostMessage(gin::Arguments* const args) {
-  if (!node_service_remote_.is_connected())
+  if (!connector_ || connector_closed_)
     return;
 
   blink::TransferableMessage transferable_message;
@@ -449,7 +449,7 @@ void UtilityProcessWrapper::OnV8FatalError(const std::string& location,
 }
 
 void UtilityProcessWrapper::CreateAndSendURLLoaderFactory(bool /* crashed */) {
-  if (!node_service_remote_.is_connected())
+  if (!node_service_remote_.is_bound() || !node_service_remote_.is_connected())
     return;
 
   node_service_remote_->UpdateURLLoaderFactory(CreateURLLoaderFactoryParams());

--- a/spec/fixtures/crash-cases/utility-process-post-message-on-exit/index.js
+++ b/spec/fixtures/crash-cases/utility-process-post-message-on-exit/index.js
@@ -1,0 +1,23 @@
+// Calling postMessage() on a utility process from its 'exit' listener, or
+// after the process has gone away, must be a no-op rather than crashing the
+// main process.
+const { app, utilityProcess } = require('electron');
+
+const path = require('node:path');
+
+app.whenReady().then(() => {
+  const child = utilityProcess.fork(path.join(__dirname, 'utility.js'));
+  child.on('exit', () => {
+    child.postMessage('after-exit');
+    setTimeout(() => {
+      child.postMessage('after-exit-later');
+      app.quit();
+    });
+  });
+  child.once('message', () => {
+    // Child is up; quit while it is still running so the exit event is
+    // delivered from the shutdown path.
+    child.postMessage('before-exit');
+    app.quit();
+  });
+});

--- a/spec/fixtures/crash-cases/utility-process-post-message-on-exit/utility.js
+++ b/spec/fixtures/crash-cases/utility-process-post-message-on-exit/utility.js
@@ -1,0 +1,3 @@
+process.parentPort.on('message', () => {});
+process.parentPort.postMessage('ready');
+setInterval(() => {}, 1000);


### PR DESCRIPTION
#### Description of Change

- `utilityProcess.postMessage()` no longer crashes the main process when called after the child has gone away (e.g. from the `'exit'` listener, or during app shutdown while a utility process is still running); it is now a no-op in that state.
- Adds a crash-case fixture covering both paths.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed a crash when calling `utilityProcess.postMessage()` after the utility process had exited.
