### PR TITLE
fix: settle pending upload stream reads when a net.request ends

### DIFF
--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -177,11 +177,9 @@ class ChunkedBodyStream extends Writable {
     this._downstream = pipe;
     if (this._pendingChunk) {
       const doneWriting = (maybeError: Error | void) => {
-        // If the underlying request has been aborted, we honestly don't care about the error
-        // all work should cease as soon as we abort anyway, this error is probably a
-        // "mojo pipe disconnected" error (code=9)
-        if (this._clientRequest._aborted) return;
-
+        // This also runs when the request was aborted mid-write: the write
+        // then settles with the abort error, as Node.js does, and no 'error'
+        // event follows because the request is already destroyed by then.
         const cb = this._pendingCallback!;
         delete this._pendingCallback;
         delete this._pendingChunk;
@@ -369,6 +367,10 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this._chunkedEncoding = !!value;
     if (this._chunkedEncoding) {
       this._body = new ChunkedBodyStream(this);
+      // A write that fails because the request ended first is reported
+      // through the write callback on this request; the body stream must not
+      // also raise it as an unhandled 'error' of its own.
+      this._body.on('error', () => {});
       this._urlLoaderOptions.body = (pipe: NodeJS.DataPipe) => {
         (this._body! as ChunkedBodyStream).startReading(pipe);
       };

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -267,7 +267,7 @@ void UtilityProcessWrapper::OnServiceProcessLaunch(
     EmitWithoutEvent("stdout", stdout_read_fd_);
   if (stderr_read_fd_ != -1)
     EmitWithoutEvent("stderr", stderr_read_fd_);
-  if (url_loader_network_observer_.has_value()) {
+  if (url_loader_network_observer_) {
     url_loader_network_observer_->set_process_id(pid_);
   }
   EmitWithoutEvent("spawn");
@@ -463,7 +463,8 @@ UtilityProcessWrapper::CreateURLLoaderFactoryParams() {
   loader_params->is_orb_enabled = false;
   loader_params->is_trusted = true;
   if (create_network_observer_) {
-    url_loader_network_observer_.emplace();
+    url_loader_network_observer_ =
+        std::make_unique<electron::URLLoaderNetworkObserver>();
     loader_params->url_loader_network_observer =
         url_loader_network_observer_->Bind();
   }

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -132,7 +132,7 @@ class UtilityProcessWrapper final
       "Context tracking of remote is not needed in the browser process.")
   mojo::Remote<node::mojom::NodeService> node_service_remote_;
   cppgc::Member<Session> session_;
-  std::optional<electron::URLLoaderNetworkObserver>
+  std::unique_ptr<electron::URLLoaderNetworkObserver>
       url_loader_network_observer_;
   base::CallbackListSubscription network_service_gone_subscription_;
   gin_helper::SelfKeepAlive<UtilityProcessWrapper> keep_alive_{this};

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -6,11 +6,13 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
+#include "base/byte_size.h"
 #include "base/check_op.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/span.h"
@@ -21,6 +23,7 @@
 #include "content/public/common/url_utils.h"
 #include "gin/object_template_builder.h"
 #include "gin/persistent.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
 #include "net/base/auth.h"
@@ -30,6 +33,7 @@
 #include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"
+#include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/cpp/url_util.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
@@ -56,6 +60,7 @@
 #include "third_party/blink/public/common/loader/referrer_utils.h"
 #include "third_party/blink/public/mojom/fetch/fetch_api_request.mojom.h"
 #include "v8/include/cppgc/allocation.h"
+#include "v8/include/cppgc/persistent.h"
 #include "v8/include/v8-cppgc.h"
 #include "v8/include/v8-traced-handle.h"
 
@@ -210,6 +215,25 @@ class JSChunkedDataPipeGetter final
   static const gin::WrapperInfo kWrapperInfo;
   ~JSChunkedDataPipeGetter() override = default;
 
+  // Called when the request this getter feeds is over. Dropping the receiver
+  // disconnects whoever is still reading the upload body (the network service
+  // or a protocol handler holding the stream), and both treat that as the
+  // body ending with an error instead of waiting forever for a size that will
+  // never be reported. The size reply is deliberately not answered with an
+  // error here: the network service DCHECKs that it only arrives while the
+  // stream is still healthy.
+  void Abort() {
+    // A write still in flight would otherwise never settle: its completion
+    // callback dies with |data_producer_| below.
+    if (pending_write_) {
+      is_writing_ = false;
+      std::move(*pending_write_)
+          .RejectWithErrorMessage(net::ErrorToString(net::ERR_ABORTED));
+      pending_write_.reset();
+    }
+    Finished();
+  }
+
   JSChunkedDataPipeGetter(
       v8::Isolate* isolate,
       v8::Local<v8::Function> body_func,
@@ -267,19 +291,21 @@ class JSChunkedDataPipeGetter final
     auto buffer = buffer_val.As<v8::ArrayBufferView>();
     is_writing_ = true;
     bytes_written_ += buffer->ByteLength();
+    pending_write_ = std::move(promise);
     data_producer_->Write(
         std::make_unique<BufferDataSource>(buffer),
         base::BindOnce(&JSChunkedDataPipeGetter::OnWriteChunkComplete,
                        // We're OK to use Unretained here because we own
                        // |data_producer_|.
-                       base::Unretained(this), std::move(promise)));
+                       base::Unretained(this)));
     return handle;
   }
 
-  void OnWriteChunkComplete(gin_helper::Promise<void> promise,
-                            MojoResult result) {
+  void OnWriteChunkComplete(MojoResult result) {
     DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
     is_writing_ = false;
+    gin_helper::Promise<void> promise = std::move(*pending_write_);
+    pending_write_.reset();
     if (result == MOJO_RESULT_OK) {
       promise.Resolve();
     } else {
@@ -307,6 +333,7 @@ class JSChunkedDataPipeGetter final
 
   SEQUENCE_CHECKER(sequence_checker_);
   GetSizeCallback size_callback_;
+  std::optional<gin_helper::Promise<void>> pending_write_;
   GC_PLUGIN_IGNORE(
       "Context tracking of receiver is not needed in the browser process.")
   mojo::Receiver<network::mojom::ChunkedDataPipeGetter> receiver_{this};
@@ -345,6 +372,140 @@ const net::NetworkTrafficAnnotationTag kTrafficAnnotation =
 const gin::WrapperInfo SimpleURLLoaderWrapper::kWrapperInfo =
     electron::MakeWrapperInfo(electron::kElectronSimpleURLLoaderWrapper);
 
+class SimpleURLLoaderClient final
+    : public network::SimpleURLLoaderStreamConsumer,
+      public network::mojom::URLLoaderNetworkServiceObserver {
+ public:
+  explicit SimpleURLLoaderClient(
+      cppgc::WeakPersistent<gin::WeakCell<SimpleURLLoaderWrapper>> owner)
+      : owner_(std::move(owner)) {}
+
+  mojo::PendingRemote<network::mojom::URLLoaderNetworkServiceObserver> Bind() {
+    mojo::PendingRemote<network::mojom::URLLoaderNetworkServiceObserver> remote;
+    receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+    return remote;
+  }
+
+ private:
+  SimpleURLLoaderWrapper* owner() const {
+    auto* cell = owner_.Get();
+    return cell ? cell->Get() : nullptr;
+  }
+
+  // network::SimpleURLLoaderStreamConsumer:
+  void OnDataReceived(std::string_view chunk,
+                      base::OnceClosure resume) override {
+    if (auto* wrapper = owner())
+      wrapper->OnDataReceived(chunk, std::move(resume));
+    else
+      std::move(resume).Run();
+  }
+
+  void OnComplete(bool success) override {
+    if (auto* wrapper = owner())
+      wrapper->OnComplete(success);
+  }
+
+  void OnRetry(base::OnceClosure start_retry) override {}
+
+  // network::mojom::URLLoaderNetworkServiceObserver:
+  void OnAuthRequired(
+      const std::optional<base::UnguessableToken>& window_id,
+      int32_t request_id,
+      const GURL& url,
+      bool first_auth_attempt,
+      const net::AuthChallengeInfo& auth_info,
+      const scoped_refptr<net::HttpResponseHeaders>& head_headers,
+      mojo::PendingRemote<network::mojom::AuthChallengeResponder>
+          auth_challenge_responder) override {
+    if (auto* wrapper = owner()) {
+      wrapper->OnAuthRequired(window_id, request_id, url, first_auth_attempt,
+                              auth_info, head_headers,
+                              std::move(auth_challenge_responder));
+    }
+  }
+
+  void OnSSLCertificateError(const GURL& url,
+                             int net_error,
+                             const net::SSLInfo& ssl_info,
+                             bool fatal,
+                             OnSSLCertificateErrorCallback response) override {
+    std::move(response).Run(net_error);
+  }
+
+  void OnCertificateRequested(
+      const std::optional<base::UnguessableToken>& window_id,
+      const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+      mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+          client_cert_responder) override {
+    if (auto* wrapper = owner()) {
+      wrapper->OnCertificateRequested(window_id, cert_info,
+                                      std::move(client_cert_responder));
+    }
+  }
+
+  void OnLocalNetworkAccessPermissionRequired(
+      network::mojom::TransportType transport_type,
+      network::mojom::IPAddressSpace ip_address_space,
+      OnLocalNetworkAccessPermissionRequiredCallback callback) override {}
+
+  void OnPlatformLocalNetworkPermissionRequired(
+      OnPlatformLocalNetworkPermissionRequiredCallback callback) override {
+    std::move(callback).Run(false);
+  }
+
+  void OnClearSiteData(
+      const GURL& url,
+      const std::string& header_value,
+      int32_t load_flags,
+      const std::optional<net::CookiePartitionKey>& cookie_partition_key,
+      bool partitioned_state_allowed_only,
+      OnClearSiteDataCallback callback) override {
+    std::move(callback).Run();
+  }
+
+  void OnLoadingStateUpdate(network::mojom::LoadInfoPtr info,
+                            OnLoadingStateUpdateCallback callback) override {
+    std::move(callback).Run();
+  }
+
+  void OnSharedStorageHeaderReceived(
+      const url::Origin& request_origin,
+      std::vector<network::mojom::SharedStorageModifierMethodWithOptionsPtr>
+          methods,
+      const std::optional<std::string>& with_lock,
+      OnSharedStorageHeaderReceivedCallback callback) override {
+    std::move(callback).Run();
+  }
+
+  void OnAdAuctionEventRecordHeaderReceived(
+      network::AdAuctionEventRecord event_record,
+      const std::optional<url::Origin>& top_frame_origin) override {}
+
+  void OnDataUseUpdate(int32_t network_traffic_annotation_id_hash,
+                       base::ByteSize recv_bytes,
+                       base::ByteSize sent_bytes) override {}
+
+  void OnWebSocketConnectedToLocalNetwork(
+      const GURL& request_url,
+      network::mojom::IPAddressSpace ip_address_space) override {}
+
+  void Clone(
+      mojo::PendingReceiver<network::mojom::URLLoaderNetworkServiceObserver>
+          observer) override {
+    receivers_.Add(this, std::move(observer));
+  }
+
+  void OnUrlLoaderConnectedToLocalNetwork(
+      const GURL& request_url,
+      network::mojom::IPAddressSpace response_address_space,
+      network::mojom::IPAddressSpace client_address_space,
+      network::mojom::IPAddressSpace target_address_space) override {}
+
+  cppgc::WeakPersistent<gin::WeakCell<SimpleURLLoaderWrapper>> owner_;
+  mojo::ReceiverSet<network::mojom::URLLoaderNetworkServiceObserver> receivers_;
+};
+
 SimpleURLLoaderWrapper::SimpleURLLoaderWrapper(
     ElectronBrowserContext* browser_context,
     std::unique_ptr<network::ResourceRequest> request,
@@ -363,14 +524,13 @@ SimpleURLLoaderWrapper::SimpleURLLoaderWrapper(
         !URLLoaderBundle::GetInstance()
              ->ShouldUseNetworkObserverfromURLLoaderFactory();
   }
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  client_ = std::make_unique<SimpleURLLoaderClient>(
+      cppgc::WeakPersistent<gin::WeakCell<SimpleURLLoaderWrapper>>(
+          weak_factory_.GetWeakCell(
+              isolate->GetCppHeap()->GetAllocationHandle())));
   if (create_network_observer) {
-    mojo::PendingRemote<network::mojom::URLLoaderNetworkServiceObserver>
-        url_loader_network_observer_remote;
-    url_loader_network_observer_receivers_.Add(
-        this,
-        url_loader_network_observer_remote.InitWithNewPipeAndPassReceiver());
-    request_->trusted_params->url_loader_network_observer =
-        std::move(url_loader_network_observer_remote);
+    request_->trusted_params->url_loader_network_observer = client_->Bind();
   }
   // Chromium filters headers using browser rules, while for net module we have
   // every header passed. The following setting will allow us to capture the
@@ -420,7 +580,7 @@ void SimpleURLLoaderWrapper::Start() {
       &SimpleURLLoaderWrapper::OnDownloadProgress, weak_cell));
 
   url_loader_factory_ = GetURLLoaderFactoryForURL(request_ref->url);
-  loader_->DownloadAsStream(url_loader_factory_.get(), this);
+  loader_->DownloadAsStream(url_loader_factory_.get(), client_.get());
 }
 
 SimpleURLLoaderWrapper::~SimpleURLLoaderWrapper() = default;
@@ -460,53 +620,21 @@ void SimpleURLLoaderWrapper::OnAuthRequired(
   Emit("login", auth_info, std::move(cb));
 }
 
-void SimpleURLLoaderWrapper::OnSSLCertificateError(
-    const GURL& url,
-    int net_error,
-    const net::SSLInfo& ssl_info,
-    bool fatal,
-    OnSSLCertificateErrorCallback response) {
-  std::move(response).Run(net_error);
-}
-
-void SimpleURLLoaderWrapper::OnClearSiteData(
-    const GURL& url,
-    const std::string& header_value,
-    int32_t load_flags,
-    const std::optional<net::CookiePartitionKey>& cookie_partition_key,
-    bool partitioned_state_allowed_only,
-    OnClearSiteDataCallback callback) {
-  std::move(callback).Run();
-}
-void SimpleURLLoaderWrapper::OnLoadingStateUpdate(
-    network::mojom::LoadInfoPtr info,
-    OnLoadingStateUpdateCallback callback) {
-  std::move(callback).Run();
-}
-
-void SimpleURLLoaderWrapper::OnSharedStorageHeaderReceived(
-    const url::Origin& request_origin,
-    std::vector<network::mojom::SharedStorageModifierMethodWithOptionsPtr>
-        methods,
-    const std::optional<std::string>& with_lock,
-    OnSharedStorageHeaderReceivedCallback callback) {
-  std::move(callback).Run();
-}
-
-void SimpleURLLoaderWrapper::Clone(
-    mojo::PendingReceiver<network::mojom::URLLoaderNetworkServiceObserver>
-        observer) {
-  url_loader_network_observer_receivers_.Add(this, std::move(observer));
-}
-
-void SimpleURLLoaderWrapper::OnPlatformLocalNetworkPermissionRequired(
-    OnPlatformLocalNetworkPermissionRequiredCallback callback) {
-  std::move(callback).Run(false);
+void SimpleURLLoaderWrapper::OnCertificateRequested(
+    const std::optional<base::UnguessableToken>& window_id,
+    const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
+    mojo::PendingRemote<network::mojom::ClientCertificateResponder>
+        client_cert_responder) {
+  // This line does not route client certificate requests to the app
+  // (select-client-certificate for net requests landed in 44); keep the
+  // observer's previous no-op behaviour.
 }
 
 void SimpleURLLoaderWrapper::Cancel() {
   loader_.reset();
   url_loader_factory_.reset();
+  if (chunk_pipe_getter_)
+    chunk_pipe_getter_->Abort();
   keep_alive_.Clear();
   // This ensures that no further callbacks will be called, so there's no need
   // for additional guards.
@@ -756,6 +884,8 @@ void SimpleURLLoaderWrapper::OnComplete(bool success) {
   }
   loader_.reset();
   url_loader_factory_.reset();
+  if (chunk_pipe_getter_)
+    chunk_pipe_getter_->Abort();
   keep_alive_.Clear();
 }
 

--- a/shell/common/api/electron_api_url_loader.h
+++ b/shell/common/api/electron_api_url_loader.h
@@ -10,19 +10,15 @@
 #include <string_view>
 #include <vector>
 
-#include "base/byte_size.h"
 #include "base/memory/raw_ptr.h"
 #include "base/sequence_checker.h"
 #include "gin/weak_cell.h"
 #include "gin/wrappable.h"
-#include "mojo/public/cpp/bindings/receiver_set.h"
-#include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom-forward.h"
 #include "services/network/public/mojom/url_loader_network_service_observer.mojom.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "shell/browser/event_emitter_mixin.h"
-#include "shell/common/gc_plugin.h"
 #include "shell/common/gin_helper/self_keep_alive.h"
 #include "url/gurl.h"
 #include "v8/include/cppgc/member.h"
@@ -49,13 +45,12 @@ class ElectronBrowserContext;
 namespace electron::api {
 
 class JSChunkedDataPipeGetter;
+class SimpleURLLoaderClient;
 
 /** Wraps a SimpleURLLoader to make it usable from JavaScript */
 class SimpleURLLoaderWrapper final
     : public gin::Wrappable<SimpleURLLoaderWrapper>,
-      public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper>,
-      private network::SimpleURLLoaderStreamConsumer,
-      private network::mojom::URLLoaderNetworkServiceObserver {
+      public gin_helper::EventEmitterMixin<SimpleURLLoaderWrapper> {
  public:
   ~SimpleURLLoaderWrapper() override;
   static SimpleURLLoaderWrapper* Create(gin::Arguments* args);
@@ -77,13 +72,11 @@ class SimpleURLLoaderWrapper final
                          JSChunkedDataPipeGetter* chunk_pipe_getter);
 
  private:
-  // SimpleURLLoaderStreamConsumer:
-  void OnDataReceived(std::string_view string_view,
-                      base::OnceClosure resume) override;
-  void OnComplete(bool success) override;
-  void OnRetry(base::OnceClosure start_retry) override {}
+  friend class SimpleURLLoaderClient;
 
-  // network::mojom::URLLoaderNetworkServiceObserver:
+  void OnDataReceived(std::string_view string_view, base::OnceClosure resume);
+  void OnComplete(bool success);
+
   void OnAuthRequired(
       const std::optional<base::UnguessableToken>& window_id,
       int32_t request_id,
@@ -92,55 +85,12 @@ class SimpleURLLoaderWrapper final
       const net::AuthChallengeInfo& auth_info,
       const scoped_refptr<net::HttpResponseHeaders>& head_headers,
       mojo::PendingRemote<network::mojom::AuthChallengeResponder>
-          auth_challenge_responder) override;
-  void OnSSLCertificateError(const GURL& url,
-                             int net_error,
-                             const net::SSLInfo& ssl_info,
-                             bool fatal,
-                             OnSSLCertificateErrorCallback response) override;
+          auth_challenge_responder);
   void OnCertificateRequested(
       const std::optional<base::UnguessableToken>& window_id,
       const scoped_refptr<net::SSLCertRequestInfo>& cert_info,
       mojo::PendingRemote<network::mojom::ClientCertificateResponder>
-          client_cert_responder) override {}
-  void OnLocalNetworkAccessPermissionRequired(
-      network::mojom::TransportType transport_type,
-      network::mojom::IPAddressSpace ip_address_space,
-      OnLocalNetworkAccessPermissionRequiredCallback callback) override {}
-  void OnPlatformLocalNetworkPermissionRequired(
-      OnPlatformLocalNetworkPermissionRequiredCallback callback) override;
-  void OnClearSiteData(
-      const GURL& url,
-      const std::string& header_value,
-      int32_t load_flags,
-      const std::optional<net::CookiePartitionKey>& cookie_partition_key,
-      bool partitioned_state_allowed_only,
-      OnClearSiteDataCallback callback) override;
-  void OnLoadingStateUpdate(network::mojom::LoadInfoPtr info,
-                            OnLoadingStateUpdateCallback callback) override;
-  void OnSharedStorageHeaderReceived(
-      const url::Origin& request_origin,
-      std::vector<network::mojom::SharedStorageModifierMethodWithOptionsPtr>
-          methods,
-      const std::optional<std::string>& with_lock,
-      OnSharedStorageHeaderReceivedCallback callback) override;
-  void OnDataUseUpdate(int32_t network_traffic_annotation_id_hash,
-                       base::ByteSize recv_bytes,
-                       base::ByteSize sent_bytes) override {}
-  void OnWebSocketConnectedToLocalNetwork(
-      const GURL& request_url,
-      network::mojom::IPAddressSpace ip_address_space) override {}
-  void Clone(
-      mojo::PendingReceiver<network::mojom::URLLoaderNetworkServiceObserver>
-          observer) override;
-  void OnUrlLoaderConnectedToLocalNetwork(
-      const GURL& request_url,
-      network::mojom::IPAddressSpace response_address_space,
-      network::mojom::IPAddressSpace client_address_space,
-      network::mojom::IPAddressSpace target_address_space) override {}
-  void OnAdAuctionEventRecordHeaderReceived(
-      network::AdAuctionEventRecord event_record,
-      const std::optional<url::Origin>& top_frame_origin) override {}
+          client_cert_responder);
 
   scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactoryForURL(
       const GURL& url);
@@ -162,12 +112,9 @@ class SimpleURLLoaderWrapper final
   int request_options_;
   std::unique_ptr<network::ResourceRequest> request_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  // The client receives callbacks from |loader_| and must outlive it.
+  std::unique_ptr<SimpleURLLoaderClient> client_;
   std::unique_ptr<network::SimpleURLLoader> loader_;
-
-  GC_PLUGIN_IGNORE(
-      "Context tracking of receivers is not needed in the browser process.")
-  mojo::ReceiverSet<network::mojom::URLLoaderNetworkServiceObserver>
-      url_loader_network_observer_receivers_;
   cppgc::Member<JSChunkedDataPipeGetter> chunk_pipe_getter_;
   gin_helper::SelfKeepAlive<SimpleURLLoaderWrapper> keep_alive_{this};
   gin::WeakCellFactory<SimpleURLLoaderWrapper> weak_factory_{this};

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1,4 +1,4 @@
-import { net, session, ClientRequest, ClientRequestConstructorOptions, utilityProcess } from 'electron/main';
+import { net, protocol, session, ClientRequest, ClientRequestConstructorOptions, utilityProcess } from 'electron/main';
 
 import { expect } from 'chai';
 
@@ -764,6 +764,154 @@ describe('net module', () => {
         await p;
         expect(requestReceivedByServer).to.equal(true);
         expect(requestAbortEventEmitted).to.equal(true);
+      });
+
+      it('should settle a pending upload stream read in a protocol handler when the request is aborted', async () => {
+        // A protocol handler that reads the chunked upload body slowly and
+        // never responds; the read it parks must not be left pending forever
+        // once the request is torn down.
+        let pendingRead: Promise<number> | undefined;
+        const reached = new Promise<void>((resolve, reject) => {
+          protocol.interceptStreamProtocol('http', (request, callback) => {
+            (async () => {
+              const streamElement = (request.uploadData || []).find((e: any) => e.type === 'stream');
+              if (!streamElement) {
+                callback({ statusCode: 400, data: null as any });
+                reject(new Error('request had no stream upload element'));
+                return;
+              }
+              const body: any = (streamElement as any).body;
+              // Drain the chunk that was already written, then park a read.
+              await body.read(new Uint8Array(1024));
+              pendingRead = body.read(new Uint8Array(1024));
+              resolve();
+            })();
+          });
+        });
+        defer(() => protocol.uninterceptProtocol('http'));
+
+        const urlRequest = net.request({ method: 'POST', url: 'http://pending-upload-read' });
+        urlRequest.on('error', () => {});
+        urlRequest.chunkedEncoding = true;
+        urlRequest.write('hello');
+        await reached;
+
+        const aborted = once(urlRequest, 'abort');
+        urlRequest.abort();
+        await aborted;
+        await expect(pendingRead).to.eventually.be.rejectedWith('ERR_FAILED');
+      });
+
+      it('should preserve the request error when settling a pending upload stream read', async () => {
+        let failRequest: (() => void) | undefined;
+        let pendingRead: Promise<number> | undefined;
+        const reached = new Promise<void>((resolve, reject) => {
+          protocol.interceptStreamProtocol('http', (request, callback) => {
+            failRequest = () => callback({ error: -2 } as any);
+            (async () => {
+              const streamElement = (request.uploadData || []).find((e: any) => e.type === 'stream');
+              if (!streamElement) {
+                callback({ statusCode: 400, data: null as any });
+                reject(new Error('request had no stream upload element'));
+                return;
+              }
+              const body: any = (streamElement as any).body;
+              await body.read(new Uint8Array(1024));
+              pendingRead = body.read(new Uint8Array(1024));
+              resolve();
+            })().catch(reject);
+          });
+        });
+        defer(() => protocol.uninterceptProtocol('http'));
+
+        const urlRequest = net.request({ method: 'POST', url: 'http://failed-pending-upload-read' });
+        urlRequest.on('error', () => {});
+        urlRequest.chunkedEncoding = true;
+        urlRequest.write('hello');
+        await reached;
+
+        const readError = expect(pendingRead).to.eventually.be.rejectedWith('ERR_FAILED');
+        failRequest!();
+        await readError;
+      });
+
+      it('should settle an in-flight upload write when the response completes early', async () => {
+        let completeRequest: (() => void) | undefined;
+        const reached = new Promise<void>((resolve, reject) => {
+          protocol.interceptStreamProtocol('http', (request, callback) => {
+            completeRequest = () => callback({ statusCode: 200, data: null as any });
+            const streamElement = (request.uploadData || []).find((e: any) => e.type === 'stream');
+            if (!streamElement) {
+              callback({ statusCode: 400, data: null as any });
+              reject(new Error('request had no stream upload element'));
+              return;
+            }
+            const body: any = (streamElement as any).body;
+            body.read(new Uint8Array(1)).then(() => resolve(), reject);
+          });
+        });
+        defer(() => protocol.uninterceptProtocol('http'));
+
+        const urlRequest = net.request({ method: 'POST', url: 'http://early-upload-response' });
+        urlRequest.on('error', () => {});
+        urlRequest.chunkedEncoding = true;
+        const responseReceived = once(urlRequest, 'response');
+        let writeCallbackCalled = false;
+        const writeCompleted = new Promise<Error | undefined>((resolve) => {
+          urlRequest.write(Buffer.alloc(4 * kOneMegaByte), 'buffer', (error?: Error | null) => {
+            writeCallbackCalled = true;
+            resolve(error || undefined);
+          });
+        });
+        await reached;
+        expect(writeCallbackCalled).to.equal(false);
+
+        completeRequest!();
+        const [response] = await responseReceived;
+        await collectStreamBody(response);
+        const writeError = await writeCompleted;
+        expect(writeError).to.be.an.instanceOf(Error);
+        expect(writeError!.message).to.contain('ERR_ABORTED');
+      });
+
+      it('should settle an in-flight upload write when the request is aborted', async () => {
+        const reached = new Promise<void>((resolve, reject) => {
+          protocol.interceptStreamProtocol('http', (request, callback) => {
+            const streamElement = (request.uploadData || []).find((element: any) => element.type === 'stream');
+            if (!streamElement) {
+              callback({ statusCode: 400, data: null as any });
+              reject(new Error('request had no stream upload element'));
+              return;
+            }
+            const body: any = (streamElement as any).body;
+            body.read(new Uint8Array(1)).then(() => resolve(), reject);
+          });
+        });
+        defer(() => protocol.uninterceptProtocol('http'));
+
+        const urlRequest = net.request({ method: 'POST', url: 'http://aborted-upload-write' });
+        urlRequest.on('error', () => {
+          expect.fail('Unexpected error event');
+        });
+        urlRequest.chunkedEncoding = true;
+        let writeCallbackCalled = false;
+        const writeCompleted = new Promise<Error | undefined>((resolve) => {
+          urlRequest.write(Buffer.alloc(4 * kOneMegaByte), 'buffer', (error?: Error | null) => {
+            writeCallbackCalled = true;
+            resolve(error || undefined);
+          });
+        });
+        await reached;
+        expect(writeCallbackCalled).to.equal(false);
+
+        const aborted = once(urlRequest, 'abort');
+        urlRequest.abort();
+        await aborted;
+        // Like Node.js, which settles a write cancelled by abort() with an
+        // error (ECANCELED); the request itself emits 'abort', not 'error'.
+        const writeError = await writeCompleted;
+        expect(writeError).to.be.an.instanceOf(Error);
+        expect(writeError!.message).to.contain('ERR_ABORTED');
       });
 
       test('it should be able to abort an HTTP request after request end and before response', async () => {

--- a/spec/cpp-heap-spec.ts
+++ b/spec/cpp-heap-spec.ts
@@ -551,7 +551,12 @@ describe('cpp heap', () => {
             rejectReached = reject;
           });
 
+          // The handler deliberately never responds. Hold on to `callback`: the
+          // native side only references it weakly, and if the GC loops below
+          // collect it the request fails with ERR_FAILED before `request.end()`
+          // and the test would then be measuring a dead request.
           protocol.interceptStreamProtocol('http', (request: any, callback: any) => {
+            (globalThis as any).heldInterceptCallback = callback;
             (async () => {
               try {
                 const elements = request.uploadData || [];
@@ -622,6 +627,7 @@ describe('cpp heap', () => {
             request.abort();
             return { ok: false, error: String(err) };
           } finally {
+            delete (globalThis as any).heldInterceptCallback;
             protocol.uninterceptProtocol('http');
             setTimeout(() => app.quit());
           }


### PR DESCRIPTION
Backport of #53341

See that PR for details. Differences from `main`: the observer overrides Chromium 153 removed (`OnSharedStorageHeaderReceived`, `OnAdAuctionEventRecordHeaderReceived`) are kept on the new `SimpleURLLoaderClient` since this line's Chromium still has them, and `OnCertificateRequested` stays the no-op it always was here because the net `select-client-certificate` support (#52162) is not on 43-x-y.

Notes: Fixed a pending read on a `net.request` chunked upload stream inside a protocol handler never settling when the request failed or was aborted.
