### PR TITLE
feat: add deviceBoundSessions fuse for DBSC on Windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -534,6 +534,7 @@ source_set("electron_lib") {
     "//components/prefs",
     "//components/security_state/content",
     "//components/tracing:tracing_metrics",
+    "//components/unexportable_keys",
     "//components/upload_list",
     "//components/user_prefs",
     "//components/viz/host",

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -10,5 +10,6 @@
   "only_load_app_from_asar": "0",
   "load_browser_process_specific_v8_snapshot": "0",
   "grant_file_protocol_extra_privileges": "1",
-  "wasm_trap_handlers": "1"
+  "wasm_trap_handlers": "1",
+  "device_bound_sessions": "0"
 }

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -177,6 +177,46 @@ than they ideally should be.
 * This extra code, particularly the compare and branch before every memory reference,
 incurs a significant runtime cost.
 
+### `deviceBoundSessions`
+
+**Default:** Disabled
+
+**@electron/fuses:** `FuseV1Options.EnableDeviceBoundSessions`
+
+The `deviceBoundSessions` fuse toggles whether generic net-layer Device Bound Session Credentials (DBSC)
+are enabled in the network service. DBSC binds session cookies to hardware-backed cryptographic keys so
+that a stolen cookie cannot be replayed from another device.
+
+When this fuse is enabled, Electron configures the network service to support DBSC session registration
+and persists session state across restarts on-disk. DevTools inspection is available under
+_Application > Background Services > Device Bound Sessions_.
+
+> [!IMPORTANT]
+>
+> * **Windows only.** This fuse currently has no effect on macOS or Linux. Windows keys are managed
+>   automatically through CNG (`NCrypt`) and require a device with TPM 2.0; on a machine without one,
+>   no key provider is available and DBSC is a no-op.
+> * **macOS** needs a key service running in the browser process, configured with a keychain access
+>   group derived from the app's own code signature, because the network service's built-in provider
+>   hardcodes Chromium's access group. **Linux** has no desktop hardware key provider upstream yet.
+>   Both are tracked as follow-up work.
+> * **Software key flag rejection.** When this fuse is enabled, Electron rejects the
+>   `EnableBoundSessionCredentialsSoftwareKeysForManualTesting` feature so that a packaged app cannot
+>   have its hardware-backed protection downgraded to mock software keys at runtime.
+
+#### Testing DBSC in development
+
+Hardware-backed keys are unavailable in most development setups, and on macOS and Linux the fuse does
+nothing at all. To exercise DBSC anywhere, leave the fuse disabled and run with mock software keys:
+
+```sh
+electron . --enable-features=EnableBoundSessionCredentialsSoftwareKeysForManualTesting
+```
+
+With the fuse off, that flag also turns DBSC on in the network service. Software keys offer no hardware
+protection and exist only for local testing -- a packaged app with the fuse enabled rejects the flag, so
+this cannot be used to weaken a production app.
+
 ## How do I flip fuses?
 
 ### The easy way

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -12,9 +12,12 @@
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial.h"
+#include "base/strings/string_util.h"
 #include "components/spellcheck/common/spellcheck_features.h"
+#include "components/unexportable_keys/features.h"
 #include "content/public/common/content_features.h"
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "media/base/media_switches.h"
 #include "net/base/features.h"
 #include "printing/buildflags/buildflags.h"
@@ -44,6 +47,40 @@ void InitializeFeatureList() {
       cmd_line->GetSwitchValueASCII(::switches::kEnableFeatures);
   auto disable_features =
       cmd_line->GetSwitchValueASCII(::switches::kDisableFeatures);
+
+  if (electron::fuses::IsDeviceBoundSessionsEnabled()) {
+    // A production app that fused DBSC on must not be downgradable to mock
+    // software keys by a command-line flag, so drop any request for them and
+    // force the feature off.
+    //
+    // Only the local feature strings are touched. InitializeFeatureList() runs
+    // twice in the browser process (ElectronMainDelegate::PreBrowserMain and
+    // ElectronBrowserMainParts::PostEarlyInitialization), so rewriting the
+    // process command line here would read back its own output and append the
+    // disable entry a second time, leaking duplicates into app.commandLine and
+    // into second-instance argv. It is also unnecessary: disable overrides win
+    // in FeatureList, and child processes get their feature switches from the
+    // FeatureList instance rather than from the browser's argv.
+    std::vector<std::string_view> filtered_features;
+    for (const auto& entry :
+         base::FeatureList::SplitFeatureListString(enable_features)) {
+      std::string name, study, group, params;
+      if (base::FeatureList::ParseEnableFeatureString(entry, &name, &study,
+                                                      &group, &params) &&
+          name == unexportable_keys::
+                      kEnableBoundSessionCredentialsSoftwareKeysForManualTesting
+                          .name) {
+        continue;
+      }
+      filtered_features.emplace_back(entry);
+    }
+    enable_features = base::JoinString(filtered_features, ",");
+    disable_features +=
+        std::string(",") +
+        unexportable_keys::
+            kEnableBoundSessionCredentialsSoftwareKeysForManualTesting.name;
+  }
+
   // A renderer's command line depends on the WebContents it is created for,
   // so Electron warms one spare itself (for the first sandboxed window) rather
   // than letting content keep one alive at all times; apps that open many

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "base/base_switches.h"
 #include "base/command_line.h"

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -6,8 +6,11 @@
 
 #include <utility>
 
+#include "base/feature_list.h"
+#include "build/build_config.h"
 #include "chrome/browser/browser_features.h"
 #include "chrome/common/chrome_constants.h"
+#include "components/unexportable_keys/features.h"
 #include "content/public/browser/shared_cors_origin_access_list.h"
 #include "electron/fuses.h"
 #include "net/http/http_util.h"
@@ -33,6 +36,26 @@ bool ShouldTriggerNetworkDataMigration() {
   if (base::FeatureList::IsEnabled(features::kTriggerNetworkDataMigration))
     return true;
   return false;
+}
+
+bool ShouldEnableDeviceBoundSessions() {
+  // DBSC is only supported on Windows for now. There, unexportable keys come
+  // from the TPM via CNG and the network service's own key provider works as
+  // is. macOS needs a browser-process key service configured with an
+  // app-derived keychain access group -- the network service's provider
+  // hardcodes Chromium's -- and Linux has no hardware provider upstream at all.
+#if BUILDFLAG(IS_WIN)
+  if (electron::fuses::IsDeviceBoundSessionsEnabled())
+    return true;
+#endif
+  // Mock software keys are platform-agnostic, and this branch is only
+  // reachable with the fuse off: InitializeFeatureList() force-disables the
+  // feature when the fuse is on, so a production app can never take it. This
+  // is the supported way to exercise DBSC in development, including on
+  // platforms where hardware-backed keys are unavailable.
+  return base::FeatureList::IsEnabled(
+      unexportable_keys::
+          kEnableBoundSessionCredentialsSoftwareKeysForManualTesting);
 }
 
 }  // namespace
@@ -75,6 +98,9 @@ void NetworkContextService::ConfigureNetworkContextParams(
   network_context_params->http_cache_enabled =
       browser_context_->can_use_http_cache();
 
+  network_context_params->device_bound_sessions_enabled =
+      ShouldEnableDeviceBoundSessions();
+
   network_context_params->cookie_manager_params =
       network::mojom::CookieManagerParams::New();
 
@@ -107,6 +133,11 @@ void NetworkContextService::ConfigureNetworkContextParams(
 
     network_context_params->file_paths->trust_token_database_name =
         base::FilePath(chrome::kTrustTokenFilename);
+
+    if (network_context_params->device_bound_sessions_enabled) {
+      network_context_params->file_paths->device_bound_sessions_database_name =
+          base::FilePath(chrome::kDeviceBoundSessionsFilename);
+    }
 
     network_context_params->restore_old_session_cookies = false;
     network_context_params->persist_session_cookies = false;

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -44,15 +44,15 @@ bool ShouldEnableDeviceBoundSessions() {
   // is. macOS needs a browser-process key service configured with an
   // app-derived keychain access group -- the network service's provider
   // hardcodes Chromium's -- and Linux has no hardware provider upstream at all.
-#if BUILDFLAG(IS_WIN)
   if (electron::fuses::IsDeviceBoundSessionsEnabled())
-    return true;
-#endif
-  // Mock software keys are platform-agnostic, and this branch is only
-  // reachable with the fuse off: InitializeFeatureList() force-disables the
-  // feature when the fuse is on, so a production app can never take it. This
-  // is the supported way to exercise DBSC in development, including on
-  // platforms where hardware-backed keys are unavailable.
+    return BUILDFLAG(IS_WIN);
+
+  // Mock software keys are platform-agnostic. Reaching here means the fuse is
+  // off, so a packaged app that fused DBSC on can never take this path -- and
+  // independently of that, InitializeFeatureList() force-disables the feature
+  // whenever the fuse is on. This is the supported way to exercise DBSC in
+  // development, including on platforms where hardware-backed keys are
+  // unavailable.
   return base::FeatureList::IsEnabled(
       unexportable_keys::
           kEnableBoundSessionCredentialsSoftwareKeysForManualTesting);

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -31,6 +31,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
+#include "content/common/features.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/file_select_listener.h"
@@ -1062,6 +1063,13 @@ void InspectableWebContents::GetHostConfig(DispatchCallback callback) {
     extension_schemes.Append(scheme + ":");
   response_dict.Set("devToolsExtensionSchemes",
                     base::Value(std::move(extension_schemes)));
+
+  base::DictValue device_bound_sessions_debugging;
+  device_bound_sessions_debugging.Set(
+      "enabled",
+      base::FeatureList::IsEnabled(features::kDeviceBoundSessionsDevTools));
+  response_dict.Set("deviceBoundSessionsDebugging",
+                    std::move(device_bound_sessions_debugging));
 
   base::Value response = base::Value(std::move(response_dict));
   std::move(callback).Run(&response);

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -4,9 +4,14 @@ import { expect } from 'chai';
 
 import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import path = require('node:path');
+import { setTimeout } from 'node:timers/promises';
 
-import { startRemoteControlApp } from './lib/spec-helpers';
+import { defer, startRemoteControlApp } from './lib/spec-helpers';
+
+type RemoteControlApp = Awaited<ReturnType<typeof startRemoteControlApp>>;
 
 describe('fuses', () => {
   it('can be enabled by command-line argument during testing', async () => {
@@ -116,6 +121,109 @@ describe('fuses', () => {
       });
 
       expect(result).to.equal('persist_me');
+    });
+  });
+
+  describe('device_bound_sessions', () => {
+    const softwareKeysFeature = 'EnableBoundSessionCredentialsSoftwareKeysForManualTesting';
+
+    // Each app gets its own user data dir so the on-disk assertions below start
+    // from a clean state.
+    const startApp = async (extraArgs: string[] = []) => {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-dbsc-'));
+      const rc = await startRemoteControlApp([`--user-data-dir=${userDataDir}`, ...extraArgs]);
+      // defer() is LIFO, so this runs before startRemoteControlApp's own kill
+      // handler: stop the app here and wait for it to exit before deleting the
+      // directory, since on Windows the files stay locked until it does. The
+      // later kill is then a no-op on an already-dead process.
+      defer(async () => {
+        rc.process.kill('SIGINT');
+        await once(rc.process, 'exit').catch(() => {});
+        fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      });
+      // The DBSC store lives directly under userData unless the sandboxed-data
+      // migration has run, which only happens on Windows, so check both.
+      return {
+        rc,
+        sessionDbPaths: [
+          path.join(userDataDir, 'Device Bound Sessions'),
+          path.join(userDataDir, 'Network', 'Device Bound Sessions')
+        ]
+      };
+    };
+
+    // Feature switches reach child processes from the browser's FeatureList
+    // instance rather than from the browser's own argv, so a renderer's argv
+    // reports the effective feature state.
+    const getEffectiveFeatures = (rc: RemoteControlApp) => rc.remotely(async (fixture: string) => {
+      const bw = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true, contextIsolation: false, sandbox: false }
+      });
+      await bw.loadFile(fixture);
+      const argv: string[] = await bw.webContents.executeJavaScript('process.argv');
+      bw.destroy();
+      const valueOf = (name: string) => {
+        const arg = argv.find((a: string) => a.startsWith(`--${name}=`));
+        return arg ? arg.slice(name.length + 3) : '';
+      };
+      return { enabled: valueOf('enable-features'), disabled: valueOf('disable-features') };
+    }, path.join(__dirname, 'fixtures', 'pages', 'blank.html'));
+
+    // The session database is only created once the network context has a key
+    // service, so its presence means DBSC is actually running and not just
+    // configured.
+    const hasSessionDatabase = async (rc: RemoteControlApp, sessionDbPaths: string[]) => {
+      // Force the network context to be created.
+      await rc.remotely(async () => {
+        const { session } = require('electron');
+        await session.defaultSession.cookies.get({});
+      });
+      // The store opens its database on a background sequence.
+      for (let i = 0; i < 50; i++) {
+        if (sessionDbPaths.some((p) => fs.existsSync(p))) return true;
+        await setTimeout(100);
+      }
+      return false;
+    };
+
+    it('is off by default', async () => {
+      const { rc, sessionDbPaths } = await startApp();
+      expect(await hasSessionDatabase(rc, sessionDbPaths)).to.be.false('DBSC database should not exist');
+    });
+
+    it('is enabled by the software keys testing feature when the fuse is off', async () => {
+      const { rc, sessionDbPaths } = await startApp([`--enable-features=${softwareKeysFeature}`]);
+
+      const features = await getEffectiveFeatures(rc);
+      expect(features.enabled).to.include(softwareKeysFeature);
+      expect(features.disabled).to.not.include(softwareKeysFeature);
+
+      expect(await hasSessionDatabase(rc, sessionDbPaths)).to.be.true('DBSC database should exist');
+    });
+
+    it('rejects the software keys testing feature when the fuse is enabled', async () => {
+      const { rc } = await startApp([
+        '--set-fuse-device_bound_sessions=1',
+        `--enable-features=${softwareKeysFeature},SomeOtherFeature`
+      ]);
+
+      const features = await getEffectiveFeatures(rc);
+      expect(features.enabled).to.not.include(softwareKeysFeature);
+      expect(features.enabled).to.include('SomeOtherFeature');
+      expect(features.disabled).to.include(softwareKeysFeature);
+    });
+
+    it('does not rewrite the process command line when the fuse is enabled', async () => {
+      const { rc } = await startApp(['--set-fuse-device_bound_sessions=1']);
+      const result = await rc.remotely(() => {
+        const { app } = require('electron');
+        return app.commandLine.getSwitchValue('disable-features');
+      });
+      // InitializeFeatureList() runs twice in the browser process, so rewriting
+      // the process command line there appended the name once per run and leaked
+      // it into app.commandLine and into second-instance argv.
+      expect(result).to.not.include(softwareKeysFeature);
     });
   });
 });

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -137,8 +137,16 @@ describe('fuses', () => {
       // directory, since on Windows the files stay locked until it does. The
       // later kill is then a no-op on an already-dead process.
       defer(async () => {
-        rc.process.kill('SIGINT');
-        await once(rc.process, 'exit').catch(() => {});
+        // Only kill a child that is still running: for one that already died
+        // (a crash, or a failure earlier in the test) 'exit' has fired and
+        // once() would never settle, hanging until the mocha timeout and
+        // masking the real failure. A ChildProcess keeps its .pid after
+        // exiting, unlike UtilityProcess, so check the exit state instead.
+        if (rc.process.exitCode === null && rc.process.signalCode === null) {
+          const exit = once(rc.process, 'exit');
+          rc.process.kill('SIGINT');
+          await exit.catch(() => {});
+        }
         fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       });
       // The DBSC store lives directly under userData unless the sandboxed-data

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -170,7 +170,10 @@ describe('fuses', () => {
       });
       await bw.loadFile(fixture);
       const argv: string[] = await bw.webContents.executeJavaScript('process.argv');
-      bw.destroy();
+      // Deliberately left open. The remote-control fixture has no
+      // 'window-all-closed' handler, so destroying the last window quits the
+      // app and any later remotely() call fails with "socket hang up".
+      // startApp()'s defer() kills the app anyway.
       const valueOf = (name: string) => {
         const arg = argv.find((a: string) => a.startsWith(`--${name}=`));
         return arg ? arg.slice(name.length + 3) : '';


### PR DESCRIPTION
#### Description of Change

Adds the `deviceBoundSessions` fuse (`FuseV1Options.EnableDeviceBoundSessions`, disabled by default), enabling net-layer Device Bound Session Credentials on **Windows only**.

On Windows the network service's own key provider already works as-is: `net::device_bound_sessions::UnexportableKeyServiceFactory::GetConfig()` sets a keychain access group under `#if BUILDFLAG(IS_MAC)` only, `crypto::UnexportableKeyProvider::Config` has no members outside Apple platforms, and Electron already disables `kNetworkServiceSandbox` on Windows. So this needs no key-service plumbing — just the fuse, the network-context flag, on-disk session persistence, and the DevTools host-config bit.

macOS and Linux are deliberately out of scope here. macOS requires an `UnexportableKeyService` created in the browser process and configured with an access group derived from the app's own code signature, because the network service's built-in provider hardcodes Chromium's group and no Electron app can hold that entitlement. Linux has no upstream desktop hardware key provider yet. On both, the fuse is a documented no-op rather than something that silently fails while the docs claim otherwise. Split out of #53357, which carries the cross-platform work.

When the fuse is enabled, the `EnableBoundSessionCredentialsSoftwareKeysForManualTesting` feature is rejected so that a packaged app cannot be downgraded to mock software keys at runtime. With the fuse off, that flag enables DBSC with software keys on any platform — the supported way to exercise it in development, including where hardware-backed keys are unavailable.

Requires a companion `EnableDeviceBoundSessions = 9` in [electron/fuses](https://github.com/electron/fuses) before the documented `FuseV1Options` name resolves.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added the `deviceBoundSessions` fuse to enable Device Bound Session Credentials (DBSC) on Windows.
