### PR TITLE
docs: remove outdated Linux quirk documentation

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -38,7 +38,7 @@ app.whenReady().then(() => {
 
 * Tray icon uses [StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/)
   by default, when it is not available in user's desktop environment the
-  `GtkStatusIcon` will be used instead. If StatusNotifierItem is available, the first tray icon created will use SNI, while subsequently-created icons will use `GtkStatusIcon`.
+  `GtkStatusIcon` will be used instead.
 * The `click` event is emitted when the tray icon receives activation from
   user, however the StatusNotifierItem spec does not specify which action would
   cause an activation, for some environments it is left mouse click, but for


### PR DESCRIPTION
#### Description of Change

Due to upstream Chromium changes surrounding SNI that we pulled in (https://github.com/electron/electron/pull/53214), the quirk documented here no longer appears to be the case.

#### Checklist

- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none.
