### PR TITLE
feat: add fuse to disable Node.js stdio initialization

### DIFF
--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -10,5 +10,6 @@
   "only_load_app_from_asar": "0",
   "load_browser_process_specific_v8_snapshot": "0",
   "grant_file_protocol_extra_privileges": "1",
-  "wasm_trap_handlers": "1"
+  "wasm_trap_handlers": "1",
+  "node_stdio_initialization": "1"
 }

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -177,6 +177,21 @@ than they ideally should be.
 * This extra code, particularly the compare and branch before every memory reference,
 incurs a significant runtime cost.
 
+### `nodeStdioInitialization`
+
+**Default:** Enabled
+
+**@electron/fuses:** `FuseV1Options.EnableNodeStdioInitialization`
+
+The `nodeStdioInitialization` fuse controls whether Node.js initializes the process's standard input,
+output, and error streams. When disabled, Electron skips Node.js stdio and TTY initialization. This is
+equivalent to starting Electron with `--no-stdio-init` and allows packaged applications to opt out at
+package time, including on Windows systems where the `NUL` device is unavailable.
+
+Disabling this fuse means Node.js will not normalize the process's standard file descriptors or TTY
+state. Applications that rely on Node.js managing `stdin`, `stdout`, or `stderr` should leave this fuse
+enabled.
+
 ## How do I flip fuses?
 
 ### The easy way

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -202,7 +202,8 @@ int NodeMain() {
         node::ProcessInitializationFlags::kNoInitializeV8 |
         node::ProcessInitializationFlags::kNoInitializeNodeV8Platform;
 
-    if (command_line->HasSwitch(switches::kNoStdioInit)) {
+    if (command_line->HasSwitch(switches::kNoStdioInit) ||
+        !fuses::IsNodeStdioInitializationEnabled()) {
       process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
       // remove the option to avoid node error "bad option: --no-stdio-init"
       std::string option = std::string("--") + switches::kNoStdioInit;

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -707,7 +707,8 @@ void NodeBindings::Initialize(v8::Isolate* const isolate,
     process_flags |= node::ProcessInitializationFlags::kDisableNodeOptionsEnv;
 
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kNoStdioInit)) {
+  if (command_line->HasSwitch(switches::kNoStdioInit) ||
+      !fuses::IsNodeStdioInitializationEnabled()) {
     process_flags |= node::ProcessInitializationFlags::kNoStdioInitialization;
   } else {
 #if BUILDFLAG(IS_WIN)


### PR DESCRIPTION
#### Description of Change

Adds a new `nodeStdioInitialization` fuse, enabled by default, that controls whether Electron allows Node.js to initialize and normalize process stdio.

When disabled, both Node.js initialization paths set `node::ProcessInitializationFlags::kNoStdioInitialization`, giving packaged applications the same behavior as launching with `--no-stdio-init` without requiring a launcher or runtime command-line argument. The existing `--no-stdio-init` switch remains supported as a runtime opt-out.

This is useful for deployments on Windows systems where the `NUL` device is unavailable. In those environments, Node.js cannot replace missing standard file descriptors with `NUL`, and Electron can exit before application JavaScript has a chance to run.

The fuse defaults to enabled, so existing applications retain the current stdio initialization behavior.

Closes #52677

Assisted-By: ChatGPT, GPT-5.6 Sol

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a fuse to disable Node.js stdio initialization at package time.
