### PR TITLE
fix: serialize the target's values into the Node.js startup snapshot on cross-arch builds

### DIFF
--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -16,9 +16,15 @@ eliminating the Node bootstrap recompile.
   host_os == target_os except V8's default mac clang_arm64_v8_x64
   toolchain, which emits x64 code from an arm64 binary with no simulator.
   Neither the snapshot nor the code cache contains machine code, so what a
-  cross node_mksnapshot produces is valid on the target.
+  cross node_mksnapshot produces is valid on the target -- except for what
+  its host-compiled C++ serializes: node_constants.cc's O_* flags come
+  from the host's headers, and arm/arm64 Linux override O_DIRECTORY,
+  O_NOFOLLOW and O_DIRECT. unofficial.gni defines
+  NODE_SNAPSHOT_TARGET_LINUX_ARM for the snapshot toolchain on those
+  cross builds and node_constants.cc serializes the target's values.
 - unofficial.gni: node_mksnapshot host tool (no_chromium_code,
-  zstd:compress, NODE_USE_V8_PLATFORM=1 in v8_snapshot_toolchain,
+  zstd:compress, NODE_USE_V8_PLATFORM=1 wherever the snapshot is on, since
+  the shipped libnode deserializes what the tool's build of libnode baked,
   external_startup_data config, --electron-v8-snapshot-blob arg);
   GetEmbeddedSnapshotData() moves out of libnode into two source_sets,
   ":node_snapshot" (the generated snapshot, linked by the shipped
@@ -148,6 +154,29 @@ index e7e95ffd1eb19e3fbf6a0f65338c5f3fbd4d6302..8ce9c5c5fcf55dfc711363fe652ae3cb
    }
    code_cache_->has_code_cache = true;
  }
+diff --git a/src/node_constants.cc b/src/node_constants.cc
+index 82999148a9ee740deb13ed4cc7968f2300299b1a..1dba37d373218b791aa73c14cb41f7f9d057d0bf 100644
+--- a/src/node_constants.cc
++++ b/src/node_constants.cc
+@@ -1075,6 +1075,18 @@ void DefineCryptoConstants(Local<Object> target) {
+ #endif
+ }
+ 
++// Electron: node_mksnapshot runs on the build host, so on cross-arch builds
++// the O_* values below are the host's. arm and arm64 Linux define these three
++// differently (arch/arm64/include/uapi/asm/fcntl.h); serialize the target's.
++#if defined(NODE_SNAPSHOT_TARGET_LINUX_ARM)
++#undef O_DIRECTORY
++#define O_DIRECTORY 040000
++#undef O_NOFOLLOW
++#define O_NOFOLLOW 0100000
++#undef O_DIRECT
++#define O_DIRECT 0200000
++#endif
++
+ void DefineFsConstants(Local<Object> target) {
+   NODE_DEFINE_CONSTANT(target, UV_FS_SYMLINK_DIR);
+   NODE_DEFINE_CONSTANT(target, UV_FS_SYMLINK_JUNCTION);
 diff --git a/src/node_external_reference.h b/src/node_external_reference.h
 index b274dccdc36baae76d3a416cff19aa5aca88b892..235f74ce0e624233afbc18f1dabf7a5272d7bf60 100644
 --- a/src/node_external_reference.h
@@ -287,24 +316,38 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
+<<<<<<< HEAD
 index 504dd46249425a8e8396332bf061f1f75cdd9401..714e9937fb9eef33b6fead8d3a4aa3b85f718903 100644
+=======
+index 504dd46249425a8e8396332bf061f1f75cdd9401..0f5b0553e693f2011a9fd562be6677a8869b38af 100644
+>>>>>>> af2dcbc7f0 (fix: serialize the target's fs constants into the Node.js startup snapshot on cross-arch Linux builds (#53316))
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -32,7 +32,12 @@ template("node_gn_build") {
+@@ -32,7 +32,22 @@ template("node_gn_build") {
      } else {
        defines += [ "HAVE_AMARO=0" ]
      }
 -    if (node_use_v8_platform) {
++    # node_mksnapshot is a host tool, but the values node_constants.cc
++    # compiles in end up in the snapshot the target deserializes. arm and
++    # arm64 Linux override three open(2) flags, so tell it what it targets.
++    if (is_linux && current_toolchain == v8_snapshot_toolchain &&
++        current_cpu != target_cpu &&
++        (target_cpu == "arm" || target_cpu == "arm64")) {
++      defines += [ "NODE_SNAPSHOT_TARGET_LINUX_ARM=1" ]
++    }
 +    # Embedded in Electron, gin/Chromium owns the V8 platform (node must not
 +    # init its own -> stub V8Platform). But the standalone node_mksnapshot
-+    # host tool (v8_snapshot_toolchain, no gin) MUST own the platform or
-+    # SnapshotBuilder gets a null platform. Force the real platform in that
-+    # toolchain only; shipped libnode (default toolchain) unchanged.
-+    if (node_use_v8_platform || current_toolchain == v8_snapshot_toolchain) {
++    # host tool MUST own the platform or SnapshotBuilder gets a null
++    # platform, and the snapshot it produces bakes this macro's effects
++    # (config.hasTracing, the trace_events builtin) into the heap the
++    # shipped libnode deserializes -- so every toolchain must agree on it.
++    # Electron never initializes Node's platform (kNoInitializeNodeV8Platform).
++    if (node_use_v8_platform || node_use_node_snapshot) {
        defines += [ "NODE_USE_V8_PLATFORM=1" ]
      } else {
        defines += [ "NODE_USE_V8_PLATFORM=0" ]
-@@ -189,7 +194,10 @@ template("node_gn_build") {
+@@ -189,7 +204,10 @@ template("node_gn_build") {
      ]
  
      sources = [
@@ -316,7 +359,7 @@ index 504dd46249425a8e8396332bf061f1f75cdd9401..714e9937fb9eef33b6fead8d3a4aa3b8
        "$root_gen_dir/electron_natives.cc",
        "$target_gen_dir/node_javascript.cc",
      ] + gypi_values.node_sources
-@@ -279,20 +287,12 @@ template("node_gn_build") {
+@@ -279,20 +297,12 @@ template("node_gn_build") {
      sources = [ "src/node_main.cc" ]
      deps = [
        ":libnode",
@@ -341,7 +384,7 @@ index 504dd46249425a8e8396332bf061f1f75cdd9401..714e9937fb9eef33b6fead8d3a4aa3b8
      output_name = "node"
  
      if (is_apple) {
-@@ -308,12 +308,36 @@ template("node_gn_build") {
+@@ -308,12 +318,36 @@ template("node_gn_build") {
    if (node_use_node_snapshot) {
      if (current_toolchain == v8_snapshot_toolchain) {
        executable("node_mksnapshot") {
@@ -383,7 +426,7 @@ index 504dd46249425a8e8396332bf061f1f75cdd9401..714e9937fb9eef33b6fead8d3a4aa3b8
        }
  
        # This config disables a link time optimization "ICF", which may merge
-@@ -328,26 +352,121 @@ template("node_gn_build") {
+@@ -328,26 +362,121 @@ template("node_gn_build") {
            ldflags = [ "/OPT:NOICF" ]  # link.exe, but also lld-link.exe.
          } else if (is_apple && !use_lld) {
            ldflags = [ "-Wl,-no_deduplicate" ]  # ld64.

--- a/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
+++ b/patches/node/electron_enable_node_startup_snapshot_generation_in_chromium_s_v8.patch
@@ -155,10 +155,10 @@ index e7e95ffd1eb19e3fbf6a0f65338c5f3fbd4d6302..8ce9c5c5fcf55dfc711363fe652ae3cb
    code_cache_->has_code_cache = true;
  }
 diff --git a/src/node_constants.cc b/src/node_constants.cc
-index 82999148a9ee740deb13ed4cc7968f2300299b1a..1dba37d373218b791aa73c14cb41f7f9d057d0bf 100644
+index c9588880d05435ab9f4e23fcff74c93309664270..972f341a0559e37d8f6aaa70554bfdd33cdde76e 100644
 --- a/src/node_constants.cc
 +++ b/src/node_constants.cc
-@@ -1075,6 +1075,18 @@ void DefineCryptoConstants(Local<Object> target) {
+@@ -1025,6 +1025,18 @@ void DefineCryptoConstants(Local<Object> target) {
  #endif
  }
  
@@ -316,11 +316,7 @@ index 0842cba257d0ca36e07c97736e5b24cc77f2a053..0ee1bd02a03b6d303861cd0f8353db6c
        node::InitializeOncePerProcess(
            std::vector<std::string>(argv, argv + argc),
 diff --git a/unofficial.gni b/unofficial.gni
-<<<<<<< HEAD
-index 504dd46249425a8e8396332bf061f1f75cdd9401..714e9937fb9eef33b6fead8d3a4aa3b85f718903 100644
-=======
-index 504dd46249425a8e8396332bf061f1f75cdd9401..0f5b0553e693f2011a9fd562be6677a8869b38af 100644
->>>>>>> af2dcbc7f0 (fix: serialize the target's fs constants into the Node.js startup snapshot on cross-arch Linux builds (#53316))
+index 504dd46249425a8e8396332bf061f1f75cdd9401..8ddc543c828e844d22f8cdbd89f12a211e109290 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
 @@ -32,7 +32,22 @@ template("node_gn_build") {

--- a/patches/node/fix_use_embedder_perfetto_client_when_available.patch
+++ b/patches/node/fix_use_embedder_perfetto_client_when_available.patch
@@ -378,10 +378,10 @@ index 3765d931f8e17b33e2201ff3a0e4be84a3216356..17b990455e7d6a791998ab304418c256
 +
  #endif  // SRC_TRACING_TRACE_EVENT_PERFETTO_H_
 diff --git a/unofficial.gni b/unofficial.gni
-index 31565559059954112d4311239e420d1ffdf0421d..52d2b2246aac3b5cfef04c0f3ee7543966c5a430 100644
+index 52ce63a777b0f470a579a09082e61fdc9a209c5f..95feec90c1b21d0d4f4d0f7d700dd89f53f41aff 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -42,6 +42,11 @@ template("node_gn_build") {
+@@ -52,6 +52,11 @@ template("node_gn_build") {
      } else {
        defines += [ "NODE_USE_V8_PLATFORM=0" ]
      }

--- a/patches/node/lib_add_perfetto_support.patch
+++ b/patches/node/lib_add_perfetto_support.patch
@@ -333,10 +333,10 @@ index 06a4f8a239855571dcc67cd81e7da7a255a9ebfd..1cb3ba4df520e782037d63bf1aeaef8b
    let debugLogCategoryEnabled = false;
    let timerFlags = kNone;
 diff --git a/src/node_constants.cc b/src/node_constants.cc
-index c9588880d05435ab9f4e23fcff74c93309664270..c800bc82ec271643967c158edf03866b15edc618 100644
+index 972f341a0559e37d8f6aaa70554bfdd33cdde76e..3fb05f51698f10be35db8a38e40ab28b12a1121c 100644
 --- a/src/node_constants.cc
 +++ b/src/node_constants.cc
-@@ -1256,9 +1256,6 @@ void DefineTraceConstants(Local<Object> target) {
+@@ -1268,9 +1268,6 @@ void DefineTraceConstants(Local<Object> target) {
    NODE_DEFINE_CONSTANT(target, TRACE_EVENT_PHASE_MEMORY_DUMP);
    NODE_DEFINE_CONSTANT(target, TRACE_EVENT_PHASE_MARK);
    NODE_DEFINE_CONSTANT(target, TRACE_EVENT_PHASE_CLOCK_SYNC);

--- a/patches/node/src_add_perfetto_trace_agent.patch
+++ b/patches/node/src_add_perfetto_trace_agent.patch
@@ -1110,10 +1110,10 @@ index 0000000000000000000000000000000000000000..8cfcb52182df9a600e5cf2c1466e9ffa
 +  assert(stat.size > 0);
 +}));
 diff --git a/unofficial.gni b/unofficial.gni
-index 714e9937fb9eef33b6fead8d3a4aa3b85f718903..31565559059954112d4311239e420d1ffdf0421d 100644
+index 8ddc543c828e844d22f8cdbd89f12a211e109290..52ce63a777b0f470a579a09082e61fdc9a209c5f 100644
 --- a/unofficial.gni
 +++ b/unofficial.gni
-@@ -150,6 +150,7 @@ template("node_gn_build") {
+@@ -160,6 +160,7 @@ template("node_gn_build") {
    source_set("libnode") {
      configs += [
        ":node_internal_config",
@@ -1121,7 +1121,7 @@ index 714e9937fb9eef33b6fead8d3a4aa3b85f718903..31565559059954112d4311239e420d1f
        "//build/config/compiler:no_exit_time_destructors"
      ]
      public_configs = [
-@@ -186,6 +187,7 @@ template("node_gn_build") {
+@@ -196,6 +197,7 @@ template("node_gn_build") {
        "//third_party/zstd:headers",
        "$node_simdutf_path",
        "$node_v8_path:v8_libplatform",

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -1456,3 +1456,80 @@ describe('node feature', () => {
     });
   });
 });
+
+describe('Node.js startup snapshot', () => {
+  afterEach(closeAllWindows);
+
+  // Everything here is captured into the embedded Node.js startup snapshot by
+  // node_mksnapshot, which runs on the build host. Renderer processes bootstrap
+  // Node.js from scratch, so they hold the values this binary was actually
+  // built for; anything the snapshot took from the host instead shows up as a
+  // difference. Serialized through JSON since the bindings have null
+  // prototypes.
+  const collect = `JSON.stringify({
+    arch: process.arch,
+    platform: process.platform,
+    endianness: require('node:os').endianness(),
+    features: process.features,
+    config: process.binding('config'),
+    constants: process.binding('constants'),
+    buffer: require('node:buffer').constants
+  })`;
+  // defaultCipherList is a CLI option value that only environments owning the
+  // process state define, so it never exists in a renderer.
+  const comparable = (json: string) => {
+    const values = JSON.parse(json);
+    delete values.constants.crypto.defaultCipherList;
+    return values;
+  };
+  // eslint-disable-next-line no-eval
+  const fromThisProcess = () => comparable(eval(collect));
+
+  const fromFreshEnvironment = async () => {
+    const w = new BrowserWindow({
+      show: false,
+      webPreferences: { nodeIntegration: true, contextIsolation: false }
+    });
+    await w.loadURL('about:blank');
+    return comparable(await w.webContents.executeJavaScript(collect));
+  };
+
+  it('captures the same values as an environment bootstrapped from scratch', async () => {
+    expect(fromThisProcess()).to.deep.equal(await fromFreshEnvironment());
+  });
+
+  it('captures the same values for ELECTRON_RUN_AS_NODE', async () => {
+    const child = childProcess.spawn(process.execPath, ['-p', collect], {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      stdio: ['ignore', 'pipe', 'inherit']
+    });
+    let stdout = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    const [code] = await once(child, 'close');
+    expect(code).to.equal(0);
+    expect(comparable(stdout)).to.deep.equal(await fromFreshEnvironment());
+  });
+
+  ifit(process.platform !== 'win32')('can open a directory with O_DIRECTORY', async () => {
+    await withTempDirectory(async (dir) => {
+      const { O_RDONLY, O_DIRECTORY } = fs.constants;
+      fs.closeSync(fs.openSync(dir, O_RDONLY | O_DIRECTORY));
+    });
+  });
+
+  ifit(process.platform !== 'win32')('refuses to follow a symlink with O_NOFOLLOW', async () => {
+    await withTempDirectory(async (dir) => {
+      const target = path.join(dir, 'target');
+      const link = path.join(dir, 'link');
+      fs.writeFileSync(target, '');
+      fs.symlinkSync(target, link);
+      const { O_RDONLY, O_NOFOLLOW } = fs.constants;
+      expect(() => fs.openSync(link, O_RDONLY | O_NOFOLLOW))
+        .to.throw()
+        .with.property('code', 'ELOOP');
+    });
+  });
+});


### PR DESCRIPTION
Backport of #53316

See that PR for details.

Notes: Fixed `fs.constants.O_DIRECTORY`, `O_NOFOLLOW` and `O_DIRECT` holding x86 values on Linux arm64 and armv7l, which made opening a directory fail with `EINVAL`, and made `require('trace_events')` behave the same on cross-compiled builds as on native ones.
