### PR TITLE
fix: main process crashes from WebUI host matching, worker AI bindings, extension background page media and serial port revocation

### DIFF
--- a/shell/browser/ai/proxying_ai_manager.cc
+++ b/shell/browser/ai/proxying_ai_manager.cc
@@ -58,10 +58,10 @@ ProxyingAIManager::GetAIManagerRemote() {
     gin::WeakCell<api::Session>* session =
         api::Session::FromBrowserContext(browser_context_);
 
-    if (session && session->Get() && session->Get()->LocalAIHandler()) {
-      auto* rfh = rfh_.AsRenderFrameHostIfValid();
-      DCHECK(rfh);
-
+    // Requests that don't come from a live document (e.g. workers) are not
+    // routed to the handler; callers treat an unbound remote as unavailable.
+    auto* rfh = rfh_.AsRenderFrameHostIfValid();
+    if (rfh && session && session->Get() && session->Get()->LocalAIHandler()) {
       auto* web_contents = electron::api::WebContents::From(
           content::WebContents::FromRenderFrameHost(rfh));
       std::optional<int32_t> web_contents_id;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1125,7 +1125,6 @@ void WebContents::InitWithSessionAndOptions(
   // Trigger re-calculation of webkit prefs.
   web_contents()->NotifyPreferencesChanged();
 
-  WebContentsPermissionHelper::CreateForWebContents(web_contents());
   InitZoomController(web_contents(), options);
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
@@ -1184,6 +1183,9 @@ void WebContents::InitWithWebContents(
     bool is_guest) {
   browser_context_ = browser_context;
   web_contents->SetDelegate(this);
+  // As the delegate we route permission checks through this helper, so every
+  // adopted WebContents (including extension background pages) needs one.
+  WebContentsPermissionHelper::CreateForWebContents(web_contents.get());
 
   // A <webview> guest is created with a copy of its embedder's renderer
   // preferences, so caret browsing may already be enabled. Every path that

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -8,6 +8,7 @@
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"
+#include "content/public/common/url_constants.h"
 #include "shell/browser/ui/devtools_ui.h"
 #include "shell/browser/ui/webui/accessibility_ui.h"
 
@@ -25,9 +26,14 @@ ElectronWebUIControllerFactory::~ElectronWebUIControllerFactory() = default;
 content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) {
-  if (const std::string_view host = url.host();
-      host == chrome::kChromeUIDevToolsHost ||
-      host == chrome::kChromeUIAccessibilityHost) {
+  const std::string_view host = url.host();
+  if (host == chrome::kChromeUIDevToolsHost &&
+      (url.SchemeIs(content::kChromeDevToolsScheme) ||
+       url.SchemeIs(content::kChromeUIScheme))) {
+    return this;
+  }
+  if (host == chrome::kChromeUIAccessibilityHost &&
+      url.SchemeIs(content::kChromeUIScheme)) {
     return this;
   }
 
@@ -44,6 +50,10 @@ std::unique_ptr<content::WebUIController>
 ElectronWebUIControllerFactory::CreateWebUIControllerForURL(
     content::WebUI* web_ui,
     const GURL& url) {
+  if (GetWebUIType(web_ui->GetWebContents()->GetBrowserContext(), url) ==
+      content::WebUI::kNoWebUI) {
+    return {};
+  }
   const std::string_view host = url.host();
 
   if (host == chrome::kChromeUIDevToolsHost) {

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -131,20 +131,21 @@ void SerialChooserContext::RevokePortPermissionWebInitiated(
     const url::Origin& origin,
     const base::UnguessableToken& token,
     content::RenderFrameHost* render_frame_host) {
-  auto it = port_info_.find(token);
-  if (it != port_info_.end()) {
-    auto* permission_manager = static_cast<ElectronPermissionManager*>(
-        browser_context_->GetPermissionControllerDelegate());
-    permission_manager->RevokeDevicePermission(
-        blink::PermissionType::SERIAL, origin, PortInfoToValue(*it->second),
-        browser_context_);
-  }
-
   auto ephemeral = ephemeral_ports_.find(origin);
   if (ephemeral != ephemeral_ports_.end()) {
     std::set<base::UnguessableToken>& ports = ephemeral->second;
     ports.erase(token);
   }
+
+  auto it = port_info_.find(token);
+  if (it == port_info_.end())
+    return;
+
+  auto* permission_manager = static_cast<ElectronPermissionManager*>(
+      browser_context_->GetPermissionControllerDelegate());
+  permission_manager->RevokeDevicePermission(
+      blink::PermissionType::SERIAL, origin, PortInfoToValue(*it->second),
+      browser_context_);
 
   auto* web_contents =
       content::WebContents::FromRenderFrameHost(render_frame_host);

--- a/spec/fixtures/crash-cases/extension-background-page-media/extension/background.js
+++ b/spec/fixtures/crash-cases/extension-background-page-media/extension/background.js
@@ -1,0 +1,4 @@
+navigator.mediaDevices.enumerateDevices().then(
+  () => console.log('enumerated'),
+  (err) => console.log('enumerate failed', err)
+);

--- a/spec/fixtures/crash-cases/extension-background-page-media/extension/manifest.json
+++ b/spec/fixtures/crash-cases/extension-background-page-media/extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "background-page-media",
+  "version": "1.0",
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  }
+}

--- a/spec/fixtures/crash-cases/extension-background-page-media/index.js
+++ b/spec/fixtures/crash-cases/extension-background-page-media/index.js
@@ -1,0 +1,14 @@
+// An extension background page using navigator.mediaDevices must not crash
+// the main process.
+const { app, session, webContents } = require('electron');
+
+const { once } = require('node:events');
+const path = require('node:path');
+
+app.whenReady().then(async () => {
+  const bgPageLogged = once(app, 'web-contents-created').then(([, wc]) => once(wc, 'console-message'));
+  await session.defaultSession.extensions.loadExtension(path.join(__dirname, 'extension'));
+  await Promise.race([bgPageLogged, new Promise((resolve) => setTimeout(resolve, 5000))]);
+  if (!webContents.getAllWebContents().some((wc) => wc.getType() === 'backgroundPage')) process.exitCode = 1;
+  app.quit();
+});

--- a/spec/fixtures/crash-cases/local-ai-handler-in-worker/handler.js
+++ b/spec/fixtures/crash-cases/local-ai-handler-in-worker/handler.js
@@ -1,0 +1,2 @@
+process.parentPort.on('message', () => {});
+setInterval(() => {}, 1000);

--- a/spec/fixtures/crash-cases/local-ai-handler-in-worker/index.html
+++ b/spec/fixtures/crash-cases/local-ai-handler-in-worker/index.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html>
+  <body></body>
+</html>

--- a/spec/fixtures/crash-cases/local-ai-handler-in-worker/index.js
+++ b/spec/fixtures/crash-cases/local-ai-handler-in-worker/index.js
@@ -1,0 +1,25 @@
+// Using the LanguageModel API from a Worker while a local AI handler is
+// registered must not crash the main process.
+const { app, BrowserWindow, session, utilityProcess } = require('electron');
+
+const path = require('node:path');
+
+app.commandLine.appendSwitch('enable-blink-features', 'AIPromptAPIForWorkers');
+
+app.whenReady().then(async () => {
+  const handler = utilityProcess.fork(path.join(__dirname, 'handler.js'));
+  session.defaultSession.registerLocalAIHandler(handler);
+
+  const w = new BrowserWindow({ show: false });
+  await w.loadFile(path.join(__dirname, 'index.html'));
+  const result = await w.webContents.executeJavaScript(`
+    new Promise((resolve) => {
+      const worker = new Worker('worker.js');
+      worker.onmessage = (e) => resolve(e.data);
+      worker.onerror = (e) => resolve('error: ' + e.message);
+    })
+  `);
+  if (typeof result !== 'string') process.exitCode = 1;
+  handler.kill();
+  app.quit();
+});

--- a/spec/fixtures/crash-cases/local-ai-handler-in-worker/worker.js
+++ b/spec/fixtures/crash-cases/local-ai-handler-in-worker/worker.js
@@ -1,0 +1,7 @@
+(async () => {
+  try {
+    postMessage(typeof LanguageModel === 'undefined' ? 'no LanguageModel' : String(await LanguageModel.availability()));
+  } catch (e) {
+    postMessage('threw: ' + e.message);
+  }
+})();

--- a/spec/fixtures/crash-cases/webui-host-non-webui-scheme/index.js
+++ b/spec/fixtures/crash-cases/webui-host-non-webui-scheme/index.js
@@ -1,0 +1,16 @@
+// Navigating a regular window to a non-chrome:// URL whose host happens to
+// match a WebUI page must not be treated as a WebUI navigation.
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(async () => {
+  const w = new BrowserWindow({ show: false });
+  await w.loadURL('about:blank');
+  for (const url of ['http://accessibility/', 'http://devtools/']) {
+    await w.webContents.executeJavaScript(`location.href = ${JSON.stringify(url)}; undefined`);
+    await new Promise((resolve) => {
+      w.webContents.once('did-fail-load', resolve);
+      w.webContents.once('did-finish-load', resolve);
+    });
+  }
+  app.quit();
+});


### PR DESCRIPTION
#### Description of Change

Four small main-process crash fixes, each with a crash-case fixture (except the serial one, which needs hardware to exercise):

- `ElectronWebUIControllerFactory` matched WebUI pages by host only, so navigating a window to e.g. `http://accessibility/` was treated as a WebUI navigation and hit `NOTREACHED` in `RenderFrameHostImpl::AllowBindings`. It now also requires `chrome://` (or `devtools://` for the DevTools host).
- With `session.registerLocalAIHandler()` set, a `LanguageModel` call from a Worker reached `ProxyingAIManager` with no `RenderFrameHost` and dereferenced it. Such requests are now reported as unavailable.
- Extension background pages get `api::WebContents` as their delegate but never had a `WebContentsPermissionHelper`, so `navigator.mediaDevices.*` (and pointer/keyboard lock) from a background page dereferenced null. The helper is now created for every WebContents that `api::WebContents` adopts.
- `SerialChooserContext::RevokePortPermissionWebInitiated` dereferenced `port_info_.end()` when `SerialPort.forget()` was called for a port the context no longer knew about (e.g. after the device was unplugged).

#### Checklist

- [x] PR description included
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed main process crashes when navigating to `http://accessibility/` or `http://devtools/`, when using the `LanguageModel` API from a Worker with a local AI handler registered, when an extension background page used `navigator.mediaDevices`, and when calling `SerialPort.forget()` for a disconnected device.
