### PR TITLE
fix: terminate immediately on asar integrity violation

### DIFF
--- a/lib/node/asar-fs-wrapper.ts
+++ b/lib/node/asar-fs-wrapper.ts
@@ -7,6 +7,7 @@ import type * as Crypto from 'crypto';
 import type * as os from 'os';
 
 const asar = process._linkedBinding('electron_common_asar');
+const v8Util = process._linkedBinding('electron_common_v8_util');
 
 const Module = require('module') as NodeJS.ModuleInternal;
 
@@ -258,8 +259,19 @@ function validateBufferIntegrity(buffer: Buffer, integrity: NodeJS.AsarFileInfo[
   crypto = crypto || require('crypto');
   const actual = crypto.createHash(integrity.algorithm).update(buffer).digest('hex');
   if (actual !== integrity.hash) {
-    console.error(`ASAR Integrity Violation: got a hash mismatch (${actual} vs ${integrity.hash})`);
-    process.exit(1);
+    const message = `ASAR Integrity Violation: got a hash mismatch (${actual} vs ${integrity.hash})\n`;
+    // Written with a blocking write so it is not lost on the way out.
+    try {
+      (require('fs') as typeof import('fs')).writeSync(2, message);
+    } catch {
+      console.error(message);
+    }
+    // Terminate synchronously and bypass libc exit(): in the main process
+    // process.exit() maps to the asynchronous app.exit(), which would let JS
+    // keep running on the tampered bytes, and libc exit() runs static
+    // destructors under still-live Chromium threads, which on Windows
+    // intermittently faults with 0xC0000005.
+    v8Util.exitImmediately(1);
   }
 }
 

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -6,8 +6,10 @@
 #include <utility>
 
 #include "base/dcheck_is_on.h"
+#include "base/process/process.h"
 #include "base/run_loop.h"
 #include "electron/buildflags/buildflags.h"
+#include "gin/arguments.h"
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -92,6 +94,16 @@ void RunUntilIdle() {
   base::RunLoop().RunUntilIdle();
 }
 
+// Ends the process now with the given exit code, running no atexit handlers
+// or static destructors. The asar fs wrapper calls this on an integrity
+// violation: libc exit() would tear down statics while Chromium's threads are
+// still live, which intermittently faults (0xC0000005 on Windows).
+void ExitImmediately(gin::Arguments* args) {
+  int code = 1;
+  args->GetNext(&code);
+  base::Process::TerminateCurrentProcessImmediately(code);
+}
+
 #if DCHECK_IS_ON()
 // Test-only (DCHECK builds): per-process map of builtin id (electron/js2c/*
 // bundles and Node's own lib/ builtins compiled so far in this process) ->
@@ -118,6 +130,7 @@ void Initialize(v8::Local<v8::Object> exports,
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
   dict.SetMethod("runUntilIdle", &RunUntilIdle);
+  dict.SetMethod("exitImmediately", &ExitImmediately);
 #if DCHECK_IS_ON()
   dict.SetMethod("getJs2cCodeCacheStatus", &GetJs2cCodeCacheStatus);
 #endif

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -47,6 +47,7 @@ declare namespace NodeJS {
     requestGarbageCollectionForTesting(): void;
     runUntilIdle(): void;
     triggerFatalErrorForTesting(): void;
+    exitImmediately(code: number): never;
   }
 
   type CrashReporterBinding = Omit<Electron.CrashReporter, 'start'> & {


### PR DESCRIPTION
Backport of #53433

See that PR for details. This branch predates the `integrityViolation` helper from #52833, so the blocking stderr write and `exitImmediately(1)` are applied directly in `validateBufferIntegrity` in place of `console.error` + `process.exit(1)`.

Notes: Fixed an intermittent crash (access violation) on Windows when an ASAR integrity violation is detected, so the process now exits with code 1 as intended.
