### PR TITLE
ci: pre-seed the node-gyp header cache on Linux too

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -28,21 +28,22 @@ runs:
         echo "Skipping yarn build on linux arm"
       else
         # Pre-seed the node-gyp header cache so the parallel native-addon
-        # builds below don't race on a cold cache. Linux build containers
-        # already ship a warm cache (electron/build-images#68), so only do
-        # this on macOS / Windows runners.
-        if [ "$(uname -s)" != "Linux" ]; then
-          for i in 1 2 3; do
-            if node node_modules/node-gyp/bin/node-gyp.js install; then
-              break
-            fi
-            if [ "$i" = "3" ]; then
-              echo "node-gyp header pre-seed failed after 3 attempts" >&2
-              exit 1
-            fi
-            echo "node-gyp header pre-seed failed (attempt $i), retrying in 5s..." >&2
-            sleep 5
-          done
-        fi
+        # builds below don't race on a cold cache (nodejs/node-gyp#3301).
+        # The Linux containers ship a pre-warmed cache (electron/build-images#68)
+        # but it is keyed by the exact Node version of the runner that built the
+        # image, which does not always match the Node inside the container (the
+        # arm32v7 test image is pinned to 22.15.0), so do this everywhere; it is
+        # a no-op when the cache is already warm.
+        for i in 1 2 3; do
+          if node node_modules/node-gyp/bin/node-gyp.js install; then
+            break
+          fi
+          if [ "$i" = "3" ]; then
+            echo "node-gyp header pre-seed failed after 3 attempts" >&2
+            exit 1
+          fi
+          echo "node-gyp header pre-seed failed (attempt $i), retrying in 5s..." >&2
+          sleep 5
+        done
         node script/yarn.js install --immutable
       fi


### PR DESCRIPTION
`linux-arm` test jobs sometimes fail in "Install Dependencies" with truncated-header errors like `v8-isolate.h:5: unterminated #ifndef` ([example](https://github.com/electron/electron/actions/runs/33935184329/job/101223552917)): the native-addon fixtures build in parallel and race populating a cold node-gyp header cache (nodejs/node-gyp#3301).

- The existing pre-seed is skipped on Linux because the images ship a warm cache, but that cache is for the image-build runner's Node (22.23.2) and the arm32v7 image runs 22.15.0, so it has never been warm there. The older `armv7l` skip never matched either (arm64 host).
- ~0.6% of arm32 test jobs since June failed this way (7 of ~1,200).
- Run the pre-seed on Linux too; it's a no-op when the cache is already warm.

Not needed on main: #51816 removed the armv7l jobs.

Notes: none
