### PR TITLE
test: stop asserting inside stdio listeners in the utilityProcess spec

### DIFF
--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -1,0 +1,25 @@
+# Writing specs
+
+## Child processes and stdio
+
+- Never call `expect()` inside a stream or event listener (`'data'`, `'message'`,
+  `'exit'`). A failing assertion there is an uncaught exception, not a test
+  failure: the spec runner exits with no summary and no JUnit file, and the whole
+  shard goes red with nothing to point at. Collect what you need in the listener,
+  and assert in the test body after `await`ing whatever you are waiting for.
+- Wait for the output you expect, not for `'exit'`. `utilityProcess` drops its
+  stdio listeners the moment the child exits, so a chunk still in the pipe when
+  `'exit'` fires is lost. Accumulate output until the expected pattern appears
+  (see `outputUntil` in `api-utility-process-spec.ts`), then assert on it.
+- Don't assert on the first chunk from a pipe. stdout and stderr race, and a
+  stray warning on stderr (a `net/dns` config warning, a GPU message) can land
+  before the line you want. Match a pattern against the accumulated output.
+- Register every forked child with `deferKillUtilityProcess` (or `defer` a kill
+  for `child_process` children) right after creating it. If the expected output
+  never arrives the test fails on mocha's timeout and the code path that would
+  have killed the child is never reached; the global `afterEach` then reaps it.
+  A leaked child holds its ports (`--inspect=<port>`) and breaks the in-job
+  retry of the same test.
+- Only kill a child that is still running (`child.pid` is set). Killing and then
+  `await once(child, 'exit')` on a child that already exited hangs until the
+  test times out.

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -512,8 +512,11 @@ describe('utilityProcess module', () => {
 
   describe('behavior', () => {
     // Collects the child's stdout and stderr until `pattern` appears, then
-    // kills it and waits for it to exit. Nothing asserts inside a stream
-    // listener: a failing expect() there is an uncaught exception that takes
+    // stops the child (if it has not already exited on its own) and waits for
+    // it to go. The wait is driven by the output, not by 'exit': the stdio
+    // listeners are dropped when the child exits, so a chunk still in the pipe
+    // at that point would be lost. Nothing asserts inside a stream listener
+    // either; a failing expect() there is an uncaught exception that takes
     // the whole spec runner down instead of failing one test.
     const outputUntil = async (child: Electron.UtilityProcess, pattern: RegExp) => {
       let output = '';
@@ -525,8 +528,11 @@ describe('utilityProcess module', () => {
         child.stderr!.on('data', listener);
         child.stdout!.on('data', listener);
       });
-      child.kill();
-      await once(child, 'exit');
+      if (child.pid) {
+        const exit = once(child, 'exit');
+        child.kill();
+        await exit;
+      }
       return output;
     };
 
@@ -546,8 +552,6 @@ describe('utilityProcess module', () => {
         stdio: 'pipe',
         execArgv: ['--inspect=17364']
       });
-      // If the expected output never arrives the test fails on mocha's timeout
-      // without reaching kill(); let the global afterEach reap the child then.
       deferKillUtilityProcess(child);
       const output = await outputUntil(child, /Debugger listening on ws:/m);
       expect(output).to.contain(':17364', 'should be listening on port 17364');
@@ -558,20 +562,10 @@ describe('utilityProcess module', () => {
         stdio: 'pipe',
         execArgv: ['--dns-result-order=ipv4first']
       });
-      // If the expected output never arrives the test fails on mocha's timeout
-      // without reaching kill(); let the global afterEach reap the child then.
       deferKillUtilityProcess(child);
-
-      // The fixture prints dns.getDefaultResultOrder() to stdout and exits on
-      // its own, so wait for that rather than asserting on whichever pipe
-      // delivers first; a stray warning on stderr used to win that race.
-      let output = '';
-      child.stdout!.on('data', (data: Buffer) => {
-        output += data;
-      });
-      const [code] = await once(child, 'exit');
-      expect(code).to.equal(0);
-      expect(output.trim()).to.equal('ipv4first');
+      // The fixture prints dns.getDefaultResultOrder() and exits on its own.
+      const output = await outputUntil(child, /ipv4first|verbatim/);
+      expect(output).to.contain('ipv4first', 'default verbatim should be ipv4first');
     });
 
     ifit(process.platform !== 'win32')('supports redirecting stdout to parent process', async () => {

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -511,85 +511,58 @@ describe('utilityProcess module', () => {
   });
 
   describe('behavior', () => {
-    it('supports starting the v8 inspector with --inspect-brk', (done) => {
+    // Collects the child's stdout and stderr until `pattern` appears, then
+    // kills it and waits for it to exit. Nothing asserts inside a stream
+    // listener: a failing expect() there is an uncaught exception that takes
+    // the whole spec runner down instead of failing one test.
+    const outputUntil = async (child: Electron.UtilityProcess, pattern: RegExp) => {
+      let output = '';
+      await new Promise<void>((resolve) => {
+        const listener = (data: Buffer) => {
+          output += data;
+          if (pattern.test(output)) resolve();
+        };
+        child.stderr!.on('data', listener);
+        child.stdout!.on('data', listener);
+      });
+      child.kill();
+      await once(child, 'exit');
+      return output;
+    };
+
+    it('supports starting the v8 inspector with --inspect-brk', async () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'log.js'), [], {
         stdio: 'pipe',
         execArgv: ['--inspect-brk']
       });
-
-      let output = '';
-      const cleanup = () => {
-        child.stderr!.removeListener('data', listener);
-        child.stdout!.removeListener('data', listener);
-        child.once('exit', () => {
-          done();
-        });
-        child.kill();
-      };
-
-      const listener = (data: Buffer) => {
-        output += data;
-        if (/Debugger listening on ws:/m.test(output)) {
-          cleanup();
-        }
-      };
-
-      child.stderr!.on('data', listener);
-      child.stdout!.on('data', listener);
+      await outputUntil(child, /Debugger listening on ws:/m);
     });
 
-    it('supports starting the v8 inspector with --inspect and a provided port', (done) => {
+    it('supports starting the v8 inspector with --inspect and a provided port', async () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'log.js'), [], {
         stdio: 'pipe',
         execArgv: ['--inspect=17364']
       });
-
-      let output = '';
-      const cleanup = () => {
-        child.stderr!.removeListener('data', listener);
-        child.stdout!.removeListener('data', listener);
-        child.once('exit', () => {
-          done();
-        });
-        child.kill();
-      };
-
-      const listener = (data: Buffer) => {
-        output += data;
-        if (/Debugger listening on ws:/m.test(output)) {
-          expect(output.trim()).to.contain(':17364', 'should be listening on port 17364');
-          cleanup();
-        }
-      };
-
-      child.stderr!.on('data', listener);
-      child.stdout!.on('data', listener);
+      const output = await outputUntil(child, /Debugger listening on ws:/m);
+      expect(output).to.contain(':17364', 'should be listening on port 17364');
     });
 
-    it('supports changing dns verbatim with --dns-result-order', (done) => {
+    it('supports changing dns verbatim with --dns-result-order', async () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'dns-result-order.js'), [], {
         stdio: 'pipe',
         execArgv: ['--dns-result-order=ipv4first']
       });
 
+      // The fixture prints dns.getDefaultResultOrder() to stdout and exits on
+      // its own, so wait for that rather than asserting on whichever pipe
+      // delivers first; a stray warning on stderr used to win that race.
       let output = '';
-      const cleanup = () => {
-        child.stderr!.removeListener('data', listener);
-        child.stdout!.removeListener('data', listener);
-        child.once('exit', () => {
-          done();
-        });
-        child.kill();
-      };
-
-      const listener = (data: Buffer) => {
+      child.stdout!.on('data', (data: Buffer) => {
         output += data;
-        expect(output.trim()).to.contain('ipv4first', 'default verbatim should be ipv4first');
-        cleanup();
-      };
-
-      child.stderr!.on('data', listener);
-      child.stdout!.on('data', listener);
+      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
+      expect(output.trim()).to.equal('ipv4first');
     });
 
     ifit(process.platform !== 'win32')('supports redirecting stdout to parent process', async () => {

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -13,7 +13,7 @@ import { setImmediate } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
 import { respondOnce, randomString, kOneKiloByte } from './lib/net-helpers';
-import { ifit, listen, startRemoteControlApp } from './lib/spec-helpers';
+import { deferKillUtilityProcess, ifit, listen, startRemoteControlApp } from './lib/spec-helpers';
 import { closeWindow } from './lib/window-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures', 'api', 'utility-process');
@@ -535,6 +535,9 @@ describe('utilityProcess module', () => {
         stdio: 'pipe',
         execArgv: ['--inspect-brk']
       });
+      // If the expected output never arrives the test fails on mocha's timeout
+      // without reaching kill(); let the global afterEach reap the child then.
+      deferKillUtilityProcess(child);
       await outputUntil(child, /Debugger listening on ws:/m);
     });
 
@@ -543,6 +546,9 @@ describe('utilityProcess module', () => {
         stdio: 'pipe',
         execArgv: ['--inspect=17364']
       });
+      // If the expected output never arrives the test fails on mocha's timeout
+      // without reaching kill(); let the global afterEach reap the child then.
+      deferKillUtilityProcess(child);
       const output = await outputUntil(child, /Debugger listening on ws:/m);
       expect(output).to.contain(':17364', 'should be listening on port 17364');
     });
@@ -552,6 +558,9 @@ describe('utilityProcess module', () => {
         stdio: 'pipe',
         execArgv: ['--dns-result-order=ipv4first']
       });
+      // If the expected output never arrives the test fails on mocha's timeout
+      // without reaching kill(); let the global afterEach reap the child then.
+      deferKillUtilityProcess(child);
 
       // The fixture prints dns.getDefaultResultOrder() to stdout and exits on
       // its own, so wait for that rather than asserting on whichever pipe


### PR DESCRIPTION
#### Description of Change

- Three `utilityProcess` tests attached one `'data'` listener to both stdout and stderr of a child and called `expect()` inside it. A failing `expect` in a stream listener is an uncaught exception, so the spec runner exits with no summary and no JUnit file rather than reporting one red test. That is what took down the mac shard on [this run](https://github.com/electron/electron/actions/runs/33526360804/job/99930795371): a `net/dns` "Failed to read DnsConfig" warning on stderr beat the fixture's stdout to the `--dns-result-order` test's first chunk.
- The dns test now reads stdout only and asserts after the fixture exits, since the fixture prints one line and exits on its own.
- The two `--inspect` tests collect output until the inspector's "Debugger listening" line appears, kill the child, wait for exit, and assert afterwards.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
