### PR TITLE
fix: treat NaN window opacity as fully opaque on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -8,6 +8,7 @@
 #include <objc/objc-runtime.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -1184,7 +1185,8 @@ void NativeWindowMac::InvalidateShadow() {
 }
 
 void NativeWindowMac::SetOpacity(const double opacity) {
-  const double boundedOpacity = std::clamp(opacity, 0.0, 1.0);
+  const double boundedOpacity =
+      std::isnan(opacity) ? 1.0 : std::clamp(opacity, 0.0, 1.0);
   [window_ setAlphaValue:boundedOpacity];
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3563,6 +3563,12 @@ describe('BrowserWindow module', () => {
       w.setOpacity(-100);
       expect(w.getOpacity()).to.equal(0.0);
     });
+
+    it('treats NaN opacity as fully opaque', () => {
+      const w = new BrowserWindow({ show: false, opacity: 0.5 });
+      w.setOpacity(Number.NaN);
+      expect(w.getOpacity()).to.equal(1.0);
+    });
   });
 
   describe('BrowserWindow.setShape(rects)', () => {


### PR DESCRIPTION
#### Description of Change

`BrowserWindow.setOpacity` on macOS used `std::clamp` only. `NaN` is not ordered, so clamp keeps `NaN` and `getOpacity()` returns `NaN`.

Windows/Linux already map `NaN` to `1.0` in `NativeWindowViews::SetOpacity`. The docs say opacity is between 0.0 and 1.0 and out-of-range values are clamped to `[0, 1]`.

This change uses the same `isnan → 1.0` rule on macOS.

#### Checklist

- [x] I have filled out the PR description
- [ ] I have built and tested this change
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed `BrowserWindow.setOpacity(NaN)` on macOS returning `NaN` from `getOpacity()` instead of treating it as fully opaque.
