### PR TITLE
fix: don't throw when adding or removing console-message listeners on a destroyed WebContents

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -829,12 +829,12 @@ WebContents.prototype._init = function () {
   });
 
   this.on('newListener' as any, (eventName: string | symbol) => {
-    if (eventName === 'console-message') {
+    if (eventName === 'console-message' && !this.isDestroyed()) {
       this._setConsoleMessageObserved(true);
     }
   });
   this.on('removeListener' as any, (eventName: string | symbol) => {
-    if (eventName === 'console-message' && this.listenerCount('console-message') === 0) {
+    if (eventName === 'console-message' && !this.isDestroyed() && this.listenerCount('console-message') === 0) {
       this._setConsoleMessageObserved(false);
     }
   });

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -4037,6 +4037,40 @@ describe('webContents module', () => {
       });
       w.loadFile(path.join(fixturesPath, 'pages', 'a.html'));
     });
+
+    describe('on a destroyed WebContents', () => {
+      const destroyedWebContents = async (handler?: (...args: any[]) => void) => {
+        const w = new BrowserWindow({ show: false });
+        const wc = w.webContents;
+        if (handler) wc.on('console-message', handler);
+        const destroyed = once(wc, 'destroyed');
+        w.destroy();
+        await destroyed;
+        expect(wc.isDestroyed()).to.be.true();
+        return wc;
+      };
+
+      it('does not throw when adding a listener', async () => {
+        const wc = await destroyedWebContents();
+        expect(() => wc.on('console-message', () => {})).to.not.throw();
+        expect(wc.listenerCount('console-message')).to.equal(1);
+      });
+
+      it('does not throw when removing a listener', async () => {
+        const handler = () => {};
+        const wc = await destroyedWebContents(handler);
+        expect(() => wc.removeListener('console-message', handler)).to.not.throw();
+        expect(wc.listenerCount('console-message')).to.equal(0);
+      });
+
+      it('does not throw when removing all listeners', async () => {
+        const wc = await destroyedWebContents(() => {});
+        expect(() => wc.removeAllListeners('console-message')).to.not.throw();
+        expect(wc.listenerCount('console-message')).to.equal(0);
+        wc.on('console-message', () => {});
+        expect(() => wc.removeAllListeners()).to.not.throw();
+      });
+    });
   });
 
   describe('ipc-message event', () => {


### PR DESCRIPTION
#53115 added `newListener` / `removeListener` hooks that call `_setConsoleMessageObserved()` without checking `isDestroyed()`. EventEmitter emits those synchronously, so on a destroyed WebContents the native `Object has been destroyed` error escapes from `on('console-message')`, `removeListener('console-message')` and `removeAllListeners()`, aborting teardown sweeps partway through.

- Skip the native call in both hooks once the WebContents is destroyed; JS listener bookkeeping is unchanged.
- Specs for add, remove and `removeAllListeners` on a destroyed WebContents.

Notes: Fixed `webContents.on()`, `removeListener()` and `removeAllListeners()` throwing "Object has been destroyed" for `console-message` listeners after the WebContents was destroyed.
