### PR TITLE
ci: retry the depot_tools clones and the angle fetch on transient network errors

### DIFF
--- a/.github/actions/fix-sync/action.yml
+++ b/.github/actions/fix-sync/action.yml
@@ -158,13 +158,16 @@ runs:
       if: ${{ inputs.target-platform != 'linux' }}
       shell: bash
       run : |
+        RETRY="$PWD/src/electron/script/actions/retry.sh"
         cd src/third_party/angle
         rm -f .git/objects/info/alternates
         git remote set-url origin https://github.com/google/angle.git
         cp .git/config .git/config.backup
         git remote remove origin
         mv .git/config.backup .git/config
-        git fetch
+        # A large fetch from github.com sometimes times out mid-transfer
+        # ("curl 56", "invalid index-pack output"); retry it.
+        bash "$RETRY" git fetch
     - name: Get Windows toolchain
       if: ${{ inputs.target-platform == 'win' }}
       shell: powershell

--- a/.github/actions/install-build-tools/action.yml
+++ b/.github/actions/install-build-tools/action.yml
@@ -17,9 +17,12 @@ runs:
         git config --global core.longpaths true
       fi
       export BUILD_TOOLS_SHA=458c9bf2a51da7015351686f077d77e404149511
-      npm i -g @electron/build-tools
+      # Both fetch over the network (the first `e` command clones depot_tools),
+      # so retry them on transient failures.
+      RETRY="$PWD/src/electron/script/actions/retry.sh"
+      bash "$RETRY" npm i -g @electron/build-tools
       # Update depot_tools to ensure python
-      e d update_depot_tools
+      bash "$RETRY" e d update_depot_tools
       e auto-update disable
       # Disable further updates of depot_tools
       e d auto-update disable

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -221,7 +221,8 @@ jobs:
             git config --global core.longpaths true
             git config --global core.preloadindex true
             git config --global core.longpaths true
-            git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+            # googlesource.com sometimes cuts a clone off mid-pack; retry it.
+            bash src/electron/script/actions/retry.sh git clone --filter=tree:0 https://chromium.googlesource.com/chromium/tools/depot_tools.git
             # Ensure depot_tools does not update.
             test -d depot_tools && cd depot_tools
             touch .disable_auto_update

--- a/script/actions/retry.sh
+++ b/script/actions/retry.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Runs a command and, if it fails, runs it again with exponential backoff.
+#
+#   bash src/electron/script/actions/retry.sh <command> [args...]
+#
+# For CI steps that fetch over the network and fail on transient errors (a
+# truncated pack from googlesource.com, a GitHub 5xx, a connection reset). Only
+# wrap commands that are safe to run twice: a failed `git clone` removes its
+# partial directory and a failed `git fetch` leaves the repository as it was.
+#
+# By default it makes 4 attempts, waiting 1s, 4s and 16s between them. Override
+# with RETRY_ATTEMPTS (total attempts), RETRY_DELAY (first wait, in seconds) and
+# RETRY_FACTOR (multiplier for each later wait). The exit status is the
+# command's own status from the last attempt.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 2
+fi
+
+attempts="${RETRY_ATTEMPTS:-4}"
+delay="${RETRY_DELAY:-1}"
+factor="${RETRY_FACTOR:-4}"
+
+attempt=1
+while true; do
+  "$@" && exit 0
+  status=$?
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "::error::'$*' failed with exit code $status after $attempt attempts"
+    exit "$status"
+  fi
+  echo "::warning::'$*' failed with exit code $status (attempt $attempt of $attempts); retrying in ${delay}s"
+  sleep "$delay"
+  delay=$((delay * factor))
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
#### Description of Change

Three CI steps fetch over the network with no retry, and each has failed builds on `main` with errors that pass on a re-run:

- the test job's **Get Depot Tools** clone from googlesource.com
- **Install Build Tools**: `npm i -g @electron/build-tools`, then the depot_tools clone that the first `e` command performs (`fatal: fetch-pack: invalid index-pack output`)
- **Fixup angle git** in the fix-sync action, a large `git fetch` from github.com (`error: RPC failed; curl 56 Recv failure: Operation timed out`, e.g. https://github.com/electron/electron/actions/runs/33782849304/job/100741729272)

This adds `script/actions/retry.sh`, which reruns a command with exponential backoff (4 attempts, waiting 1s, 4s and 16s; tunable through `RETRY_ATTEMPTS`, `RETRY_DELAY` and `RETRY_FACTOR`), and prefixes those commands with it. It's a script rather than a composite action so each step stays a plain `run:` and no command has to pass through an action input. Each wrapped command is safe to repeat: a failed `git clone` removes its partial directory, and a failed `git fetch` leaves the repository as it was. A retry shows up as a warning annotation; after the last attempt the step fails with the command's own exit code, as it does today.

The depot_tools clone inside build-tools itself gets the same treatment in electron/build-tools#895, which CI picks up on its next release because this action installs the latest build-tools.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
