### PR TITLE
fix: only run the node_init preload in the principal realm

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -46,7 +46,6 @@
   "parallel/test-promise-swallowed-event",
   "parallel/test-repl-underscore",
   "parallel/test-runner-v8-deserializer",
-  "parallel/test-shadow-realm-custom-loaders",
   "parallel/test-snapshot",
   "parallel/test-strace-openat-openssl",
   "parallel/test-sqlite-backup",

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -55,6 +55,7 @@
 #include "third_party/blink/renderer/bindings/core/v8/v8_initializer.h"  // nogncheck
 #include "third_party/electron_node/src/debug_utils.h"
 #include "third_party/electron_node/src/module_wrap.h"
+#include "third_party/electron_node/src/node_realm-inl.h"
 #include "third_party/electron_node/src/node_snapshot_builder.h"
 #include "v8/include/v8-statistics.h"
 
@@ -1161,6 +1162,12 @@ void NodeBindings::EmbedThreadRunner(void* arg) {
 void OnNodePreload(node::Environment* env,
                    v8::Local<v8::Value> process,
                    v8::Local<v8::Value> require) {
+  // Node also runs the embedder preload when it bootstraps a ShadowRealm; the
+  // init bundle (asar, child_process hooks) belongs in the principal realm.
+  if (node::Realm::GetCurrent(env->isolate()->GetCurrentContext()) !=
+      env->principal_realm()) {
+    return;
+  }
   // A Node.js worker's isolate has no gin::PerIsolateData, so gin never frees
   // the callback holders created in it. Free them when the environment is torn
   // down, which happens on the worker's thread after its JavaScript has ended.


### PR DESCRIPTION
#### Description of Change

Node runs the embedder preload for every realm it bootstraps, including ShadowRealms, and Electron's preload is the `node_init` bundle (asar support, `child_process` hooks). Inside a ShadowRealm that bundle has nothing to work with and currently dies on its first line, so every `new ShadowRealm()` in a process with Node integration prints `CompileAndCall failed to evaluate electron script (electron/js2c/node_init): Uncaught TypeError: internalBinding is not a function` to stderr. `OnNodePreload` now returns early for any realm other than the principal one.

That stderr line was the only reason `parallel/test-shadow-realm-custom-loaders` was disabled, so it comes off the list; all eight `test-shadow-realm*` tests pass. #53528 carries the same guard because its asar change needs it; whichever lands second just loses the hunk.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: Fixed a spurious `node_init` error being logged when creating a `ShadowRealm` with Node.js integration enabled.
