### PR TITLE
docs: document the corsEnabled custom scheme privilege

### DIFF
--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -7,7 +7,13 @@
   * `bypassCSP` boolean (optional) - Default false.
   * `allowServiceWorkers` boolean (optional) - Default false.
   * `supportFetchAPI` boolean (optional) - Default false.
-  * `corsEnabled` boolean (optional) - Default false.
+  * `corsEnabled` boolean (optional) - Whether cross-origin requests to this
+    scheme are permitted. When true, responses served for the scheme are not
+    checked for `Access-Control-Allow-Origin`, so contents served over it are
+    readable from any origin, so only enable it for schemes whose contents are
+    safe to expose. When false, cross-origin requests from web contents fail
+    regardless of response headers; requests from the main process (e.g.
+    `net.fetch`) are unaffected. Default false.
   * `stream` boolean (optional) - Default false.
   * `codeCache` boolean (optional) - Enable V8 code cache for the scheme, only
     works when `standard` is also set to true. Default false.


### PR DESCRIPTION
#### Description of Change

`docs/api/structures/custom-scheme.md` described every entry of the `privileges` object except `corsEnabled`, whose name invites the opposite reading of its actual behavior. This adds the semantics asserted by `spec/api-protocol-spec.ts`:

- `corsEnabled: true` permits cross-origin requests to the scheme, and responses served for it are not validated for `Access-Control-Allow-Origin` — contents are readable from any origin.
- When false (the default), cross-origin requests from web contents fail regardless of response headers.
- Main-process requests (e.g. `net.fetch`) are unaffected either way.

Docs-only change. The security framing (only enable it for schemes whose contents are safe to expose) is included because the workaround text in GHSA-v3j7-r9gq-3gjw describes the flag in the opposite sense, as noted in #52498.

*Drafted with AI assistance and reviewed by the author.*

#### Checklist

<!-- Docs-only change: build/test items do not apply and were removed. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none