### PR TITLE
fix(net): support non-ASCII headers and multiple cookies in net.fetch

### DIFF
--- a/lib/browser/api/net-fetch.ts
+++ b/lib/browser/api/net-fetch.ts
@@ -1,4 +1,4 @@
-import { allowAnyProtocol } from '@electron/internal/common/api/net-client-request';
+import { allowAnyProtocol, toByteString } from '@electron/internal/common/api/net-client-request';
 
 import { ClientRequestConstructorOptions, ClientRequest, IncomingMessage, Session as SessionT } from 'electron/main';
 
@@ -110,25 +110,35 @@ export function fetchWithSession(
 
   r.on('response', (resp: IncomingMessage) => {
     if (locallyAborted) return;
-    const headers = new Headers();
-    for (const [k, v] of Object.entries(resp.headers)) {
-      headers.set(k, Array.isArray(v) ? v.join(', ') : v);
+    try {
+      const headers = new Headers();
+      for (const [k, v] of Object.entries(resp.headers)) {
+        if (Array.isArray(v)) {
+          for (const item of v) {
+            headers.append(k, toByteString(item));
+          }
+        } else if (typeof v === 'string') {
+          headers.set(k, toByteString(v));
+        }
+      }
+      const nullBodyStatus = [101, 204, 205, 304];
+      const body =
+        nullBodyStatus.includes(resp.statusCode) || req.method === 'HEAD'
+          ? null
+          : (Readable.toWeb(resp as unknown as Readable) as ReadableStream);
+      const rResp = new Response(body, {
+        headers,
+        status: resp.statusCode,
+        statusText: resp.statusMessage
+      });
+      (rResp as any).__original_resp = resp;
+      // protocol.handle relays a Response that comes back untouched without
+      // pumping its body through JS; it needs the loader and the exact stream.
+      if (body) (rResp as any).__fetch = { request: r, body: rResp.body };
+      p.resolve(rResp);
+    } catch (err: any) {
+      p.reject(err);
     }
-    const nullBodyStatus = [101, 204, 205, 304];
-    const body =
-      nullBodyStatus.includes(resp.statusCode) || req.method === 'HEAD'
-        ? null
-        : (Readable.toWeb(resp as unknown as Readable) as ReadableStream);
-    const rResp = new Response(body, {
-      headers,
-      status: resp.statusCode,
-      statusText: resp.statusMessage
-    });
-    (rResp as any).__original_resp = resp;
-    // protocol.handle relays a Response that comes back untouched without
-    // pumping its body through JS; it needs the loader and the exact stream.
-    if (body) (rResp as any).__fetch = { request: r, body: rResp.body };
-    p.resolve(rResp);
   });
 
   r.on('error', (err) => {

--- a/lib/browser/api/net-fetch.ts
+++ b/lib/browser/api/net-fetch.ts
@@ -137,6 +137,7 @@ export function fetchWithSession(
       if (body) (rResp as any).__fetch = { request: r, body: rResp.body };
       p.resolve(rResp);
     } catch (err: any) {
+      r.abort();
       p.reject(err);
     }
   });

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -1,3 +1,5 @@
+import { toByteString } from '@electron/internal/common/api/net-client-request';
+
 import { ProtocolRequest, session } from 'electron/main';
 
 import { createReadStream } from 'fs';
@@ -154,7 +156,18 @@ Protocol.prototype.handle = function (
   const success = register.call(this, scheme, async (preq: ProtocolRequest, cb: any) => {
     try {
       const body = convertToRequestBody(preq.uploadData);
-      const headers = new Headers(preq.headers);
+      const headers = new Headers();
+      if (preq.headers) {
+        for (const [k, v] of Object.entries(preq.headers)) {
+          if (Array.isArray(v)) {
+            for (const item of v) {
+              headers.append(k, toByteString(item));
+            }
+          } else if (typeof v === 'string') {
+            headers.set(k, toByteString(v));
+          }
+        }
+      }
       if (headers.get('origin') === 'null') {
         headers.delete('origin');
       }

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -187,8 +187,19 @@ Protocol.prototype.handle = function (
       } else if (res.type === 'error') {
         cb({ error: ERR_FAILED });
       } else {
+        const headersObj: Record<string, string | string[]> = {};
+        if (res.headers) {
+          for (const [k, v] of res.headers) {
+            if (k === 'set-cookie') {
+              if (!headersObj[k]) headersObj[k] = [];
+              (headersObj[k] as string[]).push(v);
+            } else {
+              headersObj[k] = v;
+            }
+          }
+        }
         const head = {
-          headers: res.headers ? Object.fromEntries(res.headers) : {},
+          headers: headersObj,
           statusCode: res.status,
           statusText: res.statusText,
           mimeType: (res as any).__original_resp?._responseHead?.mimeType

--- a/lib/common/api/net-client-request.ts
+++ b/lib/common/api/net-client-request.ts
@@ -200,6 +200,16 @@ export function allowAnyProtocol(opts: ClientRequestConstructorOptions): ClientR
   } as any;
 }
 
+export function toByteString(val: string): string {
+  if (typeof val !== 'string') return String(val);
+  for (let i = 0; i < val.length; i++) {
+    if (val.charCodeAt(i) > 255) {
+      return Buffer.from(val, 'utf-8').toString('latin1');
+    }
+  }
+  return val;
+}
+
 type ExtraURLLoaderOptions = {
   redirectPolicy: RedirectPolicy;
   headers: Record<string, { name: string; value: string | string[] }>;

--- a/spec/api-net-spec.ts
+++ b/spec/api-net-spec.ts
@@ -1974,6 +1974,39 @@ describe('net module', () => {
           expect(r.status).to.equal(200);
           await expect(r.text()).to.be.rejectedWith(/ERR_INCOMPLETE_CHUNKED_ENCODING/);
         });
+
+        test('can handle non-ASCII characters in response headers', async () => {
+          const filename = 'zażółć.txt';
+          const headerValue = `attachment; filename="${filename}"`;
+          const serverUrl = await respondOnce.toSingleURL((request, response) => {
+            response.setHeader('content-disposition', Buffer.from(headerValue, 'utf-8').toString('latin1'));
+            response.end('ok');
+          });
+          const resp = await net.fetch(serverUrl);
+          expect(resp.ok).to.be.true();
+          const header = resp.headers.get('content-disposition');
+          expect(header).to.be.a('string');
+          const decoded = Buffer.from(header!, 'latin1').toString('utf-8');
+          expect(decoded).to.equal(headerValue);
+        });
+
+        test('preserves multiple Set-Cookie headers', async () => {
+          const serverUrl = await respondOnce.toSingleURL((request, response) => {
+            response.setHeader('set-cookie', [
+              'cookie1=val1; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Path=/',
+              'cookie2=val2; Path=/'
+            ]);
+            response.end('ok');
+          });
+          const resp = await net.fetch(serverUrl);
+          expect(resp.ok).to.be.true();
+          if (typeof resp.headers.getSetCookie === 'function') {
+            const cookies = resp.headers.getSetCookie();
+            expect(cookies).to.have.lengthOf(2);
+            expect(cookies[0]).to.equal('cookie1=val1; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Path=/');
+            expect(cookies[1]).to.equal('cookie2=val2; Path=/');
+          }
+        });
       });
     });
 

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -1696,6 +1696,26 @@ describe('protocol module', () => {
       }
     });
 
+    it('accepts headers with non-ASCII characters', async () => {
+      let receivedHeader: string | null = null;
+      protocol.handle('test-scheme', (req) => {
+        receivedHeader = req.headers.get('x-non-ascii');
+        return new Response('ok');
+      });
+      defer(() => {
+        protocol.unhandle('test-scheme');
+      });
+      const resp = await net.fetch('test-scheme://foo/', {
+        headers: {
+          'x-non-ascii': Buffer.from('zażółć', 'utf-8').toString('latin1')
+        }
+      });
+      expect(resp.status).to.equal(200);
+      expect(receivedHeader).to.be.a('string');
+      const decoded = Buffer.from(receivedHeader!, 'latin1').toString('utf-8');
+      expect(decoded).to.equal('zażółć');
+    });
+
     it('normalizes urls in standard schemes', async () => {
       // NB. 'app' is registered as a standard scheme in test setup.
       protocol.handle('app', (req) => new Response(req.url));


### PR DESCRIPTION
#### Description of Change

Fixes #42244.
Refs #39469.

When `net.fetch` or `protocol.handle` receives headers containing non-ASCII characters (e.g. `attachment; filename="zażółć.txt"` or modified `User-Agent` strings), Node's WebIDL `ByteString` converter throws:
```
TypeError: Cannot convert argument to a ByteString because the character at index X has a value of Y which is greater than 255.
```
In `net-fetch.ts`, the `'response'` event listener had no error handling wrapper around `new Headers()` and `new Response()`, causing this `TypeError` to escape as an uncatchable exception on the process event loop, while the fetch promise remained pending.

In addition, array-valued response headers (such as `Set-Cookie`) were joined with `, `, which corrupted multiple cookies (especially cookies containing commas in HTTP-date strings like `Expires=Wed, 21 Oct 2026...`).

Similarly, in `protocol.ts`, `new Headers(preq.headers)` threw immediately on incoming request headers containing non-ASCII characters.

This PR addresses these issues:
1. **`toByteString` Utility**: Added and exported `toByteString(val: string): string` in `lib/common/api/net-client-request.ts` to convert strings containing code points > 255 into valid Latin-1 byte strings (`Buffer.from(val, 'utf-8').toString('latin1')`), matching WHATWG Fetch `ByteString` specifications and allowing clean round-tripping.
2. **`net-fetch` Header Handling**: Iterates and appends each header entry, calling `headers.append(k, toByteString(item))` for array values so multiple `Set-Cookie` headers are preserved without comma-joining.
3. **`net-fetch` Error Handling**: Wrapped the `r.on('response', ...)` listener in a `try ... catch` block that forwards any response construction error to `p.reject(err)`, ensuring fetch promises reject properly rather than escaping uncaught.
4. **`protocol.handle` Header Sanitization**: Populates `Headers` using `toByteString` on `preq.headers` entries so custom headers and user-agents with non-ASCII characters do not throw `TypeError`.
5. **Regression Tests**: Added tests in `spec/api-net-spec.ts` for non-ASCII response headers and multiple `Set-Cookie` preservation, and in `spec/api-protocol-spec.ts` for non-ASCII request headers in custom protocol handling.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed an uncatchable TypeError in net.fetch when receiving response headers with non-ASCII characters, and preserved multiple Set-Cookie headers.
