### PR TITLE
fix: propagate exceptions thrown by property getters on objects passed across the contextBridge

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -361,10 +361,14 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContextInner(
     // v8::Message includes some pretext that can get duplicated each time it
     // crosses the bridge we fallback to the v8::Message approach if we can't
     // pull "message" for some reason
-    v8::MaybeLocal<v8::Value> maybe_message = value.As<v8::Object>()->Get(
-        source_context, gin::ConvertToV8(isolate, "message"));
+    // Reading "message" can run a user-defined accessor which may throw; if it
+    // does, bail out and let the pending exception propagate to the caller.
     v8::Local<v8::Value> message;
-    if (maybe_message.ToLocal(&message) && message->IsString()) {
+    if (!value.As<v8::Object>()
+             ->Get(source_context, gin::ConvertToV8(isolate, "message"))
+             .ToLocal(&message))
+      return {};
+    if (message->IsString()) {
       return v8::MaybeLocal<v8::Value>(
           v8::Exception::Error(message.As<v8::String>()));
     }
@@ -699,11 +703,14 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
         }
       }
 
+      // Reading the property can run a user-defined accessor which may throw;
+      // if it does, bail out and let the pending exception propagate to the
+      // caller like any other conversion failure.
       v8::Local<v8::Value> value;
       {
         v8::Context::Scope source_context_scope(source_context);
-        if (!api.Get(key, &value))
-          continue;
+        if (!api.GetHandle()->Get(source_context, key).ToLocal(&value))
+          return {};
       }
 
       auto passed_value = PassValueToOtherContextInner(

--- a/spec/api-context-bridge-spec.ts
+++ b/spec/api-context-bridge-spec.ts
@@ -514,6 +514,43 @@ describe('contextBridge', () => {
         expect(result).to.deep.equal(['boom', 'nested boom', 3]);
       });
 
+      it('should throw when an object argument has a throwing getter', async () => {
+        await makeBindingWindow(() => {
+          contextBridge.exposeInMainWorld('example', {
+            check: (_: any) => {
+              (globalThis as any).called = true;
+            },
+            called: () => (globalThis as any).called === true
+          });
+        });
+        const result = await callWithBindings((root: any) => {
+          const getError = (fn: Function) => {
+            try {
+              fn();
+            } catch (e) {
+              return (e as Error).message;
+            }
+            return null;
+          };
+          class CustomError extends Error {
+            get message(): string {
+              throw new Error('error boom');
+            }
+          }
+          const objectError = getError(() =>
+            root.example.check({
+              a: 1,
+              get b() {
+                throw new Error('object boom');
+              }
+            })
+          );
+          const errorError = getError(() => root.example.check(new CustomError()));
+          return [objectError, errorError, root.example.called()];
+        });
+        expect(result).to.deep.equal(['object boom', 'error boom', false]);
+      });
+
       it('should throw instead of crashing when a returned array has a throwing getter', async () => {
         await makeBindingWindow(() => {
           contextBridge.exposeInMainWorld('example', {


### PR DESCRIPTION
Backport of #53289

See that PR for details. Touches the same spec file as the #53069 backport on this line, so whichever lands second will need a trivial rebase.

Notes: Fixed an issue where an exception thrown by a property getter on an object passed through `contextBridge` was swallowed instead of being thrown back to the caller.
