### PR TITLE
feat: add deviceBoundSessions fuse for Device Bound Session Credentials (DBSC)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -534,6 +534,8 @@ source_set("electron_lib") {
     "//components/prefs",
     "//components/security_state/content",
     "//components/tracing:tracing_metrics",
+    "//components/unexportable_keys",
+    "//components/unexportable_keys/mojom:mojo_service",
     "//components/upload_list",
     "//components/user_prefs",
     "//components/viz/host",

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -10,5 +10,6 @@
   "only_load_app_from_asar": "0",
   "load_browser_process_specific_v8_snapshot": "0",
   "grant_file_protocol_extra_privileges": "1",
-  "wasm_trap_handlers": "1"
+  "wasm_trap_handlers": "1",
+  "device_bound_sessions": "0"
 }

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -94,6 +94,10 @@ signing (and notarizing) your app:
 - [The `cookieEncryption` fuse](./fuses.md#cookieencryption) - Cookie encryption uses
   the same OS-level access to the Keychain as `safeStorage`, so it has the same code
   signing requirement.
+- [The `deviceBoundSessions` fuse](./fuses.md#deviceboundsessions) - Hardware-backed
+  session credentials use the Secure Enclave via Keychain, so the app must be signed with a
+  team identifier and carry a `keychain-access-groups` entitlement for
+  `<TeamID>.<BundleID>.unexportable-keys`.
 - [`autoUpdater`](../api/auto-updater.md) - `Squirrel.Mac` requires the app to be
   signed for automatic updates to work at all.
 

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -177,6 +177,53 @@ than they ideally should be.
 * This extra code, particularly the compare and branch before every memory reference,
 incurs a significant runtime cost.
 
+### `deviceBoundSessions`
+
+**Default:** Disabled
+
+**@electron/fuses:** `FuseV1Options.EnableDeviceBoundSessions`
+
+The `deviceBoundSessions` fuse toggles whether generic net-layer Device Bound Session Credentials (DBSC)
+are enabled in the network service. DBSC binds session cookies to hardware-backed cryptographic keys
+(e.g., TPM 2.0 on Windows, Secure Enclave on macOS) to protect user sessions against cookie theft and session hijacking.
+
+When this fuse is enabled, Electron configures the network service to support DBSC session registration
+and persists session state across restarts on-disk. DevTools inspection is available under
+_Application > Background Services > Device Bound Sessions_.
+
+On Windows and macOS, signing keys are created and used in the browser process rather than in the
+sandboxed network process. On Linux, upstream Chromium still creates them in the network process
+(`network::features::kUseUnexportableKeyServiceInBrowserProcess` is disabled by default there).
+
+> [!IMPORTANT]
+>
+> * **macOS:** Similar to [`safeStorage`](../api/safe-storage.md) and [`cookieEncryption`](#cookieencryption),
+>   DBSC on macOS uses the Secure Enclave via Keychain, which requires the app to be
+>   [code signed](./code-signing.md#macos-apis-that-require-code-signing) with a team identifier and
+>   provisioned with the `keychain-access-groups` entitlement containing
+>   `<TeamID>.<BundleID>.unexportable-keys`. Electron derives that access group from the app's own code
+>   signature and bundle identifier at runtime. An app that is unsigned, ad-hoc signed, or missing the
+>   entitlement gets no key provider, and DBSC is a no-op.
+> * **Windows:** Requires a device with TPM 2.0. Keys are managed automatically via Windows CNG (`NCrypt`).
+> * **Linux:** Upstream Chromium does not yet have desktop hardware TPM key provider support.
+> * **Software Key Flag Rejection:** When this fuse is enabled, Electron rejects and strips the
+>   `EnableBoundSessionCredentialsSoftwareKeysForManualTesting` flag so that production apps cannot have
+>   their hardware-backed protection downgraded to mock software keys.
+
+#### Testing DBSC in development
+
+Hardware-backed keys are unavailable in most development setups: macOS builds are usually unsigned,
+Linux has no key provider, and not every Windows machine has a TPM 2.0. To exercise DBSC there, leave
+the fuse disabled and run with mock software keys:
+
+```sh
+electron . --enable-features=EnableBoundSessionCredentialsSoftwareKeysForManualTesting
+```
+
+With the fuse off, that flag also turns DBSC on in the network service. Software keys offer no hardware
+protection and exist only for local testing — a packaged app with the fuse enabled rejects the flag,
+so this cannot be used to weaken a production app.
+
 ## How do I flip fuses?
 
 ### The easy way

--- a/filenames.gni
+++ b/filenames.gni
@@ -466,6 +466,8 @@ filenames = {
     "shell/browser/net/cert_verifier_client.h",
     "shell/browser/net/client_certificate_responder_delegate.cc",
     "shell/browser/net/client_certificate_responder_delegate.h",
+    "shell/browser/net/device_bound_sessions.cc",
+    "shell/browser/net/device_bound_sessions.h",
     "shell/browser/net/electron_url_loader_factory.cc",
     "shell/browser/net/electron_url_loader_factory.h",
     "shell/browser/net/network_context_service.cc",

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -12,9 +12,12 @@
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial.h"
+#include "base/strings/string_util.h"
 #include "components/spellcheck/common/spellcheck_features.h"
+#include "components/unexportable_keys/features.h"
 #include "content/public/common/content_features.h"
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "media/base/media_switches.h"
 #include "net/base/features.h"
 #include "printing/buildflags/buildflags.h"
@@ -44,6 +47,40 @@ void InitializeFeatureList() {
       cmd_line->GetSwitchValueASCII(::switches::kEnableFeatures);
   auto disable_features =
       cmd_line->GetSwitchValueASCII(::switches::kDisableFeatures);
+
+  if (electron::fuses::IsDeviceBoundSessionsEnabled()) {
+    // A production app that fused DBSC on must not be downgradable to mock
+    // software keys by a command-line flag, so drop any request for them and
+    // force the feature off.
+    //
+    // Only the local feature strings are touched. InitializeFeatureList() runs
+    // twice in the browser process (ElectronMainDelegate::PreBrowserMain and
+    // ElectronBrowserMainParts::PostEarlyInitialization), so rewriting the
+    // process command line here would read back its own output and append the
+    // disable entry a second time, leaking duplicates into app.commandLine and
+    // into second-instance argv. It is also unnecessary: disable overrides win
+    // in FeatureList, and child processes get their feature switches from the
+    // FeatureList instance rather than from the browser's argv.
+    std::vector<std::string_view> filtered_features;
+    for (const auto& entry :
+         base::FeatureList::SplitFeatureListString(enable_features)) {
+      std::string name, study, group, params;
+      if (base::FeatureList::ParseEnableFeatureString(entry, &name, &study,
+                                                      &group, &params) &&
+          name == unexportable_keys::
+                      kEnableBoundSessionCredentialsSoftwareKeysForManualTesting
+                          .name) {
+        continue;
+      }
+      filtered_features.emplace_back(entry);
+    }
+    enable_features = base::JoinString(filtered_features, ",");
+    disable_features +=
+        std::string(",") +
+        unexportable_keys::
+            kEnableBoundSessionCredentialsSoftwareKeysForManualTesting.name;
+  }
+
   // A renderer's command line depends on the WebContents it is created for,
   // so Electron warms one spare itself (for the first sandboxed window) rather
   // than letting content keep one alive at all times; apps that open many

--- a/shell/browser/net/device_bound_sessions.cc
+++ b/shell/browser/net/device_bound_sessions.cc
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/net/device_bound_sessions.h"
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "base/feature_list.h"
+#include "base/files/file_path.h"
+#include "base/no_destructor.h"
+#include "build/build_config.h"
+#include "components/unexportable_keys/background_task_origin.h"
+#include "components/unexportable_keys/features.h"
+#include "components/unexportable_keys/unexportable_key_service_impl.h"
+#include "components/unexportable_keys/unexportable_key_task_manager.h"
+#include "crypto/unexportable_key.h"
+#include "electron/fuses.h"
+
+#if BUILDFLAG(IS_MAC)
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "base/apple/foundation_util.h"
+#include "base/apple/osstatus_logging.h"
+#include "base/apple/scoped_cftyperef.h"
+#include "base/containers/span.h"
+#include "base/logging.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/sys_string_conversions.h"
+#include "crypto/hash.h"
+#endif  // BUILDFLAG(IS_MAC)
+
+namespace electron {
+
+namespace {
+
+bool IsSoftwareKeysForManualTestingEnabled() {
+  return base::FeatureList::IsEnabled(
+      unexportable_keys::
+          kEnableBoundSessionCredentialsSoftwareKeysForManualTesting);
+}
+
+#if BUILDFLAG(IS_MAC)
+// Returns "<TeamID>.<BundleID>.unexportable-keys" for the running app, or an
+// empty string when it cannot be derived. macOS requires the binary to be
+// codesigned with a matching `keychain-access-groups` entitlement, so an
+// unsigned or ad-hoc signed build has no usable group.
+std::string GetKeychainAccessGroup() {
+  CFBundleRef main_bundle = CFBundleGetMainBundle();
+  CFStringRef bundle_id =
+      main_bundle ? CFBundleGetIdentifier(main_bundle) : nullptr;
+  if (!bundle_id) {
+    return {};
+  }
+
+  base::apple::ScopedCFTypeRef<SecCodeRef> self_code;
+  OSStatus status =
+      SecCodeCopySelf(kSecCSDefaultFlags, self_code.InitializeInto());
+  if (status != errSecSuccess) {
+    OSSTATUS_LOG(ERROR, status) << "SecCodeCopySelf";
+    return {};
+  }
+
+  base::apple::ScopedCFTypeRef<SecStaticCodeRef> static_code;
+  status = SecCodeCopyStaticCode(self_code.get(), kSecCSDefaultFlags,
+                                 static_code.InitializeInto());
+  if (status != errSecSuccess) {
+    // Unsigned builds are the common development case, not an error.
+    if (status != errSecCSUnsigned) {
+      OSSTATUS_LOG(ERROR, status) << "SecCodeCopyStaticCode";
+    }
+    return {};
+  }
+
+  base::apple::ScopedCFTypeRef<CFDictionaryRef> signing_info;
+  status =
+      SecCodeCopySigningInformation(static_code.get(), kSecCSSigningInformation,
+                                    signing_info.InitializeInto());
+  if (status != errSecSuccess) {
+    OSSTATUS_LOG(ERROR, status) << "SecCodeCopySigningInformation";
+    return {};
+  }
+
+  // Absent for unsigned, ad-hoc signed, and self-signed binaries.
+  CFStringRef team_id = base::apple::GetValueFromDictionary<CFStringRef>(
+      signing_info.get(), kSecCodeInfoTeamIdentifier);
+  if (!team_id) {
+    return {};
+  }
+
+  return base::StrCat({base::SysCFStringRefToUTF8(team_id), ".",
+                       base::SysCFStringRefToUTF8(bundle_id),
+                       ".unexportable-keys"});
+}
+#endif  // BUILDFLAG(IS_MAC)
+
+// Returns the key provider configuration for the browser context rooted at
+// `context_path`, or nullopt when this app cannot use unexportable keys at all.
+std::optional<crypto::UnexportableKeyProvider::Config> GetKeyProviderConfig(
+    [[maybe_unused]] const base::FilePath& context_path) {
+  crypto::UnexportableKeyProvider::Config config;
+#if BUILDFLAG(IS_MAC)
+  config.keychain_access_group = GetKeychainAccessGroup();
+  if (config.keychain_access_group.empty()) {
+    // crypto CHECKs on an empty access group, and a group the app is not
+    // entitled to would fail anyway. The mock software provider used for
+    // manual testing never touches the keychain, so it is still usable.
+    if (!IsSoftwareKeysForManualTestingEnabled()) {
+      LOG(WARNING) << "Device Bound Sessions are enabled but no keychain "
+                      "access group could be derived for this app, so no keys "
+                      "are available. The app must be code signed with a team "
+                      "identifier and hold a keychain-access-groups "
+                      "entitlement for <TeamID>.<BundleID>.unexportable-keys.";
+      return std::nullopt;
+    }
+  } else {
+    // Scope this context's keys so that another context's garbage collector
+    // does not delete them. `context_path` is unique per session: the default
+    // session uses the user data dir, `persist:` partitions live under
+    // Partitions/.
+    const std::array<uint8_t, crypto::hash::kSha256Size> context_hash =
+        crypto::hash::Sha256(context_path.value());
+    config.application_tag = base::StrCat(
+        {config.keychain_access_group, ".",
+         base::HexEncodeLower(base::span(context_hash).first(8u)), ".dbsc"});
+  }
+#endif  // BUILDFLAG(IS_MAC)
+  return config;
+}
+
+// The task manager is stateless scheduling machinery, so every context's
+// service can share one. It must outlive them all.
+unexportable_keys::UnexportableKeyTaskManager& GetSharedTaskManager() {
+  static base::NoDestructor<unexportable_keys::UnexportableKeyTaskManager>
+      instance;
+  return *instance;
+}
+
+}  // namespace
+
+bool ShouldEnableDeviceBoundSessions() {
+  // The fuse is the production switch. With the fuse off, the software-keys
+  // testing feature also turns DBSC on: mock keys are the only way to exercise
+  // it in development on Linux, on unsigned macOS builds, and on Windows
+  // machines without a TPM 2.0. A fused app never reaches this branch because
+  // InitializeFeatureList() force-disables that feature.
+  return fuses::IsDeviceBoundSessionsEnabled() ||
+         IsSoftwareKeysForManualTestingEnabled();
+}
+
+std::unique_ptr<unexportable_keys::UnexportableKeyService>
+CreateDeviceBoundSessionsKeyService(const base::FilePath& context_path) {
+  std::optional<crypto::UnexportableKeyProvider::Config> config =
+      GetKeyProviderConfig(context_path);
+  if (!config ||
+      !unexportable_keys::UnexportableKeyServiceImpl::
+          IsUnexportableKeyProviderSupported(*config)) {
+    return nullptr;
+  }
+
+  return std::make_unique<unexportable_keys::UnexportableKeyServiceImpl>(
+      GetSharedTaskManager(),
+      unexportable_keys::BackgroundTaskOrigin::kDeviceBoundSessionCredentials,
+      std::move(*config));
+}
+
+}  // namespace electron

--- a/shell/browser/net/device_bound_sessions.h
+++ b/shell/browser/net/device_bound_sessions.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_NET_DEVICE_BOUND_SESSIONS_H_
+#define ELECTRON_SHELL_BROWSER_NET_DEVICE_BOUND_SESSIONS_H_
+
+#include <memory>
+
+namespace base {
+class FilePath;
+}  // namespace base
+
+namespace unexportable_keys {
+class UnexportableKeyService;
+}  // namespace unexportable_keys
+
+namespace electron {
+
+// Whether Device Bound Session Credentials should be configured on new network
+// contexts.
+bool ShouldEnableDeviceBoundSessions();
+
+// Creates the `UnexportableKeyService` that DBSC signs with for the browser
+// context rooted at `context_path`, or nullptr when this platform or this app
+// cannot provide unexportable keys.
+//
+// The network service has its own fallback factory, but on macOS that one
+// hardcodes Chromium's keychain access group -- which no Electron app can hold
+// an entitlement for -- and it runs key operations inside the sandboxed network
+// process. Electron creates the service in the browser process instead and
+// hands the network service a remote to it. On Linux the network service keeps
+// using its own factory, because
+// network::features::kUseUnexportableKeyServiceInBrowserProcess is disabled by
+// default there.
+//
+// One service per browser context, not one per process: on macOS the config
+// carries an `application_tag` derived from `context_path`, and that tag scopes
+// DBSC's periodic garbage collection. A collector deletes every key in the
+// access group whose tag matches its prefix and whose wrapped key is not in its
+// own store, so two sessions sharing a tag would delete each other's keys.
+std::unique_ptr<unexportable_keys::UnexportableKeyService>
+CreateDeviceBoundSessionsKeyService(const base::FilePath& context_path);
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_NET_DEVICE_BOUND_SESSIONS_H_

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -18,7 +18,14 @@
 #include "shell/browser/browser_process_impl.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/browser/electron_browser_context.h"
+#include "shell/browser/net/device_bound_sessions.h"
 #include "shell/browser/net/system_network_context_manager.h"
+
+#if BUILDFLAG(ENABLE_DEVICE_BOUND_SESSIONS)
+#include "components/unexportable_keys/mojom/unexportable_key_service.mojom.h"
+#include "components/unexportable_keys/mojom/unexportable_key_service_proxy_impl.h"
+#include "services/network/public/cpp/features.h"
+#endif
 
 namespace electron {
 
@@ -75,6 +82,37 @@ void NetworkContextService::ConfigureNetworkContextParams(
   network_context_params->http_cache_enabled =
       browser_context_->can_use_http_cache();
 
+  network_context_params->device_bound_sessions_enabled =
+      ShouldEnableDeviceBoundSessions();
+
+#if BUILDFLAG(ENABLE_DEVICE_BOUND_SESSIONS)
+  // Without a key service the network service falls back to its own factory,
+  // which hardcodes Chromium's keychain access group on macOS (no Electron app
+  // can hold that entitlement) and runs key operations inside the sandboxed
+  // network process. Create the service here instead and pass a remote to it,
+  // mirroring what ProfileNetworkContextService does in Chrome.
+  if (network_context_params->device_bound_sessions_enabled &&
+      base::FeatureList::IsEnabled(
+          network::features::kUseUnexportableKeyServiceInBrowserProcess)) {
+    if (!unexportable_key_service_) {
+      unexportable_key_service_ = CreateDeviceBoundSessionsKeyService(path);
+    }
+    if (unexportable_key_service_) {
+      mojo::PendingRemote<unexportable_keys::mojom::UnexportableKeyService>
+          key_service_remote;
+      // The proxy is recreated on every call so that a restarted network
+      // service gets a live pipe; the key service itself is kept, because its
+      // keys are this context's.
+      unexportable_key_service_proxy_ =
+          std::make_unique<unexportable_keys::UnexportableKeyServiceProxyImpl>(
+              unexportable_key_service_.get(),
+              key_service_remote.InitWithNewPipeAndPassReceiver());
+      network_context_params->bound_sessions_unexportable_key_service =
+          std::move(key_service_remote);
+    }
+  }
+#endif  // BUILDFLAG(ENABLE_DEVICE_BOUND_SESSIONS)
+
   network_context_params->cookie_manager_params =
       network::mojom::CookieManagerParams::New();
 
@@ -107,6 +145,11 @@ void NetworkContextService::ConfigureNetworkContextParams(
 
     network_context_params->file_paths->trust_token_database_name =
         base::FilePath(chrome::kTrustTokenFilename);
+
+    if (network_context_params->device_bound_sessions_enabled) {
+      network_context_params->file_paths->device_bound_sessions_database_name =
+          base::FilePath(chrome::kDeviceBoundSessionsFilename);
+    }
 
     network_context_params->restore_old_session_cookies = false;
     network_context_params->persist_session_cookies = false;

--- a/shell/browser/net/network_context_service.h
+++ b/shell/browser/net/network_context_service.h
@@ -10,6 +10,7 @@
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "components/keyed_service/core/keyed_service.h"
+#include "net/net_buildflags.h"
 #include "services/cert_verifier/public/mojom/cert_verifier_service_factory.mojom-forward.h"
 #include "services/network/public/mojom/network_context.mojom-forward.h"
 
@@ -22,6 +23,11 @@ class FilePath;
 namespace content {
 class BrowserContext;
 }  // namespace content
+
+namespace unexportable_keys {
+class UnexportableKeyService;
+class UnexportableKeyServiceProxyImpl;
+}  // namespace unexportable_keys
 
 namespace electron {
 
@@ -51,6 +57,15 @@ class NetworkContextService : public KeyedService {
   raw_ptr<ElectronBrowserContext> browser_context_;
   ProxyConfigMonitor proxy_config_monitor_;
   std::unique_ptr<CookieEncryptionProviderImpl> cookie_encryption_provider_;
+#if BUILDFLAG(ENABLE_DEVICE_BOUND_SESSIONS)
+  // This context's DBSC signing keys. Declared before the proxy, which holds a
+  // bare pointer to it, so that the proxy is destroyed first.
+  std::unique_ptr<unexportable_keys::UnexportableKeyService>
+      unexportable_key_service_;
+  // Serves the network service's calls into `unexportable_key_service_`.
+  std::unique_ptr<unexportable_keys::UnexportableKeyServiceProxyImpl>
+      unexportable_key_service_proxy_;
+#endif
 };
 
 }  // namespace electron

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -31,6 +31,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
+#include "content/common/features.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/file_select_listener.h"
@@ -1062,6 +1063,13 @@ void InspectableWebContents::GetHostConfig(DispatchCallback callback) {
     extension_schemes.Append(scheme + ":");
   response_dict.Set("devToolsExtensionSchemes",
                     base::Value(std::move(extension_schemes)));
+
+  base::DictValue device_bound_sessions_debugging;
+  device_bound_sessions_debugging.Set(
+      "enabled",
+      base::FeatureList::IsEnabled(features::kDeviceBoundSessionsDevTools));
+  response_dict.Set("deviceBoundSessionsDebugging",
+                    std::move(device_bound_sessions_debugging));
 
   base::Value response = base::Value(std::move(response_dict));
   std::move(callback).Run(&response);

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -4,9 +4,14 @@ import { expect } from 'chai';
 
 import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import path = require('node:path');
+import { setTimeout } from 'node:timers/promises';
 
-import { startRemoteControlApp } from './lib/spec-helpers';
+import { defer, startRemoteControlApp } from './lib/spec-helpers';
+
+type RemoteControlApp = Awaited<ReturnType<typeof startRemoteControlApp>>;
 
 describe('fuses', () => {
   it('can be enabled by command-line argument during testing', async () => {
@@ -116,6 +121,109 @@ describe('fuses', () => {
       });
 
       expect(result).to.equal('persist_me');
+    });
+  });
+
+  describe('device_bound_sessions', () => {
+    const softwareKeysFeature = 'EnableBoundSessionCredentialsSoftwareKeysForManualTesting';
+
+    // Each app gets its own user data dir so the on-disk assertions below start
+    // from a clean state.
+    const startApp = async (extraArgs: string[] = []) => {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-dbsc-'));
+      const rc = await startRemoteControlApp([`--user-data-dir=${userDataDir}`, ...extraArgs]);
+      // defer() is LIFO, so this runs before startRemoteControlApp's own kill
+      // handler: stop the app here and wait for it to exit before deleting the
+      // directory, since on Windows the files stay locked until it does. The
+      // later kill is then a no-op on an already-dead process.
+      defer(async () => {
+        rc.process.kill('SIGINT');
+        await once(rc.process, 'exit').catch(() => {});
+        fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      });
+      // The DBSC store lives directly under userData unless the sandboxed-data
+      // migration has run, which only happens on Windows, so check both.
+      return {
+        rc,
+        sessionDbPaths: [
+          path.join(userDataDir, 'Device Bound Sessions'),
+          path.join(userDataDir, 'Network', 'Device Bound Sessions')
+        ]
+      };
+    };
+
+    // Feature switches reach child processes from the browser's FeatureList
+    // instance rather than from the browser's own argv, so a renderer's argv
+    // reports the effective feature state.
+    const getEffectiveFeatures = (rc: RemoteControlApp) => rc.remotely(async (fixture: string) => {
+      const bw = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true, contextIsolation: false, sandbox: false }
+      });
+      await bw.loadFile(fixture);
+      const argv: string[] = await bw.webContents.executeJavaScript('process.argv');
+      bw.destroy();
+      const valueOf = (name: string) => {
+        const arg = argv.find((a: string) => a.startsWith(`--${name}=`));
+        return arg ? arg.slice(name.length + 3) : '';
+      };
+      return { enabled: valueOf('enable-features'), disabled: valueOf('disable-features') };
+    }, path.join(__dirname, 'fixtures', 'pages', 'blank.html'));
+
+    // The session database is only created once the network context has a key
+    // service, so its presence means DBSC is actually running and not just
+    // configured.
+    const hasSessionDatabase = async (rc: RemoteControlApp, sessionDbPaths: string[]) => {
+      // Force the network context to be created.
+      await rc.remotely(async () => {
+        const { session } = require('electron');
+        await session.defaultSession.cookies.get({});
+      });
+      // The store opens its database on a background sequence.
+      for (let i = 0; i < 50; i++) {
+        if (sessionDbPaths.some((p) => fs.existsSync(p))) return true;
+        await setTimeout(100);
+      }
+      return false;
+    };
+
+    it('is off by default', async () => {
+      const { rc, sessionDbPaths } = await startApp();
+      expect(await hasSessionDatabase(rc, sessionDbPaths)).to.be.false('DBSC database should not exist');
+    });
+
+    it('is enabled by the software keys testing feature when the fuse is off', async () => {
+      const { rc, sessionDbPaths } = await startApp([`--enable-features=${softwareKeysFeature}`]);
+
+      const features = await getEffectiveFeatures(rc);
+      expect(features.enabled).to.include(softwareKeysFeature);
+      expect(features.disabled).to.not.include(softwareKeysFeature);
+
+      expect(await hasSessionDatabase(rc, sessionDbPaths)).to.be.true('DBSC database should exist');
+    });
+
+    it('rejects the software keys testing feature when the fuse is enabled', async () => {
+      const { rc } = await startApp([
+        '--set-fuse-device_bound_sessions=1',
+        `--enable-features=${softwareKeysFeature},SomeOtherFeature`
+      ]);
+
+      const features = await getEffectiveFeatures(rc);
+      expect(features.enabled).to.not.include(softwareKeysFeature);
+      expect(features.enabled).to.include('SomeOtherFeature');
+      expect(features.disabled).to.include(softwareKeysFeature);
+    });
+
+    it('does not rewrite the process command line when the fuse is enabled', async () => {
+      const { rc } = await startApp(['--set-fuse-device_bound_sessions=1']);
+      const result = await rc.remotely(() => {
+        const { app } = require('electron');
+        return app.commandLine.getSwitchValue('disable-features');
+      });
+      // InitializeFeatureList() runs twice in the browser process, so rewriting
+      // the process command line there appended the name once per run and leaked
+      // it into app.commandLine and into second-instance argv.
+      expect(result).to.not.include(softwareKeysFeature);
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

This PR introduces the `deviceBoundSessions` fuse (`FuseV1Options.EnableDeviceBoundSessions`, disabled by default) to enable generic net-layer Device Bound Session Credentials (DBSC) support in Electron:

1. **Fuse Gating & Configuration:** Gated behind `electron::fuses::IsDeviceBoundSessionsEnabled()`:
   - Configures `network_context_params->device_bound_sessions_enabled` in `NetworkContextService`.
   - Persists DBSC sessions across restarts on-disk by setting `network_context_params->file_paths->device_bound_sessions_database_name` when enabled.
2. **DevTools Support:** DevTools session inspection is enabled under *Application > Background Services > Device Bound Sessions* via `features::kDeviceBoundSessionsDevTools` matching upstream Chromium behavior.
3. **Production Security Enforcement:** In `shell/browser/feature_list.cc`, when the `deviceBoundSessions` fuse is enabled in a production binary, Electron strips and disables `EnableBoundSessionCredentialsSoftwareKeysForManualTesting` from the feature flags and command-line arguments. This ensures that production apps cannot be downgraded to mock software keys via runtime flags.
4. **Documentation & Unit Tests:**
   - Added `### deviceBoundSessions` to [`docs/tutorial/fuses.md`](docs/tutorial/fuses.md).
   - Documented macOS Keychain entitlement requirements in [`docs/tutorial/code-signing.md`](docs/tutorial/code-signing.md).
   - Added unit tests in [`spec/fuses-spec.ts`](spec/fuses-spec.ts) covering testing argument enablement, flag stripping when enabled, and flag preservation when disabled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `deviceBoundSessions` fuse to enable Device Bound Session Credentials (DBSC).
