### PR TITLE
fix: allow the PDF viewer to show a save file picker again

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -240,6 +240,7 @@
 #include "components/pdf/browser/pdf_navigation_throttle.h"
 #include "components/pdf/browser/pdf_url_loader_request_interceptor.h"
 #include "components/pdf/common/constants.h"  // nogncheck
+#include "components/pdf/common/pdf_util.h"   // nogncheck
 #include "pdf/pdf_features.h"
 #include "shell/browser/electron_pdf_document_helper_client.h"
 #include "ui/webui/resources/cr_components/help_bubble/help_bubble.mojom.h"  // nogncheck
@@ -1850,6 +1851,13 @@ ElectronBrowserClient::MaybeOverrideLocalURLCrossOriginEmbedderPolicy(
   content::RenderFrameHost* pdf_embedder = pdf_extension->GetParent();
   CHECK(pdf_embedder);
   return pdf_embedder->GetCrossOriginEmbedderPolicy();
+}
+
+bool ElectronBrowserClient::IsCrossOriginSubframeAllowedToShowFilePicker(
+    content::RenderFrameHost* render_frame_host,
+    const url::Origin& requesting_origin) {
+  // Let the PDF viewer save edited PDFs via window.showSaveFilePicker().
+  return IsPdfExtensionOrigin(requesting_origin);
 }
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -100,6 +100,9 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   std::optional<network::CrossOriginEmbedderPolicy>
   MaybeOverrideLocalURLCrossOriginEmbedderPolicy(
       content::NavigationHandle* navigation_handle) override;
+  bool IsCrossOriginSubframeAllowedToShowFilePicker(
+      content::RenderFrameHost* render_frame_host,
+      const url::Origin& requesting_origin) override;
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
   bool DoesSiteRequireDedicatedProcess(content::BrowserContext* browser_context,
                                        const GURL& effective_site_url) override;


### PR DESCRIPTION
#### Description of Change

Fixes #53286
Refs CL:7806164

- Chromium 150 moved the authoritative cross-origin file-picker check from the renderer-side `ContentClient::IsFilePickerAllowedForCrossOriginSubframe()` to a new browser-side `ContentBrowserClient::IsCrossOriginSubframeAllowedToShowFilePicker()` hook. Electron only overrode the old hook (#51042), so the browser-side check fell through to the default and denied the PDF viewer's "save with your changes" picker with `NotAllowedError: Third party iframes are not allowed to show a file picker`.
- Override the new hook for the PDF extension origin, matching Chrome's fast path in `ChromeContentBrowserClient`.

Verified locally on Linux by loading a PDF and calling `window.showSaveFilePicker()` from the PDF extension frame with a user gesture: before this change it rejects with the error above, after it the native save dialog opens.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed the PDF viewer failing to save an edited PDF with `NotAllowedError: Third party iframes are not allowed to show a file picker`.
