### PR TITLE
test: time the macOS x64 test shards on Rosetta and macos-15-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
   # reported as skipped, which branch protection treats as satisfied.
   lint:
     needs: setup
-    if: ${{ !inputs.skip-lint }}
+    if: ${{ false && (!inputs.skip-lint) }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-electron-lint.yml
     permissions:
       contents: read
@@ -145,7 +145,7 @@ jobs:
   # Docs Only Jobs
   docs-only:
     needs: [setup, checkout-linux]
-    if: ${{ needs.setup.outputs.docs-only == 'true' }}
+    if: ${{ false && (needs.setup.outputs.docs-only == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-electron-docs-only.yml
     permissions:
       contents: read
@@ -189,7 +189,7 @@ jobs:
   # skip it via the docs-only output instead.
   checkout-linux:
     needs: setup
-    if: ${{ (needs.setup.outputs.src == 'true' || needs.setup.outputs.docs-only == 'true') && !inputs.skip-linux }}
+    if: ${{ false && ((needs.setup.outputs.src == 'true' || needs.setup.outputs.docs-only == 'true') && !inputs.skip-linux) }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read
@@ -221,7 +221,7 @@ jobs:
 
   checkout-windows:
     needs: setup
-    if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
+    if: ${{ false && (needs.setup.outputs.src == 'true' && !inputs.skip-windows) }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     runs-on: electron-arc-centralus-linux-amd64-32core
     permissions:
       contents: read
@@ -269,7 +269,7 @@ jobs:
 
   build-siso-linux:
     needs: setup
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
@@ -278,7 +278,7 @@ jobs:
 
   build-siso-windows:
     needs: setup
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-segment-build-siso.yml
     permissions:
       contents: read
@@ -287,6 +287,7 @@ jobs:
 
   # GN Check Jobs
   macos-gn-check:
+    if: false # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
     permissions:
       contents: read
@@ -303,7 +304,7 @@ jobs:
     permissions:
       contents: read
     needs: checkout-linux
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       target-platform: linux
       target-archs: x64 arm64
@@ -313,6 +314,7 @@ jobs:
       ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
 
   windows-gn-check:
+    if: false # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-segment-electron-gn-check.yml
     permissions:
       contents: read
@@ -355,12 +357,65 @@ jobs:
       SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
       SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
   
+  # TEMP(macos-x64 runner timing): the x64 build's tests on the arm64 macos-15 runners, under Rosetta.
+  # display-server only names this variant, keeping its concurrency group and
+  # artifact names apart from the other x64 test runs.
+  macos-x64-test-rosetta:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    uses: ./.github/workflows/pipeline-segment-electron-test.yml
+    needs: [macos-x64]
+    with:
+      target-platform: macos
+      target-arch: x64
+      test-runs-on: macos-15
+      display-server: rosetta
+      enable-ssh: ${{ inputs.enable-ssh || false }}
+    secrets:
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+
+  # TEMP(macos-x64 runner timing): the x64 build's tests on the standard (non-large) Intel runners.
+  # display-server only names this variant, keeping its concurrency group and
+  # artifact names apart from the other x64 test runs.
+  macos-x64-test-intel:
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    uses: ./.github/workflows/pipeline-segment-electron-test.yml
+    needs: [macos-x64]
+    with:
+      target-platform: macos
+      target-arch: x64
+      test-runs-on: macos-15-intel
+      display-server: intel
+      enable-ssh: ${{ inputs.enable-ssh || false }}
+    secrets:
+      CI_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+      CHROMIUM_GIT_COOKIE: ${{ secrets.CHROMIUM_GIT_COOKIE }}
+      CHROMIUM_GIT_COOKIE_WINDOWS_STRING: ${{ secrets.CHROMIUM_GIT_COOKIE_WINDOWS_STRING }}
+      CLOUDFLARE_TUNNEL_CERT: ${{ secrets.CLOUDFLARE_TUNNEL_CERT }}
+      CLOUDFLARE_USER_CA_CERT: ${{ secrets.CLOUDFLARE_USER_CA_CERT }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      ELECTRON_RBE_JWT: ${{ secrets.ELECTRON_RBE_JWT }}
+      SSH_DEBUG_AUTHORIZED_USERS: ${{ secrets.SSH_DEBUG_AUTHORIZED_USERS }}
+
   # macos-arm64, linux-x64, and windows-x64 carry the clang-tidy legs. When a
   # change touches no native code (per setup's native filter), run-clang-tidy
   # skips the clang-tidy job inside the reusable workflow - like the lint
   # skip above, the check is still reported as skipped, which branch
   # protection treats as satisfied.
   macos-arm64:
+    if: false # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     permissions:
       contents: read
       issues: read
@@ -398,7 +453,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test-and-nan.yml
     needs: [setup, checkout-linux, build-siso-linux]
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       clang-tidy-runs-on: electron-arc-centralus-linux-amd64-8core
@@ -432,7 +487,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: [checkout-linux, build-siso-linux]
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       test-runs-on: electron-arc-centralus-linux-amd64-4core
@@ -464,7 +519,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: [checkout-linux, build-siso-linux]
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       test-runs-on: electron-arc-centralus-linux-amd64-4core
@@ -496,7 +551,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: [checkout-linux, build-siso-linux]
-    if: ${{ needs.setup.outputs.src == 'true' }}
+    if: ${{ false && (needs.setup.outputs.src == 'true') }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: electron-arc-centralus-linux-amd64-32core
       test-runs-on: ubuntu-22.04-arm
@@ -521,6 +576,7 @@ jobs:
       SUDOWOODO_EXCHANGE_URL: ${{ secrets.SUDOWOODO_EXCHANGE_URL }}
     
   test-linux-arm64-64k:
+    if: false # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     uses: ./.github/workflows/pipeline-segment-electron-test-64k.yml
     permissions:
       contents: read
@@ -538,7 +594,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-tidy-and-test.yml
     needs: [setup, checkout-windows, build-siso-windows]
-    if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
+    if: ${{ false && (needs.setup.outputs.src == 'true' && !inputs.skip-windows) }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: garm-windows-x64-32core
       clang-tidy-runs-on: electron-arc-centralus-linux-amd64-8core
@@ -570,7 +626,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/pipeline-electron-build-and-test.yml
     needs: [checkout-windows, build-siso-windows]
-    if: ${{ needs.setup.outputs.src == 'true' && !inputs.skip-windows }}
+    if: ${{ false && (needs.setup.outputs.src == 'true' && !inputs.skip-windows) }} # TEMP(macos-x64 runner timing): only the macOS x64 lanes run on this draft
     with:
       build-runs-on: garm-windows-x64-32core
       test-runs-on: windows-11-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,7 +337,8 @@ jobs:
     needs: [checkout-macos, build-siso-macos]
     with:
       build-runs-on: macos-15-xlarge
-      test-runs-on: macos-15-large
+      # TEMP(macos-x64 runner timing): second pass, Rosetta only.
+      test-runs-on: macos-15
       target-platform: macos
       target-arch: x64
       is-release: false
@@ -361,6 +362,7 @@ jobs:
   # display-server only names this variant, keeping its concurrency group and
   # artifact names apart from the other x64 test runs.
   macos-x64-test-rosetta:
+    if: false # TEMP(macos-x64 runner timing): first pass only
     permissions:
       contents: read
       issues: read
@@ -387,6 +389,7 @@ jobs:
   # display-server only names this variant, keeping its concurrency group and
   # artifact names apart from the other x64 test runs.
   macos-x64-test-intel:
+    if: false # TEMP(macos-x64 runner timing): first pass only
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -338,6 +338,9 @@ jobs:
         NPM_CONFIG_MSVS_VERSION: '2022'
         TARGET_PLATFORM: ${{ inputs.target-platform }}
         DISPLAY_SERVER: ${{ inputs.display-server }}
+        # Build the spec's native addons for the Electron under test, not the host:
+        # an x64 build can run on an arm64 runner under Rosetta.
+        npm_config_arch: ${{ inputs.target-arch }}
         SHARD: ${{ matrix.shard }}
         SHARD_COUNT: ${{ case(inputs.display-server == 'wayland', 1, inputs.target-platform == 'macos' && inputs.is-ubsan, 3, inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }}
       run: |
@@ -458,7 +461,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
-        name: ${{ inputs.target-platform == 'linux' && format('test_artifacts_{0}_{1}_{2}', env.ARTIFACT_KEY, inputs.display-server, matrix.shard) || format('test_artifacts_{0}_{1}', env.ARTIFACT_KEY, matrix.shard) }}
+        name: ${{ (inputs.target-platform == 'linux' || inputs.display-server != 'x11') && format('test_artifacts_{0}_{1}_{2}', env.ARTIFACT_KEY, inputs.display-server, matrix.shard) || format('test_artifacts_{0}_{1}', env.ARTIFACT_KEY, matrix.shard) }}
         path: src/electron/spec/artifacts
         if-no-files-found: ignore
     - name: Wait for active SSH sessions

--- a/.github/workflows/pipeline-segment-electron-test.yml
+++ b/.github/workflows/pipeline-segment-electron-test.yml
@@ -338,13 +338,23 @@ jobs:
         NPM_CONFIG_MSVS_VERSION: '2022'
         TARGET_PLATFORM: ${{ inputs.target-platform }}
         DISPLAY_SERVER: ${{ inputs.display-server }}
-        # Build the spec's native addons for the Electron under test, not the host:
-        # an x64 build can run on an arm64 runner under Rosetta.
+        # Build the spec's native addons for the Electron under test, not the
+        # host: an x64 build can run on an arm64 runner under Rosetta.
         npm_config_arch: ${{ inputs.target-arch }}
         SHARD: ${{ matrix.shard }}
         SHARD_COUNT: ${{ case(inputs.display-server == 'wayland', 1, inputs.target-platform == 'macos' && inputs.is-ubsan, 3, inputs.target-platform == 'linux', 3, inputs.target-platform == 'macos' && inputs.target-arch == 'x64', 3, 2) }}
       run: |
         cd src/electron
+        # yarn install built the native addons for the host. Under Rosetta the
+        # Electron under test is x64, so rebuild them for x64. (The spec runner
+        # rebuilds the ones that need Electron's headers itself, using
+        # npm_config_arch.)
+        if [ "$TARGET_PLATFORM" = "macos" ] && [ "$(uname -m)" = "arm64" ] && [ "$TARGET_ARCH" = "x64" ]; then
+          for addon in spec/fixtures/native-addon/*/; do
+            echo "Rebuilding $addon for x64"
+            (cd "$addon" && node "$OLDPWD/node_modules/node-gyp/bin/node-gyp.js" rebuild --arch=x64)
+          done
+        fi
         export ELECTRON_TEST_RESULTS_DIR=`pwd`/junit
         # Get which tests are on this shard
         tests_files=$(node script/split-tests "$SHARD" "$SHARD_COUNT")

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6921,9 +6921,11 @@ describe('BrowserWindow module', () => {
 
     ifdescribe(process.platform === 'darwin')('kiosk state', () => {
       describe('with properties', () => {
-        it('can be set with a constructor property', () => {
+        it('can be set with a constructor property', async () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.kiosk).to.be.true();
+          // Let the fullscreen transition finish; see leaveFullScreen().
+          await once(w, 'enter-full-screen');
         });
 
         it('can be changed ', async () => {
@@ -6942,9 +6944,11 @@ describe('BrowserWindow module', () => {
       });
 
       describe('with functions', () => {
-        it('can be set with a constructor property', () => {
+        it('can be set with a constructor property', async () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.isKiosk()).to.be.true();
+          // Let the fullscreen transition finish; see leaveFullScreen().
+          await once(w, 'enter-full-screen');
         });
 
         it('can be changed ', async () => {

--- a/spec/api-menu-spec.ts
+++ b/spec/api-menu-spec.ts
@@ -828,14 +828,28 @@ describe('Menu module', function () {
     let w: BrowserWindow;
     let menu: Menu;
 
+    // closePopup() only asks the menu to close. AppKit runs one menu at a time,
+    // so a popup opened before the previous one has closed never shows. Wait
+    // for the close before the next test opens its menu.
+    let popupOpen = false;
+
     beforeEach(() => {
       w = new BrowserWindow({ show: false, width: 200, height: 200 });
       menu = Menu.buildFromTemplate([{ label: '1' }, { label: '2' }, { label: '3' }]);
+      popupOpen = false;
+      menu.on('menu-will-show', () => {
+        popupOpen = true;
+      });
+      menu.on('menu-will-close', () => {
+        popupOpen = false;
+      });
     });
 
     afterEach(async () => {
+      const closed = popupOpen ? once(menu, 'menu-will-close') : null;
       menu.closePopup();
       menu.closePopup(w);
+      if (closed) await Promise.race([closed, setTimeout(5000)]);
       await closeWindow(w);
       w = null as unknown as BrowserWindow;
     });

--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -4,8 +4,19 @@ import { expect } from 'chai';
 
 import { once } from 'node:events';
 
+// On macOS, destroying a fullscreen window animates it out of its Space, and
+// AppKit ignores fullscreen requests from other windows until that finishes.
+// Leave fullscreen first so the next test doesn't start inside the animation.
+async function leaveFullScreen(window: BaseWindow) {
+  if (process.platform !== 'darwin' || !window.isFullScreen()) return;
+  const left = once(window, 'leave-full-screen');
+  window.setFullScreen(false);
+  await Promise.race([left, new Promise((resolve) => setTimeout(resolve, 5000))]);
+}
+
 async function ensureWindowIsClosed(window: BaseWindow | null) {
   if (window && !window.isDestroyed()) {
+    await leaveFullScreen(window);
     if (window instanceof BrowserWindow && window.webContents && !window.webContents.isDestroyed()) {
       // If a window isn't destroyed already, and it has non-destroyed WebContents,
       // then calling destroy() won't immediately destroy it, as it may have


### PR DESCRIPTION
#### Description of Change

Experiment, not for merge. Times the macOS x64 test shards on three runner types from one build:

| job | runner |
|---|---|
| `macos-x64` (baseline) | `macos-15-large` (Intel) |
| `macos-x64-test-rosetta` | `macos-15` (arm64), x64 Electron under Rosetta |
| `macos-x64-test-intel` | `macos-15-intel` (standard Intel) |

Every other lane is disabled in the `TEMP:` commit. The second commit is a candidate fix for the seven macOS specs that time out on their first attempt in every run; it applies to all three variants alike.

#### Checklist

- [x] PR description included

#### Release Notes

Notes: none
