### PR TITLE
fix: persist window state when a display-mode transition ends

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -240,10 +240,14 @@ void BaseWindow::OnWindowHide() {
 }
 
 void BaseWindow::OnWindowMaximize() {
+  // Persist the display mode; bounds events fired during the transition
+  // are skipped by SaveWindowState, so nothing else would.
+  window_->DebouncedSaveWindowState();
   Emit("maximize");
 }
 
 void BaseWindow::OnWindowUnmaximize() {
+  window_->DebouncedSaveWindowState();
   Emit("unmaximize");
 }
 
@@ -294,10 +298,12 @@ void BaseWindow::OnWindowMoved() {
 }
 
 void BaseWindow::OnWindowEnterFullScreen() {
+  window_->DebouncedSaveWindowState();
   Emit("enter-full-screen");
 }
 
 void BaseWindow::OnWindowLeaveFullScreen() {
+  window_->DebouncedSaveWindowState();
   Emit("leave-full-screen");
 }
 

--- a/shell/common/api/electron_api_testing.cc
+++ b/shell/common/api/electron_api_testing.cc
@@ -8,6 +8,8 @@
 #include "base/dcheck_is_on.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
+#include "chrome/browser/browser_process.h"
+#include "components/prefs/pref_service.h"
 #include "content/browser/network_service_instance_impl.h"  // nogncheck
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/common/content_switches.h"
@@ -201,6 +203,24 @@ std::optional<gin_helper::Promise<void>>& GetHeldPromise() {
   return held_promise;
 }
 
+// Writes any pending local state (window state persistence, per-host zoom
+// levels, ...) to disk now. PrefService otherwise batches writes on a 10s
+// timer, which is what a test polling the prefs file would wait on.
+v8::Local<v8::Promise> CommitPendingLocalStateWrites(v8::Isolate* isolate) {
+  gin_helper::Promise<void> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+  PrefService* local_state =
+      g_browser_process ? g_browser_process->local_state() : nullptr;
+  if (!local_state) {
+    promise.RejectWithErrorMessage("No local state in this process");
+    return handle;
+  }
+  local_state->CommitPendingWrite(base::BindOnce(
+      [](gin_helper::Promise<void> promise) { promise.Resolve(); },
+      std::move(promise)));
+  return handle;
+}
+
 void HoldPromiseForTesting(gin::Arguments* args) {
   GetHeldPromise().emplace(args->isolate());
 }
@@ -237,6 +257,8 @@ void Initialize(v8::Local<v8::Object> exports,
                  &InvokeHeldOnceCallbackForTesting);
   dict.SetMethod("clearHeldCallbacksForTesting", &ClearHeldCallbacksForTesting);
   dict.SetMethod("holdPromiseForTesting", &HoldPromiseForTesting);
+  dict.SetMethod("commitPendingLocalStateWrites",
+                 &CommitPendingLocalStateWrites);
   dict.SetMethod("clearHeldPromiseForTesting", &ClearHeldPromiseForTesting);
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -37,7 +37,7 @@ import * as nodeUrl from 'node:url';
 import { emittedUntil, emittedNTimes } from './lib/events-helpers';
 import { randomString } from './lib/net-helpers';
 import { HexColors, hasCapturableScreen, ScreenCapture } from './lib/screen-helpers';
-import { ifit, ifdescribe, defer, listen, waitUntil, isWayland } from './lib/spec-helpers';
+import { ifit, ifdescribe, defer, listen, waitUntil, isWayland, isTestingBindingAvailable } from './lib/spec-helpers';
 import { closeWindow, closeAllWindows } from './lib/window-helpers';
 
 const fixtures = path.resolve(__dirname, 'fixtures');
@@ -8077,27 +8077,46 @@ describe('BrowserWindow module', () => {
       }
     };
 
-    const waitForPrefsUpdate = async (initialModTime: Date, preferencesPath: string): Promise<void> => {
+    // Window state reaches the prefs file through PrefService, which batches
+    // writes on a 10s timer. Testing builds can force the write; otherwise
+    // poll for it.
+    const flushPrefs = isTestingBindingAvailable()
+      ? () => process._linkedBinding('electron_common_testing').commitPendingLocalStateWrites()
+      : null;
+
+    const waitForPrefsUpdate = async (
+      initialModTime: Date,
+      preferencesPath: string,
+      isExpectedState: () => boolean = () => true
+    ): Promise<void> => {
       const startTime = Date.now();
       const timeoutMs = 20000;
       while (true) {
+        // The save itself is debounced by 200ms before it reaches PrefService.
+        if (flushPrefs) {
+          await setTimeout(250);
+          await flushPrefs();
+        }
         const currentModTime = getPrefsModTime(preferencesPath);
 
-        if (currentModTime > initialModTime) {
+        if (currentModTime > initialModTime && isExpectedState()) {
           return;
         }
 
         if (Date.now() - startTime > timeoutMs) {
           throw new Error(`Window state was not flushed to disk within ${timeoutMs}ms`);
         }
-        // Wait for 1 second before checking again
-        await setTimeout(1000);
+        await setTimeout(flushPrefs ? 50 : 1000);
       }
     };
 
     const waitForPrefsFileCreation = async (preferencesPath: string) => {
       while (!fs.existsSync(preferencesPath)) {
-        await setTimeout(1000);
+        if (flushPrefs) {
+          await setTimeout(250);
+          await flushPrefs();
+        }
+        await setTimeout(flushPrefs ? 50 : 1000);
       }
     };
 
@@ -8114,13 +8133,25 @@ describe('BrowserWindow module', () => {
         show: false,
         ...options
       });
+      // A fullscreen or kiosk window saves again once its transition ends.
+      // Forcing the write can land the pre-transition save first, so wait
+      // for the state the caller asked for, not just for a change.
+      const saved = (): boolean => {
+        if (!options?.fullscreen && !options?.kiosk) return true;
+        const state = getWindowStateFromDisk(windowName, preferencesPath);
+        return (
+          !!state &&
+          (options.fullscreen ? state.fullscreen === true : true) &&
+          (options.kiosk ? state.kiosk === true : true)
+        );
+      };
       if (!fs.existsSync(preferencesPath)) {
         // File doesn't exist, wait for creation
         await waitForPrefsFileCreation(preferencesPath);
       } else {
         // File exists, wait for update
         const initialModTime = getPrefsModTime(preferencesPath);
-        await waitForPrefsUpdate(initialModTime, preferencesPath);
+        await waitForPrefsUpdate(initialModTime, preferencesPath, saved);
       }
       // Ensure window is destroyed because we can't create another window with the same name otherwise
       w.destroy();


### PR DESCRIPTION
Only `resize` and `move` scheduled a window-state save. Entering or leaving fullscreen and maximizing or unmaximizing did not, and bounds events fired during those transitions are skipped by `SaveWindowState`. So an app that went fullscreen (or maximized) and quit without moving the window lost that state on next launch.

`BaseWindow::OnWindowEnterFullScreen`, `OnWindowLeaveFullScreen`, `OnWindowMaximize` and `OnWindowUnmaximize` now schedule a save, the same way `OnWindowResize` and `OnWindowMove` do. All three platforms route through these hooks.

This PR also speeds up the `windowStatePersistence` spec, which is what surfaced the bug:

- Window state reaches disk through `PrefService`, which batches writes on a 10s timer. The spec polled the prefs file once a second and waited on that timer for every save.
- `electron_common_testing` (DCHECK builds only) gains `commitPendingLocalStateWrites()`, which forces the write and resolves when it lands. The spec uses it when available and falls back to polling otherwise.
- `createAndSaveWindowState` now waits for the state it asked for (`fullscreen`/`kiosk` on disk), not for any change. With the forced flush, the pre-transition save could land first, which is how the missing transition save showed up.

Locally the suite went from 408s to 251s (the remaining time is mostly the multi-monitor tests, which need a virtual display this machine can't create, timing out). On CI it was ~4 minutes of the slowest macOS x64 shard.

Notes: Fixed window state not being persisted when a window entered or left fullscreen, or was maximized or unmaximized, without also being moved or resized.
