### PR TITLE
docs: clarify child (helper) entitlements for MAS builds — sandbox vs. hardened-runtime JIT keys

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -282,6 +282,56 @@ signAsync({
 })
 ```
 
+#### Child (helper) entitlements: sandbox vs. hardened-runtime keys
+
+When using the App Sandbox together with the hardened runtime (required for
+MAS), helper processes need care with **two different kinds** of entitlements.
+Confusing them is a common cause of helpers crashing at startup with
+`EXC_BREAKPOINT` on macOS.
+
+- **Sandbox-resource entitlements** (`com.apple.security.network.*`,
+  `com.apple.security.files.*`, `com.apple.security.automation.*`, ...) belong
+  to the App Sandbox layer. Helpers signed with `com.apple.security.inherit`
+  **inherit** these from the main app. Do **not** re-declare them on the
+  helper — duplicating them makes the helper crash in
+  `_libsecinit_appsandbox` during early `dyld` startup.
+
+- **Hardened-runtime (code-signing) entitlements** — most importantly the V8
+  JIT triple `com.apple.security.cs.allow-jit`,
+  `com.apple.security.cs.allow-unsigned-executable-memory`, and
+  `com.apple.security.cs.disable-library-validation` — are **per-process and
+  are NOT inherited** through sandbox `inherit`. Any helper that runs V8
+  (Electron's renderer/GPU/utility helpers) must carry these itself, or it
+  crashes in `v8::Isolate::Initialize`.
+
+A minimal child (helper) entitlements file for a MAS build therefore looks
+like:
+
+```xml title='child-entitlements.plist'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+> Symptom guide: a helper crashing in `_libsecinit_appsandbox` usually means a
+> duplicated sandbox-resource key; a helper crashing in
+> `v8::Isolate::Initialize` usually means a missing hardened-runtime JIT key.
+> Symbolicate the report with `@electron/symbolicate-mac` to confirm before
+> changing entitlements.
+
 #### Network access
 
 Enable outgoing network connections to allow your app to connect to a server:


### PR DESCRIPTION
#### Description of Change

Adds a "Child (helper) entitlements" subsection to the Mac App Store Submission
Guide's "Additional entitlements" section, clarifying the difference between
two kinds of entitlements that are easy to confuse:

- **Sandbox-resource** keys (`network.*`, `files.*`, `automation.*`) are
  inherited by helpers via `com.apple.security.inherit` and must NOT be
  re-declared on the helper (doing so crashes `_libsecinit_appsandbox`).
- **Hardened-runtime JIT** keys (`cs.allow-jit`,
  `cs.allow-unsigned-executable-memory`, `cs.disable-library-validation`) are
  per-process, are NOT inherited, and must be kept on any helper that runs V8
  (removing them crashes `v8::Isolate::Initialize`).

It also adds a minimal correct child-entitlements plist and a short
symptom→cause guide. The current guide shows a child entitlements file with
only `app-sandbox` + `inherit` (in the collapsed "Extra steps without
`@electron/osx-sign`" block), which is correct for pure sandbox permissions
but leaves these two common real-world crashes undocumented. This bit us in
production on macOS 26 (MAS build, `EXC_BREAKPOINT` at startup) and was only
resolved by separating the two entitlement kinds. Documentation only; no code
changes.

#### Checklist

- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none
