### PR TITLE
ci: use a download-artifact fork that doesn't parse the event file at import

### DIFF
--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -202,6 +202,12 @@ jobs:
     # node_modules, ./depot_tools, ./generated_artifacts_*, ./src_artifacts_*,
     # system CUPS state) and none reads another's output; the env/PATH changes
     # they make are only consumed after the group's implicit wait.
+    # The download steps use a fork of actions/download-artifact: the runner
+    # rewrites $GITHUB_EVENT_PATH as each step in this group starts, and the
+    # upstream action parses that file at import, so it intermittently died
+    # with "JSON at position 8192" before downloading anything. The fork reads
+    # the payload lazily (it is never needed here). Drop it once actions/runner
+    # stops rewriting the file per step.
     - parallel:
         - name: Install Dependencies
           uses: ./src/electron/.github/actions/install-dependencies
@@ -220,12 +226,12 @@ jobs:
             test -d depot_tools && cd depot_tools
             touch .disable_auto_update
         - name: Download Generated Artifacts
-          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+          uses: MarshallOfSound/download-artifact@bbfa5717ecb46c82dc6248b7d261d45f77a7c71a # v8.0.1 + lazy event payload read
           with:
             name: generated_artifacts_${{ env.ARTIFACT_KEY }}
             path: ./generated_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}
         - name: Download Src Artifacts
-          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+          uses: MarshallOfSound/download-artifact@bbfa5717ecb46c82dc6248b7d261d45f77a7c71a # v8.0.1 + lazy event payload read
           with:
             name: src_artifacts_${{ env.ARTIFACT_KEY }}
             path: ./src_artifacts_${{ matrix.build-type }}_${{ inputs.target-arch }}


### PR DESCRIPTION
#### Description of Change

The two `download-artifact` steps in the test job's `parallel:` setup group have failed `main` four times since mid-August (08-18, 08-20, 08-27, 09-01) with

```
SyntaxError: Expected double-quoted property name in JSON at position 8192
    at new Context (.../download-artifact/dist/index.js)
```

before downloading anything. Cause: actions/runner rewrites `$GITHUB_EVENT_PATH` at the start of every step (`ExecutionContext.WriteWebhookPayload`), and `@actions/github`'s `Context` constructor — which runs at import in any action that depends on it, download-artifact included via `@actions/artifact` — reads and parses that file eagerly. Inside a parallel group a sibling step starting at the wrong moment hands it a half-written file. Sequential steps never hit this, which is why it only appeared once the group was introduced.

This points those two steps at a fork of download-artifact v8.0.1 whose only change is to read the payload lazily (with a short retry on a parse error). download-artifact never reads the payload — run id and repo come from inputs/env — so in practice the file is no longer touched at all. The steps stay parallel; everything else about the action (retries, digest verification) is unchanged. The runner-side fix is filed separately; once a runner release stops rewriting the file per step this can go back to upstream.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
