### PR TITLE
fix: crash with objectTemplate exhaustion from sending ipc messages

### DIFF
--- a/shell/common/gin_converters/frame_converter.cc
+++ b/shell/common/gin_converters/frame_converter.cc
@@ -4,12 +4,15 @@
 
 #include "shell/common/gin_converters/frame_converter.h"
 
+#include <cstdint>
+
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/common/gin_helper/accessor.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/node_util.h"
+#include "v8/include/v8-primitive.h"
 
 namespace gin {
 
@@ -55,19 +58,17 @@ Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::ToV8(
   if (!rfh)
     return v8::Null(isolate);
 
-  const int32_t process_id = rfh->GetProcess()->GetID().GetUnsafeValue();
-  const int routing_id = rfh->GetRoutingID();
+  // The two ids are packed into a BigInt rather than stored in the internal
+  // fields of an object because building such an object requires an
+  // ObjectTemplate and caching via gin::PerContextData which is not
+  // necessary here as the token never reaches JS, it is only the payload
+  // of the native data property installed by gin_helper::Dictionary::SetGetter.
+  const uint64_t token = (static_cast<uint64_t>(static_cast<uint32_t>(
+                              rfh->GetProcess()->GetID().GetUnsafeValue()))
+                          << 32) |
+                         static_cast<uint32_t>(rfh->GetRoutingID());
 
-  v8::Local<v8::ObjectTemplate> templ = v8::ObjectTemplate::New(isolate);
-  templ->SetInternalFieldCount(2);
-
-  v8::Local<v8::Object> rfh_obj =
-      templ->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
-
-  rfh_obj->SetInternalField(0, v8::Number::New(isolate, process_id));
-  rfh_obj->SetInternalField(1, v8::Number::New(isolate, routing_id));
-
-  return rfh_obj;
+  return v8::BigInt::NewFromUnsigned(isolate, token);
 }
 
 // static
@@ -75,24 +76,19 @@ bool Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     gin_helper::AccessorValue<content::RenderFrameHost*>* out) {
-  v8::Local<v8::Object> rfh_obj;
-  if (!ConvertFromV8(isolate, val, &rfh_obj))
+  if (!val->IsBigInt())
     return false;
 
-  if (rfh_obj->InternalFieldCount() != 2)
+  bool lossless = false;
+  const uint64_t token = val.As<v8::BigInt>()->Uint64Value(&lossless);
+  if (!lossless)
     return false;
 
-  v8::Local<v8::Value> process_id_wrapper =
-      rfh_obj->GetInternalField(0).As<v8::Value>();
-  v8::Local<v8::Value> routing_id_wrapper =
-      rfh_obj->GetInternalField(1).As<v8::Value>();
-
-  if (process_id_wrapper.IsEmpty() || !process_id_wrapper->IsNumber() ||
-      routing_id_wrapper.IsEmpty() || !routing_id_wrapper->IsNumber())
-    return false;
-
-  const int process_id = process_id_wrapper.As<v8::Number>()->Value();
-  const int routing_id = routing_id_wrapper.As<v8::Number>()->Value();
+  // Both ids are signed (e.g. MSG_ROUTING_NONE), so go back
+  // through uint32_t to undo the packing before reinterpreting the sign bit.
+  const int process_id =
+      static_cast<int32_t>(static_cast<uint32_t>(token >> 32));
+  const int routing_id = static_cast<int32_t>(static_cast<uint32_t>(token));
 
   auto* rfh = content::RenderFrameHost::FromID(process_id, routing_id);
 

--- a/spec/api-ipc-spec.ts
+++ b/spec/api-ipc-spec.ts
@@ -6,7 +6,7 @@ import { EventEmitter, once } from 'node:events';
 import * as http from 'node:http';
 import * as path from 'node:path';
 
-import { defer, listen } from './lib/spec-helpers';
+import { defer, listen, startRemoteControlApp } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
@@ -1115,6 +1115,58 @@ describe('ipc module', () => {
       w.loadURL(`http://127.0.0.1:${port}`); // cross-origin navigation
       const [{ senderFrame }] = await onUnloadIpc;
       expect(senderFrame.detached).to.be.true();
+    });
+  });
+
+  describe('event frame accessors', () => {
+    it('does not create an ObjectTemplate for every message', async () => {
+      const { remotely } = await startRemoteControlApp(['--expose-internals']);
+      const { messageCount, templatesCreated } = await remotely(
+        async (heap: string) => {
+          const { BrowserWindow, ipcMain } = require('electron');
+          const { recordState } = require(heap);
+
+          const channel = 'ipc-object-template-test';
+          const messageCount = 50;
+
+          const countObjectTemplates = () =>
+            recordState().snapshot.filter((node: any) => node.name === 'system / ObjectTemplateInfo').length;
+
+          const retainedEvents: any[] = [];
+          (globalThis as any).retainedEvents = retainedEvents;
+
+          const w = new BrowserWindow({
+            show: false,
+            webPreferences: { nodeIntegration: true, contextIsolation: false }
+          });
+          const handler = (event: Electron.IpcMainEvent) => {
+            retainedEvents.push(event);
+            event.returnValue = undefined;
+          };
+
+          ipcMain.on(channel, handler);
+          try {
+            await w.loadURL('about:blank');
+            const send = (count: number) =>
+              w.webContents.executeJavaScript(`
+                for (let i = 0; i < ${count}; ++i) require('electron').ipcRenderer.sendSync('${channel}');
+              `);
+
+            await send(1);
+            const templatesBefore = countObjectTemplates();
+            await send(messageCount);
+            const templatesAfter = countObjectTemplates();
+
+            return { messageCount, templatesCreated: templatesAfter - templatesBefore };
+          } finally {
+            ipcMain.removeListener(channel, handler);
+            w.destroy();
+          }
+        },
+        path.join(__dirname, '../../third_party/electron_node/test/common/heap')
+      );
+
+      expect(templatesCreated).to.be.below(messageCount / 2);
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/53380

#### Release Notes

Notes: Fixed application crash after a large number of IPC messages from renderers.