### PR TITLE
feat: add continuous swipe gesture events on macOS

### DIFF
--- a/docs/api/base-window.md
+++ b/docs/api/base-window.md
@@ -332,6 +332,32 @@ configured to allow this kind of swiping anymore, so in order for it to emit pro
 'Swipe between pages' preference in `System Preferences > Trackpad > More Gestures` must be
 set to 'Swipe with two or three fingers'.
 
+#### Event: 'swipe-gesture' _macOS_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53522
+```
+-->
+
+Returns:
+
+* `event` Event
+* `direction` string - Can be `left` or `right`.
+* `phase` string - Can be `began`, `changed`, `ended`, or `cancelled`.
+* `progress` number - The gesture's progress, from `0` to `1`.
+
+Emitted during a continuous horizontal swipe tracked by macOS. The window starts
+tracking when the first listener is added and stops when the last listener is
+removed. The application decides whether and how to respond to the gesture.
+
+While tracking is enabled, recognized horizontal swipe gestures are consumed by
+the window instead of being delivered as horizontal scroll events.
+
+This event requires the "Swipe between pages" setting in
+`System Settings > Trackpad > More Gestures` to be enabled.
+
 #### Event: 'rotate-gesture' _macOS_
 
 Returns:

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -416,6 +416,32 @@ configured to allow this kind of swiping anymore, so in order for it to emit pro
 'Swipe between pages' preference in `System Preferences > Trackpad > More Gestures` must be
 set to 'Swipe with two or three fingers'.
 
+#### Event: 'swipe-gesture' _macOS_
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53522
+```
+-->
+
+Returns:
+
+* `event` Event
+* `direction` string - Can be `left` or `right`.
+* `phase` string - Can be `began`, `changed`, `ended`, or `cancelled`.
+* `progress` number - The gesture's progress, from `0` to `1`.
+
+Emitted during a continuous horizontal swipe tracked by macOS. The window starts
+tracking when the first listener is added and stops when the last listener is
+removed. The application decides whether and how to respond to the gesture.
+
+While tracking is enabled, recognized horizontal swipe gestures are consumed by
+the window instead of being delivered as horizontal scroll events.
+
+This event requires the "Swipe between pages" setting in
+`System Settings > Trackpad > More Gestures` to be enabled.
+
 #### Event: 'rotate-gesture' _macOS_
 
 Returns:

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -16,6 +16,19 @@ BaseWindow.prototype._init = function (this: TLWT) {
     const menu = app.applicationMenu;
     if (menu) this.setMenu(menu);
   }
+
+  if (process.platform === 'darwin') {
+    EventEmitter.prototype.on.call(this, 'newListener', (event: string | symbol) => {
+      if (event === 'swipe-gesture' && this.listenerCount(event) === 0) {
+        this._setSwipeGestureEnabled(true);
+      }
+    });
+    EventEmitter.prototype.on.call(this, 'removeListener', (event: string | symbol) => {
+      if (event === 'swipe-gesture' && this.listenerCount(event) === 0) {
+        this._setSwipeGestureEnabled(false);
+      }
+    });
+  }
 };
 
 BaseWindow.prototype.setTouchBar = function (touchBar) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -305,6 +305,12 @@ void BaseWindow::OnWindowSwipe(const std::string& direction) {
   Emit("swipe", direction);
 }
 
+void BaseWindow::OnWindowSwipeGesture(const std::string& direction,
+                                      const std::string& phase,
+                                      double progress) {
+  Emit("swipe-gesture", direction, phase, progress);
+}
+
 void BaseWindow::OnWindowRotateGesture(float rotation) {
   Emit("rotate-gesture", rotation);
 }
@@ -912,6 +918,10 @@ bool BaseWindow::IsHiddenInMissionControl() {
 void BaseWindow::SetHiddenInMissionControl(bool hidden) {
   window_->SetHiddenInMissionControl(hidden);
 }
+
+void BaseWindow::SetSwipeGestureEnabled(bool enabled) {
+  window_->SetSwipeGestureEnabled(enabled);
+}
 #endif
 
 void BaseWindow::SetTouchBar(
@@ -1349,6 +1359,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                  &BaseWindow::IsHiddenInMissionControl)
       .SetMethod("setHiddenInMissionControl",
                  &BaseWindow::SetHiddenInMissionControl)
+      .SetMethod("_setSwipeGestureEnabled", &BaseWindow::SetSwipeGestureEnabled)
 #endif
       .SetMethod("_setTouchBarItems", &BaseWindow::SetTouchBar)
       .SetMethod("_refreshTouchBarItem", &BaseWindow::RefreshTouchBarItem)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -95,6 +95,9 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowMove() override;
   void OnWindowMoved() override;
   void OnWindowSwipe(const std::string& direction) override;
+  void OnWindowSwipeGesture(const std::string& direction,
+                            const std::string& phase,
+                            double progress) override;
   void OnWindowRotateGesture(float rotation) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;
@@ -226,6 +229,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
 
   bool IsHiddenInMissionControl();
   void SetHiddenInMissionControl(bool hidden);
+  void SetSwipeGestureEnabled(bool enabled);
 #endif
 
   void SetTouchBar(std::vector<gin_helper::PersistentDictionary> items);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -676,6 +676,13 @@ void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
   observers_.Notify(&NativeWindowObserver::OnWindowSwipe, direction);
 }
 
+void NativeWindow::NotifyWindowSwipeGesture(const std::string& direction,
+                                            const std::string& phase,
+                                            double progress) {
+  observers_.Notify(&NativeWindowObserver::OnWindowSwipeGesture, direction,
+                    phase, progress);
+}
+
 void NativeWindow::NotifyWindowRotateGesture(float rotation) {
   observers_.Notify(&NativeWindowObserver::OnWindowRotateGesture, rotation);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -249,6 +249,7 @@ class NativeWindow : public views::WidgetDelegate {
   virtual std::optional<gfx::Point> GetWindowButtonPosition() const = 0;
   virtual void RedrawTrafficLights() = 0;
   virtual void UpdateFrame() = 0;
+  virtual void SetSwipeGestureEnabled(bool enabled) {}
 #endif
 
 // whether windows should be ignored by mission control
@@ -332,6 +333,9 @@ class NativeWindow : public views::WidgetDelegate {
   void NotifyWindowWillMove(const gfx::Rect& new_bounds, bool* prevent_default);
   void NotifyWindowMoved();
   void NotifyWindowSwipe(const std::string& direction);
+  void NotifyWindowSwipeGesture(const std::string& direction,
+                                const std::string& phase,
+                                double progress);
   void NotifyWindowRotateGesture(float rotation);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -135,6 +135,7 @@ class NativeWindowMac : public NativeWindow,
   std::optional<gfx::Point> GetWindowButtonPosition() const override;
   void RedrawTrafficLights() override;
   void UpdateFrame() override;
+  void SetSwipeGestureEnabled(bool enabled) override;
   void SetTouchBar(
       std::vector<gin_helper::PersistentDictionary> items) override;
   void RefreshTouchBarItem(const std::string& item_id) override;
@@ -214,6 +215,7 @@ class NativeWindowMac : public NativeWindow,
   ElectronTouchBar* touch_bar() const { return touch_bar_; }
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
   bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
+  bool swipe_gesture_enabled() const { return swipe_gesture_enabled_; }
 
   // We need to save the result of windowWillUseStandardFrame:defaultFrame
   // because macOS calls it with what it refers to as the "best fit" frame for a
@@ -307,6 +309,7 @@ class NativeWindowMac : public NativeWindow,
   bool was_maximizable_ = false;
   bool was_movable_ = false;
   bool is_active_ = false;
+  bool swipe_gesture_enabled_ = false;
   NSRect original_frame_;
   NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1220,6 +1220,10 @@ void NativeWindowMac::SetHiddenInMissionControl(bool hidden) {
   SetCollectionBehavior(hidden, NSWindowCollectionBehaviorTransient);
 }
 
+void NativeWindowMac::SetSwipeGestureEnabled(bool enabled) {
+  swipe_gesture_enabled_ = enabled;
+}
+
 void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool forward) {
   [window_ setIgnoresMouseEvents:ignore];
   if (!ignore) {

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -87,6 +87,9 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowMove() {}
   virtual void OnWindowMoved() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
+  virtual void OnWindowSwipeGesture(const std::string& direction,
+                                    const std::string& phase,
+                                    double progress) {}
   virtual void OnWindowRotateGesture(float rotation) {}
   virtual void OnWindowSheetBegin() {}
   virtual void OnWindowSheetEnd() {}

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -4,6 +4,9 @@
 
 #include "shell/browser/ui/cocoa/electron_ns_window.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "base/strings/sys_string_conversions.h"
 #include "electron/mas.h"
 #include "shell/browser/api/electron_api_web_contents.h"
@@ -147,9 +150,31 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
 }
 #endif
 
+const char* SwipeGesturePhaseName(NSEventPhase phase) {
+  switch (phase) {
+    case NSEventPhaseBegan:
+      return "began";
+    case NSEventPhaseChanged:
+      return "changed";
+    case NSEventPhaseEnded:
+      return "ended";
+    case NSEventPhaseCancelled:
+      return "cancelled";
+    default:
+      return nullptr;
+  }
+}
+
+// Chromium's HistorySwiper also uses renderer overscroll state and owns Chrome
+// navigation UI. This window-level event instead treats listener registration
+// as the explicit opt-in to AppKit swipe tracking.
+
 }  // namespace
 
-@implementation ElectronNSWindow
+@implementation ElectronNSWindow {
+  NSSize _swipeGestureDelta;
+  BOOL _trackingSwipeGesture;
+}
 
 @synthesize acceptsFirstMouse;
 @synthesize enableLargerThanScreen;
@@ -193,11 +218,14 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
     SwizzleSwipeWithEvent(view, @selector(swiz_nsview_swipeWithEvent:));
 #endif  // IS_MAS_BUILD
     shell_ = shell;
+    _swipeGestureDelta = NSZeroSize;
+    _trackingSwipeGesture = NO;
   }
   return self;
 }
 
 - (void)cleanup {
+  _trackingSwipeGesture = NO;
   shell_ = nullptr;
 }
 
@@ -221,9 +249,75 @@ void SwizzleSwipeWithEvent(NSView* view, SEL swiz_selector) {
     return nil;
 }
 
+- (BOOL)handleSwipeGestureEvent:(NSEvent*)event {
+  if (!shell_ || !shell_->swipe_gesture_enabled() ||
+      event.type != NSEventTypeScrollWheel) {
+    return NO;
+  }
+
+  if (_trackingSwipeGesture)
+    return YES;
+
+  if (event.phase == NSEventPhaseBegan) {
+    _swipeGestureDelta = NSZeroSize;
+    return NO;
+  }
+
+  if (event.phase != NSEventPhaseChanged ||
+      event.momentumPhase != NSEventPhaseNone ||
+      !NSEvent.swipeTrackingFromScrollEventsEnabled) {
+    return NO;
+  }
+
+  _swipeGestureDelta.width += event.scrollingDeltaX;
+  _swipeGestureDelta.height += event.scrollingDeltaY;
+  if (std::abs(_swipeGestureDelta.width) <=
+      std::abs(_swipeGestureDelta.height)) {
+    return NO;
+  }
+
+  const std::string direction =
+      _swipeGestureDelta.width < 0 ? "right" : "left";
+  _trackingSwipeGesture = YES;
+  __weak ElectronNSWindow* weakSelf = self;
+  [event
+      trackSwipeEventWithOptions:NSEventSwipeTrackingLockDirection
+        dampenAmountThresholdMin:-1
+                             max:1
+                    usingHandler:^(CGFloat gestureAmount, NSEventPhase phase,
+                                   BOOL isComplete, BOOL* stop) {
+                      ElectronNSWindow* strongSelf = weakSelf;
+                      if (!strongSelf || !strongSelf->shell_ ||
+                          !strongSelf->shell_->swipe_gesture_enabled()) {
+                        if (strongSelf) {
+                          strongSelf->_trackingSwipeGesture = NO;
+                          strongSelf->_swipeGestureDelta = NSZeroSize;
+                        }
+                        *stop = YES;
+                        return;
+                      }
+
+                      const char* phaseName = SwipeGesturePhaseName(phase);
+                      if (phaseName) {
+                        strongSelf->shell_->NotifyWindowSwipeGesture(
+                            direction, phaseName,
+                            std::clamp(std::abs(gestureAmount), 0.0, 1.0));
+                      }
+
+                      if (isComplete) {
+                        strongSelf->_trackingSwipeGesture = NO;
+                        strongSelf->_swipeGestureDelta = NSZeroSize;
+                      }
+                    }];
+  return YES;
+}
+
 // NSWindow overrides.
 
 - (void)sendEvent:(NSEvent*)event {
+  if ([self handleSwipeGestureEvent:event])
+    return;
+
   // Draggable regions only respond to left-click dragging, but the system will
   // still suppress right-clicks in a draggable region. Temporarily disabling
   // draggable regions allows the underlying views to respond to right-click

--- a/spec/api-base-window-spec.ts
+++ b/spec/api-base-window-spec.ts
@@ -84,7 +84,41 @@ describe('BaseWindow module', () => {
   });
 
   ifdescribe(process.platform === 'darwin')('macOS events', () => {
-    eventSubscriptionTests(['swipe', 'rotate-gesture', 'new-window-for-tab']);
+    eventSubscriptionTests([
+      'swipe',
+      'swipe-gesture',
+      'rotate-gesture',
+      'new-window-for-tab'
+    ]);
+
+    it('observes swipe gestures only while listeners are registered', () => {
+      const w = new BaseWindow({ show: false });
+      const calls: boolean[] = [];
+      w._setSwipeGestureEnabled = (enabled) => calls.push(enabled);
+      const first = () => {};
+      const second = () => {};
+
+      w.on('swipe-gesture', first);
+      w.on('swipe-gesture', second);
+      w.off('swipe-gesture', first);
+      w.off('swipe-gesture', second);
+
+      expect(calls).to.deep.equal([true, false]);
+    });
+
+    it('continues observing after removing all swipe gesture listeners', () => {
+      const w = new BaseWindow({ show: false });
+      const calls: boolean[] = [];
+      w._setSwipeGestureEnabled = (enabled) => calls.push(enabled);
+      const listener = () => {};
+
+      w.on('swipe-gesture', listener);
+      w.removeAllListeners('swipe-gesture');
+      w.on('swipe-gesture', listener);
+      w.off('swipe-gesture', listener);
+
+      expect(calls).to.deep.equal([true, false, true, false]);
+    });
   });
 
   describe('BaseWindow.close()', () => {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -36,6 +36,7 @@ declare namespace Electron {
     _setTouchBarItems: (items: TouchBarItemType[]) => void;
     _setEscapeTouchBarItem: (item: TouchBarItemType | {}) => void;
     _refreshTouchBarItem: (itemID: string) => void;
+    _setSwipeGestureEnabled: (enabled: boolean) => void;
     on(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;
     removeListener(
       event: '-touch-bar-interaction',


### PR DESCRIPTION
#### Description of Change

This is a focused successor to #49235 that preserves its event-based direction while addressing the earlier API review feedback.

- Adds a macOS-only `swipe-gesture` event to `BaseWindow` and `BrowserWindow`, reporting `direction`, `phase`, and normalized `progress`.
- Starts native AppKit tracking when the first event listener is added and stops it after the last listener is removed. There is no constructor flag or application-wide event monitor.
- Leaves navigation and visual feedback to the application. Electron does not assume which `WebContents` a `BaseWindow` should navigate.
- Stops native tracking if the window is destroyed or all `swipe-gesture` listeners are removed during a gesture.
- Documents that recognized horizontal gestures are consumed while a listener is registered; without a listener, ordinary horizontal scrolling is unaffected.

#### Chromium integration

Chromium's `HistorySwiper` was evaluated for direct reuse. It is coupled to renderer input acknowledgements, overscroll state, Chrome's history overlay, and browser navigation. Those policies do not fit a window-level Electron event, particularly because a `BaseWindow` can contain zero or multiple `WebContents`.

This implementation uses the same underlying AppKit `trackSwipeEventWithOptions:` mechanism while keeping navigation and UI policy in the application.

Credit to @KikoTs for the original implementation and direction in #49235. The commit retains Kiril as a co-author. Closes #2683.

#### Validation

- `e build`
- `node script/lint.js --changed`
- `npm test -- --grep='BaseWindow module'` — 79 passed, 0 failed
- API JSON and TypeScript definitions generated successfully as part of the focused test command
- `git diff --check`
- Physical macOS trackpad validation:
  - left and right direction
  - `began`, `changed`, `ended`, and `cancelled` phases
  - progress bounded to `[0, 1]`, including reversing toward zero
  - listener removal and re-registration
  - normal horizontal scrolling with capture disabled and swipe capture with a listener registered

Magic Mouse behavior was not physically validated.

The implementation was developed with Codex assistance, disclosed in the commit trailer.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added a macOS `swipe-gesture` window event that reports continuous horizontal swipe progress.
