### PR TITLE
perf: build the draggable region in O(n log n) instead of O(n²)

### DIFF
--- a/shell/browser/ui/drag_util.cc
+++ b/shell/browser/ui/drag_util.cc
@@ -4,20 +4,40 @@
 
 #include "shell/browser/ui/drag_util.h"
 
+#include <vector>
+
 #include "third_party/blink/public/mojom/page/draggable_region.mojom.h"
+#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkRegion.h"
+#include "ui/gfx/geometry/rect.h"
 
 namespace electron {
 
 // Convert draggable regions in raw format to SkRegion format.
+//
+// The regions arrive in document order and later ones win, so a `no-drag`
+// rect punches a hole in the `drag` rects before it and a later `drag` rect
+// can fill it again. Applying them one SkRegion::op() at a time is quadratic in
+// the number of rects (each op is linear in the region built so far), which
+// stalls the UI thread for ~100 ms at 10k rects. Instead, union each run of
+// consecutive same-kind rects with SkRegion::setRects(), which is
+// divide-and-conquer, and fold the runs in order; the result is identical.
 SkRegion DraggableRegionsToSkRegion(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions) {
   SkRegion sk_region;
-  for (const auto& region : regions) {
-    sk_region.op(
-        SkIRect::MakeLTRB(region->bounds.x(), region->bounds.y(),
-                          region->bounds.right(), region->bounds.bottom()),
-        region->draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
+  std::vector<SkIRect> run;
+  for (size_t i = 0; i < regions.size();) {
+    const bool draggable = regions[i]->draggable;
+    run.clear();
+    for (; i < regions.size() && regions[i]->draggable == draggable; ++i) {
+      const gfx::Rect& bounds = regions[i]->bounds;
+      run.push_back(SkIRect::MakeLTRB(bounds.x(), bounds.y(), bounds.right(),
+                                      bounds.bottom()));
+    }
+    SkRegion run_region;
+    run_region.setRects(run);
+    sk_region.op(run_region,
+                 draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
   }
   return sk_region;
 }


### PR DESCRIPTION
#### Description of Change

`DraggableRegionsToSkRegion` (browser UI thread, run on every `DraggableRegionsChanged` from the renderer) applied each rect with its own `SkRegion::op()`. Each op is linear in the region built so far, so N non‑adjacent `app-region` rects cost O(N²): a page with a few thousand draggable tiles stalls the whole app for 100 ms–seconds every time layout moves them.

- Union each run of consecutive same‑kind rects with `SkRegion::setRects()` (divide‑and‑conquer) and fold the runs in document order. Later rects still win over earlier ones, so the result is identical to before; checked against the old loop on 20k randomized inputs (mixed drag/no‑drag order, empty and negative rects) with zero differences.
- Release‑Skia timings for one update, disjoint 18×18 tiles / one drag rect with N‑1 no‑drag holes:

| rects | before | after |
|---:|---:|---:|
| 1,000 | 1.1 ms | 0.07 ms |
| 10,000 | 106–114 ms | 0.74 ms |
| 30,000 | 0.94–1.04 s | 2.5 ms |

- End to end (frameless window, 40 layouts that each shift 10k regions): main‑process max stall 2.6 s → no gap over 9 ms. Heavily interleaved drag/no‑drag sequences fall back toward the old cost since order has to be preserved, but never worse than before.

#### Checklist

- [x] PR description included
- [x] `npm test` passes

#### Release Notes

Notes: Fixed the app becoming unresponsive when a page has a very large number of `app-region` draggable elements.
