### PR TITLE
fix: crash in webRequest proxy for redirected CORS preflights and frameless factories

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1522,7 +1522,11 @@ void ElectronBrowserClient::WillCreateURLLoaderFactory(
   DCHECK(web_request);
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  if (!web_request->HasListener()) {
+  // Factories for requests made from the main process (e.g. net.fetch) have
+  // no frame and are not routed through extensions.
+  const bool is_browser_process_request =
+      type == URLLoaderFactoryType::kNavigation && !frame_host;
+  if (!web_request->HasListener() && !is_browser_process_request) {
     auto* web_request_api = extensions::BrowserContextKeyedAPIFactory<
         extensions::WebRequestAPI>::Get(browser_context);
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -516,6 +516,11 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToStartRequest(
   }
 
   if (current_request_uses_header_client_ && !redirect_url_.is_empty()) {
+    if (for_cors_preflight_) {
+      // CORS preflight doesn't support redirect.
+      OnRequestError(network::URLLoaderCompletionStatus(net::ERR_FAILED));
+      return;
+    }
     HandleBeforeRequestRedirect();
     return;
   }

--- a/spec/fixtures/crash-cases/net-fetch-with-webrequest-extension/extension/manifest.json
+++ b/spec/fixtures/crash-cases/net-fetch-with-webrequest-extension/extension/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "webrequest-permission",
+  "version": "1.0",
+  "manifest_version": 3,
+  "permissions": ["webRequest"],
+  "host_permissions": ["<all_urls>"]
+}

--- a/spec/fixtures/crash-cases/net-fetch-with-webrequest-extension/index.js
+++ b/spec/fixtures/crash-cases/net-fetch-with-webrequest-extension/index.js
@@ -1,0 +1,21 @@
+// net.fetch() from the main process must work when an extension with the
+// webRequest permission is loaded and no session.webRequest listeners are
+// registered.
+const { app, net, session } = require('electron');
+
+const http = require('node:http');
+const { once } = require('node:events');
+const path = require('node:path');
+
+app.whenReady().then(async () => {
+  const server = http.createServer((req, res) => res.end('ok'));
+  await once(server.listen(0, '127.0.0.1'), 'listening');
+  const url = `http://127.0.0.1:${server.address().port}/`;
+
+  await session.defaultSession.extensions.loadExtension(path.join(__dirname, 'extension'));
+  const res = await net.fetch(url);
+  if ((await res.text()) !== 'ok') process.exitCode = 1;
+  const fileRes = await net.fetch(require('node:url').pathToFileURL(__filename).toString());
+  if (!(await fileRes.text()).includes('webRequest permission')) process.exitCode = 1;
+  app.quit();
+});

--- a/spec/fixtures/crash-cases/webrequest-redirect-cors-preflight/index.js
+++ b/spec/fixtures/crash-cases/webrequest-redirect-cors-preflight/index.js
@@ -1,0 +1,38 @@
+// Returning a redirectURL from onBeforeRequest for a CORS preflight request is
+// not supported and should fail the request rather than crash the main process.
+const { app, BrowserWindow, session } = require('electron');
+
+const http = require('node:http');
+const { once } = require('node:events');
+
+app.whenReady().then(async () => {
+  const page = http.createServer((req, res) => res.end('<html></html>'));
+  const api = http.createServer((req, res) => {
+    res.setHeader('access-control-allow-origin', '*');
+    res.setHeader('access-control-allow-headers', '*');
+    res.end('{}');
+  });
+  await Promise.all([page, api].map((s) => once(s.listen(0, '127.0.0.1'), 'listening')));
+  const pageUrl = `http://127.0.0.1:${page.address().port}/`;
+  const apiUrl = `http://127.0.0.1:${api.address().port}/`;
+
+  session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
+    if (details.method === 'OPTIONS' && details.url === apiUrl) {
+      callback({ redirectURL: apiUrl + 'elsewhere' });
+    } else {
+      callback({});
+    }
+  });
+
+  const w = new BrowserWindow({ show: false });
+  await w.loadURL(pageUrl);
+  // Cross-origin with a non-simple header so that a preflight is sent.
+  await w.webContents.executeJavaScript(`
+    fetch(${JSON.stringify(apiUrl)}, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-custom': '1' },
+      body: '{}'
+    }).then(r => r.status, e => String(e))
+  `);
+  app.quit();
+});


### PR DESCRIPTION
#### Description of Change

- Returning `{ redirectURL }` from a `session.webRequest.onBeforeRequest` listener for a CORS preflight request crashed the main process; the preflight now fails instead (redirecting a preflight is not supported), matching the upstream extensions implementation this code is derived from.
- With an extension that has the `webRequest` permission loaded and no `session.webRequest` listeners registered, `net.fetch()` / `net.request()` from the main process crashed because the frameless URL loader factory was handed to the extensions WebRequest layer as a navigation factory. Main-process factories now stay on Electron's own proxy.
- Adds a crash-case fixture for each.

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed crashes in the main process when a `webRequest.onBeforeRequest` listener redirected a CORS preflight request, and when calling `net.fetch()` with a `webRequest`-permission extension loaded.
