### PR TITLE
fix: renderer crash after IPC to a window.open() child with its own contextIsolation

### DIFF
--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -4,6 +4,8 @@
 
 #include "shell/renderer/electron_render_frame_observer.h"
 
+#include <optional>
+
 #include "base/memory/ref_counted_memory.h"
 #include "base/trace_event/trace_event.h"
 #include "content/public/renderer/render_frame.h"
@@ -183,6 +185,13 @@ void ElectronRenderFrameObserver::CreateIsolatedWorldContext() {
 }
 
 bool ElectronRenderFrameObserver::ShouldNotifyClient(int world_id) const {
+  // Once this frame has a Node.js environment, only the world of its context
+  // is notified. Choosing from the current WebPreferences instead would create
+  // a second environment, or skip the release of the first, when they change.
+  if (std::optional<int> env_world_id =
+          renderer_client_->GetEnvironmentWorldId(render_frame_))
+    return *env_world_id == world_id;
+
   const auto& prefs = render_frame_->GetBlinkPreferences();
 
   // about:blank subframes commit synchronously in the renderer and never get

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -54,6 +54,9 @@ struct ElectronRendererClient::FrameEnvironment {
   raw_ptr<NodeBindings> node_bindings;
   raw_ptr<ElectronBindings> electron_bindings;
   std::shared_ptr<node::Environment> environment;
+  // The world of |environment|'s context, recorded while Blink can still map
+  // the context to its frame.
+  int world_id = 0;
   base::WeakPtrFactory<FrameEnvironment> weak_factory{this};
 };
 
@@ -139,6 +142,8 @@ void ElectronRendererClient::DidCreateScriptContext(
   auto frame_env = std::make_unique<FrameEnvironment>(
       render_frame->IsMainFrame(), node_bindings_.get(),
       electron_bindings_.get());
+  frame_env->world_id =
+      render_frame->GetWebFrame()->GetScriptContextWorldId(renderer_context);
   NodeBindings* node_bindings = frame_env->node_bindings;
 
   // Setup node environment for each window.
@@ -304,6 +309,20 @@ void ElectronRendererClient::SetUpWebAssemblyTrapHandler() {
     electron::SetUpWebAssemblyTrapHandler();
   }
 #endif
+}
+
+v8::Local<v8::Context> ElectronRendererClient::GetEnvironmentContext(
+    content::RenderFrame* render_frame) const {
+  node::Environment* env = GetEnvironment(render_frame);
+  return env ? env->context() : v8::Local<v8::Context>();
+}
+
+std::optional<int> ElectronRendererClient::GetEnvironmentWorldId(
+    content::RenderFrame* render_frame) const {
+  auto iter = environments_.find(render_frame);
+  if (iter == environments_.end())
+    return std::nullopt;
+  return iter->second->world_id;
 }
 
 node::Environment* ElectronRendererClient::GetEnvironment(

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_RENDERER_ELECTRON_RENDERER_CLIENT_H_
 
 #include <memory>
+#include <optional>
 
 #include "base/containers/flat_map.h"
 #include "shell/renderer/renderer_client_base.h"
@@ -32,6 +33,10 @@ class ElectronRendererClient : public RendererClientBase {
   void DidCreateScriptContext(v8::Isolate* isolate,
                               v8::Local<v8::Context> context,
                               content::RenderFrame* render_frame) override;
+  v8::Local<v8::Context> GetEnvironmentContext(
+      content::RenderFrame* render_frame) const override;
+  std::optional<int> GetEnvironmentWorldId(
+      content::RenderFrame* render_frame) const override;
   void WillReleaseScriptContext(v8::Isolate* isolate,
                                 v8::Local<v8::Context> context,
                                 content::RenderFrame* render_frame) override;

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -589,11 +589,26 @@ v8::Local<v8::Context> RendererClientBase::GetContext(
     v8::Isolate* isolate) const {
   auto* render_frame = content::RenderFrame::FromWebFrame(frame);
   DCHECK(render_frame);
+  if (render_frame) {
+    v8::Local<v8::Context> env_context = GetEnvironmentContext(render_frame);
+    if (!env_context.IsEmpty())
+      return env_context;
+  }
   if (render_frame && render_frame->GetBlinkPreferences().context_isolation)
     return frame->GetScriptContextFromWorldId(isolate,
                                               WorldIDs::ISOLATED_WORLD_ID);
   else
     return frame->MainWorldScriptContext();
+}
+
+v8::Local<v8::Context> RendererClientBase::GetEnvironmentContext(
+    content::RenderFrame* render_frame) const {
+  return {};
+}
+
+std::optional<int> RendererClientBase::GetEnvironmentWorldId(
+    content::RenderFrame* render_frame) const {
+  return std::nullopt;
 }
 
 bool RendererClientBase::IsWebViewFrame(

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -6,6 +6,7 @@
 #define ELECTRON_SHELL_RENDERER_RENDERER_CLIENT_BASE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "content/public/renderer/content_renderer_client.h"
@@ -73,6 +74,18 @@ class RendererClientBase : public content::ContentRendererClient
   // Get the context that the Electron API is running in.
   v8::Local<v8::Context> GetContext(blink::WebLocalFrame* frame,
                                     v8::Isolate* isolate) const;
+
+  // The context of |render_frame|'s Node.js environment, or an empty handle if
+  // it has none. Once a frame has an environment, the Electron API stays in
+  // that context until it is released, even if the frame's WebPreferences
+  // change: a window.open() child starts with its opener's preferences and
+  // gets its own later.
+  virtual v8::Local<v8::Context> GetEnvironmentContext(
+      content::RenderFrame* render_frame) const;
+
+  // The world of GetEnvironmentContext(), if |render_frame| has an environment.
+  virtual std::optional<int> GetEnvironmentWorldId(
+      content::RenderFrame* render_frame) const;
 
   static void AllowGuestViewElementDefinition(
       v8::Isolate* isolate,

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -4333,6 +4333,74 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    describe('window.open() child that does not inherit contextIsolation: false', () => {
+      // The child gets contextIsolation: true unless the handler overrides it,
+      // but its synchronous about:blank document starts with the opener's
+      // WebPreferences, so its Node.js environment is created in the main
+      // world. The Electron API has to stay in that context.
+      const preload = path.join(fixtures, 'module', 'preload-window-open-ping.js');
+
+      afterEach(closeAllWindows);
+
+      const waitForPreload = (href: string) =>
+        new Promise<void>((resolve) => {
+          const handler = (_e: Electron.IpcMainEvent, ranIn: string) => {
+            if (ranIn !== href) return;
+            ipcMain.removeListener('window-open-ping-preload-ran', handler);
+            resolve();
+          };
+          ipcMain.on('window-open-ping-preload-ran', handler);
+        });
+
+      const openChild = async () => {
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: { sandbox: false, contextIsolation: false }
+        });
+        w.webContents.setWindowOpenHandler(() => ({
+          action: 'allow',
+          overrideBrowserWindowOptions: { show: false, webPreferences: { sandbox: false, preload } }
+        }));
+        await w.loadFile(path.join(fixtures, 'api', 'blank.html'));
+        const preloadRan = waitForPreload('about:blank');
+        const created = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow]>;
+        await w.webContents.executeJavaScript("void window.open('', 'child')");
+        const [child] = await created;
+        await preloadRan;
+        return { w, child };
+      };
+
+      // Rejects as soon as the renderer goes away, instead of timing out.
+      const unlessGone = <T>(w: BrowserWindow, promise: Promise<T>) =>
+        Promise.race([
+          promise,
+          once(w.webContents, 'render-process-gone').then(([, details]): never => {
+            throw new Error(`renderer went away: ${details.reason}`);
+          })
+        ]);
+
+      // Resolves with the URL of the document whose preload answered.
+      const ping = async (w: BrowserWindow, child: BrowserWindow) => {
+        const pong = once(ipcMain, 'window-open-pong');
+        child.webContents.send('window-open-ping');
+        const [, href] = await unlessGone(w, pong);
+        return href;
+      };
+
+      it('receives IPC from the main process in its preload', async () => {
+        const { w, child } = await openChild();
+        expect(await ping(w, child)).to.equal('about:blank');
+      });
+
+      it('receives IPC from the main process after it navigates', async () => {
+        const { w, child } = await openChild();
+        const preloadRan = waitForPreload('about:blank?next');
+        await w.webContents.executeJavaScript("window.open('', 'child').location.href = 'about:blank?next'");
+        await unlessGone(w, preloadRan);
+        expect(await ping(w, child)).to.equal('about:blank?next');
+      });
+    });
+
     describe('preload script stack traces', () => {
       afterEach(closeAllWindows);
       // Preloads are compiled via ScriptCompiler::CompileFunction(), which

--- a/spec/fixtures/module/preload-window-open-ping.js
+++ b/spec/fixtures/module/preload-window-open-ping.js
@@ -1,0 +1,7 @@
+// Preload fixture for the window.open() contextIsolation spec. Reports each
+// document it runs in and answers pings from the main process from it.
+const { ipcRenderer } = require('electron');
+ipcRenderer.send('window-open-ping-preload-ran', location.href);
+ipcRenderer.on('window-open-ping', () => {
+  ipcRenderer.send('window-open-pong', location.href);
+});


### PR DESCRIPTION
Backport of #53535

See that PR for details. The only conflict was the include block in `shell/renderer/electron_render_frame_observer.cc` (this branch does not have `<utility>` and `<vector>` there).

Notes: Fixed a renderer crash when the main process sent IPC to, or a page navigated, a same-process `window.open()` child whose `contextIsolation` differed from its opener's.
