### PR TITLE
fix: hide childless container views from the accessibility tree

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -199,12 +199,8 @@ View::View(views::View* view) : view_(view) {
 }
 
 View::View() : View(new views::View()) {
-  // A default-constructed View wraps a plain container that has no content of
-  // its own. While it is childless, hide it from assistive technology:
-  // otherwise it is exposed as an empty "pane" that wins accessibility
-  // hit-tests over content painted beneath it, e.g. a BrowserWindow's
-  // WebContentsView, which is a sibling painted below the window's
-  // contentView. See https://github.com/electron/electron/issues/42945.
+  // A plain container with no children is an empty "pane" to assistive
+  // technology; keep it out of the accessibility tree (#42945).
   hide_from_ax_when_childless_ = true;
   UpdateChildlessAccessibilityState();
 }
@@ -576,12 +572,7 @@ void View::OnChildViewRemoved(views::View* observed_view, views::View* child) {
 void View::UpdateChildlessAccessibilityState() {
   if (!hide_from_ax_when_childless_ || !view_)
     return;
-  const bool childless = view_->children().empty();
-  // Ignored removes the node from the accessibility tree; invisible makes
-  // ViewAXPlatformNodeDelegate::HitTestSync skip it, letting hit-tests fall
-  // through to content painted beneath it.
-  view_->GetViewAccessibility().SetIsIgnored(childless);
-  view_->GetViewAccessibility().SetIsInvisible(childless);
+  view_->GetViewAccessibility().SetIsIgnored(view_->children().empty());
 }
 
 // static

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -21,6 +21,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "ui/compositor/layer.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/flex_layout.h"
@@ -197,7 +198,16 @@ View::View(views::View* view) : view_(view) {
   view_->AddObserver(this);
 }
 
-View::View() : View(new views::View()) {}
+View::View() : View(new views::View()) {
+  // A default-constructed View wraps a plain container that has no content of
+  // its own. While it is childless, hide it from assistive technology:
+  // otherwise it is exposed as an empty "pane" that wins accessibility
+  // hit-tests over content painted beneath it, e.g. a BrowserWindow's
+  // WebContentsView, which is a sibling painted below the window's
+  // contentView. See https://github.com/electron/electron/issues/42945.
+  hide_from_ax_when_childless_ = true;
+  UpdateChildlessAccessibilityState();
+}
 
 View::~View() {
   if (!view_)
@@ -552,10 +562,26 @@ void View::OnViewIsDeleting(views::View* observed_view) {
   view_ = nullptr;
 }
 
+void View::OnChildViewAdded(views::View* observed_view, views::View* child) {
+  UpdateChildlessAccessibilityState();
+}
+
 void View::OnChildViewRemoved(views::View* observed_view, views::View* child) {
   std::erase_if(child_views_, [child](const ChildPair& child_view) {
     return child_view.first == child;
   });
+  UpdateChildlessAccessibilityState();
+}
+
+void View::UpdateChildlessAccessibilityState() {
+  if (!hide_from_ax_when_childless_ || !view_)
+    return;
+  const bool childless = view_->children().empty();
+  // Ignored removes the node from the accessibility tree; invisible makes
+  // ViewAXPlatformNodeDelegate::HitTestSync skip it, letting hit-tests fall
+  // through to content painted beneath it.
+  view_->GetViewAccessibility().SetIsIgnored(childless);
+  view_->GetViewAccessibility().SetIsInvisible(childless);
 }
 
 // static

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -68,8 +68,12 @@ class View : public gin_helper::EventEmitter<View>,
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;
+  void OnChildViewAdded(views::View* observed_view,
+                        views::View* child) override;
   void OnChildViewRemoved(views::View* observed_view,
                           views::View* child) override;
+
+  void UpdateChildlessAccessibilityState();
 
   ui::Layer* GetLayer();
   void ApplyBorderRadius();
@@ -79,6 +83,7 @@ class View : public gin_helper::EventEmitter<View>,
   std::optional<int> border_radius_;
 
   bool delete_view_ = true;
+  bool hide_from_ax_when_childless_ = false;
   raw_ptr<views::View> view_ = nullptr;
 };
 

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/native_window.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -32,6 +33,10 @@
 #include "ui/display/display.h"
 #include "ui/display/screen.h"
 #include "ui/display/types/display_constants.h"
+#include "ui/gfx/geometry/rect_conversions.h"
+#include "ui/gfx/geometry/rect_f.h"
+#include "ui/views/view_targeter.h"
+#include "ui/views/view_targeter_delegate.h"
 #include "ui/views/widget/widget.h"
 
 #if !BUILDFLAG(IS_MAC)
@@ -76,6 +81,38 @@ struct Converter<electron::NativeWindow::TitleBarStyle> {
 };
 
 }  // namespace gin
+
+namespace {
+
+// In BrowserWindow, the WebContentsView is a sibling of content_view_ placed
+// beneath it so user-added child views paint above web content. content_view_
+// covers the whole window, so the default bounds check would make every
+// hit-test stop at it. Only intersect where a child does, so the parent's
+// targeter and ViewAXPlatformNodeDelegate::HitTestSync both skip content_view_
+// and fall through to the WebContentsView. Only DoesIntersectRect is narrowed;
+// TargetForRect must keep its contract (see #51576).
+class ContentViewTargeterDelegate : public views::ViewTargeterDelegate {
+ public:
+  bool DoesIntersectRect(const views::View* target,
+                         const gfx::Rect& rect) const override {
+    if (!views::ViewTargeterDelegate::DoesIntersectRect(target, rect)) {
+      return false;
+    }
+    for (const views::View* child : target->children()) {
+      if (!child->GetVisible() || !child->GetCanProcessEventsWithinSubtree()) {
+        continue;
+      }
+      gfx::RectF rect_in_child(rect);
+      views::View::ConvertRectToTarget(target, child, &rect_in_child);
+      if (child->HitTestRect(gfx::ToEnclosingRect(rect_in_child))) {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+}  // namespace
 
 namespace electron {
 
@@ -173,6 +210,12 @@ NativeWindow::~NativeWindow() {
   if (widget_->widget_delegate())
     widget_->OnNativeWidgetDestroyed();
   NotifyWindowClosed();
+}
+
+// static
+void NativeWindow::InstallContentViewTargeter(views::View* content_view) {
+  content_view->SetEventTargeter(std::make_unique<views::ViewTargeter>(
+      std::make_unique<ContentViewTargeterDelegate>()));
 }
 
 void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -493,6 +493,12 @@ class NativeWindow : public views::WidgetDelegate {
   const views::Widget* GetWidget() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
+
+  // Makes |content_view| hit-test-transparent except where one of its
+  // children covers the target point, so that mouse targeting and
+  // accessibility hit-tests fall through to the sibling WebContentsView that
+  // BrowserWindow places beneath it.
+  static void InstallContentViewTargeter(views::View* content_view);
   void FlushPendingRootLayout(views::View* view);
 
   static inline constexpr base::cstring_view kNativeWindowKey =

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -40,11 +40,8 @@
 #include "third_party/webrtc/modules/desktop_capture/mac/window_list_utils.h"
 #include "ui/base/hit_test.h"
 #include "ui/display/screen.h"
-#include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/views/background.h"
 #include "ui/views/cocoa/native_widget_mac_ns_window_host.h"
-#include "ui/views/view_targeter.h"
-#include "ui/views/view_targeter_delegate.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/native_frame_view_mac.h"
 
@@ -111,49 +108,6 @@ struct Converter<electron::NativeWindowMac::VisualEffectState> {
 };
 
 }  // namespace gin
-
-namespace {
-
-// A ViewTargeterDelegate installed on content_view_ that makes it
-// hit-test-transparent except where one of its descendants covers the
-// target rect.
-//
-// In BrowserWindow, the WebContentsView is added as a sibling of
-// content_view_ at a lower z-order so that user-added child views paint
-// above web content. content_view_ itself covers the full window, so the
-// default DoesIntersectRect (a bounds check) would always return true and
-// the parent targeter would stop there, never reaching the WebContentsView
-// behind it. By only intersecting where a child actually does, the parent's
-// default TargetForRect loop skips content_view_ and falls through to the
-// sibling, ultimately resolving to the WebContentsView's NativeViewHost so
-// BridgedContentView::hitTest: routes the event to RenderWidgetHostViewCocoa.
-//
-// This must never affect TargetForRect's contract — it only narrows
-// HitTestRect, which the default loop already handles by skipping the child.
-// Returning nullptr from TargetForRect (the previous approach) violated the
-// contract and crashed RootView::UpdateCursor (see #51576).
-class ContentViewTargeterDelegate : public views::ViewTargeterDelegate {
- public:
-  bool DoesIntersectRect(const views::View* target,
-                         const gfx::Rect& rect) const override {
-    if (!views::ViewTargeterDelegate::DoesIntersectRect(target, rect)) {
-      return false;
-    }
-    for (const views::View* child : target->children()) {
-      if (!child->GetVisible() || !child->GetCanProcessEventsWithinSubtree()) {
-        continue;
-      }
-      gfx::RectF rect_in_child(rect);
-      views::View::ConvertRectToTarget(target, child, &rect_in_child);
-      if (child->HitTestRect(gfx::ToEnclosingRect(rect_in_child))) {
-        return true;
-      }
-    }
-    return false;
-  }
-};
-
-}  // namespace
 
 namespace electron {
 
@@ -378,10 +332,7 @@ void NativeWindowMac::SetContentView(views::View* view) {
 
   set_content_view(view);
 
-  // Make content_view_ hit-test-transparent where it has no covering child
-  // so events fall through to the sibling WebContentsView in BrowserWindow.
-  view->SetEventTargeter(std::make_unique<views::ViewTargeter>(
-      std::make_unique<ContentViewTargeterDelegate>()));
+  InstallContentViewTargeter(view);
 
   root_view->AddChildViewRaw(content_view());
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -571,6 +571,7 @@ void NativeWindowViews::SetContentView(views::View* view) {
   }
   set_content_view(view);
   focused_view_ = view;
+  InstallContentViewTargeter(view);
   root_view_.GetMainView()->AddChildViewRaw(content_view());
   FlushPendingRootLayout(root_view_.GetMainView());
 }


### PR DESCRIPTION
#### Description of Change

Since #41256, a `BrowserWindow`'s `WebContentsView` is a **sibling** of the window's `contentView`, inserted before it so that `contentView` children paint on top of the web contents. `BaseWindow` auto-creates its `contentView` as a plain `views::View` covering the whole window, and that container sits **above** the web contents in the view order.

`ViewAXPlatformNodeDelegate::HitTestSync` searches children topmost-first and returns the first child whose `HitTestPoint()` succeeds. With a plain bounds check, the full-window `contentView` wins every accessibility hit-test over the web contents beneath it, whether or not it has children: with no children it is the final result (the empty pane in #42945, bisected to `30.0.0-beta.8` / #41256), and with children it still wins for every point outside them, e.g. anywhere outside a `BrowserView`. NVDA's mouse tracking lands on the empty pane and goes silent.

`View::HitTestPoint()` is `GetEffectiveViewTargeter()->DoesIntersectRect()`, so a `ViewTargeter` on `contentView` governs both mouse targeting and accessibility hit-tests. macOS already installs exactly such a targeter (`ContentViewTargeterDelegate`, from #50330 and #51617) so mouse events fall through to the `WebContentsView`. This PR:

- Moves that delegate into `NativeWindow::InstallContentViewTargeter()` and calls it from both `NativeWindowMac::SetContentView` and `NativeWindowViews::SetContentView`, so on Windows and Linux `contentView` only intersects a point where one of its visible children does. Accessibility hit-tests and views mouse targeting then fall through to the `WebContentsView` wherever no child covers the point, regardless of how many children `contentView` has. macOS behaviour is unchanged.
- Marks a default-constructed `api::View`'s plain container as **ignored** while it has no children, so the empty pane also disappears from tree navigation (the extra pane seen in Inspect.exe). As soon as children are added it returns to the tree. Views wrapped by `api::View` subclasses (`WebContentsView`, `ImageView`, etc.) are unaffected.

On Windows and Linux, mouse events over web content are delivered to the `RenderWidgetHostViewAura` window and never reach the views `RootView`, so the targeter only changes views targeting where neither web content nor a `contentView` child is under the point; there the target becomes the main view instead of the empty container, and neither handles mouse events.

#### Verification

Linux, AT-SPI `Component.GetAccessibleAtPoint` from the window frame (same `HitTestSync` path), Xvfb, `app.setAccessibilitySupportEnabled(true)`. Baseline is Electron 44.2.0; "patched" is this branch.

| Scenario | Point | Baseline | Patched |
|---|---|---|---|
| empty `contentView` | window centre | empty panel (`contentView`) | `document web` |
| 40x40 child in corner | window centre | panel (`contentView`, 1 child) | `document web` |
| 40x40 child in corner | inside child | panel (child) | panel (`contentView`; childless child is ignored) |
| 40x40 child in corner | beside child | panel (`contentView`, 1 child) | `static` "Hello a11y" (web content) |
| `BrowserView` 200x150 | window centre | panel (`contentView`, 1 child) | `document web` |
| `BrowserView` 200x150 | inside BrowserView | `document web` (BrowserView) | `document web` (BrowserView) |
| `BrowserView` 200x150 | beside BrowserView | panel (`contentView`, 1 child) | `paragraph` (web content) |

The empty `contentView` no longer appears under the main view in the tree. Not verified on Windows with NVDA / Inspect.exe; repro steps are in #42945. cc @codebytere

Fixes #42945

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes locally — Linux build verified with the AT-SPI hit-tests above; native accessibility hit-testing is not observable from the JS specs
- [x] relevant documentation is changed or added — no API change
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples)

#### Release Notes

Notes: Fixed screen readers detecting an empty pane instead of the window's web contents (e.g. broken NVDA mouse tracking) caused by the BrowserWindow's contentView container overlaying the WebContentsView in the accessibility tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
