### PR TITLE
refactor: register Electron's js2c bundles as internal Node builtins

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,8 +34,8 @@ import("filenames.libcxx.gni")
 import("filenames.libcxxabi.gni")
 
 declare_args() {
-  # Emit a build-time V8 code cache for the electron/js2c/* bundles. When
-  # false an empty stub is compiled and bundles compile from source.
+  # Emit a build-time V8 code cache for the internal/electron/js2c/* bundles.
+  # When false an empty stub is compiled and bundles compile from source.
   #
   # Cross-arch is supported: the generator is built in v8_snapshot_toolchain
   # (V8_TARGET_ARCH set to the target) and reads the target's snapshot blob,
@@ -213,7 +213,7 @@ webpack_build("electron_browser_bundle") {
   inputs = auto_filenames.browser_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.browser.js"
-  out_file = "$target_gen_dir/js2c/browser_init.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/browser_init.js"
 }
 
 webpack_build("electron_renderer_bundle") {
@@ -222,7 +222,7 @@ webpack_build("electron_renderer_bundle") {
   inputs = auto_filenames.renderer_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.renderer.js"
-  out_file = "$target_gen_dir/js2c/renderer_init.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/renderer_init.js"
 }
 
 webpack_build("electron_worker_bundle") {
@@ -231,7 +231,7 @@ webpack_build("electron_worker_bundle") {
   inputs = auto_filenames.worker_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.worker.js"
-  out_file = "$target_gen_dir/js2c/worker_init.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/worker_init.js"
 }
 
 webpack_build("electron_sandboxed_renderer_bundle") {
@@ -240,7 +240,7 @@ webpack_build("electron_sandboxed_renderer_bundle") {
   inputs = auto_filenames.sandbox_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.sandboxed_renderer.js"
-  out_file = "$target_gen_dir/js2c/sandbox_bundle.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/sandbox_bundle.js"
 }
 
 webpack_build("electron_isolated_renderer_bundle") {
@@ -249,7 +249,7 @@ webpack_build("electron_isolated_renderer_bundle") {
   inputs = auto_filenames.isolated_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.isolated_renderer.js"
-  out_file = "$target_gen_dir/js2c/isolated_bundle.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/isolated_bundle.js"
 }
 
 webpack_build("electron_node_bundle") {
@@ -258,7 +258,7 @@ webpack_build("electron_node_bundle") {
   inputs = auto_filenames.node_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.node.js"
-  out_file = "$target_gen_dir/js2c/node_init.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/node_init.js"
 }
 
 webpack_build("electron_utility_bundle") {
@@ -267,7 +267,7 @@ webpack_build("electron_utility_bundle") {
   inputs = auto_filenames.utility_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.utility.js"
-  out_file = "$target_gen_dir/js2c/utility_init.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/utility_init.js"
 }
 
 webpack_build("electron_preload_realm_bundle") {
@@ -276,7 +276,7 @@ webpack_build("electron_preload_realm_bundle") {
   inputs = auto_filenames.preload_realm_bundle_deps
 
   config_file = "//electron/build/webpack/webpack.config.preload_realm.js"
-  out_file = "$target_gen_dir/js2c/preload_realm_bundle.js"
+  out_file = "$root_gen_dir/internal/electron/js2c/preload_realm_bundle.js"
 }
 
 action("electron_js2c") {
@@ -293,14 +293,14 @@ action("electron_js2c") {
   ]
 
   sources = [
-    "$target_gen_dir/js2c/browser_init.js",
-    "$target_gen_dir/js2c/isolated_bundle.js",
-    "$target_gen_dir/js2c/node_init.js",
-    "$target_gen_dir/js2c/preload_realm_bundle.js",
-    "$target_gen_dir/js2c/renderer_init.js",
-    "$target_gen_dir/js2c/sandbox_bundle.js",
-    "$target_gen_dir/js2c/utility_init.js",
-    "$target_gen_dir/js2c/worker_init.js",
+    "$root_gen_dir/internal/electron/js2c/browser_init.js",
+    "$root_gen_dir/internal/electron/js2c/isolated_bundle.js",
+    "$root_gen_dir/internal/electron/js2c/node_init.js",
+    "$root_gen_dir/internal/electron/js2c/preload_realm_bundle.js",
+    "$root_gen_dir/internal/electron/js2c/renderer_init.js",
+    "$root_gen_dir/internal/electron/js2c/sandbox_bundle.js",
+    "$root_gen_dir/internal/electron/js2c/utility_init.js",
+    "$root_gen_dir/internal/electron/js2c/worker_init.js",
   ]
 
   inputs = sources
@@ -918,11 +918,11 @@ if (current_toolchain == default_toolchain) {
   }
 }
 
-# Build-time host tool emitting V8 code caches for the electron/js2c/* framework
-# bundles. Built in v8_snapshot_toolchain (like node_mksnapshot) so it links V8
-# with V8_TARGET_ARCH set to the target and reads the target's snapshot blob --
-# the cache it emits is keyed to the target's read-only checksum and flag hash.
-# Cross-OS stays off; see electron_generate_js2c_code_cache.
+# Build-time host tool emitting V8 code caches for the internal/electron/js2c/*
+# framework bundles. Built in v8_snapshot_toolchain (like node_mksnapshot) so it
+# links V8 with V8_TARGET_ARCH set to the target and reads the target's snapshot
+# blob -- the cache it emits is keyed to the target's read-only checksum and
+# flag hash. Cross-OS stays off; see electron_generate_js2c_code_cache.
 if (electron_generate_js2c_code_cache) {
   if (current_toolchain == v8_snapshot_toolchain) {
     executable("electron_natives_codecache") {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -68,7 +68,7 @@ if (nodeIntegration) {
   const { makeRequireFunction } = __non_webpack_require__(
     'internal/modules/helpers'
   ) as typeof import('@node/lib/internal/modules/helpers');
-  global.module = new Module('electron/js2c/renderer_init');
+  global.module = new Module('internal/electron/js2c/renderer_init');
   global.require = makeRequireFunction(global.module) as NodeRequire;
 
   // Set the __filename to the path of html file if it is file: protocol.

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -12,7 +12,7 @@ const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_co
 const { makeRequireFunction } = __non_webpack_require__(
   'internal/modules/helpers'
 ) as typeof import('@node/lib/internal/modules/helpers');
-global.module = new Module('electron/js2c/worker_init');
+global.module = new Module('internal/electron/js2c/worker_init');
 global.require = makeRequireFunction(global.module) as NodeRequire;
 
 // Set the __filename to the path of html file if it is file: protocol.

--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -41,7 +41,6 @@
   "parallel/test-openssl-ca-options",
   "parallel/test-os-checked-function",
   "parallel/test-process-versions",
-  "parallel/test-process-get-builtin",
   "parallel/test-repl-mode",
   "parallel/test-promise-swallowed-event",
   "parallel/test-repl-underscore",

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -101,10 +101,10 @@ void ExitImmediately(gin::Arguments* args) {
 }
 
 #if DCHECK_IS_ON()
-// Test-only (DCHECK builds): per-process map of builtin id (electron/js2c/*
-// bundles and Node's own lib/ builtins compiled so far in this process) ->
-// whether its build-time/snapshot code cache was consumed. Backs the
-// code-cache spec.
+// Test-only (DCHECK builds): per-process map of builtin id
+// (internal/electron/js2c/* bundles and Node's own lib/ builtins compiled so
+// far in this process) -> whether its build-time/snapshot code cache was
+// consumed. Backs the code-cache spec.
 v8::Local<v8::Value> GetJs2cCodeCacheStatus(v8::Isolate* isolate) {
   gin_helper::Dictionary dict = gin_helper::Dictionary::CreateEmpty(isolate);
   for (const auto& [id, accepted] : node::builtins::ElectronJs2cCacheStatus())

--- a/shell/common/electron_natives_codecache_main.cc
+++ b/shell/common/electron_natives_codecache_main.cc
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 //
 // Build-time host tool that emits the V8 code cache for the embedded
-// electron/js2c/* bundles -- and, for flavors whose processes host a Node.js
-// environment that is not deserialized from the embedded Node startup
+// internal/electron/js2c/* bundles -- and, for flavors whose processes host a
+// Node.js environment that is not deserialized from the embedded Node startup
 // snapshot, Node's own lib/**/*.js builtins -- for one process flavor, as a
 // generated .cc defining electron::internal::Js2cCache<Flavor>(). Run once per
 // flavor with that flavor's V8 flag set and snapshot blob (both feed V8's
@@ -93,7 +93,7 @@ const char* FlavorFn(std::string_view flavor) {
 // and would roughly double the per-flavor cache (~5.5 of ~12 MB) for no
 // startup benefit. They keep compiling from source on first use, as before.
 bool ShouldCacheNodeBuiltin(std::string_view id) {
-  constexpr std::string_view kJs2cPrefix = "electron/js2c/";
+  constexpr std::string_view kJs2cPrefix = "internal/electron/js2c/";
   constexpr std::string_view kDepsPrefix = "internal/deps/";
   return id.substr(0, kJs2cPrefix.size()) != kJs2cPrefix &&
          id.substr(0, kDepsPrefix.size()) != kDepsPrefix;
@@ -190,7 +190,7 @@ int main(int argc, char* argv[]) {
             : v8::Context::New(isolate);
     v8::Context::Scope context_scope(context);
 
-    // The ctor self-registers all builtins, incl. electron/js2c/*.
+    // The ctor self-registers all builtins, incl. internal/electron/js2c/*.
     node::builtins::BuiltinLoader loader;
     // Eagerly compile every inner function, not just the top-level wrapper,
     // so the cache covers the whole bundle and the consuming process never
@@ -251,8 +251,9 @@ int main(int argc, char* argv[]) {
         return 1;
       }
       for (const auto& info : node_caches) {
-        // (The electron/js2c/* ids are registered as builtins too; the ones
-        // this flavor needs were compiled above with their real parameters.)
+        // (The internal/electron/js2c/* ids are registered as builtins too; the
+        // ones this flavor needs were compiled above with their real
+        // parameters.)
         if (!ShouldCacheNodeBuiltin(info.id))
           continue;
         caches.emplace_back(

--- a/shell/common/js2c_bundle_ids.h
+++ b/shell/common/js2c_bundle_ids.h
@@ -12,24 +12,27 @@
 #include "v8/include/v8-isolate.h"
 #include "v8/include/v8-primitive.h"
 
-// The electron/js2c/* framework bundle ids and the parameter names each
-// bundle's wrapper function is compiled with. The ids and params feed V8's
-// code-cache key (source + params hash), so the build-time codecache
-// generator (electron_natives_codecache_main.cc) must compile each bundle
-// with the exact same params its runtime CompileAndCall site uses -- this
-// header keeps both sides in sync. spec/api-js2c-code-cache-spec.ts also
-// asserts every bundle's cache is consumed, catching any drift.
+// The internal/electron/js2c/* framework bundle ids and the parameter names
+// each bundle's wrapper function is compiled with. The ids and params feed V8's
+// code-cache key (source + params hash), so the build-time codecache generator
+// (electron_natives_codecache_main.cc) must compile each bundle with the exact
+// same params its runtime CompileAndCall site uses -- this header keeps both
+// sides in sync. spec/api-js2c-code-cache-spec.ts also asserts every bundle's
+// cache is consumed, catching any drift.
 namespace electron::js2c {
 
-inline constexpr char kSandboxBundleId[] = "electron/js2c/sandbox_bundle";
-inline constexpr char kIsolatedBundleId[] = "electron/js2c/isolated_bundle";
+inline constexpr char kSandboxBundleId[] =
+    "internal/electron/js2c/sandbox_bundle";
+inline constexpr char kIsolatedBundleId[] =
+    "internal/electron/js2c/isolated_bundle";
 inline constexpr char kPreloadRealmBundleId[] =
-    "electron/js2c/preload_realm_bundle";
-inline constexpr char kNodeInitId[] = "electron/js2c/node_init";
-inline constexpr char kBrowserInitId[] = "electron/js2c/browser_init";
-inline constexpr char kRendererInitId[] = "electron/js2c/renderer_init";
-inline constexpr char kUtilityInitId[] = "electron/js2c/utility_init";
-inline constexpr char kWorkerInitId[] = "electron/js2c/worker_init";
+    "internal/electron/js2c/preload_realm_bundle";
+inline constexpr char kNodeInitId[] = "internal/electron/js2c/node_init";
+inline constexpr char kBrowserInitId[] = "internal/electron/js2c/browser_init";
+inline constexpr char kRendererInitId[] =
+    "internal/electron/js2c/renderer_init";
+inline constexpr char kUtilityInitId[] = "internal/electron/js2c/utility_init";
+inline constexpr char kWorkerInitId[] = "internal/electron/js2c/worker_init";
 
 // Wrapper function parameter names for the bundles compiled via
 // util::CompileAndCall.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -1031,14 +1031,14 @@ void RefreshCachedNodeOptions(v8::Local<v8::Context> context,
 }  // namespace
 
 void NodeBindings::LoadEnvironment(node::Environment* env) {
-  // Re-assert Electron's build-time cache for the electron/js2c/* framework
-  // bundles (browser_init etc.). Every BuiltinLoader already starts from it
-  // (InstallProcessCodeCache), but when booting from the Node startup snapshot
-  // Environment's constructor then merges the caches node_mksnapshot embedded
-  // for the same bundle ids over it; RefreshCodeCache uses insert_or_assign, so
-  // this puts the build-time (eagerly compiled) entries back on top while the
-  // node-internal entries are kept. A no-op merge when bootstrapped from
-  // scratch.
+  // Re-assert Electron's build-time cache for the internal/electron/js2c/*
+  // framework bundles (browser_init etc.). Every BuiltinLoader already starts
+  // from it (InstallProcessCodeCache), but when booting from the Node startup
+  // snapshot Environment's constructor then merges the caches node_mksnapshot
+  // embedded for the same bundle ids over it; RefreshCodeCache uses
+  // insert_or_assign, so this puts the build-time (eagerly compiled) entries
+  // back on top while the node-internal entries are kept. A no-op merge when
+  // bootstrapped from scratch.
   electron::util::FeedEnvironmentCodeCache(env);
 
   // The init bundle is this process's entry script: like Node's own runMain it
@@ -1052,7 +1052,7 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
   const bool break_first_line = debug_options->break_first_line;
   debug_options->break_first_line = false;
   const std::string bundle_id =
-      "electron/js2c/" + std::string(ProcessType()) + "_init";
+      "internal/electron/js2c/" + std::string(ProcessType()) + "_init";
   node::LoadEnvironment(
       env,
       [&](const node::StartExecutionCallbackInfo& info) {

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -213,7 +213,7 @@ class NodeBindings {
 
   // Which environment we are running.
   // "browser" / "renderer" / "worker" / "utility"; names process.type and
-  // the electron/js2c/<type>_init bundle.
+  // the internal/electron/js2c/<type>_init bundle.
   std::string_view ProcessType() const;
 
   const BrowserEnvironment browser_env_;

--- a/shell/common/node_natives_code_cache.h
+++ b/shell/common/node_natives_code_cache.h
@@ -34,13 +34,13 @@ enum class Js2cCacheFlavor {
 // one (true): pass `node::Environment::GetCurrent(context) != nullptr`.
 Js2cCacheFlavor CurrentProcessJs2cCacheFlavor(bool has_node_env = true);
 
-// Build-time V8 code cache for the embedded electron/js2c/* bundles -- plus,
-// for flavors whose Node environment is bootstrapped from scratch rather than
-// deserialized from the embedded Node startup snapshot, Node's own builtins --
-// fed to the BuiltinLoader so they are deserialized rather than parsed +
-// compiled from source on startup. Empty when no generated cache was built; V8
-// also gracefully falls back to compiling from source on a stale/mismatched
-// blob.
+// Build-time V8 code cache for the embedded internal/electron/js2c/* bundles --
+// plus, for flavors whose Node environment is bootstrapped from scratch rather
+// than deserialized from the embedded Node startup snapshot, Node's own
+// builtins -- fed to the BuiltinLoader so they are deserialized rather than
+// parsed + compiled from source on startup. Empty when no generated cache was
+// built; V8 also gracefully falls back to compiling from source on a
+// stale/mismatched blob.
 const std::vector<node::builtins::CodeCacheInfo>& GetNativesCodeCache(
     Js2cCacheFlavor flavor);
 

--- a/spec/api-js2c-code-cache-spec.ts
+++ b/spec/api-js2c-code-cache-spec.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
 import { copyApp } from './lib/fs-helpers';
 import { ifdescribe, isTestingBindingAvailable } from './lib/spec-helpers';
 
-// Asserts the build-time V8 code cache for each electron/js2c/* bundle -- and
+// Asserts the build-time V8 code cache for each internal/electron/js2c/* bundle -- and
 // for Node's own builtins, from the embedded Node snapshot in the browser
 // process and from the build-time cache everywhere else -- is consumed (not
 // compiled from source) in every process type. Runs in a separately-spawned
@@ -56,7 +56,7 @@ function expectConsumed(status: Status, id: string) {
 // to pull one in.
 function expectNodeBuiltinsConsumed(status: Status, processType: string) {
   const nodeIds = Object.keys(status).filter(
-    (id) => !id.startsWith('electron/js2c/') && !id.startsWith('internal/deps/')
+    (id) => !id.startsWith('internal/electron/js2c/') && !id.startsWith('internal/deps/')
   );
   expect(nodeIds.length, `${processType} should have compiled some Node builtins`).to.be.greaterThan(20);
   const notConsumed = nodeIds.filter((id) => !status[id]);
@@ -67,18 +67,18 @@ ifdescribe(isTestingBindingAvailable())('js2c build-time code cache', () => {
   it('is consumed across browser / sandboxed renderer / renderer / utility / run-as-node', async () => {
     const r = await runFixtureApp(process.execPath);
 
-    expectConsumed(r.browser, 'electron/js2c/browser_init');
-    expectConsumed(r.browser, 'electron/js2c/node_init');
+    expectConsumed(r.browser, 'internal/electron/js2c/browser_init');
+    expectConsumed(r.browser, 'internal/electron/js2c/node_init');
 
-    expectConsumed(r.sandbox, 'electron/js2c/sandbox_bundle');
+    expectConsumed(r.sandbox, 'internal/electron/js2c/sandbox_bundle');
 
-    expectConsumed(r.renderer, 'electron/js2c/renderer_init');
-    expectConsumed(r.renderer, 'electron/js2c/node_init');
+    expectConsumed(r.renderer, 'internal/electron/js2c/renderer_init');
+    expectConsumed(r.renderer, 'internal/electron/js2c/node_init');
 
-    expectConsumed(r.utility, 'electron/js2c/utility_init');
-    expectConsumed(r.utility, 'electron/js2c/node_init');
+    expectConsumed(r.utility, 'internal/electron/js2c/utility_init');
+    expectConsumed(r.utility, 'internal/electron/js2c/node_init');
 
-    expectConsumed(r.runAsNode, 'electron/js2c/node_init');
+    expectConsumed(r.runAsNode, 'internal/electron/js2c/node_init');
 
     for (const processType of ['browser', 'renderer', 'utility', 'runAsNode'] as const) {
       expectNodeBuiltinsConsumed(r[processType], processType);
@@ -120,8 +120,8 @@ ifdescribe(isTestingBindingAvailable())('js2c build-time code cache', () => {
       const r = await runFixtureApp(
         process.platform === 'darwin' ? path.resolve(appPath, 'Contents/MacOS/Electron') : appPath
       );
-      expectConsumed(r.utility, 'electron/js2c/utility_init');
-      expectConsumed(r.runAsNode, 'electron/js2c/node_init');
+      expectConsumed(r.utility, 'internal/electron/js2c/utility_init');
+      expectConsumed(r.runAsNode, 'internal/electron/js2c/node_init');
       for (const processType of ['browser', 'renderer', 'utility', 'runAsNode'] as const) {
         expectNodeBuiltinsConsumed(r[processType], processType);
       }

--- a/spec/fixtures/api/js2c-code-cache/util-child.js
+++ b/spec/fixtures/api/js2c-code-cache/util-child.js
@@ -1,4 +1,4 @@
-// Reports the utility process's electron/js2c/* build-time code-cache
+// Reports the utility process's internal/electron/js2c/* build-time code-cache
 // status back to the parent for the js2c-code-cache spec.
 const v8Util = process._linkedBinding('electron_common_v8_util');
 process.parentPort.postMessage(v8Util.getJs2cCodeCacheStatus());


### PR DESCRIPTION
#### Description of Change

Electron's framework bundles were registered with Node as `electron/js2c/<name>`. Node treats every builtin id that does not start with `internal/` as public, so they showed up in `require('module').builtinModules`, and `require('node:electron/js2c/browser_init')` / `process.getBuiltinModule('electron/js2c/browser_init')` would load and run the browser init bundle in whatever process asked, which under `ELECTRON_RUN_AS_NODE` dereferences a null `ElectronBrowserClient` and crashes. That was only ever "needed" because Node's `runMain` had to be able to load the bundle by id; with #53537 running the bundles from the embedder callback nothing requires them to be public.

The bundles are now emitted under `gen/internal/electron/js2c/`, so js2c registers them as `internal/electron/js2c/<name>`: they disappear from `builtinModules`, `require`/`getBuiltinModule` return `ERR_UNKNOWN_BUILTIN_MODULE`/`undefined` for them like any other internal id, and `parallel/test-process-get-builtin` (which iterates `builtinModules`) passes and comes off the disabled list. The visible side effect is that stack frames inside Electron's bundles read `node:internal/electron/js2c/browser_init` instead of `node:electron/js2c/browser_init`.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes

#### Release Notes

Notes: Electron's internal JavaScript bundles are no longer listed in `require('module').builtinModules` or loadable through `process.getBuiltinModule()`.



