### PR TITLE
fix: initialize the system FontConfig before GTK starts on Linux

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -78,6 +78,8 @@
 #endif
 
 #if BUILDFLAG(IS_LINUX)
+#include <dlfcn.h>
+
 #include "base/environment.h"
 #include "components/dbus/thread_linux/dbus_thread_linux.h"
 #include "device/bluetooth/bluetooth_adapter_factory.h"
@@ -207,7 +209,49 @@ ElectronBrowserMainParts::ElectronBrowserMainParts()
   self_ = this;
 }
 
-ElectronBrowserMainParts::~ElectronBrowserMainParts() = default;
+#if BUILDFLAG(IS_LINUX)
+namespace {
+
+// Resolved via dlsym: a direct reference would bind to Chromium's bundled
+// FontConfig rather than the system copy GTK and Pango use.
+void* SystemFontConfigSymbol(const char* name) {
+  void* lib = dlopen("libfontconfig.so.1", RTLD_NOW);
+  return lib ? dlsym(lib, name) : nullptr;
+}
+
+// Pango >= 1.52 calls FcInit() from its own thread while the main thread does
+// the same during GTK init, corrupting FontConfig state (pango#784). Doing it
+// once beforehand makes both later calls no-ops.
+class SystemFontConfigInit : public base::PlatformThread::Delegate {
+ public:
+  void ThreadMain() override {
+    if (auto fc_init =
+            reinterpret_cast<int (*)()>(SystemFontConfigSymbol("FcInit"))) {
+      fc_init();
+    }
+  }
+};
+
+// Read by FontConfig at load; an app may set these from its main script.
+constexpr base::cstring_view kFontConfigEnvVars[] = {
+    "FONTCONFIG_FILE", "FONTCONFIG_PATH", "FONTCONFIG_SYSROOT"};
+
+std::vector<std::optional<std::string>> SnapshotFontConfigEnv() {
+  auto env = base::Environment::Create();
+  std::vector<std::optional<std::string>> values;
+  for (base::cstring_view name : kFontConfigEnvVars)
+    values.push_back(env->GetVar(name));
+  return values;
+}
+
+}  // namespace
+#endif  // BUILDFLAG(IS_LINUX)
+
+ElectronBrowserMainParts::~ElectronBrowserMainParts() {
+#if BUILDFLAG(IS_LINUX)
+  JoinSystemFontConfigInit();
+#endif
+}
 
 // static
 ElectronBrowserMainParts* ElectronBrowserMainParts::Get() {
@@ -270,6 +314,15 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
   node_bindings_->Initialize(isolate, context);
+
+#if BUILDFLAG(IS_LINUX)
+  // Runs during Node.js environment creation and is joined before any app
+  // code can run, so nothing else touches FontConfig or the environment.
+  const auto fontconfig_env = SnapshotFontConfigEnv();
+  static base::NoDestructor<SystemFontConfigInit> system_fontconfig_init;
+  base::PlatformThread::Create(0, system_fontconfig_init.get(),
+                               &system_fontconfig_thread_);
+#endif
   // Create the global environment.
   node_env_ = node_bindings_->CreateEnvironment(
       isolate, context, js_env_->platform(),
@@ -296,11 +349,25 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   // Wrap the uv loop with global env.
   node_bindings_->set_uv_env(node_env_.get());
 
+#if BUILDFLAG(IS_LINUX)
+  JoinSystemFontConfigInit();
+#endif
+
   // Load everything.
   node_bindings_->LoadEnvironment(node_env_.get());
 
   // Wait for app
   node_bindings_->JoinAppCode();
+
+#if BUILDFLAG(IS_LINUX)
+  // Reload if the app's main script changed the FontConfig environment.
+  if (fontconfig_env != SnapshotFontConfigEnv()) {
+    if (auto fc_reinit = reinterpret_cast<int (*)()>(
+            SystemFontConfigSymbol("FcInitReinitialize"))) {
+      fc_reinit();
+    }
+  }
+#endif
 
   // We already initialized the feature list in PreEarlyInitialization(), but
   // the user JS script would not have had a chance to alter the command-line
@@ -486,6 +553,15 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   views_delegate_ = std::make_unique<ViewsDelegate>();
 #endif
 }
+
+#if BUILDFLAG(IS_LINUX)
+void ElectronBrowserMainParts::JoinSystemFontConfigInit() {
+  if (system_fontconfig_thread_.is_null())
+    return;
+  base::PlatformThread::Join(system_fontconfig_thread_);
+  system_fontconfig_thread_ = base::PlatformThreadHandle();
+}
+#endif  // BUILDFLAG(IS_LINUX)
 
 int ElectronBrowserMainParts::PreMainMessageLoopRun() {
   // Run user's main script before most things get initialized, so we can have

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -225,6 +225,7 @@ void* SystemFontConfigSymbol(const char* name) {
 class SystemFontConfigInit : public base::PlatformThread::Delegate {
  public:
   void ThreadMain() override {
+    base::PlatformThread::SetName("SystemFontConfigInit");
     if (auto fc_init =
             reinterpret_cast<int (*)()>(SystemFontConfigSymbol("FcInit"))) {
       fc_init();
@@ -319,6 +320,8 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   // Runs during Node.js environment creation and is joined before any app
   // code can run, so nothing else touches FontConfig or the environment.
   const auto fontconfig_env = SnapshotFontConfigEnv();
+  // If the thread cannot be created the handle stays null, the join is a
+  // no-op and GTK initializes FontConfig itself as before.
   static base::NoDestructor<SystemFontConfigInit> system_fontconfig_init;
   base::PlatformThread::Create(0, system_fontconfig_init.get(),
                                &system_fontconfig_thread_);

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -11,6 +11,7 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/task/single_thread_task_runner.h"
+#include "base/threading/platform_thread.h"
 #include "content/public/browser/browser_main_parts.h"
 #include "electron/buildflags/buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -144,6 +145,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
 #if BUILDFLAG(IS_LINUX)
+  void JoinSystemFontConfigInit();
+
+  base::PlatformThreadHandle system_fontconfig_thread_;
+
   std::unique_ptr<ui::DarkModeManagerLinux> dark_mode_manager_;
   std::unique_ptr<ui::LinuxUiGetter> linux_ui_getter_;
 #endif


### PR DESCRIPTION
#### Description of Change

Fixes #53200

- Pango 1.52+ spawns a `[pango] fontconfig` thread that calls `FcInit()` as soon as GTK creates its font map, and that races the main thread's own first fontconfig call during toolkit initialization. Both parse the configuration at once and corrupt fontconfig's global state; it later surfaces as a PartitionAlloc freelist check (SIGTRAP, #53200) or a NULL dereference inside expat (microsoft/vscode#322185). Upstream: pango#784, pango#872.
- Initialize the system fontconfig once on a helper thread that runs while the Node.js environment is created and is joined before any app code runs, so both later `FcInit()` calls return immediately. Nothing else touches fontconfig or calls `setenv` during that window. Resolved via `dlsym` because the binary also contains Chromium's bundled fontconfig with hidden visibility, which is a separate copy with separate state (that is also why `gfx::GetGlobalFontConfig()` in `gtk_ui.cc` does not prevent this).
- If the app's main script changed `FONTCONFIG_FILE`, `FONTCONFIG_PATH` or `FONTCONFIG_SYSROOT`, reload the configuration after the join so GTK still sees what the app asked for.

Main-thread cost, measured with a temporary log around the join (Testing build, Xvfb, warm cache, 8 launches):

| | median |
|---|---|
| helper thread `FcInit()` | 3.8 ms (off main thread) |
| main thread wait at the join | 27 µs |
| reload when the app changed the env | 3.6 ms (only in that case) |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an intermittent crash at startup on Linux caused by a race between Pango and the main thread initializing fontconfig.
