### PR TITLE
chore: cherry-pick 16 changes from chromium, v8, skia, libyuv

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -301,3 +301,12 @@ m152_extensions_disallow_error_documents_from_spoofing.patch
 m152_fix_overflow_in_crashpad.patch
 m152_gpu_add_flush_queries_before_deleting_or_unbinding_fbo.patch
 revert_only_preload_swiftshader_in_gpu_sandbox_init_when_allowed.patch
+cherry-pick-a74693810877.patch
+cherry-pick-109d4363b05b.patch
+cherry-pick-02ddefa1eb9e.patch
+cherry-pick-d39395c9f94c.patch
+cherry-pick-c4ad58ae4d25.patch
+cherry-pick-b9cc197cf022.patch
+cherry-pick-7d3266fe2240.patch
+cherry-pick-b643479522e2.patch
+cherry-pick-bbc335d274ed.patch

--- a/patches/chromium/cherry-pick-02ddefa1eb9e.patch
+++ b/patches/chromium/cherry-pick-02ddefa1eb9e.patch
@@ -1,0 +1,177 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Zager <szager@chromium.org>
+Date: Wed, 8 Jul 2026 20:48:33 -0700
+Subject: [M150] [HiC] Invalidate cached paint when content is moved into
+ canvas
+
+Original change's description:
+> [HiC] Invalidate cached paint when content is moved into canvas
+>
+> Bug: 517931625
+> Change-Id: I4b024abe0d670a30daab5089ac2a9c4942bb27c8
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7997860
+> Reviewed-by: Philip Rogers <pdr@chromium.org>
+> Commit-Queue: Stefan Zager <szager@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1653242}
+
+(cherry picked from commit 4ca9747a45ccaf8beda9ed8803333b4b6bfc1bfe)
+
+Bug: 528588695,517931625
+Change-Id: I4b024abe0d670a30daab5089ac2a9c4942bb27c8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8061624
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: Stefan Zager <szager@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#3062}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/third_party/blink/renderer/core/dom/element.cc b/third_party/blink/renderer/core/dom/element.cc
+index 9defc3828f9cc014dee957afba71d21f1a4402a4..c81c41d3b1c653bfd016e2e52aa3186dd70b949e 100644
+--- a/third_party/blink/renderer/core/dom/element.cc
++++ b/third_party/blink/renderer/core/dom/element.cc
+@@ -245,6 +245,7 @@
+ #include "third_party/blink/renderer/core/page/scrolling/root_scroller_controller.h"
+ #include "third_party/blink/renderer/core/page/scrolling/sync_scroll_attempt_heuristic.h"
+ #include "third_party/blink/renderer/core/page/spatial_navigation.h"
++#include "third_party/blink/renderer/core/paint/object_paint_invalidator.h"
+ #include "third_party/blink/renderer/core/paint/paint_layer.h"
+ #include "third_party/blink/renderer/core/paint/paint_layer_scrollable_area.h"
+ #include "third_party/blink/renderer/core/probe/core_probes.h"
+@@ -4407,6 +4408,18 @@ void Element::SetIsCanvasOrInCanvasSubtree(bool value) {
+   DidChangeIsCanvasOrInCanvasSubtree();
+ }
+ 
++void Element::DidChangeIsCanvasOrInCanvasSubtree() {
++  if (auto* layout_object = GetLayoutObject()) {
++    layout_object->SetNeedsPaintPropertyUpdate();
++    if (layout_object->HasLayer()) {
++      To<LayoutBoxModelObject>(layout_object)->Layer()->SetNeedsRepaint();
++    }
++    ObjectPaintInvalidator(*layout_object)
++        .InvalidateDisplayItemClient(*layout_object,
++                                     PaintInvalidationReason::kUncacheable);
++  }
++}
++
+ void Element::RemovedFrom(ContainerNode& insertion_point) {
+   bool was_in_document = insertion_point.isConnected();
+   if (Element* parent = DynamicTo<Element>(insertion_point)) {
+diff --git a/third_party/blink/renderer/core/dom/element.h b/third_party/blink/renderer/core/dom/element.h
+index 679c68de8de552bc33833e013b3e7cd62fb51c99..a1acbe030d45ecb020001ca68746d97a1cc00011 100644
+--- a/third_party/blink/renderer/core/dom/element.h
++++ b/third_party/blink/renderer/core/dom/element.h
+@@ -1103,7 +1103,7 @@ class CORE_EXPORT Element : public ContainerNode {
+     return HasElementFlag(ElementFlags::kIsCanvasOrInCanvasSubtree);
+   }
+   // Called when `IsCanvasOrInCanvasSubtree()` has changed.
+-  virtual void DidChangeIsCanvasOrInCanvasSubtree() {}
++  virtual void DidChangeIsCanvasOrInCanvasSubtree();
+   // Like `IsCanvasOrInCanvasSubtree()`, but excludes the outermost <canvas>.
+   bool IsInCanvasSubtree() const;
+ 
+diff --git a/third_party/blink/renderer/core/html/forms/html_input_element.cc b/third_party/blink/renderer/core/html/forms/html_input_element.cc
+index b6a14cccb84ff3ba7db8a03f0509998bf935c334..46934cd796a8a5b6b8bbeb91e6edf29ac3f9df7a 100644
+--- a/third_party/blink/renderer/core/html/forms/html_input_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_input_element.cc
+@@ -1296,6 +1296,7 @@ void HTMLInputElement::SetSuggestedValue(const String& value) {
+ }
+ 
+ void HTMLInputElement::DidChangeIsCanvasOrInCanvasSubtree() {
++  TextControlElement::DidChangeIsCanvasOrInCanvasSubtree();
+   if (RuntimeEnabledFeatures::CanvasDrawElementEnabled(GetExecutionContext()) &&
+       IsInCanvasSubtree()) {
+     // Hide suggested values when under canvas, to prevent leaking this
+diff --git a/third_party/blink/renderer/core/html/forms/html_select_element.cc b/third_party/blink/renderer/core/html/forms/html_select_element.cc
+index fc87e0520ded1d367c250b7f422c2f13c1760cf1..4d78199ea863c6e5b323c3c8f517cc85b5e4d1dc 100644
+--- a/third_party/blink/renderer/core/html/forms/html_select_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_select_element.cc
+@@ -841,6 +841,7 @@ int HTMLSelectElement::SelectedListIndex() const {
+ }
+ 
+ void HTMLSelectElement::DidChangeIsCanvasOrInCanvasSubtree() {
++  HTMLFormControlElementWithState::DidChangeIsCanvasOrInCanvasSubtree();
+   if (RuntimeEnabledFeatures::CanvasDrawElementEnabled(GetExecutionContext()) &&
+       IsInCanvasSubtree()) {
+     // Hide suggested values when under canvas, to prevent leaking this
+diff --git a/third_party/blink/renderer/core/html/forms/html_text_area_element.cc b/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
+index 7bde0d26d04c9c0a2e820f90f4e9528b430a8c43..dceb9a65b5eaa25c2faa537eb41c5988099cca87 100644
+--- a/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
++++ b/third_party/blink/renderer/core/html/forms/html_text_area_element.cc
+@@ -669,6 +669,7 @@ void HTMLTextAreaElement::SetSuggestedValue(const String& value) {
+ }
+ 
+ void HTMLTextAreaElement::DidChangeIsCanvasOrInCanvasSubtree() {
++  TextControlElement::DidChangeIsCanvasOrInCanvasSubtree();
+   if (RuntimeEnabledFeatures::CanvasDrawElementEnabled(GetExecutionContext()) &&
+       IsInCanvasSubtree()) {
+     // Hide suggested values when under canvas, to prevent leaking this
+diff --git a/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/background-image-in-iframe-ignored.tentative.https.sub.html b/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/background-image-in-iframe-ignored.tentative.https.sub.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..5dc64d562baf1914e71b26d7931f15469c088d82
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/background-image-in-iframe-ignored.tentative.https.sub.html
+@@ -0,0 +1,36 @@
++<!DOCTYPE HTML>
++<html>
++<head>
++  <title>drawElementImage does not draw cross-origin background images</title>
++  <script src='/resources/testharness.js'></script>
++  <script src='/resources/testharnessreport.js'></script>
++  <script src='/html/canvas/resources/canvas-tests.js'></script>
++  <script src="/html/canvas/resources/wait-for-canvas-paint.js"></script>
++</head>
++
++<body>
++  <iframe id="iframe" src="support/subframe-cross-origin-background-image.https.sub.html"></iframe>
++  <canvas id="canvas" width="300" height="150" layoutsubtree>
++    <div id="child"></div>
++  </canvas>
++
++  <script>
++  window.onload = () => {
++    promise_test(async function(t) {
++      await waitForCanvasPaint(canvas);
++
++      // Atomically move the iframe into the canvas.
++      child.moveBefore(iframe, null);
++
++      await waitForCanvasPaint(canvas);
++      const context = canvas.getContext("2d");
++      context.drawElementImage(child, 0, 0);
++      const imgData = context.getImageData(0, 0, canvas.width, canvas.height);
++      let pixel = _getPixelFromImageData(imgData, 50, 50);
++      assert_array_equals(pixel, [0, 128, 0, 255],
++                          "Cross-origin background image in iframe should not draw");
++    });
++  };
++  </script>
++</body>
++</html>
+diff --git a/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/support/subframe-cross-origin-background-image.https.sub.html b/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/support/subframe-cross-origin-background-image.https.sub.html
+new file mode 100644
+index 0000000000000000000000000000000000000000..48c81b7ecf8b6affaa29fa36e8e4767e22e6917a
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/html/canvas/element/manual/draw-element-image/privacy/support/subframe-cross-origin-background-image.https.sub.html
+@@ -0,0 +1,22 @@
++<!DOCTYPE HTML>
++<html>
++<head>
++  <title>subframe with cross-origin background image</title>
++  <style>
++  body {
++    background-color: rgb(0 128 0);
++  }
++  div {
++    position: absolute;
++    left: 0px;
++    top: 0px;
++    width: 100px;
++    height: 100px;
++    background-image: url("https://{{hosts[alt][www]}}:{{ports[https][0]}}/images/red-100x100.png");
++  }
++  </style>
++</head>
++
++<body><div></div></body>
++
++</html>

--- a/patches/chromium/cherry-pick-109d4363b05b.patch
+++ b/patches/chromium/cherry-pick-109d4363b05b.patch
@@ -1,0 +1,285 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kramer Ge <fangzhoug@chromium.org>
+Date: Mon, 13 Jul 2026 10:48:22 -0700
+Subject: [M144-LTS][Ozone/Wayland]Guard all delegate() calls with weak_this
+
+delegate() calls may implicitly destroy WaylandWindow. Guard direct and
+indirect calls to delegate() state changes with weak_this if such calls
+are followed by potential deref of WaylandWindow members.
+
+(cherry picked from commit 87abcfa5b16b689587f94f40e6e7de88db11313a)
+
+Fixed: 518007484
+Change-Id: I9fe00496ee807f3416c9a9a2dedeef352e4a63e6
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8043107
+Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Kramer Ge <fangzhoug@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#1657588}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8068557
+Reviewed-by: Kramer Ge <fangzhoug@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7559@{#5086}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_bubble.cc b/ui/ozone/platform/wayland/host/wayland_bubble.cc
+index ef876a70515d7969f5966d076d59c519d84f6b02..99379bf16a5182dafd33df1d45d83bffc314ccfb 100644
+--- a/ui/ozone/platform/wayland/host/wayland_bubble.cc
++++ b/ui/ozone/platform/wayland/host/wayland_bubble.cc
+@@ -34,8 +34,15 @@ void WaylandBubble::Show(bool inactive) {
+     return;
+   }
+ 
++  auto weak_this = AsWeakPtr();
+   UpdateWindowScale(false);
++  if (!weak_this) {
++    return;
++  }
+   AddToParentAsSubsurface();
++  if (!weak_this) {
++    return;
++  }
+   WaylandWindow::Show(inactive);
+ }
+ 
+@@ -96,7 +103,11 @@ void WaylandBubble::Deactivate() {
+ }
+ 
+ void WaylandBubble::UpdateWindowScale(bool update_bounds) {
++  auto weak_this = AsWeakPtr();
+   WaylandWindow::UpdateWindowScale(update_bounds);
++  if (!weak_this) {
++    return;
++  }
+   if (subsurface_) {
+     SetSubsurfacePosition();
+   }
+@@ -131,7 +142,11 @@ void WaylandBubble::AddToParentAsSubsurface() {
+   CHECK(parent_window());
+ 
+   // We need to make sure that window scale matches the parent window.
++  auto weak_this = AsWeakPtr();
+   UpdateWindowScale(true);
++  if (!weak_this) {
++    return;
++  }
+ 
+   subsurface_ =
+       root_surface()->CreateSubsurface(parent_window()->root_surface());
+diff --git a/ui/ozone/platform/wayland/host/wayland_frame_manager.cc b/ui/ozone/platform/wayland/host/wayland_frame_manager.cc
+index 96448ba03b1bffd662299950d68e61db3e02395b..8e544d7a2f37585a64bd51a80d34945c2dbdf063 100644
+--- a/ui/ozone/platform/wayland/host/wayland_frame_manager.cc
++++ b/ui/ozone/platform/wayland/host/wayland_frame_manager.cc
+@@ -198,7 +198,11 @@ void WaylandFrameManager::MaybeProcessPendingFrame() {
+     if (!ValidateRect(config.bounds_rect)) {
+       fatal_error_message_ = kBoundsRectNanOrInf;
+     } else {
++      auto weak_this = weak_factory_.GetWeakPtr();
+       window_->OnSequencePoint(frame->seq);
++      if (!weak_this) {
++        return;
++      }
+       // During a tab dragging session, OnSequencePoint() can implicitly invoke
+       // Hide(). |pending_frames_| will be cleared and we should return
+       // directly.
+diff --git a/ui/ozone/platform/wayland/host/wayland_popup.cc b/ui/ozone/platform/wayland/host/wayland_popup.cc
+index 8b5b03e7579b43b496909f1fc0a909ab9f614f60..75c74757a552d5038eff6292bcef64ba350faf87 100644
+--- a/ui/ozone/platform/wayland/host/wayland_popup.cc
++++ b/ui/ozone/platform/wayland/host/wayland_popup.cc
+@@ -57,7 +57,11 @@ bool WaylandPopup::CreateShellPopup() {
+       parent_window()->applied_state().window_scale) {
+     // If scale changed while this was hidden (when WaylandPopup hides, parent
+     // window's child is reset), update buffer scale accordingly.
++    auto weak_this = AsWeakPtr();
+     UpdateWindowScale(true);
++    if (!weak_this) {
++      return false;
++    }
+   }
+ 
+   auto bounds_dip =
+@@ -123,13 +127,21 @@ void WaylandPopup::Show(bool inactive) {
+   // Map parent window as WaylandPopup cannot become a visible child of a
+   // window that is not mapped.
+   DCHECK(parent_window());
+-  if (!parent_window()->IsVisible())
++  auto weak_this = AsWeakPtr();
++  if (!parent_window()->IsVisible()) {
+     parent_window()->Show(false);
++  }
++  if (!weak_this) {
++    return;
++  }
+ 
+-  if (!CreateShellPopup()) {
++  if (!CreateShellPopup() && weak_this) {
+     Close();
+     return;
+   }
++  if (!weak_this) {
++    return;
++  }
+ 
+   connection()->Flush();
+   WaylandWindow::Show(inactive);
+@@ -250,7 +262,11 @@ void WaylandPopup::HandlePopupConfigure(const gfx::Rect& bounds_dip) {
+ 
+ void WaylandPopup::HandleSurfaceConfigure(uint32_t serial) {
+   if (schedule_redraw_) {
++    auto weak_this = AsWeakPtr();
+     delegate()->OnDamageRect(gfx::Rect{applied_state().size_px});
++    if (!weak_this) {
++      return;
++    }
+     schedule_redraw_ = false;
+   }
+   ProcessPendingConfigureState(serial);
+diff --git a/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc b/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
+index 77bfc42bb211d138dd9c88fbf7627a8146ffa847..be83f61c2b36ead50e8ff93eccd11de756a53d04 100644
+--- a/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
+@@ -530,7 +530,11 @@ void WaylandToplevelWindow::HandleToplevelConfigureWithOrigin(
+   if (window_states.tiled_edges != applied_state().tiled_edges) {
+     // This configure changes the decoration insets.  We should adjust the
+     // bounds appropriately.
++    auto weak_this = AsWeakPtr();
+     delegate()->OnWindowTiledStateChanged(window_states.tiled_edges);
++    if (!weak_this) {
++      return;
++    }
+   }
+ 
+   pending_configure_state_.tiled_edges = window_states.tiled_edges;
+@@ -868,7 +872,11 @@ void WaylandToplevelWindow::TriggerStateChanges(
+   // TODO(crbug.com/40276379): Remove this once this is async.
+   auto previous_state = applied_state().window_state;
+   ForceApplyWindowStateDoNotUse(window_state);
++  auto weak_this = AsWeakPtr();
+   delegate()->OnWindowStateChanged(previous_state, window_state);
++  if (!weak_this) {
++    return;
++  }
+   connection()->Flush();
+ }
+ 
+diff --git a/ui/ozone/platform/wayland/host/wayland_window.cc b/ui/ozone/platform/wayland/host/wayland_window.cc
+index 36bf67c904288289ec05090631ac74ab518cb70b..3cb0cc54ce4cb52229ebba90c4d0ce1897585905 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -163,7 +163,11 @@ void WaylandWindow::UpdateWindowScale(bool update_bounds) {
+   const auto window_scale = connection_->UsePerSurfaceScaling()
+                                 ? GetPreferredScaleFactor()
+                                 : GetScaleFactorFromEnteredOutputs();
++  auto weak_this = AsWeakPtr();
+   SetWindowScale(window_scale.value_or(1.0f));
++  if (!weak_this) {
++    return;
++  }
+ 
+   // Propagate update to the popups.
+   if (child_popup_) {
+diff --git a/ui/ozone/platform/wayland/host/wayland_window_unittest.cc b/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+index 4eeaf54d3adfa7d46ec143e7c7a4f0148d69e3c7..b0c9f538c7d8ffeed9737bcf4c3f690505b530cc 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window_unittest.cc
+@@ -5432,6 +5432,102 @@ TEST_P(WaylandWindowTest, HandleToplevelConfigureSyncCloseOnDeactivate) {
+   EXPECT_FALSE(window_);
+ }
+ 
++TEST_P(WaylandWindowTest, WaylandBubbleUpdateWindowScaleUaf) {
++  MockWaylandPlatformWindowDelegate bubble_delegate(connection_.get());
++  gfx::Rect bubble_bounds(10, 10, 50, 50);
++  auto wayland_bubble =
++      CreateWaylandWindowWithParams(PlatformWindowType::kBubble, bubble_bounds,
++                                    &bubble_delegate, window_->GetWidget());
++  ASSERT_TRUE(wayland_bubble);
++
++  bubble_delegate.set_on_state_update_callback(
++      base::BindLambdaForTesting([&]() {
++        wayland_bubble.reset();
++        return true;
++      }));
++
++  // This should not crash.
++  wayland_bubble->UpdateWindowScale(true);
++}
++
++TEST_P(WaylandWindowTest, WaylandBubbleShowUaf) {
++  MockWaylandPlatformWindowDelegate bubble_delegate(connection_.get());
++  PlatformWindowInitProperties properties;
++  properties.bounds = gfx::Rect(10, 10, 50, 50);
++  properties.type = PlatformWindowType::kBubble;
++  properties.parent_widget = window_->GetWidget();
++  auto wayland_bubble = bubble_delegate.CreateWaylandWindow(
++      connection_.get(), std::move(properties));
++  ASSERT_TRUE(wayland_bubble);
++
++  bubble_delegate.set_on_state_update_callback(
++      base::BindLambdaForTesting([&]() {
++        wayland_bubble.reset();
++        return true;
++      }));
++
++  // This should not crash.
++  wayland_bubble->Show(false);
++}
++
++TEST_P(WaylandWindowTest, WaylandPopupShowUaf) {
++  MockWaylandPlatformWindowDelegate popup_delegate(connection_.get());
++  PlatformWindowInitProperties properties;
++  properties.bounds = gfx::Rect(10, 10, 50, 50);
++  properties.type = PlatformWindowType::kPopup;
++  properties.parent_widget = window_->GetWidget();
++  auto wayland_popup = popup_delegate.CreateWaylandWindow(
++      connection_.get(), std::move(properties));
++  ASSERT_TRUE(wayland_popup);
++
++  popup_delegate.set_on_state_update_callback(base::BindLambdaForTesting([&]() {
++    wayland_popup.reset();
++    return true;
++  }));
++
++  // This should not crash.
++  wayland_popup->Show(false);
++}
++
++TEST_P(WaylandWindowTest, WaylandToplevelWindowOnPaintAsActiveChangedUaf) {
++  testing::NiceMock<MockWaylandPlatformWindowDelegate> toplevel_delegate(
++      connection_.get());
++  PlatformWindowInitProperties properties;
++  properties.bounds = gfx::Rect(10, 10, 100, 100);
++  properties.type = PlatformWindowType::kWindow;
++  auto toplevel_window = toplevel_delegate.CreateWaylandWindow(
++      connection_.get(), std::move(properties));
++  ASSERT_TRUE(toplevel_window);
++
++  EXPECT_CALL(toplevel_delegate, OnPaintAsActiveChanged(::testing::_))
++      .WillOnce(
++          ::testing::InvokeWithoutArgs([&]() { toplevel_window.reset(); }));
++
++  WaylandWindow::WindowStates window_states;
++  window_states.is_activated = true;
++  // This should not crash.
++  toplevel_window->HandleToplevelConfigure(100, 100, window_states);
++}
++
++TEST_P(WaylandWindowTest, WaylandToplevelWindowTriggerStateChangesUaf) {
++  testing::NiceMock<MockWaylandPlatformWindowDelegate> toplevel_delegate(
++      connection_.get());
++  PlatformWindowInitProperties properties;
++  properties.bounds = gfx::Rect(10, 10, 100, 100);
++  properties.type = PlatformWindowType::kWindow;
++  auto toplevel_window = toplevel_delegate.CreateWaylandWindow(
++      connection_.get(), std::move(properties));
++  ASSERT_TRUE(toplevel_window);
++
++  EXPECT_CALL(toplevel_delegate,
++              OnWindowStateChanged(::testing::_, ::testing::_))
++      .WillOnce(
++          ::testing::InvokeWithoutArgs([&]() { toplevel_window.reset(); }));
++
++  // This should not crash.
++  toplevel_window->Maximize();
++}
++
+ INSTANTIATE_TEST_SUITE_P(XdgVersionStableTest,
+                          WaylandWindowTest,
+                          Values(wl::ServerConfig{}));

--- a/patches/chromium/cherry-pick-7d3266fe2240.patch
+++ b/patches/chromium/cherry-pick-7d3266fe2240.patch
@@ -1,0 +1,187 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xinchao Tian <xinchaotian@microsoft.com>
+Date: Fri, 10 Jul 2026 04:43:01 -0700
+Subject: [M150] Guard against re-entrant destruction in CreateNewWindow
+
+Original change's description:
+> Guard against re-entrant destruction in CreateNewWindow
+>
+> CreateNewWindow() (opener-suppressed path) calls
+> delegate_->AddNewContents() and then continues using state owned by this
+> (opener, delegate_, primary frame tree).
+>
+> On Windows, AddNewContents() may enter a nested message loop while
+> showing a new browser window. A window-close message can destroy the
+> opener WebContents during this call, causing use-after-free.
+>
+> Fix by capturing a WeakPtr to this before calling AddNewContents() and
+> aborting if it is invalidated, similar to existing weak_new_contents
+> logic.
+>
+> Add a browsertest that destroys the opener inside AddNewContents() to
+> prevent regressions.
+>
+> Bug: 527676561
+> Change-Id: If224916a349113845cce68c438b04f451126d6ee
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8003496
+> Commit-Queue: Xinchao Tian <xinchaotian@microsoft.com>
+> Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
+> Reviewed-by: Bo Liu <boliu@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1653497}
+
+(cherry picked from commit c889717537a805003583d4f5d88fd45204b58c67)
+
+Bug: 533270856,527676561
+Change-Id: If224916a349113845cce68c438b04f451126d6ee
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8074598
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3145}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 44ff26546c1c8f498784afca1c26deb45ccb9e87..a756cf1eaa598dc3d237b62fa7d7f1f5e548182d 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -10365,9 +10365,16 @@ void RenderFrameHostImpl::CreateNewWindow(
+ 
+   // The non-owning pointer |new_frame_tree| is valid in this stack frame at
+   // least until the call to ShowCreatedWindow() below.
++  base::WeakPtr<RenderFrameHostImpl> weak_self = GetWeakPtr();
+   FrameTree* new_frame_tree =
+       delegate_->CreateNewWindow(this, *params, is_new_browsing_instance,
+                                  was_consumed, cloned_namespace.get());
++  if (!weak_self) {
++    // This RFH may be deleted after CreateNewWindow() due to a nested message
++    // loop (e.g. showing the new window closes the window hosting `this`). See
++    // crbug.com/527676561.
++    return;
++  }
+ 
+   transient_allow_popup_.Deactivate();
+ 
+diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
+index 8fcea8528de4c10a6a2b730f130f6c5fdc9c92a8..e24c2cd92be8f49703f2782409e2f2b88ffa0afa 100644
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -5639,12 +5639,20 @@ FrameTree* WebContentsImpl::CreateNewWindow(
+   bool was_blocked = false;
+   base::WeakPtr<WebContentsImpl> weak_new_contents =
+       new_contents_impl->weak_factory_.GetWeakPtr();
++  base::WeakPtr<WebContentsImpl> weak_this = weak_factory_.GetWeakPtr();
+   WebContentsImpl* contents_to_load = new_contents_impl;
+   if (delegate_) {
+     WebContents* web_contents_navigated = delegate_->AddNewContents(
+         this, std::move(new_contents), params.target_url, params.disposition,
+         *params.features, has_user_gesture, &was_blocked);
+ 
++    if (!weak_this) {
++      // `this` may be deleted after AddNewContents() due to a nested message
++      // loop (e.g. the window hosting the opener is closed). See
++      // crbug.com/527676561.
++      return nullptr;
++    }
++
+     if (base::FeatureList::IsEnabled(features::kPwaNavigationCapturing)) {
+       // The delegate may delete |new_contents_impl| during AddNewContents().
+       // If that occurs and there isn't a replacement contents returned, exit.
+diff --git a/content/browser/web_contents/web_contents_impl_browsertest.cc b/content/browser/web_contents/web_contents_impl_browsertest.cc
+index 25244d502fc72239075aa8a5c18afa97d198988a..1766bf3c4b767ad2f8521318dff85751968de64b 100644
+--- a/content/browser/web_contents/web_contents_impl_browsertest.cc
++++ b/content/browser/web_contents/web_contents_impl_browsertest.cc
+@@ -3600,6 +3600,94 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest, TitleUpdateOnRestore) {
+ 
+ namespace {
+ 
++// A WebContentsDelegate whose AddNewContents() runs a caller-provided closure
++// before returning. The closure is used to destroy the opener WebContents
++// synchronously, simulating the re-entrant destruction that can happen when
++// AddNewContents() spins a nested run loop (e.g. on Windows, showing the new
++// browser window dispatches native messages that can close the opener window).
++class DestroyOpenerOnAddNewContentsDelegate : public WebContentsDelegate {
++ public:
++  explicit DestroyOpenerOnAddNewContentsDelegate(base::OnceClosure on_add)
++      : on_add_(std::move(on_add)) {}
++
++  WebContents* AddNewContents(
++      WebContents* source,
++      std::unique_ptr<WebContents> new_contents,
++      const GURL& target_url,
++      WindowOpenDisposition disposition,
++      const blink::mojom::WindowFeatures& window_features,
++      bool user_gesture,
++      bool* was_blocked) override {
++    // Keep the new popup alive so that CreateNewWindow()'s `weak_new_contents`
++    // guard does NOT short-circuit. Otherwise the function would return early
++    // before reaching the code that dereferences the (now destroyed) opener,
++    // and the regression would not be exercised.
++    new_contents_ = std::move(new_contents);
++    WebContents* raw_new_contents = new_contents_.get();
++    if (on_add_) {
++      std::move(on_add_).Run();
++    }
++    return raw_new_contents;
++  }
++
++ private:
++  base::OnceClosure on_add_;
++  std::unique_ptr<WebContents> new_contents_;
++};
++
++}  // namespace
++
++// Regression test for a use-after-free where the opener WebContents is
++// destroyed re-entrantly while WebContentsImpl::CreateNewWindow() is calling
++// WebContentsDelegate::AddNewContents(). With an opener-suppressed
++// (`noopener`) window.open(), CreateNewWindow() drives the new window through
++// the delegate and then keeps using `this` (and `delegate_`/`opener`) after
++// AddNewContents() returns. If the opener is torn down during that call, the
++// trailing code used to run on freed memory. See crbug.com/527676561.
++IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest,
++                       CreateNewWindowOpenerDestroyedInAddNewContents) {
++  ASSERT_TRUE(embedded_test_server()->Start());
++
++  // Create an opener WebContents owned by the test, so the delegate can destroy
++  // it from within AddNewContents().
++  WebContents::CreateParams create_params(
++      shell()->web_contents()->GetBrowserContext());
++  create_params.desired_renderer_state =
++      WebContents::CreateParams::kInitializeAndWarmupRendererProcess;
++  std::unique_ptr<WebContents> opener(WebContents::Create(create_params));
++  WebContents* opener_ptr = opener.get();
++
++  base::RunLoop run_loop;
++  DestroyOpenerOnAddNewContentsDelegate delegate(
++      base::BindLambdaForTesting([&]() {
++        // Destroy the opener (`this` inside CreateNewWindow()) synchronously.
++        opener.reset();
++        run_loop.Quit();
++      }));
++  opener_ptr->SetDelegate(&delegate);
++
++  const GURL opener_url(
++      embedded_test_server()->GetURL("a.com", "/title1.html"));
++  ASSERT_TRUE(NavigateToURL(opener_ptr, opener_url));
++
++  // Open a new window with `noopener` so CreateNewWindow() takes the
++  // opener-suppressed path that shows/navigates the window via the delegate.
++  // The script is run fire-and-forget because the opener frame is destroyed
++  // while the window.open() IPC is being handled.
++  const GURL popup_url(
++      embedded_test_server()->GetURL("a.com", "/title2.html"));
++  ExecuteScriptAsync(
++      opener_ptr,
++      JsReplace("window.open($1, '_blank', 'noopener');", popup_url));
++
++  // The opener is destroyed during AddNewContents(). The test passes if this
++  // completes without a use-after-free (caught under ASAN).
++  run_loop.Run();
++  EXPECT_FALSE(opener);
++}
++
++namespace {
++
+ class OutgoingSetRendererPrefsMojoWatcher {
+  public:
+   explicit OutgoingSetRendererPrefsMojoWatcher(RenderViewHostImpl* rvh)

--- a/patches/chromium/cherry-pick-a74693810877.patch
+++ b/patches/chromium/cherry-pick-a74693810877.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kramer Ge <fangzhoug@chromium.org>
+Date: Wed, 8 Jul 2026 14:06:34 -0700
+Subject: [M150] [ozone/wayland]Safely handle destruction during
+ drag_finished_callback
+
+Original change's description:
+> [ozone/wayland]Safely handle destruction during drag_finished_callback
+>
+> drag_finished_callback_.Run(operation) can invoke arbitrary
+> views/delegate logic which may destroy this WaylandWindow. To avoid UAF
+> of fields, add a weakptr check.
+>
+> To ensure base::RunLoop is quit, move the member quit_closure to stack.
+>
+> Fixed: 517100492
+> Change-Id: Ib3fa884e86a1088de9cb356f721ca490736d3acf
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8041831
+> Commit-Queue: Kramer Ge <fangzhoug@chromium.org>
+> Reviewed-by: Thomas Anderson <thomasanderson@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1658008}
+
+(cherry picked from commit e9d7be2570c7e86a960b21554b9563b19ad38f91)
+
+Bug: 532408447,517100492
+Change-Id: Ib3fa884e86a1088de9cb356f721ca490736d3acf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8062588
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3037}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/ui/ozone/platform/wayland/host/wayland_data_drag_controller_unittest.cc b/ui/ozone/platform/wayland/host/wayland_data_drag_controller_unittest.cc
+index c0699afba8b8f61a182101c79bca621b48899b3b..5c425de1a07665bcbc31091debec129a189c86c6 100644
+--- a/ui/ozone/platform/wayland/host/wayland_data_drag_controller_unittest.cc
++++ b/ui/ozone/platform/wayland/host/wayland_data_drag_controller_unittest.cc
+@@ -30,6 +30,8 @@
+ #include "ui/base/dragdrop/os_exchange_data.h"
+ #include "ui/base/dragdrop/os_exchange_data_provider_factory.h"
+ #include "ui/events/base_event_utils.h"
++#include "ui/events/event.h"
++#include "ui/events/types/event_type.h"
+ #include "ui/gfx/geometry/point.h"
+ #include "ui/gfx/geometry/vector2d.h"
+ #include "ui/gfx/native_ui_types.h"
+@@ -908,6 +910,36 @@ TEST_P(WaylandDataDragControllerTest, DestroyOriginSurface) {
+   SendDndCancelled();
+ }
+ 
++// Verifies the drag loop exits gracefully when the origin window is destroyed
++// while dispatching the synthetic pointer release at drag-session close.
++TEST_P(WaylandDataDragControllerTest,
++       DestroyOriginWindowDuringDragSessionClose) {
++  FocusAndPressLeftPointerButton(window_.get(), &delegate_);
++
++  // Once the drag session has started, emulate a successful drop. The
++  // controller will synthesize a release for the still-pressed pointer button;
++  // have the delegate destroy the origin window from within that event's
++  // dispatch, mimicking a queued close task running in a nested loop.
++  ScheduleTestTask(base::BindLambdaForTesting([&]() {
++    EXPECT_CALL(delegate_, DispatchEvent(_)).WillRepeatedly([&](Event* event) {
++      if (event->type() == EventType::kMouseReleased) {
++        window_.reset();
++      }
++    });
++    SendDndFinished();
++  }));
++
++  OSExchangeData os_exchange_data;
++  os_exchange_data.SetString(sample_text_for_dnd());
++  EXPECT_CALL(drag_started_callback_, Run()).Times(1);
++  EXPECT_FALSE(window_->StartDrag(
++      os_exchange_data, DragDropTypes::DRAG_COPY, DragEventSource::kMouse,
++      /*cursor=*/{}, /*can_grab_pointer=*/true, drag_started_callback_.Get(),
++      drag_finished_callback_.Get(), /*location_delegate=*/nullptr));
++
++  EXPECT_FALSE(window_);
++}
++
+ // Ensures drag/drop events are properly propagated to non-toplevel windows.
+ TEST_P(WaylandDataDragControllerTest, DragToNonToplevelWindows) {
+   auto* origin_window = window_.get();
+diff --git a/ui/ozone/platform/wayland/host/wayland_window.cc b/ui/ozone/platform/wayland/host/wayland_window.cc
+index 17f883751ab8e686182ecc6f0600fefe051594e8..36bf67c904288289ec05090631ac74ab518cb70b 100644
+--- a/ui/ozone/platform/wayland/host/wayland_window.cc
++++ b/ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -911,16 +911,23 @@ void WaylandWindow::OnDragSessionClose(DragOperation operation) {
+     // is about to shut down. Do nothing and return.
+     return;
+   }
++  // Running `drag_finished_callback_` and dispatching the synthetic pointer
++  // release below may spin a nested run loop in which `this` gets destroyed,
++  // so move the quit closure onto the stack to ensure the drag loop is still
++  // quit in that case.
++  base::OnceClosure quit_closure = std::move(drag_loop_quit_closure_);
++  auto alive = AsWeakPtr();
+   std::move(drag_finished_callback_).Run(operation);
+   // Skip releasing any pointer buttons for the case of a window drag driven by
+   // the data drag controller.
+   // TODO: crbug.com/40238145 - Refactor this per discussion at
+   // crrev.com/c/5570335/comment/0b8811fc_818028c9/.
+-  if (!connection()->data_drag_controller()->IsWindowDragSessionRunning()) {
++  if (alive &&
++      !connection()->data_drag_controller()->IsWindowDragSessionRunning()) {
+     connection()->event_source()->ReleasePressedPointerButtons(
+         this, EventTimeForNow());
+   }
+-  std::move(drag_loop_quit_closure_).Run();
++  std::move(quit_closure).Run();
+ }
+ 
+ bool WaylandWindow::Initialize(PlatformWindowInitProperties properties) {

--- a/patches/chromium/cherry-pick-b643479522e2.patch
+++ b/patches/chromium/cherry-pick-b643479522e2.patch
@@ -1,0 +1,282 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Mon, 13 Jul 2026 09:40:07 -0700
+Subject: [M150] [X11] Guard XDragDropClient and X11Window against destruction
+ during DnD
+
+Original change's description:
+> [X11] Guard XDragDropClient and X11Window against destruction during DnD
+>
+> X11Window owns XDragDropClient. During drag-and-drop event handling,
+> callbacks into target/delegate drop handlers (such as PerformDrop,
+> OnBeforeDragLeave, and UpdateDrag) can spin nested run loops. If the
+> associated window is closed/destroyed while the nested loop is running,
+> both X11Window and XDragDropClient are destroyed.
+>
+> When the nested loop unwinds, continuing execution in the outer stack
+> frames of XDragDropClient and X11Window leads to Use-After-Free (UAF)
+> vulnerabilities from raw pointer dereferences and virtual method calls.
+>
+> This CL fixes the issue by adding base::WeakPtr liveness guards around
+> every re-entrant delegate callback in XDragDropClient and X11Window.
+>
+> Fixed: 532929679
+> Change-Id: I5d3e89014993df43cf45db1ff2f1b7825b57ebe5
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8071147
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1660006}
+
+(cherry picked from commit e4ce9e74fdba5992af9d41349ca3644cfed78c98)
+
+Bug: 533660933,532929679
+Change-Id: I5d3e89014993df43cf45db1ff2f1b7825b57ebe5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8086914
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3339}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/ui/base/x/x11_drag_drop_client.cc b/ui/base/x/x11_drag_drop_client.cc
+index f1c43001fec27c0881cc6e66baee61b30dd82e8d..4a9fb4d7be85f1a786dc98349074dabf337ac71a 100644
+--- a/ui/base/x/x11_drag_drop_client.cc
++++ b/ui/base/x/x11_drag_drop_client.cc
+@@ -234,8 +234,12 @@ std::vector<x11::Atom> XDragDropClient::GetOfferedDragOperations() const {
+ 
+ void XDragDropClient::CompleteXdndPosition(x11::Window source_window,
+                                            const gfx::Point& screen_point) {
++  base::WeakPtr<XDragDropClient> alive = weak_factory_.GetWeakPtr();
+   DragOperation drag_operation =
+       PreferredDragOperation(delegate_->UpdateDrag(screen_point));
++  if (!alive) {
++    return;
++  }
+ 
+   // Sends an XdndStatus message back to the source_window. l[2,3]
+   // theoretically represent an area in the window where the current action is
+@@ -428,7 +432,11 @@ void XDragDropClient::OnXdndStatus(const x11::ClientMessageEvent& event) {
+ 
+ void XDragDropClient::OnXdndLeave(const x11::ClientMessageEvent& event) {
+   DVLOG(1) << "OnXdndLeave";
++  base::WeakPtr<XDragDropClient> alive = weak_factory_.GetWeakPtr();
+   delegate_->OnBeforeDragLeave();
++  if (!alive) {
++    return;
++  }
+   ResetDragContext();
+ }
+ 
+@@ -437,7 +445,11 @@ void XDragDropClient::OnXdndDrop(const x11::ClientMessageEvent& event) {
+ 
+   auto source_window = static_cast<x11::Window>(event.data.data32[0]);
+ 
++  base::WeakPtr<XDragDropClient> alive = weak_factory_.GetWeakPtr();
+   DragOperation drag_operation = delegate_->PerformDrop();
++  if (!alive) {
++    return;
++  }
+ 
+   auto xev = PrepareXdndClientMessage(kXdndFinished, source_window);
+   xev.data.data32[1] = (drag_operation != DragOperation::kNone) ? 1 : 0;
+diff --git a/ui/base/x/x11_drag_drop_client.h b/ui/base/x/x11_drag_drop_client.h
+index 88360078bbcdb2a9d5c16cd2254b83cfda4c5781..f5f7717c641117b2f883419b4e0f07c46764ace4 100644
+--- a/ui/base/x/x11_drag_drop_client.h
++++ b/ui/base/x/x11_drag_drop_client.h
+@@ -9,6 +9,7 @@
+ 
+ #include "base/component_export.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "base/timer/timer.h"
+ #include "ui/base/dragdrop/mojom/drag_drop_types.mojom-shared.h"
+ #include "ui/base/x/selection_utils.h"
+@@ -251,6 +252,8 @@ class COMPONENT_EXPORT(UI_BASE_X) XDragDropClient {
+   // only if we have previously received a status message from
+   // |source_current_window_|.
+   bool status_received_since_enter_ = false;
++
++  base::WeakPtrFactory<XDragDropClient> weak_factory_{this};
+ };
+ 
+ }  // namespace ui
+diff --git a/ui/ozone/platform/x11/test/x11_drag_drop_client_unittest.cc b/ui/ozone/platform/x11/test/x11_drag_drop_client_unittest.cc
+index 225d83cf8ceecfcd714f0a0bcd228d953866b8a8..aa0299e4f5d2ced8e92488a604524e93cc4a2f09 100644
+--- a/ui/ozone/platform/x11/test/x11_drag_drop_client_unittest.cc
++++ b/ui/ozone/platform/x11/test/x11_drag_drop_client_unittest.cc
+@@ -15,6 +15,7 @@
+ #include "base/memory/ptr_util.h"
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/scoped_refptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "base/run_loop.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/task/single_thread_task_runner.h"
+@@ -510,6 +511,7 @@ class X11DragDropClientTest : public testing::Test {
+   }
+ 
+   TestDragDropClient* client() { return client_.get(); }
++  gfx::AcceleratedWidget GetWidget() { return window_->GetWidget(); }
+ 
+  private:
+   std::unique_ptr<base::test::TaskEnvironment> task_env_;
+@@ -831,4 +833,100 @@ TEST_F(X11DragDropClientTest, RejectAfterMouseRelease) {
+   EXPECT_EQ(DragOperation::kNone, result);
+ }
+ 
++class OwningDelegate : public XDragDropClient::Delegate {
++ public:
++  OwningDelegate() = default;
++  ~OwningDelegate() override = default;
++
++  void SetClient(std::unique_ptr<XDragDropClient> client) {
++    client_ = std::move(client);
++  }
++
++  XDragDropClient* client() { return client_.get(); }
++
++  // XDragDropClient::Delegate:
++  std::optional<gfx::AcceleratedWidget> GetDragWidget() override {
++    return std::nullopt;
++  }
++
++  int UpdateDrag(const gfx::Point& screen_point) override {
++    if (destroy_during_update_drag_) {
++      client_.reset();
++    }
++    return 0;
++  }
++
++  void UpdateCursor(mojom::DragOperation negotiated_operation) override {}
++  void OnBeginForeignDrag(x11::Window window) override {}
++  void OnEndForeignDrag() override {}
++
++  void OnBeforeDragLeave() override {
++    if (destroy_during_before_drag_leave_) {
++      client_.reset();
++    }
++  }
++
++  mojom::DragOperation PerformDrop() override {
++    if (destroy_during_perform_drop_) {
++      client_.reset();
++    }
++    return mojom::DragOperation::kNone;
++  }
++
++  void EndDragLoop() override {}
++
++  bool destroy_during_update_drag_ = false;
++  bool destroy_during_before_drag_leave_ = false;
++  bool destroy_during_perform_drop_ = false;
++
++ private:
++  std::unique_ptr<XDragDropClient> client_;
++};
++
++TEST_F(X11DragDropClientTest, ClientDestroyedDuringPerformDrop) {
++  OwningDelegate delegate;
++  auto client = std::make_unique<XDragDropClient>(
++      &delegate, static_cast<x11::Window>(GetWidget()));
++  delegate.SetClient(std::move(client));
++  delegate.destroy_during_perform_drop_ = true;
++
++  x11::ClientMessageEvent event;
++  event.type = x11::GetAtom("XdndDrop");
++  event.format = 32;
++  event.data.data32[0] = 1;  // dummy source_window
++
++  // This should not crash!
++  delegate.client()->HandleXdndEvent(event);
++  EXPECT_EQ(delegate.client(), nullptr);
++}
++
++TEST_F(X11DragDropClientTest, ClientDestroyedDuringOnBeforeDragLeave) {
++  OwningDelegate delegate;
++  auto client = std::make_unique<XDragDropClient>(
++      &delegate, static_cast<x11::Window>(GetWidget()));
++  delegate.SetClient(std::move(client));
++  delegate.destroy_during_before_drag_leave_ = true;
++
++  x11::ClientMessageEvent event;
++  event.type = x11::GetAtom("XdndLeave");
++  event.format = 32;
++
++  // This should not crash!
++  delegate.client()->HandleXdndEvent(event);
++  EXPECT_EQ(delegate.client(), nullptr);
++}
++
++TEST_F(X11DragDropClientTest, ClientDestroyedDuringUpdateDrag) {
++  OwningDelegate delegate;
++  auto client = std::make_unique<XDragDropClient>(
++      &delegate, static_cast<x11::Window>(GetWidget()));
++  delegate.SetClient(std::move(client));
++  delegate.destroy_during_update_drag_ = true;
++
++  // CompleteXdndPosition is called to trigger UpdateDrag
++  // Let's call CompleteXdndPosition(1, {}) on the client.
++  delegate.client()->CompleteXdndPosition(static_cast<x11::Window>(1), {});
++  EXPECT_EQ(delegate.client(), nullptr);
++}
++
+ }  // namespace ui
+diff --git a/ui/ozone/platform/x11/x11_window.cc b/ui/ozone/platform/x11/x11_window.cc
+index 8c574a193674ec55e0b54d0b694e4fcbf43a22ae..42a1e756d1b0b3405f0e63f03a8804f088fcdb89 100644
+--- a/ui/ozone/platform/x11/x11_window.cc
++++ b/ui/ozone/platform/x11/x11_window.cc
+@@ -1694,17 +1694,28 @@ int X11Window::UpdateDrag(const gfx::Point& connection_point) {
+       XDragDropClient::GetForWindow(target_current_context->source_window());
+   gfx::PointF local_point_in_dip =
+       platform_window_delegate_->ConvertScreenPointToLocalDIP(connection_point);
++  base::WeakPtr<X11Window> alive = weak_ptr_factory_.GetWeakPtr();
+   if (!notified_enter_) {
+     drop_handler->OnDragEnter(local_point_in_dip, suggested_operations,
+                               GetKeyModifiers(source_client));
++    if (!alive) {
++      return DragDropTypes::DRAG_NONE;
++    }
+ 
+     // TODO(crbug.com/40073696): Factor DataFetched out of Enter callback.
+     drop_handler->OnDragDataAvailable(std::move(data));
++    if (!alive) {
++      return DragDropTypes::DRAG_NONE;
++    }
+ 
+     notified_enter_ = true;
+   }
+-  allowed_drag_operations_ = drop_handler->OnDragMotion(
++  int allowed_operations = drop_handler->OnDragMotion(
+       local_point_in_dip, suggested_operations, GetKeyModifiers(source_client));
++  if (!alive) {
++    return DragDropTypes::DRAG_NONE;
++  }
++  allowed_drag_operations_ = allowed_operations;
+   return allowed_drag_operations_;
+ }
+ 
+@@ -1728,7 +1739,11 @@ void X11Window::OnBeforeDragLeave() {
+   if (!drop_handler) {
+     return;
+   }
++  base::WeakPtr<X11Window> alive = weak_ptr_factory_.GetWeakPtr();
+   drop_handler->OnDragLeave();
++  if (!alive) {
++    return;
++  }
+   notified_enter_ = false;
+ }
+ 
+@@ -1743,8 +1758,12 @@ DragOperation X11Window::PerformDrop() {
+     return DragOperation::kNone;
+   }
+ 
++  base::WeakPtr<X11Window> alive = weak_ptr_factory_.GetWeakPtr();
+   drop_handler->OnDragDrop(GetKeyModifiers(
+       XDragDropClient::GetForWindow(target_current_context->source_window())));
++  if (!alive) {
++    return DragOperation::kNone;
++  }
+   notified_enter_ = false;
+   return PreferredDragOperation(allowed_drag_operations_);
+ }

--- a/patches/chromium/cherry-pick-b9cc197cf022.patch
+++ b/patches/chromium/cherry-pick-b9cc197cf022.patch
@@ -1,0 +1,258 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tzarial <zork@google.com>
+Date: Thu, 27 Aug 2026 02:24:00 -0700
+Subject: [M144] [agy][gpu] Fix FBO delete-while-bound bug
+
+Original change's description:
+> [agy][gpu] Fix FBO delete-while-bound bug
+>
+> Ensure the previous framebuffer is restored before deleting the
+> temporary framebuffer in GLTextureHolder::ReadbackToMemory.
+>
+> Some drivers retain an internal reference to the previously bound FBO
+> across bind transitions; deleting it while bound and then rebinding
+> can dereference freed driver state.
+>
+> Fixed: 525317502
+> Test: gpu_unittests --gtest_filter=GLTextureHolderTest.*
+> Change-Id: I359330bb3d1d07c7605b85039081a5f70d8c10c4
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8015318
+> Reviewed-by: Corentin Wallez <cwallez@chromium.org>
+> Reviewed-by: Colin Blundell <blundell@chromium.org>
+> Commit-Queue: Tzarial <zork@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1657204}
+
+(cherry picked from commit a5d9f9795433c7ca292222bfa1f894eb584c0c6a)
+
+Bug: 539302213,525317502
+Change-Id: I359330bb3d1d07c7605b85039081a5f70d8c10c4
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8156763
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Reviewed-by: Corentin Wallez <cwallez@chromium.org>
+Commit-Queue: Corentin Wallez <cwallez@chromium.org>
+Reviewed-by: Colin Blundell <blundell@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7559@{#5285}
+Cr-Branched-From: 223dfbac1c7542a06b422390d954afe5b560b607-refs/heads/main@{#1552494}
+
+diff --git a/gpu/BUILD.gn b/gpu/BUILD.gn
+index c2416a21bb3799e0d2e3969df4969f6ce5d064ff..55833ad9a10f098e5f1c679c24f1f794a371eac0 100644
+--- a/gpu/BUILD.gn
++++ b/gpu/BUILD.gn
+@@ -489,6 +489,7 @@ test("gpu_unittests") {
+     "command_buffer/service/shared_context_state_unittest.cc",
+     "command_buffer/service/shared_image/compound_image_backing_unittest.cc",
+     "command_buffer/service/shared_image/gl_repack_utils_unittest.cc",
++    "command_buffer/service/shared_image/gl_texture_holder_unittest.cc",
+     "command_buffer/service/shared_memory_region_wrapper_unittest.cc",
+     "command_buffer/service/sync_point_manager_unittest.cc",
+     "command_buffer/service/task_graph_unittest.cc",
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+index 0ca351e125917dcf36839c246fe8e4cdadef298e..54423f38d59426c81b7c0c2383256449256baa5a 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder.cc
+@@ -5,6 +5,7 @@
+ #include "gpu/command_buffer/service/shared_image/gl_texture_holder.h"
+ 
+ #include "base/bits.h"
++#include "base/memory/raw_ptr.h"
+ #include "build/build_config.h"
+ #include "gpu/command_buffer/service/shared_context_state.h"
+ #include "gpu/command_buffer/service/shared_image/gl_repack_utils.h"
+@@ -52,6 +53,29 @@ constexpr int ComputeBestAlignment(size_t bytes_per_pixel, size_t stride) {
+   return bytes_per_pixel;
+ }
+ 
++class ScopedTemporaryFramebuffer {
++ public:
++  explicit ScopedTemporaryFramebuffer(gl::GLApi* api) : api_(api) {
++    api_->glGenFramebuffersEXTFn(1, &id_);
++  }
++
++  ScopedTemporaryFramebuffer(const ScopedTemporaryFramebuffer&) = delete;
++  ScopedTemporaryFramebuffer& operator=(const ScopedTemporaryFramebuffer&) =
++      delete;
++
++  ~ScopedTemporaryFramebuffer() {
++    if (id_ != 0) {
++      api_->glDeleteFramebuffersEXTFn(1, &id_);
++    }
++  }
++
++  GLuint id() const { return id_; }
++
++ private:
++  const raw_ptr<gl::GLApi> api_;
++  GLuint id_ = 0;
++};
++
+ }  // anonymous namespace
+ 
+ // static
+@@ -357,9 +381,15 @@ bool GLTextureHolder::ReadbackToMemory(const SkPixmap& pixmap) {
+   }
+ 
+   gl::GLApi* api = gl::g_current_gl_context;
+-  GLuint framebuffer;
+-  api->glGenFramebuffersEXTFn(1, &framebuffer);
+-  gl::ScopedFramebufferBinder scoped_framebuffer_binder(framebuffer);
++  // ScopedTemporaryFramebuffer must be declared before ScopedFramebufferBinder
++  // so that when this scope exits, ScopedFramebufferBinder is destroyed first
++  // (restoring the previous framebuffer binding) before the temporary FBO is
++  // deleted. Some drivers retain an internal reference to the previously bound
++  // FBO across bind transitions; deleting it while bound can trigger a
++  // driver UAF (see https://crbug.com/525317502).
++  ScopedTemporaryFramebuffer temp_fbo(api);
++  gl::ScopedFramebufferBinder scoped_framebuffer_binder(temp_fbo.id());
++
+   // This uses GL_FRAMEBUFFER instead of GL_READ_FRAMEBUFFER as the target for
+   // GLES2 compatibility.
+   api->glFramebufferTexture2DEXTFn(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+@@ -438,8 +468,6 @@ bool GLTextureHolder::ReadbackToMemory(const SkPixmap& pixmap) {
+                         pixels);
+   }
+ 
+-  api->glDeleteFramebuffersEXTFn(1, &framebuffer);
+-
+   if (!unpack_buffer.empty()) {
+     DCHECK_GT(dst_stride, expected_stride);
+     UnpackPixelDataWithStride(size_, unpack_buffer, expected_stride, pixmap);
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder.h b/gpu/command_buffer/service/shared_image/gl_texture_holder.h
+index e2db72f3e2409046dd61579a4e68a6d4a3308cda..7a4a1d42191ea2239dce07778165d4d255706afc 100644
+--- a/gpu/command_buffer/service/shared_image/gl_texture_holder.h
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder.h
+@@ -7,6 +7,7 @@
+ 
+ #include "gpu/command_buffer/service/shared_image/gl_common_image_backing_factory.h"
+ #include "gpu/command_buffer/service/shared_image/shared_image_format_service_utils.h"
++#include "gpu/gpu_gles2_export.h"
+ #include "ui/gl/progress_reporter.h"
+ 
+ class GrPromiseImageTexture;
+@@ -17,7 +18,7 @@ class SharedContextState;
+ 
+ // Helper class that holds a single GL texture, that works with either
+ // validating or passthrough command decoder.
+-class GLTextureHolder {
++class GPU_GLES2_EXPORT GLTextureHolder {
+  public:
+   // Returns the equivalent SharedImageFormat for plane specified by
+   // `plane_index`.
+diff --git a/gpu/command_buffer/service/shared_image/gl_texture_holder_unittest.cc b/gpu/command_buffer/service/shared_image/gl_texture_holder_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..e48dbd4e318136abfa1e8053dac70bbcf3fe679c
+--- /dev/null
++++ b/gpu/command_buffer/service/shared_image/gl_texture_holder_unittest.cc
+@@ -0,0 +1,113 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "gpu/command_buffer/service/shared_image/gl_texture_holder.h"
++
++#include "base/memory/scoped_refptr.h"
++#include "components/viz/common/resources/shared_image_format.h"
++#include "gpu/command_buffer/service/shared_image/shared_image_format_service_utils.h"
++#include "gpu/command_buffer/service/texture_manager.h"
++#include "testing/gmock/include/gmock/gmock.h"
++#include "testing/gtest/include/gtest/gtest.h"
++#include "third_party/skia/include/core/SkBitmap.h"
++#include "ui/gl/gl_bindings.h"
++#include "ui/gl/gl_context_stub.h"
++#include "ui/gl/gl_mock.h"
++#include "ui/gl/gl_surface_stub.h"
++#include "ui/gl/test/gl_surface_test_support.h"
++
++namespace gpu {
++namespace {
++
++using ::testing::_;
++using ::testing::InSequence;
++using ::testing::Ne;
++using ::testing::NiceMock;
++using ::testing::Pointee;
++using ::testing::Return;
++using ::testing::SetArgPointee;
++
++class GLTextureHolderTest : public ::testing::Test {
++ protected:
++  void SetUp() override {
++    gl::SetGLGetProcAddressProc(gl::MockGLInterface::GetGLProcAddress);
++    display_ = gl::GLSurfaceTestSupport::InitializeOneOffWithMockBindings();
++    gl_ = std::make_unique<NiceMock<gl::MockGLInterface>>();
++    gl::MockGLInterface::SetGLInterface(gl_.get());
++
++    surface_ = base::MakeRefCounted<gl::GLSurfaceStub>();
++    context_ = base::MakeRefCounted<gl::GLContextStub>();
++    context_->SetGLVersionString("OpenGL ES 2.0");
++    context_->SetExtensionsString("");
++    context_->Initialize(surface_.get(), {});
++    context_->MakeCurrent(surface_.get());
++
++    ON_CALL(*gl_, CheckFramebufferStatusEXT(_))
++        .WillByDefault(Return(GL_FRAMEBUFFER_COMPLETE));
++  }
++
++  void TearDown() override {
++    context_ = nullptr;
++    surface_ = nullptr;
++    gl::MockGLInterface::SetGLInterface(nullptr);
++    gl_.reset();
++    gl::GLSurfaceTestSupport::ShutdownGL(display_);
++  }
++
++  std::unique_ptr<NiceMock<gl::MockGLInterface>> gl_;
++  scoped_refptr<gl::GLContextStub> context_;
++  scoped_refptr<gl::GLSurfaceStub> surface_;
++  raw_ptr<gl::GLDisplay> display_ = nullptr;
++};
++
++// ReadbackToMemory creates a temporary FBO for glReadPixels. The previous
++// framebuffer binding must be restored before the temporary FBO is deleted so
++// that the temporary FBO is never the previously bound FBO at the next bind
++// transition. Some drivers retain an internal reference to the previously
++// bound FBO across bind transitions; see the
++// ensure_previous_framebuffer_not_deleted driver workaround.
++TEST_F(GLTextureHolderTest, ReadbackToMemoryRestoresFramebufferBeforeDelete) {
++  constexpr GLuint kTextureId = 11;
++  constexpr GLuint kTempFboId = 22;
++  constexpr GLint kPrevFboId = 33;
++  constexpr gfx::Size kSize(4, 4);
++
++  GLTextureHolder holder(viz::SinglePlaneFormat::kRGBA_8888, kSize,
++                         /*is_passthrough=*/true,
++                         /*progress_reporter=*/nullptr);
++  GLFormatDesc format_desc;
++  format_desc.data_format = GL_RGBA;
++  format_desc.data_type = GL_UNSIGNED_BYTE;
++  format_desc.target = GL_TEXTURE_2D;
++  auto texture = base::MakeRefCounted<gles2::TexturePassthrough>(kTextureId,
++                                                                 GL_TEXTURE_2D);
++  holder.InitializeWithTexture(format_desc, texture);
++
++  ON_CALL(*gl_, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
++      .WillByDefault(SetArgPointee<1>(kPrevFboId));
++
++  {
++    InSequence seq;
++    EXPECT_CALL(*gl_, GenFramebuffersEXT(1, _))
++        .WillOnce(SetArgPointee<1>(kTempFboId));
++    EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kTempFboId));
++    EXPECT_CALL(*gl_, ReadPixels(0, 0, kSize.width(), kSize.height(), GL_RGBA,
++                                 GL_UNSIGNED_BYTE, _));
++    // The previous framebuffer binding must be restored before the temporary
++    // FBO is deleted.
++    EXPECT_CALL(*gl_, BindFramebufferEXT(GL_FRAMEBUFFER, kPrevFboId));
++    EXPECT_CALL(*gl_, DeleteFramebuffersEXT(1, Pointee(kTempFboId)));
++  }
++
++  SkBitmap bitmap;
++  bitmap.allocPixels(SkImageInfo::Make(kSize.width(), kSize.height(),
++                                       kRGBA_8888_SkColorType,
++                                       kPremul_SkAlphaType));
++  EXPECT_TRUE(holder.ReadbackToMemory(bitmap.pixmap()));
++
++  texture->MarkContextLost();
++}
++
++}  // namespace
++}  // namespace gpu

--- a/patches/chromium/cherry-pick-bbc335d274ed.patch
+++ b/patches/chromium/cherry-pick-bbc335d274ed.patch
@@ -1,0 +1,207 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Test User <chikamune@google.com>
+Date: Wed, 8 Jul 2026 17:15:53 -0700
+Subject: [M150] Reject redirects from blob: URL navigations
+
+Original change's description:
+> Reject redirects from blob: URL navigations
+>
+> NavigationURLLoaderImpl already assumes that requests to the blob:
+> scheme are never redirected and skips interceptor setup on that basis.
+> Make that assumption explicit in OnReceiveRedirect: if a redirect
+> arrives while loading a blob: URL, fail the navigation with
+> ERR_UNSAFE_REDIRECT instead of consulting bypass_redirect_checks from
+> the response head, since the underlying Blob endpoint may live outside
+> the browser process and a real blob load never produces a redirect.
+>
+> Add a content_browsertest that registers a blink::mojom::Blob whose
+> Load() responds with OnReceiveRedirect and verifies that navigating to
+> its blob: URL fails rather than following the redirect.
+>
+> TAG=agy
+> CONV=51d0251b-c784-4f07-b4fe-93b5087402df
+>
+> Fixed: 513795122
+> Change-Id: I8525501812232c2aa2bef9422d282ad4c12112e0
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8028880
+> Commit-Queue: Minoru Chikamune <chikamune@chromium.org>
+> Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1656964}
+
+(cherry picked from commit d103c7ce9b9d0fd34a59c0b46647c6db6da5aaa5)
+
+Bug: 532001785,513795122
+Change-Id: I8525501812232c2aa2bef9422d282ad4c12112e0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8067416
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3049}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/content/browser/blob_storage/blob_url_browsertest.cc b/content/browser/blob_storage/blob_url_browsertest.cc
+index 03a79efea0c99d715d447da001a90ff3b159ef39..8e96df818ac4a7ee2af2f62d30817ca6aeb45f9c 100644
+--- a/content/browser/blob_storage/blob_url_browsertest.cc
++++ b/content/browser/blob_storage/blob_url_browsertest.cc
+@@ -15,6 +15,7 @@
+ #include "content/browser/devtools/render_frame_devtools_agent_host.h"
+ #include "content/browser/permissions/permission_controller_impl.h"
+ #include "content/browser/renderer_host/render_frame_host_impl.h"
++#include "content/browser/storage_partition_impl.h"
+ #include "content/browser/web_contents/web_contents_impl.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/common/content_switches.h"
+@@ -24,17 +25,26 @@
+ #include "content/public/test/content_browser_test.h"
+ #include "content/public/test/content_browser_test_content_browser_client.h"
+ #include "content/public/test/content_browser_test_utils.h"
++#include "content/public/test/navigation_handle_observer.h"
+ #include "content/public/test/test_devtools_protocol_client.h"
+ #include "content/public/test/test_utils.h"
+ #include "content/shell/browser/shell.h"
+ #include "content/test/content_browser_test_utils_internal.h"
++#include "mojo/public/cpp/bindings/receiver_set.h"
++#include "mojo/public/cpp/bindings/remote.h"
+ #include "net/base/net_errors.h"
+ #include "net/dns/mock_host_resolver.h"
++#include "net/http/http_response_headers.h"
+ #include "net/test/embedded_test_server/embedded_test_server.h"
++#include "net/url_request/redirect_info.h"
++#include "services/network/public/mojom/url_loader.mojom.h"
++#include "services/network/public/mojom/url_response_head.mojom.h"
++#include "storage/browser/blob/blob_url_registry.h"
+ #include "storage/browser/blob/features.h"
+ #include "testing/gmock/include/gmock/gmock.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "third_party/blink/public/common/features.h"
++#include "third_party/blink/public/mojom/blob/blob.mojom.h"
+ #include "url/gurl.h"
+ #include "url/origin.h"
+ 
+@@ -229,6 +239,108 @@ IN_PROC_BROWSER_TEST_F(BlobUrlBrowserTest, ReplaceStateToAddAuthorityToBlob) {
+   EXPECT_FALSE(base::MatchPattern(window_location, "*spoof*"));
+ }
+ 
++namespace {
++
++// A blink::mojom::Blob implementation that, when Load() is called, responds
++// with a redirect to `redirect_target_` instead of a blob body. This simulates
++// a Blob endpoint that does not behave like a real blob.
++class RedirectingBlob : public blink::mojom::Blob {
++ public:
++  explicit RedirectingBlob(const GURL& redirect_target)
++      : redirect_target_(redirect_target) {}
++
++  mojo::PendingRemote<blink::mojom::Blob> BindNewPipeAndPassRemote() {
++    mojo::PendingRemote<blink::mojom::Blob> remote;
++    receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
++    return remote;
++  }
++
++  // blink::mojom::Blob:
++  void Clone(mojo::PendingReceiver<blink::mojom::Blob> receiver) override {
++    receivers_.Add(this, std::move(receiver));
++  }
++  void AsDataPipeGetter(
++      mojo::PendingReceiver<network::mojom::DataPipeGetter>) override {
++    NOTREACHED();
++  }
++  void ReadAll(mojo::ScopedDataPipeProducerHandle,
++               mojo::PendingRemote<blink::mojom::BlobReaderClient>) override {
++    NOTREACHED();
++  }
++  void ReadRange(uint64_t,
++                 uint64_t,
++                 mojo::ScopedDataPipeProducerHandle,
++                 mojo::PendingRemote<blink::mojom::BlobReaderClient>) override {
++    NOTREACHED();
++  }
++  void Load(
++      mojo::PendingReceiver<network::mojom::URLLoader> loader,
++      const std::string& method,
++      const net::HttpRequestHeaders&,
++      mojo::PendingRemote<network::mojom::URLLoaderClient> client) override {
++    loader_receiver_ = std::move(loader);
++    client_.reset();
++    client_.Bind(std::move(client));
++    net::RedirectInfo redirect_info;
++    redirect_info.status_code = net::HTTP_FOUND;
++    redirect_info.new_method = method;
++    redirect_info.new_url = redirect_target_;
++    redirect_info.new_site_for_cookies =
++        net::SiteForCookies::FromUrl(redirect_target_);
++    auto head = network::mojom::URLResponseHead::New();
++    head->headers = net::HttpResponseHeaders::TryToCreate(
++        "HTTP/1.1 302 Found\r\nLocation: " + redirect_target_.spec() + "\r\n");
++    head->encoded_data_length = 0;
++    head->bypass_redirect_checks = true;
++    client_->OnReceiveRedirect(redirect_info, std::move(head));
++  }
++  void ReadSideData(ReadSideDataCallback) override { NOTREACHED(); }
++  void CaptureSnapshot(CaptureSnapshotCallback callback) override {
++    std::move(callback).Run(0, std::nullopt);
++  }
++  void GetInternalUUID(GetInternalUUIDCallback callback) override {
++    std::move(callback).Run("");
++  }
++
++ private:
++  const GURL redirect_target_;
++  mojo::ReceiverSet<blink::mojom::Blob> receivers_;
++  mojo::PendingReceiver<network::mojom::URLLoader> loader_receiver_;
++  mojo::Remote<network::mojom::URLLoaderClient> client_;
++};
++
++}  // namespace
++
++// A blob never serves a redirect, so a navigation to a blob URL whose
++// underlying Blob endpoint replies with OnReceiveRedirect must not follow the
++// redirect, regardless of any flags carried in the response head.
++IN_PROC_BROWSER_TEST_F(BlobUrlBrowserTest,
++                       NavigationToBlobUrlDoesNotFollowRedirect) {
++  GURL url = embedded_test_server()->GetURL("a.test", "/title1.html");
++  url::Origin origin = url::Origin::Create(url);
++  ASSERT_TRUE(NavigateToURL(shell(), url));
++
++  RenderFrameHostImpl* rfh = static_cast<RenderFrameHostImpl*>(
++      shell()->web_contents()->GetPrimaryMainFrame());
++
++  const GURL redirect_target("data:text/html,redirected");
++  RedirectingBlob blob(redirect_target);
++
++  const GURL blob_url("blob:" + origin.Serialize() +
++                      "/33221100-0000-0000-0000-000000000000");
++  static_cast<StoragePartitionImpl*>(rfh->GetStoragePartition())
++      ->GetBlobUrlRegistry()
++      ->AddUrlMapping(blob_url, blob.BindNewPipeAndPassRemote(),
++                      blink::StorageKey::CreateFirstParty(origin), origin,
++                      rfh->GetProcess()->GetDeprecatedID());
++
++  NavigationHandleObserver observer(shell()->web_contents(), blob_url);
++  EXPECT_FALSE(NavigateToURL(shell(), blob_url));
++  EXPECT_TRUE(observer.is_error());
++  EXPECT_EQ(net::ERR_UNSAFE_REDIRECT, observer.net_error_code());
++  EXPECT_NE(redirect_target, shell()->web_contents()->GetLastCommittedURL());
++}
++
+ IN_PROC_BROWSER_TEST_F(BlobUrlBrowserTest,
+                        TestUseCounterForCrossPartitionSameOriginBlobURLFetch) {
+   GURL main_url = embedded_test_server()->GetURL(
+diff --git a/content/browser/loader/navigation_url_loader_impl.cc b/content/browser/loader/navigation_url_loader_impl.cc
+index 33d730f5c532eb7e5aef57ae0ee2a49e89d56ae2..315d0f0a366110661be28b970c090ad66a775f04 100644
+--- a/content/browser/loader/navigation_url_loader_impl.cc
++++ b/content/browser/loader/navigation_url_loader_impl.cc
+@@ -1574,8 +1574,11 @@ void NavigationURLLoaderImpl::OnReceiveRedirect(
+           ? head->bypass_redirect_checks
+           : bypass_redirect_checks_;
+ 
+-  if (!bypass_redirect_checks &&
+-      !IsSafeRedirectTarget(url_, redirect_info.new_url)) {
++  if (url_.SchemeIsBlob()) {
++    // Loading a blob URL never produces a redirect.
++    error = net::ERR_UNSAFE_REDIRECT;
++  } else if (!bypass_redirect_checks &&
++             !IsSafeRedirectTarget(url_, redirect_info.new_url)) {
+     error = net::ERR_UNSAFE_REDIRECT;
+   } else if (--redirect_limit_ == 0) {
+     error = net::ERR_TOO_MANY_REDIRECTS;

--- a/patches/chromium/cherry-pick-c4ad58ae4d25.patch
+++ b/patches/chromium/cherry-pick-c4ad58ae4d25.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eugene Zemtsov <eugene@chromium.org>
+Date: Fri, 10 Jul 2026 19:27:29 -0700
+Subject: [M150] media: Validate source texture format in PerformD3DCopy
+
+Original change's description:
+> media: Validate source texture format in PerformD3DCopy
+>
+> Unfortunately ID3D11DeviceContext::CopySubresourceRegion silently drops
+> copies between incompatible formats.
+> This change adds an explicit check in PerformD3DCopy to ensure the
+> source texture is DXGI_FORMAT_NV12 before copying.
+>
+> Bug: 525177160
+> Change-Id: I262079c23c553938c08cdc381b8f6d5b2b86d3ff
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8013291
+> Reviewed-by: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
+> Commit-Queue: Eugene Zemtsov <eugene@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1653876}
+
+(cherry picked from commit e156270a01df9c66dca76380e1c7796783d3394c)
+
+Bug: 530063884,525177160
+Change-Id: I262079c23c553938c08cdc381b8f6d5b2b86d3ff
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8078078
+Reviewed-by: Eugene Zemtsov <eugene@chromium.org>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/7871@{#3185}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc b/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+index f335df665a7e678f37dafee9bfe509f258b528e2..d81202fde17e8f49b354cec64a4438f960da6f45 100644
+--- a/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
++++ b/media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+@@ -2950,6 +2950,15 @@ HRESULT MediaFoundationVideoEncodeAccelerator::PerformD3DCopy(
+       release_keyed_mutex.emplace(std::move(keyed_mutex), 0);
+     }
+ 
++    D3D11_TEXTURE2D_DESC input_desc;
++    input_texture->GetDesc(&input_desc);
++
++    if (input_desc.Format != DXGI_FORMAT_NV12) {
++      LOG(ERROR) << "Format mismatch: source format " << input_desc.Format
++                 << " is not DXGI_FORMAT_NV12";
++      return E_INVALIDARG;
++    }
++
+     D3D11_BOX src_box = {static_cast<UINT>(visible_rect.x()),
+                          static_cast<UINT>(visible_rect.y()),
+                          0,

--- a/patches/chromium/cherry-pick-d39395c9f94c.patch
+++ b/patches/chromium/cherry-pick-d39395c9f94c.patch
@@ -1,0 +1,303 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 8 Jul 2026 11:26:47 -0700
+Subject: [M150] gtk: Sanitize theme and icon-theme names at write time
+
+> A compromised GPU process with an active pre-sandbox connection can send
+> malicious path-traversal sequences inside settings such as
+> gtk-icon-theme-name or gtk-theme-name via XSETTINGS. This forces the
+> browser process to resolve and parse arbitrary attacker-controlled SVG
+> files in the browser process context.
+>
+> This CL prevents the issue by:
+> 1. Extending the GtkSettings set_property interceptor to cover both
+>    gtk-icon-theme-name and gtk-theme-name on both GTK3 and GTK4.
+> 2. Replacing any invalid theme name containing path traversal sequences
+>    or absolute paths with safe defaults (Adwaita/hicolor) before GTK
+>    processes them or early notify observers can see them.
+> 3. Factoring the validator and fallback policy into gtk_util to make
+>    them unit-testable.
+> 4. Adding coverage for validation, fallbacks, and end-to-end check that
+>    notify observers never see unsanitized themes.
+>
+> Fixed: 519731111
+> Change-Id: Ie391c1577524a585cf72d50b4fc1595829649c7b
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7980058
+> Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+> Reviewed-by: Lei Zhang <thestig@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#1653501}
+
+R=thestig
+
+Bug: 519731111
+Change-Id: I0e8662bc69dba3b053d6ca4d27a59c147acf1ea9
+Fixed: 530454247
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8061149
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Commit-Queue: Thomas Anderson <thomasanderson@chromium.org>
+Cr-Commit-Position: refs/branch-heads/7871@{#3027}
+Cr-Branched-From: f542126b8c1b3e80104b26bb05ec830bd1206f29-refs/heads/main@{#1639810}
+
+diff --git a/ui/gtk/gtk_ui.cc b/ui/gtk/gtk_ui.cc
+index bec18ed2d345ff0f54f54360b7c71a8e3b44cda0..d02fc162abfefbae2e5a618a3221497bd873c263 100644
+--- a/ui/gtk/gtk_ui.cc
++++ b/ui/gtk/gtk_ui.cc
+@@ -290,22 +290,23 @@ bool IsValidSchema(ui::LinuxUiBackend backend) {
+   return true;
+ }
+ 
+-bool IsValidIconThemeName(const std::string& theme) {
+-  base::FilePath theme_path(theme);
+-  return !theme.empty() && theme != "." && !theme_path.IsAbsolute() &&
+-         !theme_path.ReferencesParent() && theme_path.BaseName() == theme_path;
++std::string GetSettingsStringProperty(const char* property_name) {
++  gchar* prop_value = nullptr;
++  g_object_get(gtk_settings_get_default(), property_name, &prop_value, nullptr);
++  std::string prop_string;
++  if (prop_value) {
++    prop_string = prop_value;
++    g_free(prop_value);
++  }
++  return prop_string;
+ }
+ 
+ std::string GetIconThemeName() {
+-  gchar* theme = nullptr;
+-  g_object_get(gtk_settings_get_default(), "gtk-icon-theme-name", &theme,
+-               nullptr);
+-  std::string theme_string;
+-  if (theme) {
+-    theme_string = theme;
+-    g_free(theme);
+-  }
+-  return theme_string;
++  return GetSettingsStringProperty("gtk-icon-theme-name");
++}
++
++std::string GetThemeName() {
++  return GetSettingsStringProperty("gtk-theme-name");
+ }
+ 
+ }  // namespace
+@@ -369,8 +370,10 @@ bool GtkUi::Initialize() {
+   // to prevent XSETTINGS updates from loading GTK modules.
+   g_object_set(settings, "gtk-modules", "", nullptr);
+   SanitizeIconThemeName();
++  SanitizeThemeName();
+   SanitizeCursorThemeName();
+   SanitizeCursorThemeSize();
++  InstallGtkSettingsInterceptor();
+   connect(settings, "notify::gtk-theme-name", &GtkUi::OnThemeChanged);
+   connect(settings, "notify::gtk-icon-theme-name", &GtkUi::OnThemeChanged);
+   connect(settings, "notify::gtk-application-prefer-dark-theme",
+@@ -521,7 +524,8 @@ void GtkUi::GetInactiveSelectionFgColor(SkColor* color) const {
+ gfx::Image GtkUi::GetIconForContentType(const std::string& content_type,
+                                         int dip_size,
+                                         float scale) const {
+-  if (!IsValidIconThemeName(GetIconThemeName())) {
++  if (!IsValidThemeName(ThemeProperty::kIconThemeName,
++                        GetIconThemeName().c_str())) {
+     return gfx::Image();
+   }
+ 
+@@ -801,7 +805,7 @@ std::string GtkUi::GetCursorThemeName() {
+ 
+ bool GtkUi::SanitizeIconThemeName() {
+   std::string theme = GetIconThemeName();
+-  if (!IsValidIconThemeName(theme)) {
++  if (!IsValidThemeName(ThemeProperty::kIconThemeName, theme.c_str())) {
+     g_object_set(gtk_settings_get_default(), "gtk-icon-theme-name", "hicolor",
+                  nullptr);
+     return true;
+@@ -809,6 +813,16 @@ bool GtkUi::SanitizeIconThemeName() {
+   return false;
+ }
+ 
++bool GtkUi::SanitizeThemeName() {
++  std::string theme = GetThemeName();
++  if (!IsValidThemeName(ThemeProperty::kThemeName, theme.c_str())) {
++    g_object_set(gtk_settings_get_default(), "gtk-theme-name", "Adwaita",
++                 nullptr);
++    return true;
++  }
++  return false;
++}
++
+ bool GtkUi::SanitizeCursorThemeName() {
+   std::string theme = GetCursorThemeName();
+   if (!ui::IsValidCursorThemeName(theme)) {
+@@ -879,7 +893,7 @@ gfx::Size GtkUi::GetPdfPaperSize(printing::PrintingContextLinux* context) {
+ #endif
+ 
+ void GtkUi::OnThemeChanged(GtkSettings* settings, GtkParamSpec* param) {
+-  if (SanitizeIconThemeName()) {
++  if (SanitizeIconThemeName() || SanitizeThemeName()) {
+     return;  // Exit early; modifying the setting re-triggered this function
+   }
+   colors_.clear();
+diff --git a/ui/gtk/gtk_ui.h b/ui/gtk/gtk_ui.h
+index 63e704c25d88fa504d4231010be26c36b50bd1b5..9f80d750e6e49e9b56f12ac63b4705fa65f2232a 100644
+--- a/ui/gtk/gtk_ui.h
++++ b/ui/gtk/gtk_ui.h
+@@ -121,6 +121,10 @@ class GtkUi : public ui::LinuxUiAndTheme {
+   // Returns true if the setting was modified.
+   bool SanitizeIconThemeName();
+ 
++  // Sanitizes the "gtk-theme-name" setting in GtkSettings if it is unsafe.
++  // Returns true if the setting was modified.
++  bool SanitizeThemeName();
++
+   // Sanitizes the "gtk-cursor-theme-name" setting in GtkSettings if it is
+   // unsafe. Returns true if the setting was modified.
+   bool SanitizeCursorThemeName();
+diff --git a/ui/gtk/gtk_util.cc b/ui/gtk/gtk_util.cc
+index 0c660a5c555d9f230d6a06f05d398cab5de01951..bf31a7daa9c66e2a48ec4e8d989aa4e4ea4e2992 100644
+--- a/ui/gtk/gtk_util.cc
++++ b/ui/gtk/gtk_util.cc
+@@ -8,11 +8,14 @@
+ #include <stddef.h>
+ 
+ #include <memory>
++#include <optional>
+ #include <string_view>
+ 
+ #include "base/compiler_specific.h"
+ #include "base/environment.h"
++#include "base/files/file_path.h"
+ #include "base/functional/callback.h"
++#include "base/notreached.h"
+ #include "base/strings/string_split.h"
+ #include "base/strings/string_tokenizer.h"
+ #include "base/strings/string_util.h"
+@@ -732,4 +735,93 @@ double GetOpacityFromContext(GtkStyleContext* context) {
+   return opacity;
+ }
+ 
++bool IsValidThemeName(ThemeProperty property, const char* theme) {
++  const bool is_key_theme = property == ThemeProperty::kKeyThemeName;
++  if (!theme) {
++    return is_key_theme;
++  }
++  std::string_view theme_str(theme);
++  if (theme_str.empty()) {
++    return is_key_theme;
++  }
++  base::FilePath theme_path(theme_str);
++  return theme_str != "." && !theme_path.IsAbsolute() &&
++         !theme_path.ReferencesParent() && theme_path.BaseName() == theme_path;
++}
++
++const char* GetThemeFallback(ThemeProperty property) {
++  switch (property) {
++    case ThemeProperty::kIconThemeName:
++      return "hicolor";
++    case ThemeProperty::kThemeName:
++      return "Adwaita";
++    case ThemeProperty::kKeyThemeName:
++      return nullptr;
++  }
++  NOTREACHED();
++}
++
++namespace {
++
++void (*g_orig_set_property)(GObject* object,
++                            guint property_id,
++                            const GValue* value,
++                            GParamSpec* pspec) = nullptr;
++
++DISABLE_CFI_ICALL
++void GtkSettingsSetProperty(GObject* object,
++                            guint property_id,
++                            const GValue* value,
++                            GParamSpec* pspec) {
++  if (pspec && pspec->name) {
++    std::string_view prop_name(pspec->name);
++    std::optional<ThemeProperty> property;
++    if (prop_name == "gtk-theme-name") {
++      property = ThemeProperty::kThemeName;
++    } else if (prop_name == "gtk-icon-theme-name") {
++      property = ThemeProperty::kIconThemeName;
++    } else if (prop_name == "gtk-key-theme-name") {
++      property = ThemeProperty::kKeyThemeName;
++    }
++    if (property) {
++      const gchar* name = g_value_get_string(value);
++      if (!IsValidThemeName(*property, name)) {
++        GValue sanitized_value = G_VALUE_INIT;
++        g_value_init(&sanitized_value, G_TYPE_STRING);
++        g_value_set_string(&sanitized_value, GetThemeFallback(*property));
++        g_orig_set_property(object, property_id, &sanitized_value, pspec);
++        g_value_unset(&sanitized_value);
++        return;
++      }
++    }
++  }
++  g_orig_set_property(object, property_id, value, pspec);
++}
++
++}  // namespace
++
++void InstallGtkSettingsInterceptor() {
++  if (!g_orig_set_property) {
++    GObjectClass* gobject_class =
++        G_OBJECT_CLASS(g_type_class_ref(GTK_TYPE_SETTINGS));
++    g_orig_set_property = gobject_class->set_property;
++    gobject_class->set_property = GtkSettingsSetProperty;
++    g_type_class_unref(gobject_class);
++  }
++}
++
++void UninstallGtkSettingsInterceptor() {
++  if (g_orig_set_property) {
++    GObjectClass* gobject_class =
++        G_OBJECT_CLASS(g_type_class_ref(GTK_TYPE_SETTINGS));
++    gobject_class->set_property = g_orig_set_property;
++    g_orig_set_property = nullptr;
++    g_type_class_unref(gobject_class);
++  }
++}
++
++GtkSettings* GetDefaultGtkSettings() {
++  return gtk_settings_get_default();
++}
++
+ }  // namespace gtk
+diff --git a/ui/gtk/gtk_util.h b/ui/gtk/gtk_util.h
+index 72679e0fb557885886cd1092ab76299e1034b782..cc90d10548256d0c8f6b4d8dc18c19f4ed87f8c2 100644
+--- a/ui/gtk/gtk_util.h
++++ b/ui/gtk/gtk_util.h
+@@ -196,6 +196,33 @@ GdkTexture* GetTextureFromRenderNode(GskRenderNode* node);
+ 
+ double GetOpacityFromContext(GtkStyleContext* context);
+ 
++enum class ThemeProperty {
++  kThemeName,
++  kIconThemeName,
++  kKeyThemeName,
++};
++
++// Returns true if `theme` is a safe, valid theme name for `property`.
++// If `theme` is null, returns true only for kKeyThemeName.
++COMPONENT_EXPORT(GTK)
++bool IsValidThemeName(ThemeProperty property, const char* theme);
++
++// Returns the safe fallback value for the given theme-related property.
++COMPONENT_EXPORT(GTK)
++const char* GetThemeFallback(ThemeProperty property);
++
++// Hook the `GtkSettings` `set_property` method to sanitize theme names.
++COMPONENT_EXPORT(GTK) void InstallGtkSettingsInterceptor();
++
++// Unhook the `GtkSettings` `set_property` method.
++COMPONENT_EXPORT(GTK) void UninstallGtkSettingsInterceptor();
++
++// Returns the default `GtkSettings` instance. This wrapper is required because
++// in component builds, raw GTK symbols loaded via stubs (including
++// `gtk_settings_get_default`) are not exported, preventing direct usage in
++// non-component targets like tests.
++COMPONENT_EXPORT(GTK) GtkSettings* GetDefaultGtkSettings();
++
+ }  // namespace gtk
+ 
+ #endif  // UI_GTK_GTK_UTIL_H_

--- a/patches/config.json
+++ b/patches/config.json
@@ -14,5 +14,6 @@
   { "patch_dir": "src/electron/patches/sqlite", "repo": "src/third_party/sqlite/src" },
   { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia" },
   { "patch_dir": "src/electron/patches/angle", "repo": "src/third_party/angle" },
-  { "patch_dir": "src/electron/patches/dawn", "repo": "src/third_party/dawn" }
+  { "patch_dir": "src/electron/patches/dawn", "repo": "src/third_party/dawn" },
+  { "patch_dir": "src/electron/patches/libyuv", "repo": "src/third_party/libyuv" }
 ]

--- a/patches/libyuv/.patches
+++ b/patches/libyuv/.patches
@@ -1,0 +1,1 @@
+cherry-pick-8aeb3a9ca363.patch

--- a/patches/libyuv/cherry-pick-8aeb3a9ca363.patch
+++ b/patches/libyuv/cherry-pick-8aeb3a9ca363.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wan-Teh Chang <wtc@google.com>
+Date: Wed, 1 Jul 2026 13:03:11 -0700
+Subject: I010ToNV12: dispatch Convert16To8Row on halfwidth
+
+The Convert16To8Row function pointer in I010ToNV12 is only ever called
+with halfwidth for the chroma planes (the Y plane goes through
+Convert16To8Plane which has its own dispatch), but its SIMD variants
+were selected based on the alignment of the full luma width. When width
+is a multiple of 32 but halfwidth is not, the bare AVX2 kernel was
+selected and over-read the chroma sources and over-wrote the temporary
+row buffer. Match the MergeUVRow dispatch in the same function and key
+on halfwidth.
+
+Bug: chromium:514748734
+Change-Id: I4c2a42857828cdcc6505ebaa65d5b6a95b0f7e55
+Reviewed-on: https://chromium-review.googlesource.com/c/libyuv/libyuv/+/8031724
+Reviewed-by: Frank Barchard <fbarchard@google.com>
+Commit-Queue: Wan-Teh Chang <wtc@google.com>
+
+diff --git a/source/convert.cc b/source/convert.cc
+index 4231b532be9739d904032c0236f8ef7f6621c307..322dccab66057a7fa7eaa252c72fa10ffa787aeb 100644
+--- a/source/convert.cc
++++ b/source/convert.cc
+@@ -676,7 +676,7 @@ int I010ToNV12(const uint16_t* src_y,
+ #if defined(HAS_CONVERT16TO8ROW_NEON)
+   if (TestCpuFlag(kCpuHasNEON)) {
+     Convert16To8Row = Convert16To8Row_Any_NEON;
+-    if (IS_ALIGNED(width, 16)) {
++    if (IS_ALIGNED(halfwidth, 16)) {
+       Convert16To8Row = Convert16To8Row_NEON;
+     }
+   }
+@@ -689,7 +689,7 @@ int I010ToNV12(const uint16_t* src_y,
+ #if defined(HAS_CONVERT16TO8ROW_SSSE3)
+   if (TestCpuFlag(kCpuHasSSSE3)) {
+     Convert16To8Row = Convert16To8Row_Any_SSSE3;
+-    if (IS_ALIGNED(width, 16)) {
++    if (IS_ALIGNED(halfwidth, 16)) {
+       Convert16To8Row = Convert16To8Row_SSSE3;
+     }
+   }
+@@ -697,7 +697,7 @@ int I010ToNV12(const uint16_t* src_y,
+ #if defined(HAS_CONVERT16TO8ROW_AVX2)
+   if (TestCpuFlag(kCpuHasAVX2)) {
+     Convert16To8Row = Convert16To8Row_Any_AVX2;
+-    if (IS_ALIGNED(width, 32)) {
++    if (IS_ALIGNED(halfwidth, 32)) {
+       Convert16To8Row = Convert16To8Row_AVX2;
+     }
+   }
+@@ -705,7 +705,7 @@ int I010ToNV12(const uint16_t* src_y,
+ #if defined(HAS_CONVERT16TO8ROW_AVX512BW)
+   if (TestCpuFlag(kCpuHasAVX512BW)) {
+     Convert16To8Row = Convert16To8Row_Any_AVX512BW;
+-    if (IS_ALIGNED(width, 64)) {
++    if (IS_ALIGNED(halfwidth, 64)) {
+       Convert16To8Row = Convert16To8Row_AVX512BW;
+     }
+   }

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -4,3 +4,6 @@ cherry-pick-30d6603d43a5.patch
 cherry-pick-cee83412c5b5.patch
 cherry-pick-5269247b7a9a.patch
 cherry-pick-680683deb765.patch
+cherry-pick-d10ea850c21d.patch
+cherry-pick-bee4c9172200.patch
+cherry-pick-3273c66a688f.patch

--- a/patches/skia/cherry-pick-3273c66a688f.patch
+++ b/patches/skia/cherry-pick-3273c66a688f.patch
@@ -1,0 +1,162 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Arthur Sonzogni <arthursonzogni@chromium.org>
+Date: Fri, 3 Jul 2026 15:03:41 +0000
+Subject: [M150] Fix Use-After-Free in SubRunAllocator
+
+Original change's description:
+> Fix Use-After-Free in SubRunAllocator
+>
+> The destruction order of `std::tuple` members is not specified by the
+> C++ standard. This is the root cause of a Use-After-Free (UAF) in
+> SubRunAllocator. Replacing the tuple with a custom struct resolves the
+> issue by guaranteeing the correct destruction order.
+>
+> The Bug:
+> During deserialization of a Slug (specifically in
+> SlugImpl::MakeFromBuffer), if the input buffer is invalid or corrupted,
+> Skia detects this and returns nullptr early.
+>
+> This early return destroys the temporary return value. In the old code
+> (using `std::tuple`), `SubRunInitializer` (index 0) was destructed
+> first and freed the backing memory.
+>
+> `SubRunAllocator` (index 2) was destructed next. Its destructor
+> (~BagOfBytes) then attempted to access fEndByte (which points inside
+> the freed memory), resulting in a UAF (read) followed by a wild-free
+> or double-free.
+>
+> The Fix:
+> We replaced the `std::tuple` with a custom helper struct
+> `AllocateAndArenaResult`:
+>
+> struct AllocateAndArenaResult {
+>     SubRunInitializer<T> initializer; // Destructed last
+>     int totalMemorySize;
+>     SubRunAllocator alloc;            // Destructed first
+> };
+>
+> Since struct members are guaranteed to be destructed in the reverse
+> order of their declaration, declaring `alloc` last guarantees it is
+> destructed before `SubRunInitializer` frees the memory.
+>
+> Additionally, this CL refactors `SubRunInitializer` to use
+> `std::unique_ptr` with a custom deleter to manage the raw memory,
+> removing the need for a manual destructor and making the ownership
+> transfer explicit via `release()`.
+>
+> Bug: skia:530646115
+> Change-Id: I80cba4fdb9eebfe16e5ec837d70b5646422fbcff
+> Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1284796
+> Commit-Queue: Kaylee Lubick <kjlubick@google.com>
+> Reviewed-by: Kaylee Lubick <kjlubick@google.com>
+
+(cherry picked from commit 014a77e8a6cd4abbd5952fd4a1815ec3a521f300)
+
+Bug: 532102500,skia:530646115
+Change-Id: I80cba4fdb9eebfe16e5ec837d70b5646422fbcff
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1288679
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: Chrome Cherry Picker <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+
+diff --git a/src/text/gpu/SubRunAllocator.h b/src/text/gpu/SubRunAllocator.h
+index ef71c3044403e965fd5d8a61aa7e545ab0cdf6b3..ff4cd0a86baf7af878a4ba8fe4fb37369d06fa14 100644
+--- a/src/text/gpu/SubRunAllocator.h
++++ b/src/text/gpu/SubRunAllocator.h
+@@ -188,23 +188,30 @@ private:
+ template <typename T>
+ class SubRunInitializer {
+ public:
+-    SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
+-    ~SubRunInitializer() {
+-        ::operator delete(fMemory);
+-    }
++    explicit SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
++
+     template <typename... Args>
+     T* initialize(Args&&... args) {
+         // Warn on more than one initialization.
+         SkASSERT(fMemory != nullptr);
+-        return new (std::exchange(fMemory, nullptr)) T(std::forward<Args>(args)...);
++        return new (fMemory.release()) T(std::forward<Args>(args)...);
+     }
+ 
+ private:
+-    void* fMemory;
++    struct Deleter {
++        // Frees the heap memory without calling a destructor.
++        // We must use `::operator delete(p)` instead of `delete p` because `p` is `void*`.
++        // Deleting a `void*` is undefined behavior in C++.
++        // This is paired with the placement `::operator new` in AllocateClassMemoryAndArena.
++        void operator()(void* p) const { ::operator delete(p); }
++    };
++    std::unique_ptr<void, Deleter> fMemory;
+ };
+ 
+-// GrSubRunAllocator provides fast allocation where the user takes care of calling the destructors
+-// of the returned pointers, and GrSubRunAllocator takes care of deleting the storage. The
++template <typename T> struct AllocateAndArenaResult;
++
++// SubRunAllocator provides fast allocation where the user takes care of calling the destructors
++// of the returned pointers, and SubRunAllocator takes care of deleting the storage. The
+ // unique_ptrs returned, are to assist in assuring the object's destructor is called.
+ // A note on zero length arrays: according to the standard a pointer must be returned, and it
+ // can't be a nullptr. In such a case, SkArena allocates one byte, but does not initialize it.
+@@ -234,20 +241,8 @@ public:
+     SubRunAllocator& operator=(SubRunAllocator&&) = default;
+ 
+     template <typename T>
+-    static std::tuple<SubRunInitializer<T>, int, SubRunAllocator>
+-    AllocateClassMemoryAndArena(int allocSizeHint) {
+-        SkASSERT_RELEASE(allocSizeHint >= 0);
+-        // Round the size after the object the optimal amount.
+-        int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
+-
+-        // Don't overflow or die.
+-        SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
+-        int totalMemorySize = sizeof(T) + extraSize;
+-
+-        void* memory = ::operator new (totalMemorySize);
+-        SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
+-        return {memory, totalMemorySize, std::move(alloc)};
+-    }
++    static AllocateAndArenaResult<T>
++    AllocateClassMemoryAndArena(int allocSizeHint);
+ 
+     template <typename T, typename... Args> T* makePOD(Args&&... args) {
+         static_assert(HasNoDestructor<T>, "This is not POD. Use makeUnique.");
+@@ -328,6 +323,34 @@ private:
+     BagOfBytes fAlloc;
+ };
+ 
++// Members are destroyed in the reverse order of their declaration:
++// https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
++// `alloc` must be destroyed first because it may contain pointers to memory owned by `initializer`.
++// `initializer` must be destroyed last because it owns the backing memory.
++// See also: https://issues.skia.org/issues/530646115
++template <typename T>
++struct AllocateAndArenaResult {
++    SubRunInitializer<T> initializer;
++    int totalMemorySize;
++    SubRunAllocator alloc;
++};
++
++template <typename T>
++inline AllocateAndArenaResult<T>
++SubRunAllocator::AllocateClassMemoryAndArena(int allocSizeHint) {
++    SkASSERT_RELEASE(allocSizeHint >= 0);
++    // Round the size after the object the optimal amount.
++    int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
++
++    // Don't overflow or die.
++    SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
++    int totalMemorySize = sizeof(T) + extraSize;
++
++    void* memory = ::operator new (totalMemorySize);
++    SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
++    return {SubRunInitializer<T>{memory}, totalMemorySize, std::move(alloc)};
++}
++
+ // Helper for defining allocators with inline/reserved storage.
+ // For argument declarations, stick to the base type (SubRunAllocator).
+ // Note: Inheriting from the storage first means the storage will outlive the

--- a/patches/skia/cherry-pick-bee4c9172200.patch
+++ b/patches/skia/cherry-pick-bee4c9172200.patch
@@ -1,0 +1,292 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Greg Daniel <egdaniel@google.com>
+Date: Mon, 13 Jul 2026 13:21:46 -0400
+Subject: Check clipped renderpass bounds against cleared stencil area
+
+* If only a portion of the stencil attachment is cleared, we should not mark the entire attachment as cleared. This CL makes it such that we check which area has most recently been cleared to make an informed decision.
+
+Bug: 514010477
+Fixed: 532408601
+Change-Id: I3800ca3125f25341dffd818f6c557692020027be
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1255256
+Reviewed-by: Robert Phillips <robertphillips@google.com>
+Commit-Queue: Greg Daniel <egdaniel@google.com>
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1292316
+Reviewed-by: Michael Ludwig <michaelludwig@google.com>
+Auto-Submit: Greg Daniel <egdaniel@google.com>
+
+diff --git a/src/gpu/ganesh/GrAttachment.h b/src/gpu/ganesh/GrAttachment.h
+index 7508c32deb59bb575bddcc18f0a01d7077233cb0..23fdaa7ff30606c280a030b69d9b7e210630ce3d 100644
+--- a/src/gpu/ganesh/GrAttachment.h
++++ b/src/gpu/ganesh/GrAttachment.h
+@@ -53,8 +53,11 @@ public:
+ 
+     skgpu::Mipmapped mipmapped() const { return fMipmapped; }
+ 
+-    bool hasPerformedInitialClear() const { return fHasPerformedInitialClear; }
+-    void markHasPerformedInitialClear() { fHasPerformedInitialClear = true; }
++    SkIRect clearedArea() const { return fClearedArea; }
++    bool hasAreaBeenCleared(SkIRect attachmentArea) const {
++        return fClearedArea.contains(attachmentArea);
++    }
++    void markAreaCleared(SkIRect area) { fClearedArea = area; }
+ 
+     // This unique key is used for attachments of the same dimensions, usage, and sample cnt which
+     // are shared between multiple render targets at the same time. Only one usage flag may be
+@@ -117,7 +120,9 @@ private:
+     UsageFlags fSupportedUsages;
+     int fSampleCnt;
+     skgpu::Mipmapped fMipmapped;
+-    bool fHasPerformedInitialClear = false;
++    // Track which area of the attachment has already been cleared to cut down on unnecessary clear
++    // operations, which can be more expensive on desktop GPUs than loads.
++    SkIRect fClearedArea = SkIRect::MakeEmpty();
+     GrMemoryless fMemoryless;
+ 
+     using INHERITED = GrSurface;
+diff --git a/src/gpu/ganesh/GrCaps.cpp b/src/gpu/ganesh/GrCaps.cpp
+index f449c35940d6833ff0ced739116c886a26857ebf..5f8e13c20bccfa7ba8abbd7131d195bfc543351f 100644
+--- a/src/gpu/ganesh/GrCaps.cpp
++++ b/src/gpu/ganesh/GrCaps.cpp
+@@ -43,6 +43,8 @@ GrCaps::GrCaps(const GrContextOptions& options) {
+     fUsePrimitiveRestart = false;
+     fPreferClientSideDynamicBuffers = false;
+     fPreferFullscreenClears = false;
++    fDiscardStencilValuesAfterRenderPass = false;
++    fClearsAreFasterThanLoads = false;
+     fTwoSidedStencilRefsAndMasksMustMatch = false;
+     fMustClearUploadedBufferData = false;
+     fShouldInitializeTextures = false;
+@@ -227,7 +229,10 @@ void GrCaps::dumpJSON(SkJSONWriter* writer) const {
+     writer->appendBool("MSAA Resolves Automatically", fMSAAResolvesAutomatically);
+     writer->appendBool("Use primitive restart", fUsePrimitiveRestart);
+     writer->appendBool("Prefer client-side dynamic buffers", fPreferClientSideDynamicBuffers);
+-    writer->appendBool("Prefer fullscreen clears (and stencil discard)", fPreferFullscreenClears);
++    writer->appendBool("Prefer fullscreen clears", fPreferFullscreenClears);
++    writer->appendBool("Discard stencil values after renderpass",
++                       fDiscardStencilValuesAfterRenderPass);
++    writer->appendBool("Clears are faster than loads", fClearsAreFasterThanLoads);
+     writer->appendBool("Two-sided Stencil Refs And Masks Must Match",
+                        fTwoSidedStencilRefsAndMasksMustMatch);
+     writer->appendBool("Must clear buffer memory", fMustClearUploadedBufferData);
+diff --git a/src/gpu/ganesh/GrCaps.h b/src/gpu/ganesh/GrCaps.h
+index 5a3b6a72336631385868b52b385b61a9f8e9682d..ce1a863baa7cc27c628a6811d4c5423a20599d29 100644
+--- a/src/gpu/ganesh/GrCaps.h
++++ b/src/gpu/ganesh/GrCaps.h
+@@ -114,10 +114,11 @@ public:
+ 
+     bool preferClientSideDynamicBuffers() const { return fPreferClientSideDynamicBuffers; }
+ 
+-    // On tilers, an initial fullscreen clear is an OPTIMIZATION. It allows the hardware to
+-    // initialize each tile with a constant value rather than loading each pixel from memory.
++    // The following 3 methods provide information that enables performance optimizations for tiler
++    // GPUs. Full clear operations (followed by discarding the content when finished) are more
++    // performant than load operations on these GPUs as they enable the hardware to initialize each
++    // tile with a constant value as opposed to loading each pixel from memory.
+     bool preferFullscreenClears() const { return fPreferFullscreenClears; }
+-
+     // Should we discard stencil values after a render pass? (Tilers get better performance if we
+     // always load stencil buffers with a "clear" op, and then discard the content when finished.)
+     bool discardStencilValuesAfterRenderPass() const {
+@@ -126,10 +127,15 @@ public:
+ #if 0
+         // This method is actually just a duplicate of preferFullscreenClears(), with a descriptive
+         // name for the sake of readability.
+-        return this->preferFullscreenClears();
++        return fDiscardStencilValuesAfterRenderPass;
+ #endif
+     }
+ 
++    // Returns whether clearing an attachment is faster than loading the attachment. This is useful
++    // when you know the values are already cleared so it doesn't matter if we load or clear at the
++    // start of a render pass.
++    bool clearsAreFasterThanLoads() const { return fClearsAreFasterThanLoads; }
++
+     // D3D does not allow the refs or masks to differ on a two-sided stencil draw.
+     bool twoSidedStencilRefsAndMasksMustMatch() const {
+         return fTwoSidedStencilRefsAndMasksMustMatch;
+@@ -605,6 +611,8 @@ protected:
+     bool fUsePrimitiveRestart                        : 1;
+     bool fPreferClientSideDynamicBuffers             : 1;
+     bool fPreferFullscreenClears                     : 1;
++    bool fDiscardStencilValuesAfterRenderPass        : 1;
++    bool fClearsAreFasterThanLoads                   : 1;
+     bool fTwoSidedStencilRefsAndMasksMustMatch       : 1;
+     bool fMustClearUploadedBufferData                : 1;
+     bool fBuffersAreInitiallyZero                    : 1;
+diff --git a/src/gpu/ganesh/gl/GrGLCaps.cpp b/src/gpu/ganesh/gl/GrGLCaps.cpp
+index c1c7c035a8e2b76740ebab3db17fe14552637f01..724c5d0dc598546da45f68639092a0e2cf39965c 100644
+--- a/src/gpu/ganesh/gl/GrGLCaps.cpp
++++ b/src/gpu/ganesh/gl/GrGLCaps.cpp
+@@ -118,6 +118,13 @@ static bool angle_backend_is_metal(GrGLANGLEBackend backend) {
+     return backend == GrGLANGLEBackend::kMetal;
+ }
+ 
++namespace {
++bool is_tiler_gpu(GrGLVendor vendor) {
++    return vendor == GrGLVendor::kARM         ||
++           vendor == GrGLVendor::kImagination ||
++           vendor == GrGLVendor::kQualcomm;
++}
++} // anonymous namespace
+ void GrGLCaps::init(const GrContextOptions& contextOptions,
+                     const GrGLContextInfo& ctxInfo,
+                     const GrGLInterface* gli) {
+@@ -221,10 +228,10 @@ void GrGLCaps::init(const GrContextOptions& contextOptions,
+         }
+     }
+ 
+-    if (ctxInfo.vendor() == GrGLVendor::kARM         ||
+-        ctxInfo.vendor() == GrGLVendor::kImagination ||
+-        ctxInfo.vendor() == GrGLVendor::kQualcomm ) {
++    if (is_tiler_gpu(ctxInfo.vendor())) {
+         fPreferFullscreenClears = true;
++        fDiscardStencilValuesAfterRenderPass = true;
++        fClearsAreFasterThanLoads = true;
+     }
+ 
+     if (GR_IS_GR_GL(standard)) {
+diff --git a/src/gpu/ganesh/ops/OpsTask.cpp b/src/gpu/ganesh/ops/OpsTask.cpp
+index d7e49fe50b62f09658c338551609cfeea1a1de5c..9f8984b69fe340b1bd34ba15ed1b380c02e9c83f 100644
+--- a/src/gpu/ganesh/ops/OpsTask.cpp
++++ b/src/gpu/ganesh/ops/OpsTask.cpp
+@@ -585,27 +585,67 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+         stencil = renderTarget->getStencilAttachment(fUsesMSAASurface);
+     }
+ 
+-    bool markStencilCleared = false;
+     GrLoadOp stencilLoadOp;
++    // Determine whether the stencil attachment's cleared area should be updated.
++    bool updateClearedStencilArea = false;
++    SkIRect boundsRequiredByStencil = fClippedContentBounds;
+     switch (fInitialStencilContent) {
+         case StencilContent::kDontCare:
+-            stencilLoadOp = GrLoadOp::kDiscard;
+-            break;
++            if (!stencil || caps.performStencilClearsAsDraws()) {
++                // This should only intentionally happen for the AtlasRenderTask which
++                // immediately inserts a clear.
++                stencilLoadOp = GrLoadOp::kDiscard;
++                break;
++            }
++            // This OpTask has a stencil, doesn't care about its contents, isn't clearing it with
++            // draws, and is going to store the result. In that case, we fallthrough to clear it so
++            // that uninitialized data won't creep into the stencil buffer.
++            [[fallthrough]];
+         case StencilContent::kUserBitsCleared:
+             SkASSERT(!caps.performStencilClearsAsDraws());
+             SkASSERT(stencil);
++            // Based upon Caps, determine which stencil load operation to use and perform any
++            // necessary updates to the renderpass's bounds and the stencil's cleared area.
++
++            // If the user bits are meant to be cleared we either do that via an initial clear the
++            // first time the area of the stencil is used, or we assume previous draws left the
++            // stencil cleared so we just load the current values. However, on some devices it is
++            // faster to just clear the stencil each time instead of doing a load.
++            //
++            // Since we'll never end up loading the stencil in this case there is no reason for us
++            // to do the clear rect tracking below, so we just break.
++            if (caps.clearsAreFasterThanLoads()) {
++                stencilLoadOp = GrLoadOp::kClear;
++                break;
++            }
++            // If stencil values are discarded after every renderpass, then we do not need to track
++            // which portion of the stencil attachment has already been cleared.
+             if (caps.discardStencilValuesAfterRenderPass()) {
+-                // Always clear the stencil if it is being discarded after render passes. This is
+-                // also an optimization because we are on a tiler and it avoids loading the values
+-                // from memory.
+                 stencilLoadOp = GrLoadOp::kClear;
+                 break;
+             }
+-            if (!stencil->hasPerformedInitialClear()) {
++
++            // If the area of the stencil attachment corresponding to this renderpass's
++            // boundsRequiredByStencil has not already been cleared, calculate new, expanded
++            // renderpass bounds by joining boundsRequiredByStencil with the cleared stencil area.
++            // Using this joint area simplifies tracking of cleared areas on the stencil attachment.
++            if (!stencil->hasAreaBeenCleared(boundsRequiredByStencil)) {
+                 stencilLoadOp = GrLoadOp::kClear;
+-                markStencilCleared = true;
++                if (!stencil->clearedArea().isEmpty()) {
++                    boundsRequiredByStencil.join(stencil->clearedArea());
++                    // We need to also intersect the bounds with the color attachment's bounds since
++                    // the stencil may be bigger. This could mean that we end up "forgetting" we
++                    // cleared the user bits in the portion of the stencil that doesn't overlap with
++                    // the color attachment - but that shouldn't have a large performance impact if
++                    // we later on need to reclear that area.
++                    boundsRequiredByStencil.intersect(
++                        SkIRect::MakeSize(renderTarget->dimensions()));
++                }
++                // We should update the stencil's cleared area if renderpass creation succeeds.
++                updateClearedStencilArea = true;
+                 break;
+             }
++
+             // SurfaceDrawContexts are required to leave the user stencil bits in a cleared state
+             // once finished, meaning the stencil values will always remain cleared after the
+             // initial clear. Just fall through to reloading the existing (cleared) stencil values
+@@ -615,6 +655,8 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+             SkASSERT(stencil);
+             stencilLoadOp = GrLoadOp::kLoad;
+             break;
++        default:
++            SkUNREACHABLE;
+     }
+ 
+     // NOTE: If fMustPreserveStencil is set, then we are executing a surfaceDrawContext that split
+@@ -633,7 +675,7 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+                                                      fUsesMSAASurface,
+                                                      stencil,
+                                                      fTargetOrigin,
+-                                                     fClippedContentBounds,
++                                                     boundsRequiredByStencil,
+                                                      fColorLoadOp,
+                                                      fLoadClearColor,
+                                                      stencilLoadOp,
+@@ -644,8 +686,8 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+     if (!renderPass) {
+         return false;
+     }
+-    if (markStencilCleared) {
+-        stencil->markHasPerformedInitialClear();
++    if (updateClearedStencilArea) {
++        stencil->markAreaCleared(boundsRequiredByStencil);
+     }
+     flushState->setOpsRenderPass(renderPass);
+     renderPass->begin();
+diff --git a/src/gpu/ganesh/vk/GrVkCaps.cpp b/src/gpu/ganesh/vk/GrVkCaps.cpp
+index b805a79ca262ba606d6f29828b8a215e8202da5a..6f9a17c48dc8a2a3fe9b5dba9a6faf723c64564d 100644
+--- a/src/gpu/ganesh/vk/GrVkCaps.cpp
++++ b/src/gpu/ganesh/vk/GrVkCaps.cpp
+@@ -302,6 +302,13 @@ bool GrVkCaps::onCanCopySurface(const GrSurfaceProxy* dst, const SkIRect& dstRec
+ 
+ }
+ 
++namespace {
++bool is_tiler_gpu(uint32_t vendorId) {
++    return vendorId == skgpu::kARM_VkVendor ||
++           vendorId == skgpu::kQualcomm_VkVendor ||
++           vendorId == skgpu::kImagination_VkVendor;
++}
++} // anonymous namespace
+ void GrVkCaps::init(const GrContextOptions& contextOptions,
+                     const skgpu::VulkanInterface* vkInterface,
+                     VkPhysicalDevice physDev,
+@@ -415,12 +422,12 @@ void GrVkCaps::init(const GrContextOptions& contextOptions,
+     this->initGrCaps(vkInterface, physDev, properties, memoryProperties, features, extensions);
+     this->initShaderCaps(properties, features);
+ 
+-    if (skgpu::kQualcomm_VkVendor == properties.vendorID) {
+-        // A "clear" load for atlases runs faster on QC than a "discard" load followed by a
++    if (is_tiler_gpu(properties.vendorID)) {
++        // A "clear" load for atlases runs faster on tiler GPUs than a "discard" load followed by a
+         // scissored clear.
+-        // On NVIDIA and Intel, the discard load followed by clear is faster.
+-        // TODO: Evaluate on ARM, Imagination, and ATI.
+         fPreferFullscreenClears = true;
++        fDiscardStencilValuesAfterRenderPass = true;
++        fClearsAreFasterThanLoads = true;
+     }
+ 
+     if (properties.vendorID == skgpu::kNvidia_VkVendor ||

--- a/patches/skia/cherry-pick-d10ea850c21d.patch
+++ b/patches/skia/cherry-pick-d10ea850c21d.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Greg Daniel <egdaniel@google.com>
+Date: Fri, 1 May 2026 16:11:53 +0000
+Subject: Defer marking stencil as cleared until after render pass creation
+ succeeds
+
+Bug: b/501861921
+Change-Id: I822d7560c3f51c0e0a49dfb1a7d3a526e5f2c0e6
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/1223896
+Reviewed-by: Thomas Smith <thomsmit@google.com>
+Commit-Queue: Greg Daniel <egdaniel@google.com>
+
+diff --git a/src/gpu/ganesh/ops/OpsTask.cpp b/src/gpu/ganesh/ops/OpsTask.cpp
+index 1bd578b9fec3cef67f099145bac36f0bb33c6ddd..d7e49fe50b62f09658c338551609cfeea1a1de5c 100644
+--- a/src/gpu/ganesh/ops/OpsTask.cpp
++++ b/src/gpu/ganesh/ops/OpsTask.cpp
+@@ -585,6 +585,7 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+         stencil = renderTarget->getStencilAttachment(fUsesMSAASurface);
+     }
+ 
++    bool markStencilCleared = false;
+     GrLoadOp stencilLoadOp;
+     switch (fInitialStencilContent) {
+         case StencilContent::kDontCare:
+@@ -602,7 +603,7 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+             }
+             if (!stencil->hasPerformedInitialClear()) {
+                 stencilLoadOp = GrLoadOp::kClear;
+-                stencil->markHasPerformedInitialClear();
++                markStencilCleared = true;
+                 break;
+             }
+             // SurfaceDrawContexts are required to leave the user stencil bits in a cleared state
+@@ -643,6 +644,9 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
+     if (!renderPass) {
+         return false;
+     }
++    if (markStencilCleared) {
++        stencil->markHasPerformedInitialClear();
++    }
+     flushState->setOpsRenderPass(renderPass);
+     renderPass->begin();
+ 

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -25,3 +25,6 @@ m152_compiler_invalidate_tracked_fields_on_checkmaps_with.patch
 7922_169_wasm_sandbox_fix_call_indirect_feedback_and_module.patch
 7922_169_reland_wasm_sandbox_post_async_compilation_tasks_as.patch
 7922_169_native_builtins_are_strict.patch
+cherry-pick-24134ecc1d1a.patch
+cherry-pick-8120dd10e82d.patch
+cherry-pick-303a64b51072.patch

--- a/patches/v8/cherry-pick-24134ecc1d1a.patch
+++ b/patches/v8/cherry-pick-24134ecc1d1a.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sam Parker <sam.parker@arm.com>
+Date: Tue, 7 Jul 2026 10:11:14 +0100
+Subject: [M150] [compiler][arm64][arm] IsOnlyUserOfNodeInSameBlock
+
+Original change's description:
+> [compiler][arm64][arm] IsOnlyUserOfNodeInSameBlock
+>
+> Don't try to use IsOnlyUserOfNodeInSameBlock when the continuation is
+> anything but a branch or set as it's possible that we've already
+> explored through the original conditional setting instruction and are
+> trying to optimise a binop that would then have to be pulled past a
+> use to be tied to the continuation.
+>
+> Bug: 524792614
+> Change-Id: I94a3c46799197c152873ea9f09e99ff4db4efccd
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8024753
+> Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
+> Commit-Queue: Sam Parker-Haynes <sam.parker@arm.com>
+> Reviewed-by: Daniel Lehmann <dlehmann@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#108482}
+
+(cherry picked from commit 78afe7b553f2befacffd4fe882e0947484b093d2)
+
+Bug: 532842962,524792614
+Change-Id: I94a3c46799197c152873ea9f09e99ff4db4efccd
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8074498
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/15.0@{#31}
+Cr-Branched-From: 0c6c73eea6994260f0a1d88469708360ea60c660-refs/heads/15.0.245@{#1}
+Cr-Branched-From: 03d64f40934c058cd1c6d7e5cead5b757a4faedd-refs/heads/main@{#107679}
+
+diff --git a/src/compiler/backend/arm/instruction-selector-arm.cc b/src/compiler/backend/arm/instruction-selector-arm.cc
+index 11a4d0e2856cd27c415b963d88066cc8644173d7..d6d739c0e80a7b04e987f3df413d773bf80f7c08 100644
+--- a/src/compiler/backend/arm/instruction-selector-arm.cc
++++ b/src/compiler/backend/arm/instruction-selector-arm.cc
+@@ -2057,10 +2057,13 @@ void MaybeReplaceCmpZeroWithFlagSettingBinop(InstructionSelector* selector,
+     cont->Overwrite(MapForFlagSettingBinop(cond));
+     *opcode = no_output_opcode;
+     *node = binop;
+-  } else if (selector->IsOnlyUserOfNodeInSameBlock(*node, binop)) {
+-    // We can also handle the case where the {node} and the comparison are in
+-    // the same basic block, and the comparison is the only user of {node} in
+-    // this basic block ({node} has users in other basic blocks).
++  } else if ((cont->IsBranch() || cont->IsSet()) &&
++             selector->IsOnlyUserOfNodeInSameBlock(*node, binop)) {
++    // We can also handle the case where the add and the compare are in the
++    // same basic block, and the compare is the only use of add in this basic
++    // block (the add has users in other basic blocks). We only do this for
++    // branches and sets as they can't end up breaking the schedule by pulling
++    // the flag-setting instruction past its users.
+     cont->Overwrite(MapForFlagSettingBinop(cond));
+     *opcode = binop_opcode;
+     *node = binop;
+diff --git a/src/compiler/backend/arm64/instruction-selector-arm64.cc b/src/compiler/backend/arm64/instruction-selector-arm64.cc
+index 163bcd6cee626d28ac213507a4237f4eeaf44b24..9792b21923bf368008e11bab9a4ab3cdb42fd3c6 100644
+--- a/src/compiler/backend/arm64/instruction-selector-arm64.cc
++++ b/src/compiler/backend/arm64/instruction-selector-arm64.cc
+@@ -3362,10 +3362,13 @@ void MaybeReplaceCmpZeroWithFlagSettingBinop(InstructionSelector* selector,
+     *opcode = no_output_opcode;
+     *node = binop;
+     *immediate_mode = binop_immediate_mode;
+-  } else if (selector->IsOnlyUserOfNodeInSameBlock(*node, binop)) {
++  } else if ((cont->IsBranch() || cont->IsSet()) &&
++             selector->IsOnlyUserOfNodeInSameBlock(*node, binop)) {
+     // We can also handle the case where the add and the compare are in the
+     // same basic block, and the compare is the only use of add in this basic
+-    // block (the add has users in other basic blocks).
++    // block (the add has users in other basic blocks). We only do this for
++    // branches and sets as they can't end up breaking the schedule by pulling
++    // the flag-setting instruction past its users.
+     cont->Overwrite(MapForFlagSettingBinop(cond));
+     *opcode = binop_opcode;
+     *node = binop;
+diff --git a/test/mjsunit/regress/wasm/regress-524792614.js b/test/mjsunit/regress/wasm/regress-524792614.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..9a90f23076c844e2a3360a77b8b78181eba83d21
+--- /dev/null
++++ b/test/mjsunit/regress/wasm/regress-524792614.js
+@@ -0,0 +1,61 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --allow-natives-syntax
++
++d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++
++const builder = new WasmModuleBuilder();
++const g = builder.addGlobal(kWasmI32, true);
++
++builder.addFunction('main', makeSig([kWasmI32], [kWasmI32, kWasmI32]))
++    .exportAs('main')
++    .addLocals(kWasmI32, 2)
++    .addBody([
++      // v2 = param 0 + 1
++      kExprLocalGet,
++      0,
++      kExprI32Const,
++      1,
++      kExprI32Add,
++      kExprLocalSet,
++      1,
++
++      // v27 = 0 - v2
++      kExprI32Const,
++      0,
++      kExprLocalGet,
++      1,
++      kExprI32Sub,
++      kExprLocalSet,
++      2,
++
++      // select(v27, 0, v27)
++      kExprLocalGet,
++      2,
++      kExprI32Const,
++      0,
++      kExprLocalGet,
++      2,
++      kExprSelect,
++
++      // If block to split the block (pushes Return use to next block)
++      kExprLocalGet,
++      0,
++      kExprIf,
++      kWasmVoid,
++      kExprI32Const,
++      0,
++      kExprGlobalSet,
++      g.index,
++      kExprEnd,
++
++      // Return v6, v2
++      kExprLocalGet,
++      1,
++    ]);
++
++const instance = builder.instantiate()
++instance.exports.main();
++%WasmTierUpFunction(instance.exports.main);

--- a/patches/v8/cherry-pick-303a64b51072.patch
+++ b/patches/v8/cherry-pick-303a64b51072.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pthier <pthier@chromium.org>
+Date: Thu, 9 Jul 2026 17:00:27 +0200
+Subject: [M150] [regexp] Hard Check that index + 1 is a Smi in
+ AdvanceStringIndex
+
+Original change's description:
+> [regexp] Hard Check that index + 1 is a Smi in AdvanceStringIndex
+>
+> Bug: 532595489
+> Change-Id: I3fb2a3246ebbf801b883cc9fe22a7903cf7b1edd
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8070079
+> Reviewed-by: Jakob Linke <jgruber@chromium.org>
+> Commit-Queue: Patrick Thier <pthier@chromium.org>
+> Auto-Submit: Patrick Thier <pthier@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#108562}
+
+(cherry picked from commit de11d56041d5aa9c5e69b031990ad17068dbef7a)
+
+Bug: 533661562,532595489
+Change-Id: I3fb2a3246ebbf801b883cc9fe22a7903cf7b1edd
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8085182
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/15.0@{#37}
+Cr-Branched-From: 0c6c73eea6994260f0a1d88469708360ea60c660-refs/heads/15.0.245@{#1}
+Cr-Branched-From: 03d64f40934c058cd1c6d7e5cead5b757a4faedd-refs/heads/main@{#107679}
+
+diff --git a/src/builtins/builtins-regexp-gen.cc b/src/builtins/builtins-regexp-gen.cc
+index ba969a0acbb15acc07cd1d9d174245d4a4e01c78..4ae55363edb751e95308fe3880e4c1e72779b161 100644
+--- a/src/builtins/builtins-regexp-gen.cc
++++ b/src/builtins/builtins-regexp-gen.cc
+@@ -1536,7 +1536,8 @@ TNode<Number> RegExpBuiltinsAssembler::AdvanceStringIndex(
+     // Must be in Smi range on the fast path. We control the value of {index}
+     // on all call-sites and can never exceed the length of the string.
+     static_assert(String::kMaxLength + 2 < Smi::kMaxValue);
+-    CSA_DCHECK(this, TaggedIsPositiveSmi(index_plus_one));
++    // TODO(532595489): Hard CHECK for now as a quick fix.
++    CSA_CHECK(this, TaggedIsPositiveSmi(index_plus_one));
+   }
+ 
+   Label if_isunicode(this), out(this);
+diff --git a/test/mjsunit/mjsunit.status b/test/mjsunit/mjsunit.status
+index 9dd7aa47dc87da0c144f76edbb9694e38ead0596..27f78d6c5eedb21adb58cf7fe197484095113f17 100644
+--- a/test/mjsunit/mjsunit.status
++++ b/test/mjsunit/mjsunit.status
+@@ -85,6 +85,9 @@
+   # Ensures that %VerifyGetJSBuiltinState() machinery works as expected.
+   'regress/regress-435630464-verification-failure': [['mode == release', SKIP], ['mode != release', FAIL]],
+ 
++  # https://crbug.com/532595489
++  'regress/regress-532595489': [FAIL, CRASH, NO_VARIANTS, ['not pointer_compression', SKIP]],
++
+   ##############################################################################
+   # Tests where variants make no sense.
+   'd8/enable-tracing': [PASS, NO_VARIANTS],
+diff --git a/test/mjsunit/regress/regress-532595489.js b/test/mjsunit/regress/regress-532595489.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..c80f7e089bc6c0a2d00d742165e47378ffe398a6
+--- /dev/null
++++ b/test/mjsunit/regress/regress-532595489.js
+@@ -0,0 +1,17 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++const re = /(?:)/;
++
++function Species() {
++  return re;
++}
++
++const pseudo_re = {
++  flags: 'g',
++  lastIndex: 1073741823,
++  constructor: { [Symbol.species]: Species },
++};
++
++RegExp.prototype[Symbol.matchAll].call(pseudo_re, '').next();

--- a/patches/v8/cherry-pick-8120dd10e82d.patch
+++ b/patches/v8/cherry-pick-8120dd10e82d.patch
@@ -1,0 +1,209 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Fri, 10 Jul 2026 11:34:05 +0200
+Subject: [M150] [stack-traces] Make .stack accessors look only at receiver
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Original change's description:
+> [stack-traces] Make .stack accessors look only at receiver
+>
+> ... when reading internal stack trace or message (i.e. [[ErrorData]]
+> slot). Update tests accordingly.
+>
+> This is a first step towards implementing Error Stack Accessor proposal
+> https://tc39.es/proposal-error-stack-accessor/#sec-get-error.prototype-stack.
+>
+> Fixed: 531319201
+> Bug: 512450179
+> Change-Id: I333769d61d20c99b59250b8cbd2dcf3172b56640
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8064992
+> Reviewed-by: Olivier Flückiger <olivf@chromium.org>
+> Commit-Queue: Igor Sheludko <ishell@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#108587}
+
+(cherry picked from commit 9cfa2ca3fee87bd2919978d73d0ea28b93493be8)
+
+Bug: 533661026,531319201,512450179
+Change-Id: I333769d61d20c99b59250b8cbd2dcf3172b56640
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/8086200
+Commit-Queue: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Auto-Submit: chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com <chrome-cherry-picker@chops-service-accounts.iam.gserviceaccount.com>
+Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Commit-Position: refs/branch-heads/15.0@{#35}
+Cr-Branched-From: 0c6c73eea6994260f0a1d88469708360ea60c660-refs/heads/15.0.245@{#1}
+Cr-Branched-From: 03d64f40934c058cd1c6d7e5cead5b757a4faedd-refs/heads/main@{#107679}
+
+diff --git a/src/execution/messages.cc b/src/execution/messages.cc
+index 00ad664760c8c4076f6be70703d4c074e3b2572a..9764ad68e225fa2cb69ce9236758e8eb97674a52 100644
+--- a/src/execution/messages.cc
++++ b/src/execution/messages.cc
+@@ -699,8 +699,8 @@ MaybeHandle<String> ErrorUtils::ToString(Isolate* isolate,
+     // is accessed the first time.
+     //
+     // If |recv| was not constructed with %Error%, use the "message" property.
+-    LookupIterator it(isolate, LookupIterator::PROTOTYPE_CHAIN_SKIP_INTERCEPTOR,
+-                      recv, isolate->factory()->error_message_symbol());
++    LookupIterator it(isolate, recv, isolate->factory()->error_message_symbol(),
++                      LookupIterator::OWN_SKIP_INTERCEPTOR);
+     Handle<Object> result = JSReceiver::GetDataProperty(&it);
+     if (it.IsFound() && IsUndefined(*result, isolate)) {
+       msg = msg_default;
+@@ -1140,9 +1140,9 @@ bool ErrorUtils::HasErrorStackSymbolOwnProperty(Isolate* isolate,
+ // static
+ ErrorUtils::StackPropertyLookupResult ErrorUtils::GetErrorStackProperty(
+     Isolate* isolate, DirectHandle<JSReceiver> maybe_error_object) {
+-  LookupIterator it(isolate, LookupIterator::PROTOTYPE_CHAIN_SKIP_INTERCEPTOR,
+-                    maybe_error_object,
+-                    isolate->factory()->error_stack_symbol());
++  LookupIterator it(isolate, maybe_error_object,
++                    isolate->factory()->error_stack_symbol(),
++                    LookupIterator::OWN_SKIP_INTERCEPTOR);
+   Handle<Object> result = JSReceiver::GetDataProperty(&it);
+ 
+   if (!it.IsFound()) {
+diff --git a/src/objects/lookup-inl.h b/src/objects/lookup-inl.h
+index b3b071d327bc9234f79f09da15f1043f80b1fe6b..67c1107c7ff0844f5b6ceb3839083b8e1b03468c 100644
+--- a/src/objects/lookup-inl.h
++++ b/src/objects/lookup-inl.h
+@@ -113,24 +113,6 @@ LookupIterator::LookupIterator(Isolate* isolate, DirectHandle<JSAny> receiver,
+   }
+ }
+ 
+-LookupIterator::LookupIterator(Isolate* isolate, Configuration configuration,
+-                               DirectHandle<JSAny> receiver,
+-                               DirectHandle<Symbol> name)
+-    : configuration_(configuration),
+-      isolate_(isolate),
+-      name_(name),
+-      receiver_(receiver),
+-      lookup_start_object_(receiver),
+-      index_(kInvalidIndex) {
+-  // This is the only lookup configuration allowed by this constructor because
+-  // it's special case allowing lookup of the private symbols on the prototype
+-  // chain. Usually private symbols are limited to OWN_SKIP_INTERCEPTOR lookups.
+-  DCHECK(*name_ == *isolate->factory()->error_stack_symbol() ||
+-         *name_ == *isolate->factory()->error_message_symbol());
+-  DCHECK_EQ(configuration, PROTOTYPE_CHAIN_SKIP_INTERCEPTOR);
+-  Start<false>();
+-}
+-
+ PropertyKey::PropertyKey(Isolate* isolate, double index) {
+   DCHECK_EQ(index, static_cast<uint64_t>(index));
+ #if V8_TARGET_ARCH_32_BIT
+diff --git a/src/objects/lookup.h b/src/objects/lookup.h
+index 8214b0e2fa288595358cd2af6a2545684266b803..7b17f0cec9c2e640f8f0efb24841780b800babff 100644
+--- a/src/objects/lookup.h
++++ b/src/objects/lookup.h
+@@ -141,13 +141,6 @@ class V8_EXPORT_PRIVATE LookupIterator final {
+                         DirectHandle<JSAny> lookup_start_object,
+                         Configuration configuration = DEFAULT);
+ 
+-  // Special case for lookup of the |error_stack_trace| private symbol in
+-  // prototype chain (usually private symbols are limited to
+-  // OWN_SKIP_INTERCEPTOR lookups).
+-  inline LookupIterator(Isolate* isolate, Configuration configuration,
+-                        DirectHandle<JSAny> receiver,
+-                        DirectHandle<Symbol> name);
+-
+   inline InternalIndex descriptor_number() const;
+   inline InternalIndex dictionary_entry() const;
+ 
+diff --git a/test/cctest/heap/test-heap.cc b/test/cctest/heap/test-heap.cc
+index bee43e6102eeaa50b0b065f951bc7498636fb785..30d026961a22d15b6d6037efeb0094f463bf2366 100644
+--- a/test/cctest/heap/test-heap.cc
++++ b/test/cctest/heap/test-heap.cc
+@@ -3798,39 +3798,13 @@ UNINITIALIZED_TEST(ReleaseStackTraceData) {
+         "} catch (e) {                "
+         "  error = e;                 "
+         "}                            ";
+-    static const char* source3 =
+-        "var error = null;            "
+-        /* Normal Error */
+-        "try {                        "
+-        /* as prototype */
+-        "  throw new Error();         "
+-        "} catch (e) {                "
+-        "  error = {};                "
+-        "  error.__proto__ = e;       "
+-        "}                            ";
+-    static const char* source4 =
+-        "var error = null;            "
+-        /* Stack overflow */
+-        "try {                        "
+-        /* as prototype   */
+-        "  (function f() { f(); })(); "
+-        "} catch (e) {                "
+-        "  error = {};                "
+-        "  error.__proto__ = e;       "
+-        "}                            ";
+     static const char* getter = "error.stack";
+     static const char* setter = "error.stack = 0";
+ 
+     ReleaseStackTraceDataTest(isolate, source1, setter);
+     ReleaseStackTraceDataTest(isolate, source2, setter);
+-    // We do not test source3 and source4 with setter, since the setter is
+-    // supposed to (untypically) write to the receiver, not the holder.  This is
+-    // to emulate the behavior of a data property.
+-
+     ReleaseStackTraceDataTest(isolate, source1, getter);
+     ReleaseStackTraceDataTest(isolate, source2, getter);
+-    ReleaseStackTraceDataTest(isolate, source3, getter);
+-    ReleaseStackTraceDataTest(isolate, source4, getter);
+   }
+   isolate->Dispose();
+ }
+diff --git a/test/cctest/test-api-stack-traces.cc b/test/cctest/test-api-stack-traces.cc
+index 99012b8b744036f7c5515d103b8ef268f8de1354..4095af193595058153b7517b0310c7d0a32e6469 100644
+--- a/test/cctest/test-api-stack-traces.cc
++++ b/test/cctest/test-api-stack-traces.cc
+@@ -670,7 +670,7 @@ TEST(RethrowBogusErrorStackTrace) {
+   v8::HandleScope scope(isolate);
+   const char* source =
+       "var e = {__proto__: new Error()} \n"
+-      "throw e;                         \n";
++      "throw e.__proto__;               \n";
+   isolate->AddMessageListener(RethrowBogusErrorStackTraceHandler);
+   isolate->SetCaptureStackTraceForUncaughtExceptions(true);
+   CompileRun(source);
+diff --git a/test/mjsunit/stack-traces-overflow.js b/test/mjsunit/stack-traces-overflow.js
+index cd690752d3dc61f96726b09c09d393bc715e2d2b..60dc034f0077a923cc4d5e641eae440c896dd9f0 100644
+--- a/test/mjsunit/stack-traces-overflow.js
++++ b/test/mjsunit/stack-traces-overflow.js
+@@ -76,35 +76,6 @@ try {
+ }
+ 
+ 
+-// Check setting/getting stack property on the prototype chain.
+-function testErrorPrototype(prototype) {
+-  var object = {};
+-  object.__proto__ = prototype;
+-  // Setting stack property overwrites prototype.stack value.
+-  object.stack = "123";
+-  assertEquals(prototype.stack, object.stack);
+-  assertEquals("123", object.stack);
+-}
+-
+-try {
+-  rec1(0);
+-} catch (e) {
+-  e.stack;
+-  testErrorPrototype(e);
+-}
+-
+-try {
+-  rec1(0);
+-} catch (e) {
+-  testErrorPrototype(e);
+-}
+-
+-try {
+-  throw new Error();
+-} catch (e) {
+-  testErrorPrototype(e);
+-}
+-
+ Error.stackTraceLimit = 3;
+ try {
+   rec1(0);


### PR DESCRIPTION
Backports the following changes:

* [`a74693810877`](https://chromium-review.googlesource.com/c/chromium/src/+/8062588) from chromium — [ozone/wayland] Safely handle destruction during drag_finished_callback ([517100492](https://crbug.com/517100492), CVE-2026-15764)
* [`109d4363b05b`](https://chromium-review.googlesource.com/c/chromium/src/+/8068557) from chromium — [Ozone/Wayland] Guard all delegate() calls with weak_this ([518007484](https://crbug.com/518007484), CVE-2026-15765)
* [`d10ea850c21d`](https://skia-review.googlesource.com/c/skia/+/1223896) from skia — Defer marking stencil as cleared until after render pass creation succeeds (prerequisite for the next change; landed between m148 and m150)
* [`bee4c9172200`](https://skia-review.googlesource.com/c/skia/+/1292316) from skia — Check clipped renderpass bounds against cleared stencil area ([514010477](https://crbug.com/514010477), CVE-2026-15766)
* [`8aeb3a9ca363`](https://chromium-review.googlesource.com/c/libyuv/libyuv/+/8031724) from libyuv — I010ToNV12: dispatch Convert16To8Row on halfwidth ([514748734](https://crbug.com/514748734), CVE-2026-15767)
* [`02ddefa1eb9e`](https://chromium-review.googlesource.com/c/chromium/src/+/8061624) from chromium — [HiC] Invalidate cached paint when content is moved into canvas ([517931625](https://crbug.com/517931625), CVE-2026-15768)
* [`d39395c9f94c`](https://chromium-review.googlesource.com/c/chromium/src/+/8061149) from chromium — gtk: Sanitize theme and icon-theme names at write time ([519731111](https://crbug.com/519731111), CVE-2026-15769)
* [`24134ecc1d1a`](https://chromium-review.googlesource.com/c/v8/v8/+/8074498) from v8 — [compiler][arm64][arm] IsOnlyUserOfNodeInSameBlock ([524792614](https://crbug.com/524792614), CVE-2026-15770)
* [`c4ad58ae4d25`](https://chromium-review.googlesource.com/c/chromium/src/+/8078078) from chromium — media: Validate source texture format in PerformD3DCopy ([525177160](https://crbug.com/525177160), CVE-2026-15771)
* [`b9cc197cf022`](https://chromium-review.googlesource.com/c/chromium/src/+/8156763) from chromium — [agy][gpu] Fix FBO delete-while-bound bug ([525317502](https://crbug.com/525317502), CVE-2026-15772)
* [`7d3266fe2240`](https://chromium-review.googlesource.com/c/chromium/src/+/8074598) from chromium — Guard against re-entrant destruction in CreateNewWindow ([527676561](https://crbug.com/527676561), CVE-2026-15773)
* [`3273c66a688f`](https://skia-review.googlesource.com/c/skia/+/1288679) from skia — Fix Use-After-Free in SubRunAllocator ([530646115](https://crbug.com/530646115), CVE-2026-15774)
* [`8120dd10e82d`](https://chromium-review.googlesource.com/c/v8/v8/+/8086200) from v8 — [stack-traces] Make .stack accessors look only at receiver ([531319201](https://crbug.com/531319201), CVE-2026-15775)
* [`303a64b51072`](https://chromium-review.googlesource.com/c/v8/v8/+/8085182) from v8 — [regexp] Hard Check that index + 1 is a Smi in AdvanceStringIndex ([532595489](https://crbug.com/532595489), CVE-2026-15776)
* [`b643479522e2`](https://chromium-review.googlesource.com/c/chromium/src/+/8086914) from chromium — [X11] Guard XDragDropClient and X11Window against destruction during DnD ([532929679](https://crbug.com/532929679), CVE-2026-15777)
* [`bbc335d274ed`](https://chromium-review.googlesource.com/c/chromium/src/+/8067416) from chromium — Reject redirects from blob: URL navigations ([513795122](https://crbug.com/513795122), CVE-2026-15778)

Two patches were adapted to 148, which lacks earlier upstream changes they were written against:

* gtk theme sanitization: the `gtk-key-theme-name` hunks were dropped because 148 never received the key-theme sanitizer; the new `IsValidThemeName`/`GtkSettings` write interceptor and `SanitizeThemeName()` are kept as upstream wrote them. The unit test file was dropped (it depends on the `gtk_unittests` target that does not exist on this branch).
* PerformD3DCopy: only the NV12 format check from this CVE fix is added; the surrounding `visible_rect` bounds check in the upstream context comes from an earlier fix that 148 also lacks.

Notes: Security: backported fixes for CVE-2026-15764, CVE-2026-15765, CVE-2026-15766, CVE-2026-15767, CVE-2026-15768, CVE-2026-15769, CVE-2026-15770, CVE-2026-15771, CVE-2026-15772, CVE-2026-15773, CVE-2026-15774, CVE-2026-15775, CVE-2026-15776, CVE-2026-15777, CVE-2026-15778.
