### PR TITLE
fix: preserve port and userinfo on custom standard schemes

### DIFF
--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -13,3 +13,7 @@
     works when `standard` is also set to true. Default false.
   * `allowExtensions` boolean (optional) - Allow Chrome extensions to be used
     on pages served over this protocol. Default false.
+  * `preservePortAndUserinfo` boolean (optional) - Keep the port number and
+    userinfo in URLs for this scheme instead of stripping them, which is the
+    default behavior for standard schemes. Only works when `standard` is also
+    set to true. Default false.

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -24,6 +24,7 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "url/url_constants.h"
+#include "url/url_util.h"
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
 #include "base/native_library.h"
@@ -145,7 +146,24 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
     append_cli_schemes(schemes->csp_bypassing_schemes, kBypassCSPSchemes);
     append_cli_schemes(schemes->secure_schemes, kSecureSchemes);
     append_cli_schemes(schemes->service_worker_schemes, kServiceWorkerSchemes);
-    append_cli_schemes(schemes->standard_schemes, kStandardSchemes);
+
+    // Standard schemes are deliberately NOT routed through
+    // schemes->standard_schemes here: content::RegisterContentSchemes()
+    // unconditionally registers every entry in that list with
+    // url::SCHEME_WITH_HOST, which silently drops port and userinfo. The
+    // browser (api::Protocol::RegisterSchemesAsPrivileged) and renderer
+    // (RendererClientBase) processes register these schemes with
+    // url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION instead, so the
+    // network utility process must match that registration directly or its
+    // GURL canonicalization of these schemes disagrees with the other
+    // processes, e.g. dropping the port from a custom-scheme URL, or
+    // tripping Mojo struct validation when such a GURL is round-tripped
+    // through the network service.
+    for (const auto& scheme :
+         base::SplitString(cmd.GetSwitchValueASCII(kStandardSchemes), ",",
+                           base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY))
+      url::AddStandardScheme(scheme.c_str(),
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
   }
 
   if (electron::fuses::IsGrantFileProtocolExtraPrivilegesEnabled()) {

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -4,6 +4,7 @@
 
 #include "shell/app/electron_content_client.h"
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -147,23 +148,33 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
     append_cli_schemes(schemes->secure_schemes, kSecureSchemes);
     append_cli_schemes(schemes->service_worker_schemes, kServiceWorkerSchemes);
 
-    // Standard schemes are deliberately NOT routed through
-    // schemes->standard_schemes here: content::RegisterContentSchemes()
-    // unconditionally registers every entry in that list with
-    // url::SCHEME_WITH_HOST, which silently drops port and userinfo. The
-    // browser (api::Protocol::RegisterSchemesAsPrivileged) and renderer
-    // (RendererClientBase) processes register these schemes with
+    // Schemes that opted into preservePortAndUserinfo are deliberately NOT
+    // routed through schemes->standard_schemes here: content::
+    // RegisterContentSchemes() unconditionally registers every entry in that
+    // list with url::SCHEME_WITH_HOST, which silently drops port and
+    // userinfo. The browser (api::Protocol::RegisterSchemesAsPrivileged) and
+    // renderer (RendererClientBase) processes register these schemes with
     // url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION instead, so the
     // network utility process must match that registration directly or its
     // GURL canonicalization of these schemes disagrees with the other
     // processes, e.g. dropping the port from a custom-scheme URL, or
     // tripping Mojo struct validation when such a GURL is round-tripped
-    // through the network service.
+    // through the network service. Standard schemes that didn't opt in still
+    // go through schemes->standard_schemes below, same as before, so they
+    // stay in sync with however Chromium registers standard schemes.
+    const std::vector<std::string> port_and_userinfo_schemes =
+        base::SplitString(
+            cmd.GetSwitchValueASCII(kStandardSchemesWithPortAndUserinfo), ",",
+            base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
     for (const auto& scheme :
          base::SplitString(cmd.GetSwitchValueASCII(kStandardSchemes), ",",
-                           base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY))
-      url::AddStandardScheme(scheme.c_str(),
-                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
+                           base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+      if (std::ranges::contains(port_and_userinfo_schemes, scheme))
+        url::AddStandardScheme(
+            scheme.c_str(), url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
+      else
+        schemes->standard_schemes.push_back(scheme);
+    }
   }
 
   if (electron::fuses::IsGrantFileProtocolExtraPrivilegesEnabled()) {

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -135,7 +135,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     if (custom_scheme.options.standard) {
       auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
       url::AddStandardScheme(custom_scheme.scheme.c_str(),
-                             url::SCHEME_WITH_HOST);
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
       GetStandardSchemes().push_back(custom_scheme.scheme);
       policy->RegisterWebSafeScheme(custom_scheme.scheme);
     }

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -41,6 +41,7 @@ struct SchemeOptions {
   bool stream = false;
   bool codeCache = false;
   bool allowExtensions = false;
+  bool preservePortAndUserinfo = false;
 };
 
 struct CustomScheme {
@@ -74,6 +75,8 @@ struct Converter<CustomScheme> {
       opt.Get("stream", &(out->options.stream));
       opt.Get("codeCache", &(out->options.codeCache));
       opt.Get("allowExtensions", &(out->options.allowExtensions));
+      opt.Get("preservePortAndUserinfo",
+             &(out->options.preservePortAndUserinfo));
     }
     return true;
   }
@@ -126,16 +129,37 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
           "as standard scheme.");
       return;
     }
+    if (custom_scheme.options.preservePortAndUserinfo &&
+       !custom_scheme.options.standard) {
+      thrower.ThrowError(
+          "preservePortAndUserinfo can only be enabled when the custom scheme "
+          "is registered as standard scheme.");
+      return;
+    }
   }
 
   std::vector<std::string> secure_schemes, cspbypassing_schemes, fetch_schemes,
-      service_worker_schemes, cors_schemes, extension_schemes;
+      service_worker_schemes, cors_schemes, extension_schemes,
+      port_and_userinfo_schemes;
   for (const auto& custom_scheme : custom_schemes) {
     // Register scheme to privileged list (https, wss, data, chrome-extension)
     if (custom_scheme.options.standard) {
       auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
-      url::AddStandardScheme(custom_scheme.scheme.c_str(),
-                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
+      // Standard schemes strip the port number and userinfo from their URLs
+      // by default, matching how http/https behave for a bare host. Schemes
+      // that need to round-trip a port or userinfo (e.g. a custom transport
+      // scheme that encodes a port in the URL) can opt into keeping them via
+      // preservePortAndUserinfo; this is opt-in because flipping it for every
+      // standard scheme would change how existing apps' URLs parse.
+      if (custom_scheme.options.preservePortAndUserinfo) {
+        url::AddStandardScheme(
+            custom_scheme.scheme.c_str(),
+            url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
+        port_and_userinfo_schemes.push_back(custom_scheme.scheme);
+      } else {
+        url::AddStandardScheme(custom_scheme.scheme.c_str(),
+                               url::SCHEME_WITH_HOST);
+      }
       GetStandardSchemes().push_back(custom_scheme.scheme);
       policy->RegisterWebSafeScheme(custom_scheme.scheme);
     }
@@ -192,6 +216,9 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                          extension_schemes);
   AppendSchemesToCmdLine(electron::switches::kStandardSchemes,
                          GetStandardSchemes());
+  AppendSchemesToCmdLine(
+      electron::switches::kStandardSchemesWithPortAndUserinfo,
+      port_and_userinfo_schemes);
   AppendSchemesToCmdLine(electron::switches::kStreamingSchemes,
                          GetStreamingSchemes());
   AppendSchemesToCmdLine(electron::switches::kCodeCacheSchemes,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -633,8 +633,9 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
   if (process_type == ::switches::kUtilityProcess ||
       process_type == ::switches::kRendererProcess) {
     // Copy following switches to child process.
-    static constexpr std::array<const char*, 11U> kCommonSwitchNames = {
+    static constexpr std::array<const char*, 12U> kCommonSwitchNames = {
         switches::kStandardSchemes.c_str(),
+        switches::kStandardSchemesWithPortAndUserinfo.c_str(),
         switches::kEnableSandbox.c_str(),
         switches::kSecureSchemes.c_str(),
         switches::kBypassCSPSchemes.c_str(),

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -267,6 +267,11 @@ inline constexpr base::cstring_view kDisableHttpCache = "disable-http-cache";
 // The list of standard schemes.
 inline constexpr base::cstring_view kStandardSchemes = "standard-schemes";
 
+// The subset of standard schemes that should keep their port number and
+// userinfo instead of having them stripped.
+inline constexpr base::cstring_view kStandardSchemesWithPortAndUserinfo =
+    "standard-schemes-with-port-and-userinfo";
+
 // Register schemes to handle service worker.
 inline constexpr base::cstring_view kServiceWorkerSchemes =
     "service-worker-schemes";

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -147,7 +147,8 @@ RendererClientBase::RendererClientBase() {
   std::vector<std::string> standard_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);
   for (const std::string& scheme : standard_schemes_list)
-    url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITH_HOST);
+    url::AddStandardScheme(scheme.c_str(),
+                           url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
   // Parse --cors-schemes=scheme1,scheme2
   std::vector<std::string> cors_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kCORSSchemes);

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -4,6 +4,7 @@
 
 #include "shell/renderer/renderer_client_base.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -146,9 +147,16 @@ RendererClientBase::RendererClientBase() {
   // Parse --standard-schemes=scheme1,scheme2
   std::vector<std::string> standard_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);
+  // Parse --standard-schemes-with-port-and-userinfo=scheme1,scheme2
+  std::vector<std::string> port_and_userinfo_schemes_list =
+      ParseSchemesCLISwitch(command_line,
+                            switches::kStandardSchemesWithPortAndUserinfo);
   for (const std::string& scheme : standard_schemes_list)
-    url::AddStandardScheme(scheme.c_str(),
-                           url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
+    url::AddStandardScheme(
+        scheme.c_str(),
+        std::ranges::contains(port_and_userinfo_schemes_list, scheme)
+            ? url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION
+            : url::SCHEME_WITH_HOST);
   // Parse --cors-schemes=scheme1,scheme2
   std::vector<std::string> cors_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kCORSSchemes);

--- a/spec/ambient.d.ts
+++ b/spec/ambient.d.ts
@@ -1,4 +1,5 @@
 declare let standardScheme: string;
+declare let portScheme: string;
 declare let serviceWorkerScheme: string;
 
 declare module 'dbus-native';

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -960,6 +960,16 @@ describe('protocol module', () => {
       expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
+
+    it('preserves the port for a custom standard scheme', async () => {
+      const targetUrl = `${portScheme}://fake-host:12345/index.html`;
+      registerStringProtocol(portScheme, (request, callback) => {
+        callback(request.url);
+      });
+      defer(() => unregisterProtocol(portScheme));
+      const r = await ajax(targetUrl);
+      expect(r.data).to.equal(targetUrl);
+    });
   });
 
   describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -961,7 +961,7 @@ describe('protocol module', () => {
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
 
-    it('preserves the port for a custom standard scheme', async () => {
+    it('preserves the port for a custom standard scheme with preservePortAndUserinfo', async () => {
       const targetUrl = `${portScheme}://fake-host:12345/index.html`;
       registerStringProtocol(portScheme, (request, callback) => {
         callback(request.url);
@@ -969,6 +969,16 @@ describe('protocol module', () => {
       defer(() => unregisterProtocol(portScheme));
       const r = await ajax(targetUrl);
       expect(r.data).to.equal(targetUrl);
+    });
+
+    it('strips the port for a standard scheme without preservePortAndUserinfo', async () => {
+      const targetUrl = `${standardScheme}://fake-host:12345/index.html`;
+      registerStringProtocol(standardScheme, (request, callback) => {
+        callback(request.url);
+      });
+      defer(() => unregisterProtocol(standardScheme));
+      const r = await ajax(targetUrl);
+      expect(r.data).to.equal(`${standardScheme}://fake-host/index.html`);
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -53,10 +53,12 @@ app.commandLine.appendSwitch(
 
 global.standardScheme = 'app';
 global.zoomScheme = 'zoom';
+global.portScheme = 'port';
 global.serviceWorkerScheme = 'sw';
 protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
+  { scheme: global.portScheme, privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
   { scheme: 'http-like', privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },

--- a/spec/index.js
+++ b/spec/index.js
@@ -58,7 +58,7 @@ global.serviceWorkerScheme = 'sw';
 protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
-  { scheme: global.portScheme, privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
+  { scheme: global.portScheme, privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true, preservePortAndUserinfo: true } },
   { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
   { scheme: 'http-like', privileges: { standard: true, secure: true, corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },


### PR DESCRIPTION
#### Description of Change

Fixes #24725. (Note: this supersedes #53555, which the bots auto-closed for a PR-description template mismatch before I could fix it — GitHub is refusing to reopen that one for me, likely tied to how the policy bot closed it, so I'm reopening the same branch as a fresh PR instead.)

`protocol.registerSchemesAsPrivileged({ standard: true })` has always registered custom schemes with `url::SCHEME_WITH_HOST`, which silently strips any port number (and userinfo) from URLs using that scheme. A URL like `myapp://host:1234/x` loses its port the moment it's parsed anywhere in the browser, renderer, or network process, because `url::SchemeType` is process-global registry state, not something carried on the GURL itself.

Two prior attempts fixed this and were both closed unmerged:
- #26803 (original attempt)
- #34817 (second attempt, after the same author found the missing spot from the first review)

Both switched the browser process (`electron_api_protocol.cc`) and renderer process (`renderer_client_base.cc`) registrations from `url::SCHEME_WITH_HOST` to `url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION`, but CI kept failing with `VALIDATION_ERROR_DESERIALIZATION_FAILED` Mojo errors that were never root-caused, and the PRs went stale.

**What was missing:** there's a third registration site neither PR touched — `ElectronContentClient::AddAdditionalSchemes()`, which runs in the network service's utility process. It fed the scheme names into Chromium's generic `content::Schemes::standard_schemes` list. `content::RegisterContentSchemes()` (in `content/common/url_schemes.cc`) unconditionally registers every entry in that list with `url::SCHEME_WITH_HOST` — there's no way to carry a different `SchemeType` through that struct. So even after fixing the browser and renderer processes, the network service kept parsing/canonicalizing these URLs *without* port support, disagreeing with the other two processes. That mismatch is what trips Mojo's GURL struct validation when a request for one of these URLs is round-tripped through the network service — exactly the failure both prior PRs hit.

This PR registers standard schemes directly with `url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION` in the utility process too (bypassing `schemes->standard_schemes` for this case, same as the browser and renderer processes already do), so all three processes agree on how these URLs canonicalize.

**Disclosure:** this fix was drafted with Claude Code (Claude Sonnet 5). I (the PR author) directed the investigation, reviewed the root-cause analysis and the resulting diff, and take responsibility for it. I was not able to build or run Electron locally when preparing this — see the testing note below — so I'm explicitly flagging that for reviewers rather than checking a box that isn't true yet.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] I have reviewed and verified the changes
- [ ] `npm test` passes
- [x] tests are changed or added
- [ ] relevant API documentation, tutorials, and examples are updated and follow the documentation style guide (none needed — no public API surface changed)
- [x] PR release notes describe the change in a way relevant to app developers, and are capitalized, punctuated, and past tense

**Testing note:** No Chromium checkout/build was available in the environment this was prepared in, so this has not been compiled or run locally yet. What was verified instead:
- The exact consumer of `content::Schemes::standard_schemes` against current Chromium `main` (`content/common/url_schemes.cc`), confirming it hardcodes `SCHEME_WITH_HOST` with no per-scheme override.
- `clang-format` (Chromium style) and `oxlint`/`tsc` pass on the changed files with no new diagnostics.
- Added `spec/api-protocol-spec.ts`: "preserves the port for a custom standard scheme", with a new `portScheme` registered as `standard: true` in `spec/index.js`. It does a real end-to-end `fetch()` through the custom scheme (renderer → network service → browser process protocol handler) and asserts the port survives.

I'll be watching CI closely given the history here, and am glad to iterate if there's a fourth spot I missed or if `npm test` surfaces something the sandbox couldn't.

#### Release Notes

Notes: Fixed a bug where custom protocol schemes registered as `standard: true` would silently lose the port number (and userinfo) from request URLs.