### PR TITLE
ci: don't fail the macOS build when Homebrew can't reach its API during cleanup

### DIFF
--- a/.github/actions/free-space-macos/action.yml
+++ b/.github/actions/free-space-macos/action.yml
@@ -104,8 +104,9 @@ runs:
 
         # remove homebrew packages we don't need
         if command -v brew &> /dev/null; then
-          brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 gcc@15 llvm@18 gradle maven ant azure-cli bazel
-          brew autoremove
+          # Best-effort: brew fetches formulae.brew.sh metadata even to uninstall, and a DNS blip there must not fail the build (the rm -rf above is the real reclaim).
+          brew uninstall -f --zap aws-sam-cli session-manager-plugin gcc gcc@13 gcc@14 gcc@15 llvm@18 gradle maven ant azure-cli bazel || true
+          brew autoremove || true
         fi
 
         # lipo off some huge binaries arm64 versions to save space


### PR DESCRIPTION
#### Description of Change

The macOS free-space action uninstalls a handful of Homebrew packages to reclaim disk before the build. `brew uninstall` / `brew autoremove` still fetch formula metadata from formulae.brew.sh, so when a hosted runner had a DNS blip the cleanup step exited 1 and took the whole macOS build job with it (this is what failed `main` on 2026-08-29: `curl: (6) Could not resolve host: formulae.brew.sh`).

The `rm -rf` lines above do the real reclaiming; the brew portion is a few GB of nice-to-have. This makes the two brew commands best-effort so a network hiccup there can't fail a build. The step itself stays required.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
