### PR TITLE
build: remove requirement of empty commit message body

### DIFF
--- a/script/lint-roller-chromium-changes.mjs
+++ b/script/lint-roller-chromium-changes.mjs
@@ -369,15 +369,6 @@ async function main() {
     if (firstLine === PATCHES_UPDATE_MSG) {
       let commitValid = true;
 
-      // Must have no commit message body
-      const bodyLines = commit.message.trim().split('\n').slice(1);
-      const nonEmptyBodyLines = bodyLines.filter((line) => line.trim().length > 0);
-      if (nonEmptyBodyLines.length > 0) {
-        console.error(`  ❌ "${PATCHES_UPDATE_MSG}" commit must not have a commit message body`);
-        hasErrors = true;
-        commitValid = false;
-      }
-
       const changedFiles = getChangedFilesForCommit(commit.sha);
       if (!changedFiles || changedFiles.length === 0) {
         console.error(`  ❌ Could not determine changed files for "${PATCHES_UPDATE_MSG}" commit`);


### PR DESCRIPTION
#### Description of Change

The chromium roller commit linting was failing on a commit like this:
```
chore: update patches
Signed-off-by: John Kleinschmidt <jkleinsc@electronjs.org>
```
This should be a valid commit.  The `Signed-off-by` gets added to the commit when a commit is signed off via `git commit --amend --signoff` or `git rebase -i --signoff HEAD~n`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->none
