### PR TITLE
fix: main process crashes from WebUI host matching, worker AI bindings, extension background page media and serial port revocation

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1122,7 +1122,6 @@ void WebContents::InitWithSessionAndOptions(
   // Trigger re-calculation of webkit prefs.
   web_contents()->NotifyPreferencesChanged();
 
-  WebContentsPermissionHelper::CreateForWebContents(web_contents());
   InitZoomController(web_contents(), options);
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
@@ -1181,6 +1180,9 @@ void WebContents::InitWithWebContents(
     bool is_guest) {
   browser_context_ = browser_context;
   web_contents->SetDelegate(this);
+  // As the delegate we route permission checks through this helper, so every
+  // adopted WebContents (including extension background pages) needs one.
+  WebContentsPermissionHelper::CreateForWebContents(web_contents.get());
 
   // A <webview> guest is created with a copy of its embedder's renderer
   // preferences, so caret browsing may already be enabled. Every path that

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -8,6 +8,7 @@
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"
+#include "content/public/common/url_constants.h"
 #include "shell/browser/ui/devtools_ui.h"
 #include "shell/browser/ui/webui/accessibility_ui.h"
 
@@ -25,9 +26,14 @@ ElectronWebUIControllerFactory::~ElectronWebUIControllerFactory() = default;
 content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) {
-  if (const std::string_view host = url.host();
-      host == chrome::kChromeUIDevToolsHost ||
-      host == chrome::kChromeUIAccessibilityHost) {
+  const std::string_view host = url.host();
+  if (host == chrome::kChromeUIDevToolsHost &&
+      (url.SchemeIs(content::kChromeDevToolsScheme) ||
+       url.SchemeIs(content::kChromeUIScheme))) {
+    return this;
+  }
+  if (host == chrome::kChromeUIAccessibilityHost &&
+      url.SchemeIs(content::kChromeUIScheme)) {
     return this;
   }
 
@@ -44,6 +50,10 @@ std::unique_ptr<content::WebUIController>
 ElectronWebUIControllerFactory::CreateWebUIControllerForURL(
     content::WebUI* web_ui,
     const GURL& url) {
+  if (GetWebUIType(web_ui->GetWebContents()->GetBrowserContext(), url) ==
+      content::WebUI::kNoWebUI) {
+    return {};
+  }
   const std::string_view host = url.host();
 
   if (host == chrome::kChromeUIDevToolsHost) {

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -132,20 +132,21 @@ void SerialChooserContext::RevokePortPermissionWebInitiated(
     const url::Origin& origin,
     const base::UnguessableToken& token,
     content::RenderFrameHost* render_frame_host) {
-  auto it = port_info_.find(token);
-  if (it != port_info_.end()) {
-    auto* permission_manager = static_cast<ElectronPermissionManager*>(
-        browser_context_->GetPermissionControllerDelegate());
-    permission_manager->RevokeDevicePermission(
-        blink::PermissionType::SERIAL, origin, PortInfoToValue(*it->second),
-        browser_context_);
-  }
-
   auto ephemeral = ephemeral_ports_.find(origin);
   if (ephemeral != ephemeral_ports_.end()) {
     std::set<base::UnguessableToken>& ports = ephemeral->second;
     ports.erase(token);
   }
+
+  auto it = port_info_.find(token);
+  if (it == port_info_.end())
+    return;
+
+  auto* permission_manager = static_cast<ElectronPermissionManager*>(
+      browser_context_->GetPermissionControllerDelegate());
+  permission_manager->RevokeDevicePermission(
+      blink::PermissionType::SERIAL, origin, PortInfoToValue(*it->second),
+      browser_context_);
 
   auto* web_contents =
       content::WebContents::FromRenderFrameHost(render_frame_host);

--- a/spec/fixtures/crash-cases/extension-background-page-media/extension/background.js
+++ b/spec/fixtures/crash-cases/extension-background-page-media/extension/background.js
@@ -1,0 +1,4 @@
+navigator.mediaDevices.enumerateDevices().then(
+  () => console.log('enumerated'),
+  (err) => console.log('enumerate failed', err)
+);

--- a/spec/fixtures/crash-cases/extension-background-page-media/extension/manifest.json
+++ b/spec/fixtures/crash-cases/extension-background-page-media/extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "background-page-media",
+  "version": "1.0",
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  }
+}

--- a/spec/fixtures/crash-cases/extension-background-page-media/index.js
+++ b/spec/fixtures/crash-cases/extension-background-page-media/index.js
@@ -1,0 +1,14 @@
+// An extension background page using navigator.mediaDevices must not crash
+// the main process.
+const { app, session, webContents } = require('electron');
+
+const { once } = require('node:events');
+const path = require('node:path');
+
+app.whenReady().then(async () => {
+  const bgPageLogged = once(app, 'web-contents-created').then(([, wc]) => once(wc, 'console-message'));
+  await session.defaultSession.extensions.loadExtension(path.join(__dirname, 'extension'));
+  await Promise.race([bgPageLogged, new Promise((resolve) => setTimeout(resolve, 5000))]);
+  if (!webContents.getAllWebContents().some((wc) => wc.getType() === 'backgroundPage')) process.exitCode = 1;
+  app.quit();
+});

--- a/spec/fixtures/crash-cases/webui-host-non-webui-scheme/index.js
+++ b/spec/fixtures/crash-cases/webui-host-non-webui-scheme/index.js
@@ -1,0 +1,16 @@
+// Navigating a regular window to a non-chrome:// URL whose host happens to
+// match a WebUI page must not be treated as a WebUI navigation.
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(async () => {
+  const w = new BrowserWindow({ show: false });
+  await w.loadURL('about:blank');
+  for (const url of ['http://accessibility/', 'http://devtools/']) {
+    await w.webContents.executeJavaScript(`location.href = ${JSON.stringify(url)}; undefined`);
+    await new Promise((resolve) => {
+      w.webContents.once('did-fail-load', resolve);
+      w.webContents.once('did-finish-load', resolve);
+    });
+  }
+  app.quit();
+});


### PR DESCRIPTION
Backport of #53305

See that PR for details. The `LanguageModel` worker fix is left out: the local AI handler does not exist on this line.

Notes: Fixed main process crashes when navigating to `http://accessibility/` or `http://devtools/`, when an extension background page used `navigator.mediaDevices`, and when calling `SerialPort.forget()` for a disconnected device.
