### PR TITLE
feat: support per-corner radii in View.setBorderRadius()

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -14,8 +14,6 @@ import("//third_party/widevine/cdm/widevine.gni")
 static_library("chrome") {
   visibility = [ "//electron:electron_lib" ]
   sources = [
-    "//ash/style/rounded_rect_cutout_path_builder.cc",
-    "//ash/style/rounded_rect_cutout_path_builder.h",
     "//chrome/browser/app_mode/app_mode_utils.cc",
     "//chrome/browser/app_mode/app_mode_utils.h",
     "//chrome/browser/browser_features.cc",

--- a/docs/api/view.md
+++ b/docs/api/view.md
@@ -110,9 +110,23 @@ Examples of valid `color` values:
 > [!NOTE]
 > Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBAA` or `RGB`.
 
-#### `view.setBorderRadius(radius)`
+#### `view.setBorderRadius(borderRadius)`
 
-* `radius` Integer - Border radius size in pixels.
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/51472
+    description: "`setBorderRadius` now accepts an object with per-corner radii."
+```
+-->
+
+* `borderRadius` Integer | Object - Border radius. When an `Integer`, it is applied
+  uniformly to all four corners. When an `Object`, it must contain the following
+  properties:
+  * `topLeft` Integer - Radius of the top-left corner, in pixels.
+  * `topRight` Integer - Radius of the top-right corner, in pixels.
+  * `bottomRight` Integer - Radius of the bottom-right corner, in pixels.
+  * `bottomLeft` Integer - Radius of the bottom-left corner, in pixels.
 
 > [!NOTE]
 > The area cutout of the view's border still captures clicks.

--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -10,16 +10,17 @@
 #include <string>
 #include <utility>
 
-#include "ash/style/rounded_rect_cutout_path_builder.h"
 #include "gin/data_object_builder.h"
 #include "gin/wrappable.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
+#include "third_party/skia/include/core/SkRRect.h"
 #include "ui/compositor/layer.h"
 #include "ui/views/animation/animation_builder.h"
 #include "ui/views/background.h"
@@ -170,6 +171,10 @@ struct Converter<gfx::Tween::Type> {
 }  // namespace gin
 
 namespace electron::api {
+
+constexpr char kBorderRadiusTypeError[] =
+    "`borderRadius` must be an integer or an object with integer `topLeft`, "
+    "`topRight`, `bottomRight`, and `bottomLeft` properties";
 
 using LayoutCallback = base::RepeatingCallback<views::ProposedLayout(
     const views::SizeBounds& size_bounds)>;
@@ -485,37 +490,87 @@ void View::SetBackgroundColor(std::optional<WrappedSkColor> color) {
                              : nullptr);
 }
 
-void View::SetBorderRadius(int radius) {
-  border_radius_ = radius;
+void View::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                           v8::Local<v8::Value> value) {
+  v8::Isolate* const isolate = thrower.isolate();
+  if (value->IsNumber()) {
+    int radius = 0;
+    if (!gin::ConvertFromV8(isolate, value, &radius)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
+      return;
+    }
+    border_radii_ = gfx::RoundedCornersF(static_cast<float>(radius));
+  } else if (value->IsObject()) {
+    gin_helper::Dictionary dict;
+    if (!gin::ConvertFromV8(isolate, value, &dict)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
+      return;
+    }
+    int top_left = 0;
+    int top_right = 0;
+    int bottom_right = 0;
+    int bottom_left = 0;
+    if (!dict.Get("topLeft", &top_left) || !dict.Get("topRight", &top_right) ||
+        !dict.Get("bottomRight", &bottom_right) ||
+        !dict.Get("bottomLeft", &bottom_left)) {
+      thrower.ThrowTypeError(kBorderRadiusTypeError);
+      return;
+    }
+    border_radii_ = gfx::RoundedCornersF(
+        static_cast<float>(top_left), static_cast<float>(top_right),
+        static_cast<float>(bottom_right), static_cast<float>(bottom_left));
+  } else {
+    thrower.ThrowTypeError(kBorderRadiusTypeError);
+    return;
+  }
   ApplyBorderRadius();
 }
 
 void View::ApplyBorderRadius() {
-  if (!border_radius_.has_value() || !view_)
+  if (!border_radii_.has_value() || !view_)
     return;
 
-  auto size = view_->bounds().size();
-
-  // Restrict border radius to the constraints set in the path builder class.
-  // If the constraints are exceeded, the builder will crash.
-  int radius;
-  {
-    float r = border_radius_.value() * 1.f;
-    r = std::min(r, size.width() / 2.f);
-    r = std::min(r, size.height() / 2.f);
-    r = std::max(r, 0.f);
-    radius = std::floor(r);
+  const auto size = view_->bounds().size();
+  if (size.IsEmpty()) {
+    // An empty clip path creates a fully transparent mask on a layer-backed
+    // view. Leave an existing layer mask alone until the view has bounds again.
+    if (!view_->layer())
+      view_->SetClipPath(SkPath());
+    view_->SchedulePaint();
+    OnBorderRadiusApplied(gfx::RoundedCornersF());
+    return;
   }
 
-  // RoundedRectCutoutPathBuilder has a minimum size of 32 x 32.
-  if (radius > 0 && size.width() >= 32 && size.height() >= 32) {
-    auto builder = ash::RoundedRectCutoutPathBuilder(gfx::SizeF(size));
-    builder.CornerRadius(radius);
-    view_->SetClipPath(builder.Build());
-  } else {
+  const SkRect rect = SkRect::MakeWH(static_cast<SkScalar>(size.width()),
+                                     static_cast<SkScalar>(size.height()));
+  const auto nonnegative = [](float radius) { return std::max(0.f, radius); };
+  const SkVector radii[4] = {{nonnegative(border_radii_->upper_left()),
+                              nonnegative(border_radii_->upper_left())},
+                             {nonnegative(border_radii_->upper_right()),
+                              nonnegative(border_radii_->upper_right())},
+                             {nonnegative(border_radii_->lower_right()),
+                              nonnegative(border_radii_->lower_right())},
+                             {nonnegative(border_radii_->lower_left()),
+                              nonnegative(border_radii_->lower_left())}};
+  SkRRect rrect;
+  rrect.setRectRadii(rect, radii);
+  const gfx::RoundedCornersF normalized_radii(
+      rrect.radii(SkRRect::kUpperLeft_Corner).x(),
+      rrect.radii(SkRRect::kUpperRight_Corner).x(),
+      rrect.radii(SkRRect::kLowerRight_Corner).x(),
+      rrect.radii(SkRRect::kLowerLeft_Corner).x());
+
+  // SetClipPath with an empty path creates a fully transparent mask when the
+  // view has a layer. Use the equivalent rectangular path in that case.
+  if (normalized_radii.IsEmpty() && !view_->layer())
     view_->SetClipPath(SkPath());
-  }
+  else
+    view_->SetClipPath(SkPath::RRect(rrect));
+  view_->SchedulePaint();
+  OnBorderRadiusApplied(normalized_radii);
 }
+
+void View::OnBorderRadiusApplied(const gfx::RoundedCornersF&) {}
 
 void View::SetBackgroundBlur(int blur_radius) {
   if (!view_)

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -10,11 +10,13 @@
 #include "base/memory/raw_ptr.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/event_emitter.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
 #include "v8/include/v8-value.h"
 
 namespace gin_helper {
+class ErrorThrower;
 template <typename T>
 class Handle;
 }  // namespace gin_helper
@@ -42,13 +44,16 @@ class View : public gin_helper::EventEmitter<View>,
   void SetLayout(v8::Isolate* isolate, v8::Local<v8::Object> value);
   std::vector<v8::Local<v8::Value>> GetChildren();
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
   void SetBackgroundBlur(int blur_radius);
   void SetVisible(bool visible);
   bool GetVisible() const;
 
   views::View* view() const { return view_; }
-  std::optional<int> border_radius() const { return border_radius_; }
+  const std::optional<gfx::RoundedCornersF>& border_radii() const {
+    return border_radii_;
+  }
 
   // disable copy
   View(const View&) = delete;
@@ -62,6 +67,9 @@ class View : public gin_helper::EventEmitter<View>,
   // Should delete the |view_| in destructor.
   void set_delete_view(bool should) { delete_view_ = should; }
 
+  void ApplyBorderRadius();
+  virtual void OnBorderRadiusApplied(const gfx::RoundedCornersF& border_radii);
+
  private:
   using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
 
@@ -72,11 +80,10 @@ class View : public gin_helper::EventEmitter<View>,
                           views::View* child) override;
 
   ui::Layer* GetLayer();
-  void ApplyBorderRadius();
   void ReorderChildView(gin_helper::Handle<View> child, size_t index);
 
   std::vector<ChildPair> child_views_;
-  std::optional<int> border_radius_;
+  std::optional<gfx::RoundedCornersF> border_radii_;
 
   bool delete_view_ = true;
   raw_ptr<views::View> view_ = nullptr;

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_web_contents_view.h"
 
+#include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
 #include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_web_contents.h"
@@ -16,6 +17,7 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/handle.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
@@ -70,15 +72,27 @@ void WebContentsView::SetBackgroundColor(std::optional<WrappedSkColor> color) {
   }
 }
 
-void WebContentsView::SetBorderRadius(int radius) {
-  View::SetBorderRadius(radius);
-  ApplyBorderRadius();
+void WebContentsView::SetBorderRadius(gin_helper::ErrorThrower thrower,
+                                      v8::Local<v8::Value> value) {
+  View::SetBorderRadius(thrower, value);
 }
 
-void WebContentsView::ApplyBorderRadius() {
-  if (border_radius().has_value() && api_web_contents_ && view()->GetWidget()) {
+void WebContentsView::OnBorderRadiusApplied(
+    const gfx::RoundedCornersF& border_radii) {
+  if (api_web_contents_ && view()->GetWidget()) {
     auto* view = api_web_contents_->inspectable_web_contents()->GetView();
-    view->SetCornerRadii(gfx::RoundedCornersF(border_radius().value()));
+    gfx::RoundedCornersF web_contents_radii = border_radii;
+#if defined(USE_AURA)
+    // NativeViewHostAura interprets corner radii as logical values and mirrors
+    // them in RTL layouts. Swap them here so the public API remains physical,
+    // matching the View clip path and macOS behavior.
+    if (base::i18n::IsRTL()) {
+      web_contents_radii = gfx::RoundedCornersF(
+          border_radii.upper_right(), border_radii.upper_left(),
+          border_radii.lower_left(), border_radii.lower_right());
+    }
+#endif
+    view->SetCornerRadii(web_contents_radii);
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -14,7 +14,8 @@
 
 namespace gin_helper {
 class Dictionary;
-}
+class ErrorThrower;
+}  // namespace gin_helper
 
 namespace electron::api {
 
@@ -39,7 +40,8 @@ class WebContentsView : public View,
   // Public APIs.
   gin_helper::Handle<WebContents> GetWebContents(v8::Isolate* isolate);
   void SetBackgroundColor(std::optional<WrappedSkColor> color);
-  void SetBorderRadius(int radius);
+  void SetBorderRadius(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> value);
 
   int NonClientHitTest(const gfx::Point& point) override;
 
@@ -59,7 +61,7 @@ class WebContentsView : public View,
  private:
   static gin_helper::WrappableBase* New(gin::Arguments* args);
 
-  void ApplyBorderRadius();
+  void OnBorderRadiusApplied(const gfx::RoundedCornersF& border_radii) override;
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;

--- a/spec/api-view-spec.ts
+++ b/spec/api-view-spec.ts
@@ -80,6 +80,54 @@ describe('View', () => {
     v.setBorderRadius(-9999999);
   });
 
+  it('allows setting per-corner border radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: 10, topRight: 8, bottomRight: 6, bottomLeft: 4 });
+    v.setBorderRadius({ topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 });
+  });
+
+  it('throws when per-corner keys are missing', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    const borderRadiusError = /must be an integer or an object/;
+    const borderRadius = { topLeft: 5, topRight: 5, bottomRight: 5, bottomLeft: 5 };
+    const keys = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'] as const;
+
+    for (const key of keys) {
+      const missing = { ...borderRadius } as Partial<typeof borderRadius>;
+      delete missing[key];
+      expect(() => v.setBorderRadius(missing as any)).to.throw(TypeError, borderRadiusError);
+    }
+  });
+
+  it('clamps negative and oversize per-corner radii', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius({ topLeft: -10, topRight: 9999, bottomRight: 0, bottomLeft: 5 });
+    v.setBorderRadius({ topLeft: -9999999, topRight: -1, bottomRight: -1, bottomLeft: -1 });
+  });
+
+  it('allows mixing integer and object forms', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    v.setBorderRadius(8);
+    v.setBorderRadius({ topLeft: 16, topRight: 16, bottomRight: 0, bottomLeft: 0 });
+    v.setBorderRadius(0);
+  });
+
+  it('throws on invalid border radius input', () => {
+    w = new BaseWindow({ show: false });
+    const v = new View();
+    w.setContentView(v);
+    expect(() => v.setBorderRadius('not valid' as any)).to.throw(TypeError, /must be an integer or an object/);
+    expect(() => v.setBorderRadius(1.5 as any)).to.throw(TypeError, /must be an integer or an object/);
+  });
+
   describe('view.getVisible|setVisible', () => {
     it('is visible by default', () => {
       const v = new View();

--- a/spec/api-web-contents-view-spec.ts
+++ b/spec/api-web-contents-view-spec.ts
@@ -522,12 +522,43 @@ describe('WebContentsView', () => {
       });
 
       it('should allow resetting corners', async () => {
+        // Exercise the layer-backed path, where an empty clip path would create
+        // a fully transparent mask and hide the view.
+        v.setBackgroundBlur(10);
         v.setBorderRadius(0);
 
         await nextFrameTime();
         const capture = ScreenCapture.forWindow(w);
         await capture.expectColorAtPointMatches(HexColors.GREEN, corners[0]);
         await capture.expectColorAtCenterMatches(HexColors.GREEN);
+      });
+
+      it('should preserve valid asymmetric radii', async () => {
+        const parent = new View();
+        w.setContentView(parent);
+        parent.addChildView(v);
+        v.setBounds({ x: 0, y: 0, width: 100, height: 100 });
+        v.setBorderRadius({ topLeft: 80, topRight: 20, bottomRight: 30, bottomLeft: 10 });
+
+        const capture = ScreenCapture.forWindow(w);
+        await capture.expectColorAtPointMatches(HexColors.BLUE, () => ({ x: 25, y: 15 }));
+        await capture.expectColorAtPointMatches(HexColors.GREEN, () => ({ x: 90, y: 10 }));
+        await capture.expectColorAtPointMatches(HexColors.GREEN, () => ({ x: 90, y: 90 }));
+        await capture.expectColorAtPointMatches(HexColors.GREEN, () => ({ x: 5, y: 95 }));
+      });
+
+      it('should keep the clip and compositor radii in sync after resizing', async () => {
+        const parent = new View();
+        w.setContentView(parent);
+        parent.addChildView(v);
+        v.setBorderRadius(100);
+
+        const capture = ScreenCapture.forWindow(w);
+        v.setBounds({ x: 0, y: 0, width: 40, height: 40 });
+        await capture.expectColorAtPointMatches(HexColors.GREEN, corners[0]);
+
+        v.setBounds({ x: 0, y: 0, width: 200, height: 200 });
+        await capture.expectColorAtPointMatches(HexColors.BLUE, corners[0]);
       });
 
       it('should render when set before attached', async () => {


### PR DESCRIPTION
Allow View and WebContentsView callers to provide independent top-left, top-right, bottom-right, and bottom-left radii while preserving the existing integer form.

Normalize asymmetric radii through SkRRect, keep compositor clipping synchronized across resizing and RTL layouts, and cover layer-backed reset behavior with rendering tests.

Resolves electron/electron#51342

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] I have built and tested this change
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
