### PR TITLE
ci: ignore transient host resolution failure in audit

### DIFF
--- a/.github/workflows/audit-branch-ci.yml
+++ b/.github/workflows/audit-branch-ci.yml
@@ -90,6 +90,7 @@ jobs:
                       !message.startsWith("The action 'Run Electron Tests' has timed out") &&
                       !message.startsWith("The operation was canceled") &&
                       !message.startsWith("Canceling since") &&
+                      !/Could not resolve host/.test(message) &&
                       !/Unable to make request/.test(message) &&
                       !/The requested URL returned error/.test(message),
                   )


### PR DESCRIPTION
#### Description of Change

The audit has been tripped a few times now with a `curl: (6) Could not resolve host: formulae.brew.sh` failure on macOS, so lets ignore these. We only want the audit to surface real errors, not transient network ones.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description

#### Release Notes

Notes: none
