### PR TITLE
fix: avoid UB in menu.popup with frame from OSR window on macOS

### DIFF
--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -12,9 +12,8 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/task/current_thread.h"
 #include "base/task/sequenced_task_runner.h"
-#include "content/app_shim_remote_cocoa/render_widget_host_view_cocoa.h"  // nogncheck
-#include "content/browser/renderer_host/render_widget_host_view_mac.h"  // nogncheck
 #include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/render_widget_host_view.h"
 #include "gin/persistent.h"
 #include "shell/browser/api/electron_api_base_window.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
@@ -178,12 +177,9 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
 
   if (frame && frame->render_frame_host()) {
     auto* rfh = frame->render_frame_host()->GetOutermostMainFrameOrEmbedder();
-    if (rfh && rfh->IsRenderFrameLive()) {
-      auto* rwhvm =
-          static_cast<content::RenderWidgetHostViewMac*>(rfh->GetView());
-      RenderWidgetHostViewCocoa* cocoa_view = rwhvm->GetInProcessNSView();
-      view = cocoa_view;
-
+    auto* rwhv = rfh && rfh->IsRenderFrameLive() ? rfh->GetView() : nullptr;
+    NSView* frame_view = rwhv ? rwhv->GetNativeView().GetNativeNSView() : nil;
+    if (frame_view) {
       // TODO: ui::ShowContextMenu does not dispatch the event correctly
       // if no frame is found. Fix this to remove if/else condition.
       NSEvent* dummy_event =
@@ -196,7 +192,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
                           eventNumber:0
                            clickCount:1
                              pressure:0];
-      ui::ShowContextMenu(menu, dummy_event, view, true);
+      ui::ShowContextMenu(menu, dummy_event, frame_view, true);
       return;
     }
   }

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -927,6 +927,31 @@ describe('Menu module', function () {
       }
     });
 
+    it('does not crash with an offscreen frame', async () => {
+      const osrWindow = new BrowserWindow({
+        show: false,
+        width: 200,
+        height: 200,
+        webPreferences: {
+          offscreen: true
+        }
+      });
+
+      try {
+        await osrWindow.loadURL('about:blank');
+
+        const menuWillShow = once(menu, 'menu-will-show');
+        menu.popup({ window: osrWindow, frame: osrWindow.webContents.mainFrame });
+        await menuWillShow;
+
+        const menuWillClose = once(menu, 'menu-will-close');
+        menu.closePopup(osrWindow);
+        await menuWillClose;
+      } finally {
+        await closeWindow(osrWindow, { assertNotWindows: false });
+      }
+    });
+
     // https://github.com/electron/electron/issues/35724
     // Maximizing window is enough to trigger the bug
     // FIXME(dsanders11): Test always passes on CI, even pre-fix


### PR DESCRIPTION
Backport of #53242.

See that PR for details.

Notes: Fixed a potential crash when using `menu.popup` with a frame from an offscreen rendered window