### PR TITLE
test: don't assert inside process exit/error listeners

### DIFF
--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -344,10 +344,13 @@ describe('net module', () => {
             response.writeHead(200).end('ok');
           });
           const request = net.request({ method: 'GET', url: serverUrl, credentials: 'omit' });
-          request.on('login', () => {
-            expect.fail('unexpected login event');
+          let loginEventEmitted = false;
+          request.on('login', (authInfo, cb) => {
+            loginEventEmitted = true;
+            cb();
           });
           const response = await getResponse(request);
+          expect(loginEventEmitted).to.be.false('unexpected login event');
           expect(response.statusCode).to.equal(401);
           expect(response.headers['www-authenticate']).to.equal('Basic realm="Foo"');
         });
@@ -368,8 +371,9 @@ describe('net module', () => {
         const finishPromise = once(urlRequest, 'close');
         // request "response" event
         const response = await getResponse(urlRequest);
+        let responseError: Error | undefined;
         response.on('error', (error: Error) => {
-          expect(error).to.be.an('Error');
+          responseError = error;
         });
         const statusCode = response.statusCode;
         expect(statusCode).to.equal(200);
@@ -377,10 +381,35 @@ describe('net module', () => {
         // respond end event
         const body = await collectStreamBody(response);
         expect(body).to.equal(bodyData);
+        let requestError: Error | undefined;
         urlRequest.on('error', (error) => {
-          expect(error).to.be.an('Error');
+          requestError = error;
         });
         await Promise.all([closePromise, finishPromise]);
+        expect(responseError).to.be.undefined();
+        expect(requestError).to.be.undefined();
+      });
+
+      test('request/response objects should emit error events when the connection is lost mid-body', async () => {
+        const serverUrl = await respondOnce.toSingleURL((request, response) => {
+          response.writeHead(200, { 'Content-Length': kOneKiloByte * 2 });
+          // Only send half of the promised body, then drop the connection.
+          response.write(randomString(kOneKiloByte), () => request.socket.destroy());
+        });
+
+        const urlRequest = net.request(serverUrl);
+        const requestErrorPromise = once(urlRequest, 'error');
+        const response = await getResponse(urlRequest);
+        expect(response.statusCode).to.equal(200);
+        const responseErrorPromise = once(response, 'error');
+        // The body is only read (and the dropped connection noticed) while it is being consumed.
+        response.on('data', () => {});
+        const [responseError] = await responseErrorPromise;
+        const [requestError] = await requestErrorPromise;
+        expect(responseError).to.be.an.instanceOf(Error);
+        expect(responseError.message).to.match(/^net::ERR_/);
+        expect(requestError).to.be.an.instanceOf(Error);
+        expect(requestError.message).to.equal(responseError.message);
       });
 
       test('should be able to set a custom HTTP request header before first write', async () => {
@@ -719,20 +748,24 @@ describe('net module', () => {
       }
 
       test('should be able to abort an HTTP request before first write', async () => {
+        let requestReceivedByServer = false;
         const serverUrl = await respondOnce.toSingleURL((request, response) => {
+          requestReceivedByServer = true;
           response.end();
-          expect.fail('Unexpected request event');
         });
 
         const urlRequest = net.request(serverUrl);
+        let responseEventEmitted = false;
         urlRequest.on('response', () => {
-          expect.fail('unexpected response event');
+          responseEventEmitted = true;
         });
         const aborted = once(urlRequest, 'abort');
         urlRequest.abort();
         urlRequest.write('');
         urlRequest.end();
         await aborted;
+        expect(requestReceivedByServer).to.be.false('Unexpected request event');
+        expect(responseEventEmitted).to.be.false('Unexpected response event');
       });
 
       test('it should be able to abort an HTTP request before request end', async () => {
@@ -745,14 +778,17 @@ describe('net module', () => {
         let requestAbortEventEmitted = false;
 
         urlRequest = net.request(serverUrl);
+        let responseEventEmitted = false;
         urlRequest.on('response', () => {
-          expect.fail('Unexpected response event');
+          responseEventEmitted = true;
         });
+        let finishEventEmitted = false;
         urlRequest.on('finish', () => {
-          expect.fail('Unexpected finish event');
+          finishEventEmitted = true;
         });
-        urlRequest.on('error', () => {
-          expect.fail('Unexpected error event');
+        let unexpectedError: Error | undefined;
+        urlRequest.on('error', (error) => {
+          unexpectedError = error;
         });
         urlRequest.on('abort', () => {
           requestAbortEventEmitted = true;
@@ -762,6 +798,9 @@ describe('net module', () => {
         urlRequest.chunkedEncoding = true;
         urlRequest.write(randomString(kOneKiloByte));
         await p;
+        expect(responseEventEmitted).to.be.false('Unexpected response event');
+        expect(finishEventEmitted).to.be.false('Unexpected finish event');
+        expect(unexpectedError).to.be.undefined('Unexpected error event');
         expect(requestReceivedByServer).to.equal(true);
         expect(requestAbortEventEmitted).to.equal(true);
       });
@@ -890,8 +929,9 @@ describe('net module', () => {
         defer(() => protocol.uninterceptProtocol('http'));
 
         const urlRequest = net.request({ method: 'POST', url: 'http://aborted-upload-write' });
-        urlRequest.on('error', () => {
-          expect.fail('Unexpected error event');
+        let unexpectedError: Error | undefined;
+        urlRequest.on('error', (error) => {
+          unexpectedError = error;
         });
         urlRequest.chunkedEncoding = true;
         let writeCallbackCalled = false;
@@ -912,6 +952,7 @@ describe('net module', () => {
         const writeError = await writeCompleted;
         expect(writeError).to.be.an.instanceOf(Error);
         expect(writeError!.message).to.contain('ERR_ABORTED');
+        expect(unexpectedError).to.be.undefined('Unexpected error event');
       });
 
       test('it should be able to abort an HTTP request after request end and before response', async () => {
@@ -929,17 +970,21 @@ describe('net module', () => {
         let requestFinishEventEmitted = false;
 
         urlRequest = net.request(serverUrl);
+        let responseEventEmitted = false;
         urlRequest.on('response', () => {
-          expect.fail('Unexpected response event');
+          responseEventEmitted = true;
         });
         urlRequest.on('finish', () => {
           requestFinishEventEmitted = true;
         });
-        urlRequest.on('error', () => {
-          expect.fail('Unexpected error event');
+        let unexpectedError: Error | undefined;
+        urlRequest.on('error', (error) => {
+          unexpectedError = error;
         });
         urlRequest.end(randomString(kOneKiloByte));
         await once(urlRequest, 'abort');
+        expect(responseEventEmitted).to.be.false('Unexpected response event');
+        expect(unexpectedError).to.be.undefined('Unexpected error event');
         expect(requestFinishEventEmitted).to.equal(true);
         expect(requestReceivedByServer).to.equal(true);
       });
@@ -955,18 +1000,20 @@ describe('net module', () => {
         let requestFinishEventEmitted = false;
         let requestResponseEventEmitted = false;
         let responseCloseEventEmitted = false;
+        let unexpectedError: Error | undefined;
+        let responseStatusCode: number | undefined;
+        let responseEndEventEmitted = false;
 
         const urlRequest = net.request(serverUrl);
         urlRequest.on('response', (response) => {
           requestResponseEventEmitted = true;
-          const statusCode = response.statusCode;
-          expect(statusCode).to.equal(200);
+          responseStatusCode = response.statusCode;
           response.on('data', () => {});
           response.on('end', () => {
-            expect.fail('Unexpected end event');
+            responseEndEventEmitted = true;
           });
-          response.on('error', () => {
-            expect.fail('Unexpected error event');
+          response.on('error', (error) => {
+            unexpectedError = error;
           });
           response.on('close' as any, () => {
             responseCloseEventEmitted = true;
@@ -976,14 +1023,17 @@ describe('net module', () => {
         urlRequest.on('finish', () => {
           requestFinishEventEmitted = true;
         });
-        urlRequest.on('error', () => {
-          expect.fail('Unexpected error event');
+        urlRequest.on('error', (error) => {
+          unexpectedError = error;
         });
         urlRequest.end(randomString(kOneKiloByte));
         await once(urlRequest, 'abort');
+        expect(unexpectedError).to.be.undefined('Unexpected error event');
         expect(requestFinishEventEmitted).to.be.true('request should emit "finish" event');
         expect(requestReceivedByServer).to.be.true('request should be received by the server');
         expect(requestResponseEventEmitted).to.be.true('"response" event should be emitted');
+        expect(responseStatusCode).to.equal(200);
+        expect(responseEndEventEmitted).to.be.false('Unexpected end event');
         expect(responseCloseEventEmitted).to.be.true('response should emit "close" event');
       });
 
@@ -999,20 +1049,24 @@ describe('net module', () => {
         let abortsEmitted = 0;
 
         urlRequest = net.request(serverUrl);
+        let responseEventEmitted = false;
         urlRequest.on('response', () => {
-          expect.fail('Unexpected response event');
+          responseEventEmitted = true;
         });
         urlRequest.on('finish', () => {
           requestFinishEventEmitted = true;
         });
-        urlRequest.on('error', () => {
-          expect.fail('Unexpected error event');
+        let unexpectedError: Error | undefined;
+        urlRequest.on('error', (error) => {
+          unexpectedError = error;
         });
         urlRequest.on('abort', () => {
           abortsEmitted++;
         });
         urlRequest.end(randomString(kOneKiloByte));
         await once(urlRequest, 'abort');
+        expect(responseEventEmitted).to.be.false('Unexpected response event');
+        expect(unexpectedError).to.be.undefined('Unexpected error event');
         expect(requestFinishEventEmitted).to.be.true('request should emit "finish" event');
         expect(requestReceivedByServer).to.be.true('request should be received by server');
         expect(abortsEmitted).to.equal(1, 'request should emit exactly 1 "abort" event');
@@ -1120,10 +1174,12 @@ describe('net module', () => {
           urlRequest.abort();
         });
         urlRequest.on('error', () => {});
+        let responseEventEmitted = false;
         urlRequest.on('response', () => {
-          expect.fail('Unexpected response');
+          responseEventEmitted = true;
         });
         await once(urlRequest, 'abort');
+        expect(responseEventEmitted).to.be.false('Unexpected response');
       });
 
       test('should not follow redirect when mode is error', async () => {
@@ -1205,12 +1261,12 @@ describe('net module', () => {
         const bodyData = randomString(kOneMegaByte);
         let netRequestReceived = false;
         let netRequestEnded = false;
+        let receivedBodyData = '';
 
         const [nodeServerUrl, netServerUrl] = await Promise.all([
           respondOnce.toSingleURL((request, response) => response.end(bodyData)),
           respondOnce.toSingleURL((request, response) => {
             netRequestReceived = true;
-            let receivedBodyData = '';
             request.on('data', (chunk) => {
               receivedBodyData += chunk.toString();
             });
@@ -1219,7 +1275,6 @@ describe('net module', () => {
               if (chunk) {
                 receivedBodyData += chunk.toString();
               }
-              expect(receivedBodyData).to.be.equal(bodyData);
               response.end();
             });
           })
@@ -1235,6 +1290,7 @@ describe('net module', () => {
         await collectStreamBody(netResponse);
         expect(netRequestReceived).to.be.true('net request received');
         expect(netRequestEnded).to.be.true('net request ended');
+        expect(receivedBodyData).to.equal(bodyData);
       });
 
       test('should report upload progress', async () => {

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -593,7 +593,7 @@ describe('session module', () => {
         | 'clearSharedDictionaryCache'
         | 'clearSharedDictionaryCacheForIsolationKey'
     ) => {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         let output = '';
 
         const appProcess = ChildProcess.spawn(process.execPath, [appPath, command]);
@@ -608,7 +608,7 @@ describe('session module', () => {
             resolve(JSON.parse(trimmedOutput));
           } catch (e) {
             console.error(`Error trying to deserialize ${trimmedOutput}`);
-            throw e;
+            reject(e);
           }
         });
       });

--- a/spec/api-utility-process-spec.ts
+++ b/spec/api-utility-process-spec.ts
@@ -80,20 +80,16 @@ describe('utilityProcess module', () => {
       await once(child, 'spawn');
     });
 
-    it("emits 'exit' when child process exits gracefully", (done) => {
+    it("emits 'exit' when child process exits gracefully", async () => {
       const child = utilityProcess.fork(path.join(fixturesPath, 'empty.js'));
-      child.on('exit', (code) => {
-        expect(code).to.equal(0);
-        done();
-      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(0);
     });
 
-    it("emits 'exit' when the child process file does not exist", (done) => {
+    it("emits 'exit' when the child process file does not exist", async () => {
       const child = utilityProcess.fork('nonexistent');
-      child.on('exit', (code) => {
-        expect(code).to.equal(1);
-        done();
-      });
+      const [code] = await once(child, 'exit');
+      expect(code).to.equal(1);
     });
 
     ifit(!isWindows32Bit)('emits the correct error code when child process exits nonzero', async () => {

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -1690,11 +1690,11 @@ describe('asar package', function () {
           async function (childProcess: string) {
             const echo = path.join(asarDir, 'echo.asar', 'echo');
             const process = require(childProcess).execFile(echo, ['test']);
-            const code = await new Promise((resolve) => process.once('close', resolve));
-            expect(code).to.equal(0);
-            process.on('error', function () {
-              throw new Error('error');
+            const code = await new Promise((resolve, reject) => {
+              process.once('close', resolve);
+              process.once('error', reject);
             });
+            expect(code).to.equal(0);
           },
           [childProcess]
         );

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -3200,16 +3200,12 @@ describe('chromium features', () => {
             show: false,
             ...extraPreferences
           });
-          let redirected = false;
-          w.webContents.on('render-process-gone', () => {
-            expect.fail('renderer crashed / was killed');
-          });
+          let redirectedTo: string | undefined;
           w.webContents.on('did-redirect-navigation', (event, url) => {
-            expect(url).to.equal(`${serverCrossSiteUrl}/redirected`);
-            redirected = true;
+            redirectedTo = url;
           });
           await w.loadURL(`${serverUrl}/redirect-cross-site`);
-          expect(redirected).to.be.true('didnt redirect');
+          expect(redirectedTo).to.equal(`${serverCrossSiteUrl}/redirected`, 'didnt redirect');
         });
       };
 

--- a/spec/lib/codesign-helpers.ts
+++ b/spec/lib/codesign-helpers.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import * as cp from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -99,7 +100,7 @@ export async function copyMacOSFixtureApp(
   return newPath;
 }
 
-export function spawn(cmd: string, args: string[], opts: any = {}) {
+export async function spawn(cmd: string, args: string[], opts: any = {}): Promise<{ code: number; out: string }> {
   let out = '';
   const child = cp.spawn(cmd, args, opts);
   child.stdout.on('data', (chunk: Buffer) => {
@@ -108,15 +109,9 @@ export function spawn(cmd: string, args: string[], opts: any = {}) {
   child.stderr.on('data', (chunk: Buffer) => {
     out += chunk.toString();
   });
-  return new Promise<{ code: number; out: string }>((resolve) => {
-    child.on('exit', (code, signal) => {
-      expect(signal).to.equal(null);
-      resolve({
-        code: code!,
-        out
-      });
-    });
-  });
+  const [code, signal] = await once(child, 'exit');
+  expect(signal).to.equal(null);
+  return { code, out };
 }
 
 export type SignAppOptions = {

--- a/spec/lib/msix-helpers.ts
+++ b/spec/lib/msix-helpers.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import * as cp from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -135,7 +136,7 @@ export async function getMsixPackageVersion(name: string): Promise<string | null
   return version || null;
 }
 
-export function spawn(cmd: string, args: string[], opts: any = {}): Promise<{ code: number; out: string }> {
+export async function spawn(cmd: string, args: string[], opts: any = {}): Promise<{ code: number; out: string }> {
   let out = '';
   const child = cp.spawn(cmd, args, opts);
   child.stdout.on('data', (chunk: Buffer) => {
@@ -144,13 +145,7 @@ export function spawn(cmd: string, args: string[], opts: any = {}): Promise<{ co
   child.stderr.on('data', (chunk: Buffer) => {
     out += chunk.toString();
   });
-  return new Promise<{ code: number; out: string }>((resolve) => {
-    child.on('exit', (code, signal) => {
-      expect(signal).to.equal(null);
-      resolve({
-        code: code!,
-        out
-      });
-    });
-  });
+  const [code, signal] = await once(child, 'exit');
+  expect(signal).to.equal(null);
+  return { code, out };
 }


### PR DESCRIPTION
Backport of #53426

See that PR for details. The two `fs.createReadStream` hunks in `spec/asar-spec.ts` are left out because the file descriptor tests they touch (#52833) are not on this branch.

Notes: none
