### PR TITLE
test: leave fullscreen before destroying a window on macOS

### DIFF
--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -6921,9 +6921,11 @@ describe('BrowserWindow module', () => {
 
     ifdescribe(process.platform === 'darwin')('kiosk state', () => {
       describe('with properties', () => {
-        it('can be set with a constructor property', () => {
+        it('can be set with a constructor property', async () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.kiosk).to.be.true();
+          // Let the fullscreen transition finish; see leaveFullScreen().
+          await once(w, 'enter-full-screen');
         });
 
         it('can be changed ', async () => {
@@ -6942,9 +6944,11 @@ describe('BrowserWindow module', () => {
       });
 
       describe('with functions', () => {
-        it('can be set with a constructor property', () => {
+        it('can be set with a constructor property', async () => {
           const w = new BrowserWindow({ kiosk: true });
           expect(w.isKiosk()).to.be.true();
+          // Let the fullscreen transition finish; see leaveFullScreen().
+          await once(w, 'enter-full-screen');
         });
 
         it('can be changed ', async () => {

--- a/spec/lib/window-helpers.ts
+++ b/spec/lib/window-helpers.ts
@@ -4,8 +4,19 @@ import { expect } from 'chai';
 
 import { once } from 'node:events';
 
+// On macOS, destroying a fullscreen window animates it out of its Space, and
+// AppKit ignores fullscreen requests from other windows until that finishes.
+// Leave fullscreen first so the next test doesn't start inside the animation.
+async function leaveFullScreen(window: BaseWindow) {
+  if (process.platform !== 'darwin' || !window.isFullScreen()) return;
+  const left = once(window, 'leave-full-screen');
+  window.setFullScreen(false);
+  await Promise.race([left, new Promise((resolve) => setTimeout(resolve, 5000))]);
+}
+
 async function ensureWindowIsClosed(window: BaseWindow | null) {
   if (window && !window.isDestroyed()) {
+    await leaveFullScreen(window);
     if (window instanceof BrowserWindow && window.webContents && !window.webContents.isDestroyed()) {
       // If a window isn't destroyed already, and it has non-destroyed WebContents,
       // then calling destroy() won't immediately destroy it, as it may have


### PR DESCRIPTION
#### Description of Change

Three macOS `BrowserWindow` specs time out on their first attempt in every CI run, then pass on retry. Each one runs right after a test that leaves a window fullscreen, or still entering fullscreen, which `closeAllWindows()` then destroys. AppKit animates that window out of its Space and ignores fullscreen requests from other windows until the animation ends.

- `closeWindow()` leaves fullscreen, and waits for it, before destroying a window on macOS.
- The two kiosk constructor tests wait for `enter-full-screen`.

Measured on `macos-15-large` in #53492:

| test | before | after |
|---|---|---|
| kiosk state with properties can be changed | 32 s, 1 retry | 2.3 s |
| kiosk state with functions can be changed | 32 s, 1 retry | 2.7 s |
| fullscreen state multiple windows inherit correct fullscreen state | 32 s, 1 retry | 2.7 s |

#### Checklist

- [x] PR description included

#### Release Notes

Notes: none
