### PR TITLE
fix: resolve the file dialog's parent HWND on the UI thread on Windows

### DIFF
--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -88,15 +88,13 @@ static void SetDefaultFolder(IFileDialog* dialog,
     dialog->SetFolder(folder_item);
 }
 
-static HRESULT ShowFileDialog(IFileDialog* dialog,
-                              const DialogSettings& settings) {
-  HWND parent_window =
-      settings.parent_window
-          ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
-                ->GetAcceleratedWidget()
-          : nullptr;
-
-  return dialog->Show(parent_window);
+// settings.parent_window is a NativeWindow that lives on the UI thread, so
+// resolve its HWND there; the dialog itself may run on dialog_thread.
+static HWND GetParentWindowHandle(const DialogSettings& settings) {
+  return settings.parent_window
+             ? static_cast<electron::NativeWindowViews*>(settings.parent_window)
+                   ->GetAcceleratedWidget()
+             : nullptr;
 }
 
 static void ApplySettings(IFileDialog* dialog, const DialogSettings& settings) {
@@ -156,8 +154,9 @@ static void ApplySettings(IFileDialog* dialog, const DialogSettings& settings) {
 
 }  // namespace
 
-bool ShowOpenDialogSync(const DialogSettings& settings,
-                        std::vector<base::FilePath>* paths) {
+static bool ShowOpenDialogSyncWithParent(const DialogSettings& settings,
+                                         HWND parent_window,
+                                         std::vector<base::FilePath>* paths) {
   ATL::CComPtr<IFileOpenDialog> file_open_dialog;
   HRESULT hr = file_open_dialog.CoCreateInstance(CLSID_FileOpenDialog);
 
@@ -178,7 +177,7 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
   file_open_dialog->SetOptions(options);
 
   ApplySettings(file_open_dialog, settings);
-  hr = ShowFileDialog(file_open_dialog, settings);
+  hr = file_open_dialog->Show(parent_window);
   if (FAILED(hr))
     return false;
 
@@ -209,6 +208,12 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
   return true;
 }
 
+bool ShowOpenDialogSync(const DialogSettings& settings,
+                        std::vector<base::FilePath>* paths) {
+  return ShowOpenDialogSyncWithParent(settings, GetParentWindowHandle(settings),
+                                      paths);
+}
+
 void ShowOpenDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise) {
   auto done = [](gin_helper::Promise<gin_helper::Dictionary> promise,
@@ -219,12 +224,14 @@ void ShowOpenDialog(const DialogSettings& settings,
     dict.Set("filePaths", result);
     promise.Resolve(dict);
   };
-  dialog_thread::Run(base::BindOnce(ShowOpenDialogSync, settings),
+  dialog_thread::Run(base::BindOnce(ShowOpenDialogSyncWithParent, settings,
+                                    GetParentWindowHandle(settings)),
                      base::BindOnce(done, std::move(promise)));
 }
 
-std::optional<base::FilePath> ShowSaveDialogSync(
-    const DialogSettings& settings) {
+static std::optional<base::FilePath> ShowSaveDialogSyncWithParent(
+    const DialogSettings& settings,
+    HWND parent_window) {
   ATL::CComPtr<IFileSaveDialog> file_save_dialog;
   HRESULT hr = file_save_dialog.CoCreateInstance(CLSID_FileSaveDialog);
   if (FAILED(hr))
@@ -238,7 +245,7 @@ std::optional<base::FilePath> ShowSaveDialogSync(
 
   file_save_dialog->SetOptions(options);
   ApplySettings(file_save_dialog, settings);
-  hr = ShowFileDialog(file_save_dialog, settings);
+  hr = file_save_dialog->Show(parent_window);
 
   if (FAILED(hr))
     return {};
@@ -258,6 +265,12 @@ std::optional<base::FilePath> ShowSaveDialogSync(
   return path;
 }
 
+std::optional<base::FilePath> ShowSaveDialogSync(
+    const DialogSettings& settings) {
+  return ShowSaveDialogSyncWithParent(settings,
+                                      GetParentWindowHandle(settings));
+}
+
 void ShowSaveDialog(const DialogSettings& settings,
                     gin_helper::Promise<gin_helper::Dictionary> promise) {
   auto done = [](gin_helper::Promise<gin_helper::Dictionary> promise,
@@ -268,7 +281,8 @@ void ShowSaveDialog(const DialogSettings& settings,
     dict.Set("filePath", result.value_or(base::FilePath{}));
     promise.Resolve(dict);
   };
-  dialog_thread::Run(base::BindOnce(ShowSaveDialogSync, settings),
+  dialog_thread::Run(base::BindOnce(ShowSaveDialogSyncWithParent, settings,
+                                    GetParentWindowHandle(settings)),
                      base::BindOnce(done, std::move(promise)));
 }
 

--- a/spec/asar-spec.ts
+++ b/spec/asar-spec.ts
@@ -10,7 +10,7 @@ import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
 import { Worker } from 'node:worker_threads';
 
-import { getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
+import { defer, getRemoteContext, ifdescribe, ifit, itremote, useRemoteContext } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 const features = process._linkedBinding('electron_common_features');
@@ -113,6 +113,20 @@ describe('asar package', () => {
       const src = path.join(asarDir, 'pdf.asar', 'cat.pdf');
       const savePath = path.join(importedFs.mkdtempSync(path.join(os.tmpdir(), 'asar-pdf-')), 'saved.pdf');
       const willDownload = once(w.webContents.session, 'will-download');
+      // The click loop below can start more than one download. Give the first
+      // its save path here, synchronously, and refuse the rest, so none of them
+      // ever falls through to the native Save dialog.
+      let started = false;
+      const onWillDownload = (event: Electron.Event, item: Electron.DownloadItem) => {
+        if (started) {
+          event.preventDefault();
+        } else {
+          started = true;
+          item.savePath = savePath;
+        }
+      };
+      w.webContents.session.on('will-download', onWillDownload);
+      defer(() => w.webContents.session.off('will-download', onWillDownload));
       await w.loadURL(fileUrl(src));
       // Click the viewer's download button once its plugin is up; an
       // unedited document is saved through the browser as a download.
@@ -131,7 +145,6 @@ describe('asar package', () => {
       }
       expect(downloading, 'the viewer never started a download').to.be.an('array');
       const item = downloading![1] as Electron.DownloadItem;
-      item.savePath = savePath;
       const [, state] = await once(item, 'done');
       expect(state).to.equal('completed');
       expect(item.getFilename()).to.equal('cat.pdf');


### PR DESCRIPTION
#### Description of Change

`dialog.showOpenDialog()` / `showSaveDialog()` (and the download manager's default Save prompt) run the native dialog on `dialog_thread`, and `ShowFileDialog` resolved the parent HWND *there* via `NativeWindowViews::GetAcceleratedWidget()` → `views::Widget::GetNativeWindow()`, which reads a UI-thread `WeakPtr`. In DCHECK builds that's `sequence_checker.cc: CalledOnValidSequence` and a browser-process crash ([CI hit](https://github.com/electron/electron/actions/runs/33937825078/job/101232242761)); in release builds it's an unsynchronised read of a window the UI thread may be tearing down.

- Resolve the HWND on the UI thread in `ShowOpenDialog`/`ShowSaveDialog`/`Show*DialogSync` and pass it into the dialog-thread function, the same way `message_box_win.cc` has done since the M110 roll. No header or cross-platform change.
- The CI hit came from `asar-spec.ts` "saves a packed PDF from the PDF viewer": its click loop can start a second download, which had no `will-download` handler and fell through to the real Save dialog. Give every download from that test a save path (or refuse it) synchronously in `will-download`.

#### Checklist

- [x] PR description included
- [x] `npm test` passes

#### Release Notes

Notes: Fixed a possible crash on Windows when a file dialog was shown for a window that was being closed at the same time.
