### PR TITLE
fix: ignore missing webRequest auth state

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -924,7 +924,8 @@ void WebRequest::OnLoginAuthResult(
     net::AuthCredentials* credentials,
     const std::optional<net::AuthCredentials>& maybe_creds) {
   auto nh = blocked_requests_.extract(id);
-  CHECK(nh);
+  if (!nh)
+    return;
 
   AuthRequiredResponse action =
       AuthRequiredResponse::AUTH_REQUIRED_RESPONSE_NO_ACTION;


### PR DESCRIPTION
#### Description of Change

`WebRequest::OnLoginAuthResult` currently terminates the process when its pending request entry is absent. The other asynchronous `webRequest` result handlers treat missing state as a no-op, because request cleanup may already have removed it.

This changes the authentication result handler to follow the same behavior. Valid authentication results are unchanged.

This is deliberately a minimal draft. A deterministic fail-before reproduction for the missing-state path has not yet been identified, so the draft is not ready for review.

AI disclosure: OpenAI Codex assisted with analyzing the callback lifecycle, reducing the change, formatting it, and preparing this draft.

#### Testing

- `clang-format --dry-run --Werror --lines=920:935 shell/browser/api/electron_api_web_request.cc`
- `git diff --check`

Not yet run:

- Native build
- `npm test`
- Fail-before regression test

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when a `webRequest` authentication result arrived after its request state was cleared.
