### PR TITLE
fix: preserve port and userinfo on custom standard schemes

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -24,6 +24,7 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "url/url_constants.h"
+#include "url/url_util.h"
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
 #include "base/native_library.h"
@@ -145,7 +146,24 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
     append_cli_schemes(schemes->csp_bypassing_schemes, kBypassCSPSchemes);
     append_cli_schemes(schemes->secure_schemes, kSecureSchemes);
     append_cli_schemes(schemes->service_worker_schemes, kServiceWorkerSchemes);
-    append_cli_schemes(schemes->standard_schemes, kStandardSchemes);
+
+    // Standard schemes are deliberately NOT routed through
+    // schemes->standard_schemes here: content::RegisterContentSchemes()
+    // unconditionally registers every entry in that list with
+    // url::SCHEME_WITH_HOST, which silently drops port and userinfo. The
+    // browser (api::Protocol::RegisterSchemesAsPrivileged) and renderer
+    // (RendererClientBase) processes register these schemes with
+    // url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION instead, so the
+    // network utility process must match that registration directly or its
+    // GURL canonicalization of these schemes disagrees with the other
+    // processes, e.g. dropping the port from a custom-scheme URL, or
+    // tripping Mojo struct validation when such a GURL is round-tripped
+    // through the network service.
+    for (const auto& scheme :
+         base::SplitString(cmd.GetSwitchValueASCII(kStandardSchemes), ",",
+                           base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY))
+      url::AddStandardScheme(scheme.c_str(),
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
   }
 
   if (electron::fuses::IsGrantFileProtocolExtraPrivilegesEnabled()) {

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -135,7 +135,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     if (custom_scheme.options.standard) {
       auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
       url::AddStandardScheme(custom_scheme.scheme.c_str(),
-                             url::SCHEME_WITH_HOST);
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
       GetStandardSchemes().push_back(custom_scheme.scheme);
       policy->RegisterWebSafeScheme(custom_scheme.scheme);
     }

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -147,7 +147,8 @@ RendererClientBase::RendererClientBase() {
   std::vector<std::string> standard_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);
   for (const std::string& scheme : standard_schemes_list)
-    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITH_HOST);
+    url::AddStandardScheme(scheme.c_str(),
+                           url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
   // Parse --cors-schemes=scheme1,scheme2
   std::vector<std::string> cors_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kCORSSchemes);

--- a/spec/ambient.d.ts
+++ b/spec/ambient.d.ts
@@ -1,4 +1,5 @@
 declare let standardScheme: string;
+declare let portScheme: string;
 declare let serviceWorkerScheme: string;
 
 declare module 'dbus-native';

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -960,6 +960,16 @@ describe('protocol module', () => {
       expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
+
+    it('preserves the port for a custom standard scheme', async () => {
+      const targetUrl = `${portScheme}://fake-host:12345/index.html`;
+      registerStringProtocol(portScheme, (request, callback) => {
+        callback(request.url);
+      });
+      defer(() => unregisterProtocol(portScheme));
+      const r = await ajax(targetUrl);
+      expect(r.data).to.equal(targetUrl);
+    });
   });
 
   describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {

--- a/spec/index.js
+++ b/spec/index.js
@@ -53,10 +53,12 @@ app.commandLine.appendSwitch(
 
 global.standardScheme = 'app';
 global.zoomScheme = 'zoom';
+global.portScheme = 'port';
 global.serviceWorkerScheme = 'sw';
 protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
+  { scheme: global.portScheme, privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
   { scheme: 'http-like', privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },


### PR DESCRIPTION
#### Description of Change

Fixes #24725. `protocol.registerSchemesAsPrivileged({ standard: true })` has always registered custom schemes with `url::SCHEME_WITH_HOST`, which silently strips any port number (and userinfo) from URLs using that scheme. A URL like `myapp://host:1234/x` loses its port the moment it's parsed anywhere in the browser, renderer, or network process, because `url::SchemeType` is process-global registry state, not something carried on the GURL itself.

Two prior attempts fixed this and were both closed unmerged:
- #26803 (original attempt)
- #34817 (second attempt, after the same author found the missing spot from the first review)

Both switched the browser process (`electron_api_protocol.cc`) and renderer process (`renderer_client_base.cc`) registrations from `url::SCHEME_WITH_HOST` to `url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION`, but CI kept failing with `VALIDATION_ERROR_DESERIALIZATION_FAILED` Mojo errors that were never root-caused, and the PRs went stale.

**What was missing:** there's a third registration site neither PR touched — `ElectronContentClient::AddAdditionalSchemes()`, which runs in the network service's utility process. It fed the scheme names into Chromium's generic `content::Schemes::standard_schemes` list. `content::RegisterContentSchemes()` (in `content/common/url_schemes.cc`) unconditionally registers every entry in that list with `url::SCHEME_WITH_HOST` — there's no way to carry a different `SchemeType` through that struct. So even after fixing the browser and renderer processes, the network service kept parsing/canonicalizing these URLs *without* port support, disagreeing with the other two processes. That mismatch is what trips Mojo's GURL struct validation when a request for one of these URLs is round-tripped through the network service — exactly the failure both prior PRs hit.

This PR registers standard schemes directly with `url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION` in the utility process too (bypassing `schemes->standard_schemes` for this case, same as the browser and renderer processes already do), so all three processes agree on how these URLs canonicalize.

**Disclosure:** this fix was drafted with Claude Code (Claude Sonnet 5). I (the PR author) directed the investigation, reviewed the root-cause analysis and the resulting diff, and take responsibility for it. I was not able to build or run Electron locally when preparing this — see the testing note below — so I'm explicitly flagging that for reviewers rather than checking a box that isn't true yet.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] `npm test` passes
- [x] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide (none needed — no public API surface changed)
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

**Testing note:** No Chromium checkout/build was available in the environment this was prepared in, so this has not been compiled or run locally yet. What was verified instead:
- The exact consumer of `content::Schemes::standard_schemes` against current Chromium `main` (`content/common/url_schemes.cc`), confirming it hardcodes `SCHEME_WITH_HOST` with no per-scheme override.
- `clang-format` (Chromium style) and `oxlint`/`tsc` pass on the changed files with no new diagnostics.
- Added `spec/api-protocol-spec.ts`: "preserves the port for a custom standard scheme", with a new `portScheme` registered as `standard: true` in `spec/index.js`. It does a real end-to-end `fetch()` through the custom scheme (renderer → network service → browser process protocol handler) and asserts the port survives.

I'll be watching CI closely given the history here, and am glad to iterate if there's a fourth spot I missed or if `npm test` surfaces something the sandbox couldn't.

#### Release Notes

Notes: Fixed a bug where custom protocol schemes registered as `standard: true` would silently lose the port number (and userinfo) from request URLs.