### PR TITLE
docs: require symbol-level attribution in the node upgrade skill

### DIFF
--- a/.claude/skills/electron-node-upgrade/SKILL.md
+++ b/.claude/skills/electron-node-upgrade/SKILL.md
@@ -41,6 +41,7 @@ Run these once at the start of each upgrade session:
 
 1. **Clear rerere cache** (if enabled): `git rerere clear` in both the electron and `../third_party/electron_node` repos. Stale recorded resolutions from a prior attempt can silently apply wrong merges.
 2. **Ensure pre-commit hooks are installed**: Check that `.git/hooks/pre-commit` exists. If not, run `yarn husky` to install it. The hook runs `lint-staged` which handles clang-format for C++ files.
+3. **Look for the same roll on other branches**: fetch `roller/node/main` and any sibling `roller/node/{N}-x-y` branch for the same Node.js version. If they already carry fixes, reuse them verbatim (patch names, content, commit titles, `Ref:` lines) rather than re-deriving them. See "Reuse Fixes From Sibling Roller Branches" in `references/phase-one-commit-guidelines.md`.
 
 ## Workflow
 

--- a/.claude/skills/electron-node-upgrade/references/patch-analysis.md
+++ b/.claude/skills/electron-node-upgrade/references/patch-analysis.md
@@ -6,13 +6,14 @@
 
 2. **Examine current state** of the file in the Node.js repo at mentioned line numbers
 
-3. **Check recent upstream changes:**
+3. **Check recent upstream changes** to orient yourself:
    ```bash
    cd ../third_party/electron_node
    git log --oneline -10 -- {file}
    ```
+   This list tells you what has been happening in the file. It does not tell you which commit to cite; see [Finding the Upstream Commit for a Change](#finding-the-upstream-commit-for-a-change).
 
-4. **Find Node.js PR** in commit messages:
+4. **Find the introducing commit and its Node.js PR** in its commit message:
    ```
    PR-URL: https://github.com/nodejs/node/pull/{PR_NUMBER}
    ```
@@ -67,15 +68,22 @@ When resolving a patch conflict, do NOT blindly preserve the patch's old code. I
 | Deleted code | Feature removed | Verify patch still needed |
 | V8 API bridge patch conflicts | Node.js caught up to Chromium's V8 | Patch may be deletable — verify the API is now in Node.js' V8 natively |
 
-## Using Git Blame
+## Finding the Upstream Commit for a Change
 
-To find the commit that changed specific lines:
+Attribute a fix to the commit that introduced the code it responds to, never to the commit that most recently touched the file. Work against `refs/patches/upstream-head` (the unpatched Node.js commit) so the answer is an upstream commit and not one of Electron's own patches.
 
 ```bash
 cd ../third_party/electron_node
-git blame -L {start},{end} -- {file}
-git log -1 {commit_sha}  # Look for PR-URL: line
+# by symbol: the commit that added or removed it
+git log -S'{symbol}' refs/patches/upstream-head -- {file}
+# by lines: the commit that last wrote them
+git blame -L {start},{end} refs/patches/upstream-head -- {file}
+# verify: the candidate's diff must contain the symbol
+git show {commit_sha} -- {file} | grep -n '{symbol}'
+git log -1 {commit_sha}  # Look for the PR-URL: line
 ```
+
+If the verification grep finds nothing, the candidate is a follow-up that happened to touch the same file. Follow-ups often carry `Refs:` lines pointing at the real change; follow that pointer rather than citing the follow-up.
 
 ## Verifying Patch Necessity
 

--- a/.claude/skills/electron-node-upgrade/references/phase-one-commit-guidelines.md
+++ b/.claude/skills/electron-node-upgrade/references/phase-one-commit-guidelines.md
@@ -16,7 +16,7 @@ Always include a `Co-Authored-By` trailer identifying the AI model that assisted
 
 ### Patch conflict fixes
 
-Use `fix(patch):` prefix. The title should name the upstream change, not your response to it:
+Use `fix(patch):` prefix. The title names the upstream change, not your response to it. Once you have identified the upstream commit that caused the conflict (see [Finding Commit/Issue References](#finding-commitissue-references)), use that commit's subject line verbatim after the prefix. Do not paraphrase it and do not invent a headline from the file's recent history:
 
 ```
 fix(patch): {topic headline}
@@ -66,21 +66,42 @@ Each patch conflict fix gets its own commit with its own Ref.
 
 IMPORTANT: Try really hard to find the PR or commit reference per the instructions below. Each change you made should in theory have been in response to a change made in Node.js that you identified or can identify. Try for a while to identify and include the ref in the commit message. Do not give up easily.
 
+## Reuse Fixes From Sibling Roller Branches
+
+The same Node.js version is usually rolled to `main` and to every supported release branch at about the same time, and the fixes are nearly always identical. Before writing a fix, check whether it already exists:
+
+```bash
+git fetch https://github.com/electron/electron.git roller/node/main
+git log --oneline HEAD..FETCH_HEAD -- patches/node/ filenames.auto.gni
+```
+
+Also check the sibling `roller/node/{N}-x-y` branches for the same version. If a matching fix exists, reuse it: same patch file name, same patch content, same commit title and `Ref:`. Cherry-pick the commit when it applies cleanly. Diverge only when the code on your branch genuinely differs, and say so in the commit body. Two branches carrying the same fix under different file names or different attributions is a review blocker.
+
 ## Finding Commit/Issue References
 
-Use `git log` or `git blame` on Node.js source files in `../third_party/electron_node`. Look for:
+The `Ref:` must point at the upstream commit that *introduced* the code your fix responds to, not at whichever commit most recently touched the file. Recency queries such as `git log -10 -- {file}` are for orientation only; several later commits often touch the same file, and the newest one is usually the wrong answer.
 
-```
-PR-URL: https://github.com/nodejs/node/pull/XXXXX
-```
+Required procedure, in `../third_party/electron_node`:
 
-or issue references in the patch itself:
+1. Name the exact symbol or lines your fix touches (for example the function you guarded, or the API that was renamed).
+2. Find the commit that introduced them. Use one of:
+   ```bash
+   git log -S'{symbol}' refs/patches/upstream-head -- {file}
+   git blame -L {start},{end} refs/patches/upstream-head -- {file}
+   ```
+   `refs/patches/upstream-head` is the unpatched Node.js commit, so results are upstream commits only.
+3. Verify the candidate before you cite it. Its diff must contain the symbol:
+   ```bash
+   git show {commit} -- {file} | grep -n '{symbol}'
+   ```
+   No match means you have the wrong commit. Go back to step 2.
+4. Take the reference from that commit's trailers:
+   ```
+   PR-URL: https://github.com/nodejs/node/pull/XXXXX
+   ```
+   and use its subject line as your commit title. A `Refs:` trailer in a *later* commit that mentions the same PR is not the introducing commit.
 
-```
-Refs: https://github.com/nodejs/node/issues/XXXXX
-```
-
-Note: Most Node.js patches in Electron are Electron-authored and won't have upstream references. In that case, check `git log` in the Node.js repo to find which upstream commit caused the conflict.
+For Electron-authored patches with no upstream `PR-URL:`, the same procedure still finds the upstream commit that caused the conflict; cite that commit or its issue.
 
 If no reference found after searching: `Ref: Unable to locate reference`
 

--- a/.claude/skills/electron-node-upgrade/references/phase-two-commit-guidelines.md
+++ b/.claude/skills/electron-node-upgrade/references/phase-two-commit-guidelines.md
@@ -59,14 +59,11 @@ git commit -m "chore: update patches (trivial only)"
 
 ## Finding References
 
-Use `git log` or `git blame` on Node.js source files in `../third_party/electron_node`. Look for:
+Follow the procedure in `references/phase-one-commit-guidelines.md` under "Finding Commit/Issue References": identify the symbol the build break is about, find the commit that introduced it with `git log -S` or `git blame` against `refs/patches/upstream-head`, verify that commit's diff contains the symbol, and only then take its `PR-URL:` and subject line. The most recent commit to touch the file is not the answer unless that check passes.
 
-```
-PR-URL: https://github.com/nodejs/node/pull/XXXXX
-Refs: https://github.com/nodejs/node/issues/XXXXX
-```
+Before writing any fix, also check `roller/node/main` and the sibling `roller/node/{N}-x-y` branches for the same version (phase one guidelines, "Reuse Fixes From Sibling Roller Branches"). Build breaks from a Node.js bump are the same on every branch, and the fix should be too.
 
-Note: Many Node.js patches in Electron are Electron-authored and won't have upstream `PR-URL:` lines. Check the patch's own commit message for `Refs:` lines, or use `git log` in the Node.js repo to find which upstream commit caused the build break.
+Note: Many Node.js patches in Electron are Electron-authored and won't have upstream `PR-URL:` lines. Check the patch's own commit message for `Refs:` lines, or use the procedure above to find which upstream commit caused the build break.
 
 If no reference found after searching: `Ref: Unable to locate reference`
 


### PR DESCRIPTION
#### Description of Change

Tightens the `electron-node-upgrade` skill so patch-fix commits on node roller branches cite the right upstream change.

- `references/phase-one-commit-guidelines.md`: replace "use `git log` or `git blame`" with a required procedure. Name the symbol the fix touches, find its introducing commit with `git log -S` or `git blame` against `refs/patches/upstream-head`, verify that commit's diff contains the symbol, then take its `PR-URL:` and use its subject line verbatim as the title. Recency queries like `git log -10 -- file` are explicitly not attribution.
- `references/phase-one-commit-guidelines.md`: new "Reuse Fixes From Sibling Roller Branches" section. Check `roller/node/main` and sibling `roller/node/{N}-x-y` branches for the same version first and reuse patch names, content, titles and refs verbatim.
- `references/patch-analysis.md`: same procedure in the "Finding the Upstream Commit for a Change" section, and a note that the recent-history step is for orientation only.
- `references/phase-two-commit-guidelines.md`: point at the phase-one procedure and the sibling-branch check.
- `SKILL.md`: pre-flight item to look for the same roll on other branches.

Prompted by #53250, where the guard for `ReadASN1Element` was attributed to nodejs/node#64547 (the newest commit touching `ncrypto.cc`) instead of nodejs/node#64211 (the commit that added it), and where the same JSPI fix landed under a different patch name than on `main` and 43-x-y.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
