### PR TITLE
build: accept "/Fo obj/x.obj" when reading compile_commands.json

### DIFF
--- a/script/gen-clang-tidy-ninja.py
+++ b/script/gen-clang-tidy-ninja.py
@@ -54,7 +54,10 @@ def parse_compile_command(command, source):
     if arg == '-o':
       obj = next(args)
     elif arg.startswith('/Fo'):
-      obj = arg[len('/Fo'):]
+      # GN writes "/Fo{{output}}" to compile_commands.json as "/Fo obj/x.obj"
+      # (a space before every substituted path), and "/Fo$output" as
+      # "/Foobj/x.obj"; Chromium's Windows toolchain used the former up to 154.
+      obj = arg[len('/Fo'):] or next(args)
     elif arg == '-MF':
       next(args)
     elif arg in ('-c', '/c', '-MMD', source) or arg.startswith(('/Fd', '/showIncludes')):
@@ -78,6 +81,8 @@ def tidy_steps(out_dir):
     if os.path.relpath(path, ELECTRON_DIR) in SKIPPED_SOURCES:
       continue
     compiler, obj, flags = parse_compile_command(entry['command'], entry['file'])
+    if not obj:
+      sys.exit(f'No object file (-o or /Fo) in the compile command for {entry["file"]}')
     steps.append(Step(
         source=os.path.relpath(path, out_dir),
         output=f'{obj}.tidy',


### PR DESCRIPTION
Follow-up to #53447, found on its 42/43/44 backports (#53568 #53569 #53570), where the Windows clang-tidy job failed with `multiple rules generates .tidy`.

- GN's compile-commands writer puts a space before every substituted path, so a toolchain command written `/Fo{{output}}` lands in `compile_commands.json` as `/Fo obj/x.obj`. Chromium's Windows cc/cxx tools used that form until 155 changed them to `/Fo$output` (a plain string, so `/Foobj/x.obj`). `gen-clang-tidy-ninja.py` only handled the joined form; with the spaced one every clang-cl entry parsed to an empty object path and every step got the output `.tidy`.
- Accept both forms, and exit naming the source file if an entry has no object path at all rather than writing a broken ninja file.
- No effect on main today (155 uses the joined form); this keeps main and the release branches on the same script and guards against the toolchain string changing again.

Notes: none
