### PR TITLE
fix: crash when the environment is written while another thread reads it

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1517,6 +1517,7 @@ if (is_mac) {
     } else if (is_linux) {
       sources = [
         "shell/app/electron_main_linux.cc",
+        "shell/app/environ_linux.cc",
         "shell/app/uv_stdio_fix.cc",
         "shell/app/uv_stdio_fix.h",
       ]

--- a/shell/app/environ_linux.cc
+++ b/shell/app/environ_linux.cc
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// Thread-safe setenv(), unsetenv(), putenv() and clearenv().
+//
+// Before glibc 2.41, adding a variable reallocates the `environ` array and
+// frees the old one. A getenv() running on another thread at that moment
+// reads freed memory. Electron cannot avoid this by ordering: Chromium's
+// thread pool and system libraries call getenv() at any time, and app code
+// adds variables through process.env whenever it likes.
+//
+// Because the executable is linked with -rdynamic, these definitions replace
+// glibc's for the whole process, including shared libraries such as GTK. They
+// follow the scheme glibc 2.41 adopted upstream:
+//
+//  - An `environ` array that has been published is never freed. Growing it
+//    allocates a larger array, copies the entries and publishes the new one.
+//    Capacity doubles, so the arrays that are given up total less than the
+//    live one.
+//  - "NAME=value" strings are never freed, as in every glibc version, because
+//    getenv() callers hold pointers into them. Identical strings are reused,
+//    so setting the same value again allocates nothing.
+//
+// A getenv() on another thread therefore sees either the old or the new state,
+// and every pointer it reads stays valid.
+//
+// On glibc 2.41 and later these functions call glibc's own. Those versions are
+// already safe, and their unsetenv() and clearenv() also bump a private counter
+// that getenv() checks to retry a lookup that raced with a removal. The code
+// here cannot bump that counter.
+
+#ifdef UNSAFE_BUFFERS_BUILD
+// These are libc functions over `environ`, a null-terminated array of C
+// strings with no length to check against.
+#pragma allow_unsafe_buffers
+#pragma allow_unsafe_libc_calls
+#endif
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <gnu/libc-version.h>
+#include <pthread.h>
+#include <search.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <algorithm>
+
+#include "base/memory/raw_ptr_exclusion.h"
+
+// MemorySanitizer intercepts these functions to track `environ`; leave them
+// alone in that configuration.
+#if !defined(MEMORY_SANITIZER)
+
+namespace {
+
+// glibc's own functions, when the running glibc is 2.41 or later.
+struct GlibcFunctions {
+  decltype(&::setenv) setenv;
+  decltype(&::unsetenv) unsetenv;
+  decltype(&::putenv) putenv;
+  decltype(&::clearenv) clearenv;
+};
+
+const GlibcFunctions* GetGlibcFunctionsIfSafe() {
+  static const GlibcFunctions* const functions = []() -> GlibcFunctions* {
+    int major = 0;
+    int minor = 0;
+    if (sscanf(gnu_get_libc_version(), "%d.%d", &major, &minor) != 2 ||
+        major < 2 || (major == 2 && minor < 41)) {
+      return nullptr;
+    }
+    static GlibcFunctions glibc = {
+        reinterpret_cast<decltype(&::setenv)>(dlsym(RTLD_NEXT, "setenv")),
+        reinterpret_cast<decltype(&::unsetenv)>(dlsym(RTLD_NEXT, "unsetenv")),
+        reinterpret_cast<decltype(&::putenv)>(dlsym(RTLD_NEXT, "putenv")),
+        reinterpret_cast<decltype(&::clearenv)>(dlsym(RTLD_NEXT, "clearenv")),
+    };
+    if (!glibc.setenv || !glibc.unsetenv || !glibc.putenv || !glibc.clearenv) {
+      return nullptr;
+    }
+    return &glibc;
+  }();
+  return functions;
+}
+
+pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// The array this file allocated and last published, and its size in slots.
+// Anything else in `environ` is treated as read-only and copied before a
+// change.
+char** g_owned_array = nullptr;
+size_t g_owned_capacity = 0;
+
+// Arrays this file published and then replaced. They are kept on a list, as
+// glibc does, so they stay reachable and leak checkers do not report them.
+struct RetiredArray {
+  // Never freed, so raw_ptr's use-after-free protection has nothing to do.
+  RAW_PTR_EXCLUSION char** array;
+  RAW_PTR_EXCLUSION RetiredArray* next;
+};
+RetiredArray* g_retired_arrays = nullptr;
+
+// Every "NAME=value" string setenv() has allocated, keyed by its contents.
+void* g_known_strings = nullptr;
+
+class ScopedLock {
+ public:
+  ScopedLock() { pthread_mutex_lock(&g_lock); }
+  ~ScopedLock() { pthread_mutex_unlock(&g_lock); }
+  ScopedLock(const ScopedLock&) = delete;
+  ScopedLock& operator=(const ScopedLock&) = delete;
+};
+
+void PublishArray(char** array) {
+  __atomic_store_n(&environ, array, __ATOMIC_RELEASE);
+}
+
+void StoreEntry(char** slot, char* entry) {
+  __atomic_store_n(slot, entry, __ATOMIC_RELEASE);
+}
+
+size_t CountEntries(char** array) {
+  size_t count = 0;
+  if (array) {
+    while (array[count]) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// Returns the slot holding `name`, or nullptr.
+char** FindEntry(const char* name, size_t name_len) {
+  char** array = environ;
+  if (!array) {
+    return nullptr;
+  }
+  for (char** slot = array; *slot; ++slot) {
+    if (strncmp(*slot, name, name_len) == 0 && (*slot)[name_len] == '=') {
+      return slot;
+    }
+  }
+  return nullptr;
+}
+
+// Appends `entry`, growing into a new array when the current one is full or
+// is not ours. Returns false when memory runs out.
+bool AppendEntry(char* entry) {
+  char** array = environ;
+  const size_t count = CountEntries(array);
+
+  // Slot `count` takes the entry and slot `count + 1` the terminator.
+  if (array != g_owned_array || count + 2 > g_owned_capacity) {
+    const size_t capacity = std::max(g_owned_capacity * 2, count + 2 + 16);
+    // calloc leaves every unused slot null, so the terminator is in place
+    // before the entry becomes visible.
+    auto** grown = static_cast<char**>(calloc(capacity, sizeof(char*)));
+    if (!grown) {
+      return false;
+    }
+    if (g_owned_array) {
+      auto* retired = static_cast<RetiredArray*>(malloc(sizeof(RetiredArray)));
+      if (!retired) {
+        free(grown);
+        return false;
+      }
+      *retired = {g_owned_array, g_retired_arrays};
+      g_retired_arrays = retired;
+    }
+    if (count) {
+      memcpy(grown, array, count * sizeof(char*));
+    }
+    grown[count] = entry;
+    g_owned_array = grown;
+    g_owned_capacity = capacity;
+    PublishArray(grown);
+    return true;
+  }
+
+  StoreEntry(&array[count + 1], nullptr);
+  StoreEntry(&array[count], entry);
+  return true;
+}
+
+int CompareStrings(const void* a, const void* b) {
+  return strcmp(static_cast<const char*>(a), static_cast<const char*>(b));
+}
+
+// Returns a "NAME=value" string that stays valid for the life of the process.
+char* MakeEntry(const char* name, size_t name_len, const char* value) {
+  const size_t value_len = strlen(value);
+  auto* entry = static_cast<char*>(malloc(name_len + 1 + value_len + 1));
+  if (!entry) {
+    return nullptr;
+  }
+  memcpy(entry, name, name_len);
+  entry[name_len] = '=';
+  memcpy(entry + name_len + 1, value, value_len + 1);
+
+  void* node = tsearch(entry, &g_known_strings, CompareStrings);
+  if (!node) {
+    // Not remembered, which only means it will not be reused later.
+    return entry;
+  }
+  char* known = *static_cast<char**>(node);
+  if (known != entry) {
+    free(entry);
+  }
+  return known;
+}
+
+bool IsValidName(const char* name) {
+  return name && name[0] != '\0' && !strchr(name, '=');
+}
+
+// Removes every entry for `name`. Entries shift down in place; a reader may
+// see one twice or miss one, but every pointer it reads stays valid.
+void RemoveEntries(const char* name, size_t name_len) {
+  char** array = environ;
+  if (!array) {
+    return;
+  }
+  char** slot = array;
+  while (*slot) {
+    if (strncmp(*slot, name, name_len) == 0 && (*slot)[name_len] == '=') {
+      char** to = slot;
+      do {
+        StoreEntry(to, to[1]);
+      } while (*to++);
+    } else {
+      ++slot;
+    }
+  }
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) int setenv(const char* name,
+                                                  const char* value,
+                                                  int replace) noexcept {
+  if (const GlibcFunctions* glibc = GetGlibcFunctionsIfSafe()) {
+    return glibc->setenv(name, value, replace);
+  }
+  if (!IsValidName(name)) {
+    errno = EINVAL;
+    return -1;
+  }
+  const size_t name_len = strlen(name);
+
+  ScopedLock lock;
+  char** existing = FindEntry(name, name_len);
+  if (existing && !replace) {
+    return 0;
+  }
+  char* entry = MakeEntry(name, name_len, value);
+  if (!entry) {
+    errno = ENOMEM;
+    return -1;
+  }
+  if (existing) {
+    StoreEntry(existing, entry);
+    return 0;
+  }
+  if (!AppendEntry(entry)) {
+    errno = ENOMEM;
+    return -1;
+  }
+  return 0;
+}
+
+__attribute__((visibility("default"))) int unsetenv(const char* name) noexcept {
+  if (const GlibcFunctions* glibc = GetGlibcFunctionsIfSafe()) {
+    return glibc->unsetenv(name);
+  }
+  if (!IsValidName(name)) {
+    errno = EINVAL;
+    return -1;
+  }
+  ScopedLock lock;
+  RemoveEntries(name, strlen(name));
+  return 0;
+}
+
+__attribute__((visibility("default"))) int putenv(char* string) noexcept {
+  if (const GlibcFunctions* glibc = GetGlibcFunctionsIfSafe()) {
+    return glibc->putenv(string);
+  }
+  const char* equals = strchr(string, '=');
+  ScopedLock lock;
+  if (!equals) {
+    // glibc removes the variable when the string has no '='.
+    RemoveEntries(string, strlen(string));
+    return 0;
+  }
+  const auto name_len = static_cast<size_t>(equals - string);
+  if (char** existing = FindEntry(string, name_len)) {
+    StoreEntry(existing, string);
+    return 0;
+  }
+  if (!AppendEntry(string)) {
+    errno = ENOMEM;
+    return -1;
+  }
+  return 0;
+}
+
+__attribute__((visibility("default"))) int clearenv() noexcept {
+  if (const GlibcFunctions* glibc = GetGlibcFunctionsIfSafe()) {
+    return glibc->clearenv();
+  }
+  ScopedLock lock;
+  // The array is dropped, not freed, like every array this file gives up.
+  PublishArray(nullptr);
+  return 0;
+}
+
+}  // extern "C"
+
+#endif  // !defined(MEMORY_SANITIZER)

--- a/shell/common/gin_helper/function_template.cc
+++ b/shell/common/gin_helper/function_template.cc
@@ -4,10 +4,61 @@
 
 #include "shell/common/gin_helper/function_template.h"
 
+#include <vector>
+
+#include "base/no_destructor.h"
 #include "base/strings/strcat.h"
+#include "base/synchronization/lock.h"
+#include "base/thread_annotations.h"
 #include "gin/public/gin_embedders.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 
 namespace gin_helper {
+
+namespace {
+
+// The live holders of each isolate that has no gin::PerIsolateData.
+class HoldersWithoutGin {
+ public:
+  static HoldersWithoutGin& Get() {
+    static base::NoDestructor<HoldersWithoutGin> instance;
+    return *instance;
+  }
+
+  void Add(v8::Isolate* isolate, CallbackHolderBase* holder) {
+    base::AutoLock lock(lock_);
+    holders_[isolate].insert(holder);
+  }
+
+  void Remove(v8::Isolate* isolate, CallbackHolderBase* holder) {
+    base::AutoLock lock(lock_);
+    auto it = holders_.find(isolate);
+    if (it == holders_.end()) {
+      return;
+    }
+    it->second.erase(holder);
+    if (it->second.empty()) {
+      holders_.erase(it);
+    }
+  }
+
+  std::vector<CallbackHolderBase*> TakeAll(v8::Isolate* isolate) {
+    base::AutoLock lock(lock_);
+    auto node = holders_.extract(isolate);
+    if (node.empty()) {
+      return {};
+    }
+    return {node.mapped().begin(), node.mapped().end()};
+  }
+
+ private:
+  base::Lock lock_;
+  absl::flat_hash_map<v8::Isolate*, absl::flat_hash_set<CallbackHolderBase*>>
+      holders_ GUARDED_BY(lock_);
+};
+
+}  // namespace
 
 CallbackHolderBase::DisposeObserver::DisposeObserver(
     gin::PerIsolateData* per_isolate_data,
@@ -37,10 +88,31 @@ CallbackHolderBase::CallbackHolderBase(v8::Isolate* isolate)
       dispose_observer_(gin::PerIsolateData::From(isolate), this) {
   v8_ref_.SetWeak(this, &CallbackHolderBase::FirstWeakCallback,
                   v8::WeakCallbackType::kParameter);
+  if (!gin::PerIsolateData::From(isolate)) {
+    isolate_without_gin_ = isolate;
+    HoldersWithoutGin::Get().Add(isolate, this);
+  }
 }
 
 CallbackHolderBase::~CallbackHolderBase() {
   DCHECK(v8_ref_.IsEmpty());
+  if (isolate_without_gin_) {
+    HoldersWithoutGin::Get().Remove(isolate_without_gin_, this);
+  }
+}
+
+// static
+void CallbackHolderBase::DisposeAllInIsolateWithoutGin(v8::Isolate* isolate) {
+  for (CallbackHolderBase* holder : HoldersWithoutGin::Get().TakeAll(isolate)) {
+    holder->isolate_without_gin_ = nullptr;
+    // An empty handle means a garbage collection has already run the first
+    // weak callback, and the second one will delete the holder.
+    if (holder->v8_ref_.IsEmpty()) {
+      continue;
+    }
+    holder->v8_ref_.Reset();
+    delete holder;
+  }
 }
 
 v8::Local<v8::External> CallbackHolderBase::GetHandle(v8::Isolate* isolate) {

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -68,6 +68,13 @@ class CallbackHolderBase {
 
   v8::Local<v8::External> GetHandle(v8::Isolate* isolate);
 
+  // Frees the holders created in `isolate` when it has no gin::PerIsolateData,
+  // as a Node.js worker's isolate does. gin never reports the disposal of such
+  // an isolate, and V8 does not run weak callbacks when it disposes one, so
+  // without this the holders leak. Call it on the isolate's thread once no
+  // more JavaScript will run there.
+  static void DisposeAllInIsolateWithoutGin(v8::Isolate* isolate);
+
  protected:
   explicit CallbackHolderBase(v8::Isolate* isolate);
   virtual ~CallbackHolderBase();
@@ -99,6 +106,9 @@ class CallbackHolderBase {
 
   v8::Global<v8::External> v8_ref_;
   DisposeObserver dispose_observer_;
+
+  // Set while this holder is registered for DisposeAllInIsolateWithoutGin().
+  raw_ptr<v8::Isolate> isolate_without_gin_ = nullptr;
 };
 
 template <typename Sig>

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -30,6 +30,7 @@
 #include "electron/electron_version.h"
 #include "electron/fuses.h"
 #include "electron/mas.h"
+#include "gin/per_isolate_data.h"
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/electron_command_line.h"
@@ -38,6 +39,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
+#include "shell/common/gin_helper/function_template.h"
 #include "shell/common/js2c_bundle_ids.h"
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
@@ -1146,6 +1148,18 @@ void NodeBindings::EmbedThreadRunner(void* arg) {
 void OnNodePreload(node::Environment* env,
                    v8::Local<v8::Value> process,
                    v8::Local<v8::Value> require) {
+  // A Node.js worker's isolate has no gin::PerIsolateData, so gin never frees
+  // the callback holders created in it. Free them when the environment is torn
+  // down, which happens on the worker's thread after its JavaScript has ended.
+  if (!gin::PerIsolateData::From(env->isolate())) {
+    env->AddCleanupHook(
+        [](void* isolate) {
+          gin_helper::CallbackHolderBase::DisposeAllInIsolateWithoutGin(
+              static_cast<v8::Isolate*>(isolate));
+        },
+        env->isolate());
+  }
+
   // Set custom process properties.
   gin_helper::Dictionary dict(env->isolate(), process.As<v8::Object>());
   dict.SetReadOnly("resourcesPath", GetResourcesPath());

--- a/spec/api-process-spec.ts
+++ b/spec/api-process-spec.ts
@@ -3,10 +3,12 @@ import { app } from 'electron/main';
 
 import { expect } from 'chai';
 
+import * as cp from 'node:child_process';
+import { once } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { defer } from './lib/spec-helpers';
+import { defer, ifdescribe } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('process module', () => {
@@ -132,5 +134,18 @@ describe('process module', () => {
 
   describe('main process', () => {
     generateSpecs((fn, ...args) => fn(...args));
+  });
+
+  ifdescribe(process.platform === 'linux')('process.env', () => {
+    it('can add variables while another thread reads the environment', async () => {
+      const fixture = path.join(__dirname, 'fixtures', 'api', 'environ-write-race.js');
+      const child = cp.spawn(process.execPath, [fixture], { stdio: ['ignore', 'pipe', 'inherit'] });
+      let stdout = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      const [code, signal] = await once(child, 'close');
+      expect({ code, signal, stdout: stdout.trim() }).to.deep.equal({ code: 0, signal: null, stdout: 'done' });
+    });
   });
 });

--- a/spec/fixtures/api/environ-write-race.js
+++ b/spec/fixtures/api/environ-write-race.js
@@ -1,0 +1,43 @@
+// A worker thread reads the environment while this script adds variables.
+// os.homedir() reaches getenv() through libuv without taking Node's
+// environment lock, the same way Chromium's threads and system libraries do.
+//
+// The race runs synchronously in the main script. The app exits once the
+// worker has been torn down, before the app is ready.
+const { app } = require('electron');
+
+const { Worker } = require('node:worker_threads');
+
+const STARTING = 0;
+const READING = 1;
+const STOP = 2;
+const STOPPED = 3;
+
+const state = new Int32Array(new SharedArrayBuffer(4));
+const worker = new Worker(
+  `
+  const { workerData } = require('node:worker_threads');
+  const os = require('node:os');
+  const state = new Int32Array(workerData);
+  Atomics.store(state, 0, ${READING});
+  Atomics.notify(state, 0);
+  while (Atomics.load(state, 0) !== ${STOP}) os.homedir();
+  Atomics.store(state, 0, ${STOPPED});
+  Atomics.notify(state, 0);
+`,
+  { eval: true, workerData: state.buffer }
+);
+
+// Waits while the state is `value`. Returns false after 30 seconds.
+const waitWhile = (value) => Atomics.wait(state, 0, value, 30_000) !== 'timed-out';
+
+if (!waitWhile(STARTING)) {
+  console.log('the worker did not start');
+} else {
+  for (let i = 0; i < 2000; i++) {
+    process.env[`ELECTRON_SPEC_ENVIRON_RACE_${i}`] = '1';
+  }
+  Atomics.store(state, 0, STOP);
+  console.log(waitWhile(STOP) ? 'done' : 'the worker did not stop');
+}
+worker.once('exit', () => app.exit(0));


### PR DESCRIPTION
Backport of #53491

See that PR for details. The only conflict was an include in `shell/common/node_bindings.cc` (this branch does not have `gin/per_context_data.h`, which the change does not need).

Notes: Fixed a crash on Linux when `process.env` was written while another thread was reading the environment, and a memory leak when a worker thread exits.
