### PR TITLE
fix: wrong line number and range from the macOS accessibility API in text fields

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -225,3 +225,4 @@ fix_systemd-escape_the_app_name_in_the_xdg_portal_scope_unit_name.patch
 cherry-pick-f4cb4a33442a.patch
 cherry-pick-6454cd98685d.patch
 cherry-pick-78fb4f541c61.patch
+cherry-pick-36ac8f31796a.patch

--- a/patches/chromium/cherry-pick-36ac8f31796a.patch
+++ b/patches/chromium/cherry-pick-36ac8f31796a.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rakhi Sharma <atbrakhi@igalia.com>
+Date: Wed, 22 Jul 2026 14:39:57 -0700
+Subject: Fix wrong line number and range when using macOS Accessibility in
+ text fields/areas
+
+When the caret was not at the beginning of a line, AXLineForIndex
+returned the wrong line number and AXRangeForLine failed to return the
+range for the current line.
+
+This patch makes AXLineForIndex return the line containing the caret
+index, and AXRangeForLine return the range for that same line. Also
+added a new test.
+
+Bug: 423048796
+Change-Id: Icc6bfd41f455b7372bacce888784f6b9afc34203
+AX-Relnotes: Fixes line number and line range returning wrong data when using macOS Accessibility in text fields/area
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8092671
+Reviewed-by: David Tseng <dtseng@chromium.org>
+Reviewed-by: Valerie Young <spectranaut@igalia.com>
+Commit-Queue: Rakhi Sharma <atbrakhi@igalia.com>
+Cr-Commit-Position: refs/heads/main@{#1666634}
+
+diff --git a/ui/accessibility/platform/ax_platform_node_cocoa.mm b/ui/accessibility/platform/ax_platform_node_cocoa.mm
+index 3d661db219278b20fe725c819deb040062cc5d7a..e0020501800a1f1f07ab952eebb45498389f1990 100644
+--- a/ui/accessibility/platform/ax_platform_node_cocoa.mm
++++ b/ui/accessibility/platform/ax_platform_node_cocoa.mm
+@@ -2574,12 +2574,8 @@ - (id)AXRangeForLine:(id)parameter {
+     return nil;
+   }
+ 
+-  int lineIndex = [lineNumber intValue];
+-  if (lineIndex != 0) {
+-    return nil;
+-  }
+-
+-  return [NSValue valueWithRange:[self accessibilityRangeForLine:lineIndex]];
++  return [NSValue
++      valueWithRange:[self accessibilityRangeForLine:[lineNumber intValue]]];
+ }
+ 
+ - (id)AXStringForRange:(id)parameter {
+diff --git a/ui/accessibility/platform/browser_accessibility_cocoa.mm b/ui/accessibility/platform/browser_accessibility_cocoa.mm
+index ad5f38a05615a613897c1151493ca6bdc64e8f01..2841ff2533c8facaa9bd9f771e6bea7898ac6126 100644
+--- a/ui/accessibility/platform/browser_accessibility_cocoa.mm
++++ b/ui/accessibility/platform/browser_accessibility_cocoa.mm
+@@ -1717,10 +1717,19 @@ - (NSString*)accessibilityStringForRange:(NSRange)range {
+ }
+ 
+ - (NSInteger)accessibilityLineForIndex:(NSInteger)index {
++  if (index < 0 ||
++      index >= static_cast<int>(_owner->GetValueForControl().size())) {
++    return NSNotFound;
++  }
++
+   const std::vector<int> lineStarts =
+       _owner->GetIntListAttribute(ax::mojom::IntListAttribute::kLineStarts);
+-  auto iterator = std::lower_bound(lineStarts.begin(), lineStarts.end(), index);
+-  return std::distance(lineStarts.begin(), iterator);
++  auto iterator = std::upper_bound(lineStarts.begin(), lineStarts.end(), index);
++  if (iterator == lineStarts.begin()) {
++    return 0;
++  }
++
++  return std::distance(lineStarts.begin(), iterator) - 1;
+ }
+ 
+ - (NSRange)accessibilityRangeForLine:(NSInteger)lineIndex {
+diff --git a/ui/accessibility/platform/inspect/ax_call_statement_invoker_mac.mm b/ui/accessibility/platform/inspect/ax_call_statement_invoker_mac.mm
+index c735d36d044551da5b3ee183bae3508f0ecb9abd..5ab48958ac0971f2433885054272a17561d3042f 100644
+--- a/ui/accessibility/platform/inspect/ax_call_statement_invoker_mac.mm
++++ b/ui/accessibility/platform/inspect/ax_call_statement_invoker_mac.mm
+@@ -486,7 +486,7 @@
+   }
+ 
+   // Otherwise parse argument node value.
+-  if (attribute == "AXLineForIndex" ||
++  if (attribute == "AXLineForIndex" || attribute == "AXRangeForLine" ||
+       attribute == "AXTextMarkerForIndex") {  // Int
+     return AXOptionalNSObject::NotNullOrError(PropertyNodeToInt(argument));
+   }


### PR DESCRIPTION
#### Description of Change

Cherry-picks Chromium [CL 8092671](https://chromium-review.googlesource.com/c/chromium/src/+/8092671) (crbug.com/423048796, shipped in Chromium 152 / Electron 44) to 43-x-y:

- `AXLineForIndex` used `lower_bound` over the line starts, so any caret not at the start of a line mapped to the following line. Now `upper_bound - 1`, with bounds checks.
- `AXRangeForLine` on the legacy parameterized-attribute path returned nil for every line except 0; it now forwards every line index to `accessibilityRangeForLine:`.

Only the product change is carried; the upstream browsertest and its data files are not built by Electron. Applied cleanly against 150.0.7871.250.

Closes #53403

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes

Notes: Fixed VoiceOver Braille displays showing the wrong line in multi-line text fields on macOS: `AXLineForIndex` and `AXRangeForLine` now return the line containing the caret.
