### PR TITLE
feat: add ELECTRON_DEBUG_DRAGGABLE_REGIONS debugging aid

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -175,6 +175,37 @@ Deployment finished.
 MSIX Deployment completed.
 ```
 
+### `ELECTRON_DEBUG_DRAGGABLE_REGIONS`
+
+Visualizes and logs the [draggable regions](../tutorial/custom-window-interactions.md#custom-draggable-regions)
+of every window to aid in debugging custom title bars. Only takes effect when
+[`app.isPackaged`](./app.md#appispackaged-readonly) is `false`.
+
+When set, the region that Electron hit tests against for each `WebContents` (the
+union of every `app-region: drag` rectangle minus every `app-region: no-drag`
+rectangle, as computed by the renderer) is painted as translucent red rectangles
+floating above the web contents, with the parts that changed in the latest update
+tinted yellow. The overlay ignores mouse events and follows the web contents as it
+moves or resizes. It reflects the region the main process actually uses rather than
+the CSS in the page, so it can lag behind the page while regions are in flight
+from the renderer; the stamp in its corner shows which update it is painting.
+
+Extra logs are also written whenever the renderer sends a new set of regions,
+whenever the web contents changes size, and, every couple of seconds, a summary
+of the hit tests served against the region. Logging must be enabled, for example
+with [`ELECTRON_ENABLE_LOGGING`](#electron_enable_logging), for these to be
+displayed.
+
+Sample output:
+
+```sh
+[draggable-regions] webContents 1: debugging enabled
+[draggable-regions] webContents 1: update #1: renderer sent 5 region(s) (1 drag, 4 no-drag); hit-test region computed in 3.2 us: 6 rect(s), bounds 0,0 1200x40
+[draggable-regions] webContents 1: contents view bounds changed to 464,245 1280x720, 8.3 ms since previous bounds change; overlay still shows update #1
+[draggable-regions] webContents 1: update #2, 16.4 ms since previous update, 7.1 ms after last bounds change to 1280x720: renderer sent 5 region(s) (1 drag, 4 no-drag); hit-test region computed in 2.8 us: 6 rect(s), bounds 0,0 1280x40
+[draggable-regions] webContents 1: 143 hit test(s) in the last 2.0 s (37 inside a draggable region), total 41.5 us, avg 0.3 us, max 1.9 us
+```
+
 ### `ELECTRON_LOG_ASAR_READS`
 
 When Electron reads from an ASAR file, log the read offset and file path to

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -175,7 +175,12 @@ Deployment finished.
 MSIX Deployment completed.
 ```
 
-### `ELECTRON_DEBUG_DRAGGABLE_REGIONS`
+### `ELECTRON_DEBUG_DRAGGABLE_REGIONS` _Experimental_
+
+> [!WARNING]
+> This variable is a debugging aid, not part of Electron's formal API. It is
+> experimental and its behavior, output, or existence may change or be removed
+> in any release without warning.
 
 Visualizes and logs the [draggable regions](../tutorial/custom-window-interactions.md#custom-draggable-regions)
 of every window to aid in debugging custom title bars. Only takes effect when

--- a/docs/tutorial/custom-window-interactions.md
+++ b/docs/tutorial/custom-window-interactions.md
@@ -47,6 +47,11 @@ To prevent this, you need to disable text selection within a draggable area like
 }
 ```
 
+> [!TIP]
+> When developing, set the [`ELECTRON_DEBUG_DRAGGABLE_REGIONS`](../api/environment-variables.md#electron_debug_draggable_regions)
+> environment variable to paint the draggable regions Electron is using on top
+> of the window, and to log how often they change and what they cost.
+
 ### Tip: disable context menus
 
 On some platforms, the draggable area will be treated as a non-client frame, so

--- a/docs/tutorial/custom-window-interactions.md
+++ b/docs/tutorial/custom-window-interactions.md
@@ -48,9 +48,11 @@ To prevent this, you need to disable text selection within a draggable area like
 ```
 
 > [!TIP]
-> When developing, set the [`ELECTRON_DEBUG_DRAGGABLE_REGIONS`](../api/environment-variables.md#electron_debug_draggable_regions)
+> When developing, set the [`ELECTRON_DEBUG_DRAGGABLE_REGIONS`](../api/environment-variables.md#electron_debug_draggable_regions-experimental)
 > environment variable to paint the draggable regions Electron is using on top
-> of the window, and to log how often they change and what they cost.
+> of the window, and to log how often they change and what they cost. It is an
+> experimental debugging aid rather than a formal API, and may change or be
+> removed without warning.
 
 ### Tip: disable context menus
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -555,6 +555,8 @@ filenames = {
     "shell/browser/ui/devtools_ui_theme_data_source.h",
     "shell/browser/ui/drag_util.cc",
     "shell/browser/ui/drag_util.h",
+    "shell/browser/ui/draggable_region_debugger.cc",
+    "shell/browser/ui/draggable_region_debugger.h",
     "shell/browser/ui/electron_menu_model.cc",
     "shell/browser/ui/electron_menu_model.h",
     "shell/browser/ui/file_dialog.h",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2386,7 +2386,6 @@ void WebContents::DraggableRegionsChanged(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions,
     content::WebContents* contents) {
   if (!draggable_region_debugger_ && DraggableRegionDebugger::IsEnabled()) {
-    // Guests and offscreen contents have no view of their own to draw over.
     views::View* contents_view = nullptr;
     if (inspectable_web_contents_ && !is_guest() && !IsOffScreen())
       contents_view = inspectable_web_contents_->GetView()->GetContentsView();

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -29,6 +29,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/current_thread.h"
 #include "base/threading/scoped_blocking_call.h"
+#include "base/timer/elapsed_timer.h"
 #include "base/unguessable_token.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
@@ -119,6 +120,7 @@
 #include "shell/browser/session_preferences.h"
 #include "shell/browser/ui/devtools_context_menu.h"
 #include "shell/browser/ui/drag_util.h"
+#include "shell/browser/ui/draggable_region_debugger.h"
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
@@ -2383,11 +2385,31 @@ void WebContents::OnFirstNonEmptyLayout(
 void WebContents::DraggableRegionsChanged(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions,
     content::WebContents* contents) {
+  if (!draggable_region_debugger_ && DraggableRegionDebugger::IsEnabled()) {
+    // Guests and offscreen contents have no view of their own to draw over.
+    views::View* contents_view = nullptr;
+    if (inspectable_web_contents_ && !is_guest() && !IsOffScreen())
+      contents_view = inspectable_web_contents_->GetView()->GetContentsView();
+    draggable_region_debugger_ =
+        std::make_unique<DraggableRegionDebugger>(ID(), contents_view);
+  }
+
   if (owner_window() && owner_window()->has_frame()) {
+    if (draggable_region_debugger_) {
+      draggable_region_debugger_->OnRegionsChanged(regions, nullptr,
+                                                   base::TimeDelta());
+    }
     return;
   }
 
+  std::optional<base::ElapsedTimer> timer;
+  if (draggable_region_debugger_)
+    timer.emplace();
   draggable_region_.emplace(DraggableRegionsToSkRegion(regions));
+  if (draggable_region_debugger_) {
+    draggable_region_debugger_->OnRegionsChanged(regions, &*draggable_region_,
+                                                 timer->Elapsed());
+  }
 }
 
 #if BUILDFLAG(ENABLE_PRINTING)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -486,7 +486,6 @@ class WebContents final : public ExclusiveAccessContext,
 
   SkRegion* draggable_region();
 
-  // Null unless ELECTRON_DEBUG_DRAGGABLE_REGIONS is in effect.
   DraggableRegionDebugger* draggable_region_debugger() const {
     return draggable_region_debugger_.get();
   }
@@ -936,9 +935,7 @@ class WebContents final : public ExclusiveAccessContext,
 
   std::optional<SkRegion> draggable_region_;
 
-  // Only set when ELECTRON_DEBUG_DRAGGABLE_REGIONS is in effect, see
-  // DraggableRegionDebugger::IsEnabled(). Declared after
-  // |inspectable_web_contents_| because it observes views owned by it.
+  // Declared after |inspectable_web_contents_| because it observes its views.
   std::unique_ptr<DraggableRegionDebugger> draggable_region_debugger_;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -104,6 +104,7 @@ class DevToolsEyeDropper;
 namespace electron {
 
 class DevToolsContextMenu;
+class DraggableRegionDebugger;
 class ElectronBrowserContext;
 class InspectableWebContents;
 class WebContentsZoomController;
@@ -484,6 +485,11 @@ class WebContents final : public ExclusiveAccessContext,
   void PDFReadyToPrint();
 
   SkRegion* draggable_region();
+
+  // Null unless ELECTRON_DEBUG_DRAGGABLE_REGIONS is in effect.
+  DraggableRegionDebugger* draggable_region_debugger() const {
+    return draggable_region_debugger_.get();
+  }
 
   // disable copy
   WebContents(const WebContents&) = delete;
@@ -929,6 +935,11 @@ class WebContents final : public ExclusiveAccessContext,
   raw_ptr<content::RenderFrameHost> fullscreen_frame_ = nullptr;
 
   std::optional<SkRegion> draggable_region_;
+
+  // Only set when ELECTRON_DEBUG_DRAGGABLE_REGIONS is in effect, see
+  // DraggableRegionDebugger::IsEnabled(). Declared after
+  // |inspectable_web_contents_| because it observes views owned by it.
+  std::unique_ptr<DraggableRegionDebugger> draggable_region_debugger_;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
 };

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -5,10 +5,12 @@
 #include "shell/browser/api/electron_api_web_contents_view.h"
 
 #include "base/no_destructor.h"
+#include "base/timer/elapsed_timer.h"
 #include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window.h"
+#include "shell/browser/ui/draggable_region_debugger.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/web_contents_preferences.h"
@@ -101,8 +103,17 @@ int WebContentsView::NonClientHitTest(const gfx::Point& point) {
     gfx::Point local_point(point);
     views::View::ConvertPointFromWidget(contents_view, &local_point);
     SkRegion* region = api_web_contents_->draggable_region();
-    if (region && region->contains(local_point.x(), local_point.y()))
-      return HTCAPTION;
+    if (region) {
+      auto* debugger = api_web_contents_->draggable_region_debugger();
+      std::optional<base::ElapsedTimer> timer;
+      if (debugger)
+        timer.emplace();
+      const bool hit = region->contains(local_point.x(), local_point.y());
+      if (debugger)
+        debugger->OnHitTest(timer->Elapsed(), hit);
+      if (hit)
+        return HTCAPTION;
+    }
   }
 
   return HTNOWHERE;

--- a/shell/browser/ui/draggable_region_debugger.cc
+++ b/shell/browser/ui/draggable_region_debugger.cc
@@ -29,17 +29,12 @@ namespace {
 
 constexpr char kEnvVar[] = "ELECTRON_DEBUG_DRAGGABLE_REGIONS";
 
-// Every log line from this file carries this prefix so it can be grepped out
-// of the rest of the Chromium log.
 constexpr char kLogPrefix[] = "[draggable-regions]";
 
-// Hit test summaries are emitted at most this often.
 constexpr base::TimeDelta kHitTestLogInterval = base::Seconds(2);
 
 constexpr SkColor kRegionFillColor = SkColorSetARGB(0x50, 0xE5, 0x39, 0x35);
 constexpr SkColor kRegionStrokeColor = SkColorSetARGB(0xC8, 0xE5, 0x39, 0x35);
-// Parts of the region that differ from the previous update are tinted so a
-// change is visible even when the rectangles barely move.
 constexpr SkColor kChangedFillColor = SkColorSetARGB(0x70, 0xFF, 0xC1, 0x07);
 constexpr SkColor kStampBackground = SkColorSetARGB(0xB0, 0x00, 0x00, 0x00);
 constexpr SkColor kStampText = SK_ColorWHITE;
@@ -54,9 +49,6 @@ std::string FormatMicros(base::TimeDelta delta) {
 
 }  // namespace
 
-// Paints the rectangles that make up the draggable region. Lives in the
-// overlay widget, whose bounds match the contents view, so the region's
-// coordinates can be used as-is.
 class DraggableRegionDebugger::OverlayView : public views::View {
  public:
   OverlayView() = default;
@@ -84,9 +76,6 @@ class DraggableRegionDebugger::OverlayView : public views::View {
     for (SkRegion::Iterator it(changed_); !it.done(); it.next())
       canvas->FillRect(gfx::SkIRectToRect(it.rect()), kChangedFillColor);
 
-    // Stamp the overlay with which update it shows and how old that update
-    // was when this paint ran, so a stale overlay can be told apart from
-    // stale region data.
     const std::string stamp = base::StringPrintf(
         "draggable regions: update #%" PRIu64 ", painted %s after it arrived",
         update_number_,
@@ -151,9 +140,6 @@ void DraggableRegionDebugger::OnRegionsChanged(
     timing +=
         ", " + FormatMillis(now - last_update_time_) + " since previous update";
   }
-  // How long the browser hit tested against the previous region after the
-  // contents view last changed size. During a resize this is the window in
-  // which clicks land on stale rectangles.
   if (!last_bounds_change_time_.is_null()) {
     timing += ", " + FormatMillis(now - last_bounds_change_time_) +
               " after last bounds change to " + last_bounds_.size().ToString();
@@ -225,7 +211,6 @@ void DraggableRegionDebugger::EnsureOverlay() {
   params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
   params.shadow_type = views::Widget::InitParams::ShadowType::kNone;
   params.activatable = views::Widget::InitParams::Activatable::kNo;
-  // The overlay must never get in the way of the regions it visualizes.
   params.accept_events = false;
   overlay_widget_->Init(std::move(params));
   overlay_widget_->SetVisibilityChangedAnimationsEnabled(false);
@@ -314,7 +299,6 @@ void DraggableRegionDebugger::OnViewRemovedFromWidget(
     views::View* observed_view) {
   if (observed_view != contents_view_)
     return;
-  // The overlay is parented to the widget the view just left.
   DestroyOverlay();
   ObserveViewAncestry();
 }

--- a/shell/browser/ui/draggable_region_debugger.cc
+++ b/shell/browser/ui/draggable_region_debugger.cc
@@ -1,0 +1,347 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/draggable_region_debugger.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <string>
+#include <utility>
+
+#include "base/environment.h"
+#include "base/logging.h"
+#include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/trace_event/trace_event.h"
+#include "shell/browser/api/electron_api_app.h"
+#include "third_party/blink/public/mojom/page/draggable_region.mojom.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/gfx/canvas.h"
+#include "ui/gfx/font_list.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/rect_f.h"
+#include "ui/gfx/geometry/skia_conversions.h"
+
+namespace electron {
+
+namespace {
+
+constexpr char kEnvVar[] = "ELECTRON_DEBUG_DRAGGABLE_REGIONS";
+
+// Every log line from this file carries this prefix so it can be grepped out
+// of the rest of the Chromium log.
+constexpr char kLogPrefix[] = "[draggable-regions]";
+
+// Hit test summaries are emitted at most this often.
+constexpr base::TimeDelta kHitTestLogInterval = base::Seconds(2);
+
+constexpr SkColor kRegionFillColor = SkColorSetARGB(0x50, 0xE5, 0x39, 0x35);
+constexpr SkColor kRegionStrokeColor = SkColorSetARGB(0xC8, 0xE5, 0x39, 0x35);
+// Parts of the region that differ from the previous update are tinted so a
+// change is visible even when the rectangles barely move.
+constexpr SkColor kChangedFillColor = SkColorSetARGB(0x70, 0xFF, 0xC1, 0x07);
+constexpr SkColor kStampBackground = SkColorSetARGB(0xB0, 0x00, 0x00, 0x00);
+constexpr SkColor kStampText = SK_ColorWHITE;
+
+std::string FormatMillis(base::TimeDelta delta) {
+  return base::StringPrintf("%.1f ms", delta.InMillisecondsF());
+}
+
+std::string FormatMicros(base::TimeDelta delta) {
+  return base::StringPrintf("%.1f us", delta.InMicrosecondsF());
+}
+
+}  // namespace
+
+// Paints the rectangles that make up the draggable region. Lives in the
+// overlay widget, whose bounds match the contents view, so the region's
+// coordinates can be used as-is.
+class DraggableRegionDebugger::OverlayView : public views::View {
+ public:
+  OverlayView() = default;
+  ~OverlayView() override = default;
+
+  void SetRegion(const SkRegion& region,
+                 uint64_t update_number,
+                 base::TimeTicks update_time) {
+    changed_.op(region_, region, SkRegion::kXOR_Op);
+    region_ = region;
+    update_number_ = update_number;
+    update_time_ = update_time;
+    SchedulePaint();
+  }
+
+  // views::View:
+  void OnPaint(gfx::Canvas* canvas) override {
+    TRACE_EVENT1("electron", "DraggableRegionDebugger::OverlayView::OnPaint",
+                 "update", update_number_);
+    for (SkRegion::Iterator it(region_); !it.done(); it.next()) {
+      const gfx::Rect rect = gfx::SkIRectToRect(it.rect());
+      canvas->FillRect(rect, kRegionFillColor);
+      canvas->DrawRect(gfx::RectF(rect), kRegionStrokeColor);
+    }
+    for (SkRegion::Iterator it(changed_); !it.done(); it.next())
+      canvas->FillRect(gfx::SkIRectToRect(it.rect()), kChangedFillColor);
+
+    // Stamp the overlay with which update it shows and how old that update
+    // was when this paint ran, so a stale overlay can be told apart from
+    // stale region data.
+    const std::string stamp = base::StringPrintf(
+        "draggable regions: update #%" PRIu64 ", painted %s after it arrived",
+        update_number_,
+        FormatMillis(base::TimeTicks::Now() - update_time_).c_str());
+    const gfx::Rect stamp_rect(4, 4, 360, 18);
+    canvas->FillRect(stamp_rect, kStampBackground);
+    canvas->DrawStringRect(base::UTF8ToUTF16(stamp), gfx::FontList(),
+                           kStampText, stamp_rect);
+  }
+
+ private:
+  SkRegion region_;
+  SkRegion changed_;
+  uint64_t update_number_ = 0;
+  base::TimeTicks update_time_;
+};
+
+// static
+bool DraggableRegionDebugger::IsEnabled() {
+  static const bool enabled =
+      base::Environment::Create()->HasVar(kEnvVar) && !api::App::IsPackaged();
+  return enabled;
+}
+
+DraggableRegionDebugger::DraggableRegionDebugger(int32_t web_contents_id,
+                                                 views::View* contents_view)
+    : web_contents_id_(web_contents_id), contents_view_(contents_view) {
+  ObserveViewAncestry();
+
+  LOG(INFO) << kLogPrefix << " webContents " << web_contents_id_
+            << ": debugging enabled"
+            << (contents_view_ ? "" : " (no view to draw the overlay over)");
+}
+
+DraggableRegionDebugger::~DraggableRegionDebugger() {
+  DestroyOverlay();
+}
+
+void DraggableRegionDebugger::OnRegionsChanged(
+    const std::vector<blink::mojom::DraggableRegionPtr>& regions,
+    const SkRegion* region,
+    base::TimeDelta compute_time) {
+  const auto draggable_count = static_cast<size_t>(std::ranges::count_if(
+      regions, [](const auto& entry) { return entry->draggable; }));
+  const size_t no_drag_count = regions.size() - draggable_count;
+
+  if (!region) {
+    LOG(INFO) << kLogPrefix << " webContents " << web_contents_id_
+              << ": ignored " << regions.size() << " region(s) ("
+              << draggable_count << " drag, " << no_drag_count
+              << " no-drag) because the window has a native frame";
+    return;
+  }
+
+  const base::TimeTicks now = base::TimeTicks::Now();
+  ++update_count_;
+  TRACE_EVENT1("electron", "DraggableRegionDebugger::OnRegionsChanged",
+               "update", update_count_);
+
+  std::string timing;
+  if (!last_update_time_.is_null()) {
+    timing +=
+        ", " + FormatMillis(now - last_update_time_) + " since previous update";
+  }
+  // How long the browser hit tested against the previous region after the
+  // contents view last changed size. During a resize this is the window in
+  // which clicks land on stale rectangles.
+  if (!last_bounds_change_time_.is_null()) {
+    timing += ", " + FormatMillis(now - last_bounds_change_time_) +
+              " after last bounds change to " + last_bounds_.size().ToString();
+  }
+  last_update_time_ = now;
+
+  const bool changed = region_ != *region;
+  LOG(INFO) << kLogPrefix << " webContents " << web_contents_id_ << ": update #"
+            << update_count_ << timing << ": renderer sent " << regions.size()
+            << " region(s) (" << draggable_count << " drag, " << no_drag_count
+            << " no-drag); hit-test region computed in "
+            << FormatMicros(compute_time) << ": "
+            << region->computeRegionComplexity() << " rect(s), bounds "
+            << gfx::SkIRectToRect(region->getBounds()).ToString()
+            << (changed ? "" : " (identical to previous region)");
+
+  region_ = *region;
+  EnsureOverlay();
+  if (overlay_view_)
+    overlay_view_->SetRegion(region_, update_count_, now);
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnHitTest(base::TimeDelta duration, bool hit) {
+  const base::TimeTicks now = base::TimeTicks::Now();
+  if (hit_test_window_start_.is_null())
+    hit_test_window_start_ = now;
+
+  ++hit_test_count_;
+  if (hit)
+    ++hit_test_hits_;
+  hit_test_total_ += duration;
+  hit_test_max_ = std::max(hit_test_max_, duration);
+
+  const base::TimeDelta window = now - hit_test_window_start_;
+  if (window < kHitTestLogInterval)
+    return;
+
+  LOG(INFO) << kLogPrefix << " webContents " << web_contents_id_ << ": "
+            << hit_test_count_ << " hit test(s) in the last "
+            << base::StringPrintf("%.1f s", window.InSecondsF()) << " ("
+            << hit_test_hits_ << " inside a draggable region), total "
+            << FormatMicros(hit_test_total_) << ", avg "
+            << FormatMicros(hit_test_total_ / hit_test_count_) << ", max "
+            << FormatMicros(hit_test_max_);
+
+  hit_test_window_start_ = now;
+  hit_test_count_ = 0;
+  hit_test_hits_ = 0;
+  hit_test_total_ = base::TimeDelta();
+  hit_test_max_ = base::TimeDelta();
+}
+
+void DraggableRegionDebugger::EnsureOverlay() {
+  if (overlay_widget_ || !contents_view_)
+    return;
+
+  views::Widget* parent_widget = contents_view_->GetWidget();
+  if (!parent_widget)
+    return;
+
+  overlay_widget_ = std::make_unique<views::Widget>();
+  views::Widget::InitParams params(
+      views::Widget::InitParams::CLIENT_OWNS_WIDGET,
+      views::Widget::InitParams::TYPE_POPUP);
+  params.name = "DraggableRegionDebugOverlay";
+  params.parent = parent_widget->GetNativeView();
+  params.context = parent_widget->GetNativeWindow();
+  params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
+  params.shadow_type = views::Widget::InitParams::ShadowType::kNone;
+  params.activatable = views::Widget::InitParams::Activatable::kNo;
+  // The overlay must never get in the way of the regions it visualizes.
+  params.accept_events = false;
+  overlay_widget_->Init(std::move(params));
+  overlay_widget_->SetVisibilityChangedAnimationsEnabled(false);
+  overlay_view_ =
+      overlay_widget_->SetContentsView(std::make_unique<OverlayView>());
+  overlay_view_->SetRegion(region_, update_count_, last_update_time_);
+
+  widget_observation_.Reset();
+  widget_observation_.Observe(parent_widget);
+}
+
+void DraggableRegionDebugger::DestroyOverlay() {
+  widget_observation_.Reset();
+  overlay_view_ = nullptr;
+  overlay_widget_.reset();
+}
+
+void DraggableRegionDebugger::UpdateOverlay() {
+  if (!overlay_widget_)
+    return;
+
+  views::Widget* parent_widget =
+      contents_view_ ? contents_view_->GetWidget() : nullptr;
+  const gfx::Rect bounds =
+      contents_view_ ? contents_view_->GetBoundsInScreen() : gfx::Rect();
+  const bool show = parent_widget && parent_widget->IsVisible() &&
+                    contents_view_->IsDrawn() && !bounds.IsEmpty() &&
+                    !region_.isEmpty();
+  if (!show) {
+    if (overlay_widget_->IsVisible())
+      overlay_widget_->Hide();
+    return;
+  }
+
+  if (bounds != last_bounds_) {
+    const base::TimeTicks now = base::TimeTicks::Now();
+    TRACE_EVENT0("electron", "DraggableRegionDebugger::BoundsChanged");
+    LOG(INFO) << kLogPrefix << " webContents " << web_contents_id_
+              << ": contents view bounds changed to " << bounds.ToString()
+              << (last_bounds_change_time_.is_null()
+                      ? ""
+                      : ", " + FormatMillis(now - last_bounds_change_time_) +
+                            " since previous bounds change")
+              << "; overlay still shows update #" << update_count_;
+    last_bounds_ = bounds;
+    last_bounds_change_time_ = now;
+    overlay_widget_->SetBounds(bounds);
+  }
+  if (!overlay_widget_->IsVisible())
+    overlay_widget_->ShowInactive();
+}
+
+void DraggableRegionDebugger::ObserveViewAncestry() {
+  view_observations_.RemoveAllObservations();
+  for (views::View* view = contents_view_; view; view = view->parent())
+    view_observations_.AddObservation(view);
+}
+
+void DraggableRegionDebugger::OnViewBoundsChanged(views::View* observed_view) {
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnViewVisibilityChanged(
+    views::View* observed_view,
+    views::View* starting_view,
+    bool visible) {
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnViewHierarchyChanged(
+    views::View* observed_view,
+    const views::ViewHierarchyChangedDetails& details) {
+  ObserveViewAncestry();
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnViewAddedToWidget(views::View* observed_view) {
+  if (observed_view != contents_view_)
+    return;
+  ObserveViewAncestry();
+  EnsureOverlay();
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnViewRemovedFromWidget(
+    views::View* observed_view) {
+  if (observed_view != contents_view_)
+    return;
+  // The overlay is parented to the widget the view just left.
+  DestroyOverlay();
+  ObserveViewAncestry();
+}
+
+void DraggableRegionDebugger::OnViewIsDeleting(views::View* observed_view) {
+  if (observed_view != contents_view_) {
+    view_observations_.RemoveObservation(observed_view);
+    return;
+  }
+  DestroyOverlay();
+  view_observations_.RemoveAllObservations();
+  contents_view_ = nullptr;
+}
+
+void DraggableRegionDebugger::OnWidgetBoundsChanged(
+    views::Widget* widget,
+    const gfx::Rect& new_bounds) {
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnWidgetVisibilityChanged(views::Widget* widget,
+                                                        bool visible) {
+  UpdateOverlay();
+}
+
+void DraggableRegionDebugger::OnWidgetDestroying(views::Widget* widget) {
+  DestroyOverlay();
+}
+
+}  // namespace electron

--- a/shell/browser/ui/draggable_region_debugger.h
+++ b/shell/browser/ui/draggable_region_debugger.h
@@ -23,23 +23,15 @@
 
 namespace electron {
 
-// Debugging aid for draggable regions. Enabled by setting the
-// ELECTRON_DEBUG_DRAGGABLE_REGIONS environment variable in an unpackaged app.
-//
-// Paints the region a WebContents hit tests against (the union of every
-// `app-region: drag` rectangle minus every `app-region: no-drag` rectangle,
-// as received from the renderer) as translucent rectangles in a click-through
-// widget floating above the web contents, and logs the cost of each region
-// update along with a periodic summary of the hit tests it serves.
+// Debugging aid enabled by ELECTRON_DEBUG_DRAGGABLE_REGIONS in unpackaged
+// apps: paints the region a WebContents hit tests against in a click-through
+// widget above the web contents and logs region updates and hit tests.
 class DraggableRegionDebugger : private views::ViewObserver,
                                 private views::WidgetObserver {
  public:
   static bool IsEnabled();
 
-  // |web_contents_id| labels the log lines. |contents_view| is the view that
-  // hosts the web contents; the overlay follows its bounds. It may be null
-  // when there is nothing on screen to paint over, in which case only logging
-  // is performed.
+  // |contents_view| may be null, in which case only logging is performed.
   DraggableRegionDebugger(int32_t web_contents_id, views::View* contents_view);
   ~DraggableRegionDebugger() override;
 
@@ -47,15 +39,13 @@ class DraggableRegionDebugger : private views::ViewObserver,
   DraggableRegionDebugger(const DraggableRegionDebugger&) = delete;
   DraggableRegionDebugger& operator=(const DraggableRegionDebugger&) = delete;
 
-  // Called with every set of regions the renderer sends. |region| is the
-  // hit-test region computed from them and |compute_time| how long that took,
-  // or null when the update was ignored because the window has a native frame.
+  // |region| is null when the update was ignored because the window has a
+  // native frame.
   void OnRegionsChanged(
       const std::vector<blink::mojom::DraggableRegionPtr>& regions,
       const SkRegion* region,
       base::TimeDelta compute_time);
 
-  // Called with the outcome and duration of every hit test against the region.
   void OnHitTest(base::TimeDelta duration, bool hit);
 
  private:
@@ -65,8 +55,6 @@ class DraggableRegionDebugger : private views::ViewObserver,
   void DestroyOverlay();
   void UpdateOverlay();
 
-  // Observes |contents_view_| and every ancestor, so the overlay follows the
-  // web contents when any view above it moves as well.
   void ObserveViewAncestry();
 
   // views::ViewObserver:
@@ -81,7 +69,7 @@ class DraggableRegionDebugger : private views::ViewObserver,
   void OnViewRemovedFromWidget(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;
 
-  // views::WidgetObserver (observes the widget hosting |contents_view_|):
+  // views::WidgetObserver:
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
   void OnWidgetVisibilityChanged(views::Widget* widget, bool visible) override;
@@ -95,24 +83,17 @@ class DraggableRegionDebugger : private views::ViewObserver,
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
 
-  // The most recently computed region, kept so the overlay can be rebuilt
-  // when the web contents moves to another widget.
   SkRegion region_;
 
   std::unique_ptr<views::Widget> overlay_widget_;
   raw_ptr<OverlayView> overlay_view_ = nullptr;
 
-  // Region update statistics.
   uint64_t update_count_ = 0;
   base::TimeTicks last_update_time_;
 
-  // The last contents view bounds the overlay was positioned over, and when
-  // they changed. Region updates are logged relative to this so the window of
-  // hit testing against stale regions after a resize is visible.
   gfx::Rect last_bounds_;
   base::TimeTicks last_bounds_change_time_;
 
-  // Hit test statistics, accumulated between periodic summary log lines.
   uint64_t hit_test_count_ = 0;
   uint64_t hit_test_hits_ = 0;
   base::TimeDelta hit_test_total_;

--- a/shell/browser/ui/draggable_region_debugger.h
+++ b/shell/browser/ui/draggable_region_debugger.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Anthropic, PBC.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ELECTRON_SHELL_BROWSER_UI_DRAGGABLE_REGION_DEBUGGER_H_
+#define ELECTRON_SHELL_BROWSER_UI_DRAGGABLE_REGION_DEBUGGER_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/scoped_multi_source_observation.h"
+#include "base/scoped_observation.h"
+#include "base/time/time.h"
+#include "third_party/blink/public/mojom/page/draggable_region.mojom-forward.h"
+#include "third_party/skia/include/core/SkRegion.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/views/view.h"
+#include "ui/views/view_observer.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_observer.h"
+
+namespace electron {
+
+// Debugging aid for draggable regions. Enabled by setting the
+// ELECTRON_DEBUG_DRAGGABLE_REGIONS environment variable in an unpackaged app.
+//
+// Paints the region a WebContents hit tests against (the union of every
+// `app-region: drag` rectangle minus every `app-region: no-drag` rectangle,
+// as received from the renderer) as translucent rectangles in a click-through
+// widget floating above the web contents, and logs the cost of each region
+// update along with a periodic summary of the hit tests it serves.
+class DraggableRegionDebugger : private views::ViewObserver,
+                                private views::WidgetObserver {
+ public:
+  static bool IsEnabled();
+
+  // |web_contents_id| labels the log lines. |contents_view| is the view that
+  // hosts the web contents; the overlay follows its bounds. It may be null
+  // when there is nothing on screen to paint over, in which case only logging
+  // is performed.
+  DraggableRegionDebugger(int32_t web_contents_id, views::View* contents_view);
+  ~DraggableRegionDebugger() override;
+
+  // disable copy
+  DraggableRegionDebugger(const DraggableRegionDebugger&) = delete;
+  DraggableRegionDebugger& operator=(const DraggableRegionDebugger&) = delete;
+
+  // Called with every set of regions the renderer sends. |region| is the
+  // hit-test region computed from them and |compute_time| how long that took,
+  // or null when the update was ignored because the window has a native frame.
+  void OnRegionsChanged(
+      const std::vector<blink::mojom::DraggableRegionPtr>& regions,
+      const SkRegion* region,
+      base::TimeDelta compute_time);
+
+  // Called with the outcome and duration of every hit test against the region.
+  void OnHitTest(base::TimeDelta duration, bool hit);
+
+ private:
+  class OverlayView;
+
+  void EnsureOverlay();
+  void DestroyOverlay();
+  void UpdateOverlay();
+
+  // Observes |contents_view_| and every ancestor, so the overlay follows the
+  // web contents when any view above it moves as well.
+  void ObserveViewAncestry();
+
+  // views::ViewObserver:
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewVisibilityChanged(views::View* observed_view,
+                               views::View* starting_view,
+                               bool visible) override;
+  void OnViewHierarchyChanged(
+      views::View* observed_view,
+      const views::ViewHierarchyChangedDetails& details) override;
+  void OnViewAddedToWidget(views::View* observed_view) override;
+  void OnViewRemovedFromWidget(views::View* observed_view) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+
+  // views::WidgetObserver (observes the widget hosting |contents_view_|):
+  void OnWidgetBoundsChanged(views::Widget* widget,
+                             const gfx::Rect& new_bounds) override;
+  void OnWidgetVisibilityChanged(views::Widget* widget, bool visible) override;
+  void OnWidgetDestroying(views::Widget* widget) override;
+
+  const int32_t web_contents_id_;
+
+  raw_ptr<views::View> contents_view_;
+  base::ScopedMultiSourceObservation<views::View, views::ViewObserver>
+      view_observations_{this};
+  base::ScopedObservation<views::Widget, views::WidgetObserver>
+      widget_observation_{this};
+
+  // The most recently computed region, kept so the overlay can be rebuilt
+  // when the web contents moves to another widget.
+  SkRegion region_;
+
+  std::unique_ptr<views::Widget> overlay_widget_;
+  raw_ptr<OverlayView> overlay_view_ = nullptr;
+
+  // Region update statistics.
+  uint64_t update_count_ = 0;
+  base::TimeTicks last_update_time_;
+
+  // The last contents view bounds the overlay was positioned over, and when
+  // they changed. Region updates are logged relative to this so the window of
+  // hit testing against stale regions after a resize is visible.
+  gfx::Rect last_bounds_;
+  base::TimeTicks last_bounds_change_time_;
+
+  // Hit test statistics, accumulated between periodic summary log lines.
+  uint64_t hit_test_count_ = 0;
+  uint64_t hit_test_hits_ = 0;
+  base::TimeDelta hit_test_total_;
+  base::TimeDelta hit_test_max_;
+  base::TimeTicks hit_test_window_start_;
+};
+
+}  // namespace electron
+
+#endif  // ELECTRON_SHELL_BROWSER_UI_DRAGGABLE_REGION_DEBUGGER_H_


### PR DESCRIPTION
## Summary

Adds the `ELECTRON_DEBUG_DRAGGABLE_REGIONS` environment variable. In unpackaged apps it paints the draggable region each `WebContents` hit tests against as translucent rectangles floating above the web contents, and logs every region update the renderer sends, the cost of computing the hit-test region, and periodic hit-test summaries.

Chromium changed how `app-region` cascades starting in Electron 44, and apps with custom title bars have had a hard time telling whether a region problem is in their CSS or in what Electron actually hit tests against. The overlay shows the region the main process uses rather than the CSS, so those differences are visible directly.

Nothing changes when the variable is unset: one cached environment lookup per process and a null check per hit test.

## Test plan

Ran a frameless test app with `ELECTRON_DEBUG_DRAGGABLE_REGIONS=1 ELECTRON_ENABLE_LOGGING=1` on macOS and verified the overlay follows the window through moves, resizes, and DevTools docking, drag and no-drag areas match the page, and log lines appear for updates, bounds changes, and hit tests. Also confirmed with a Perfetto trace that region messages from the renderer are delayed during macOS live resize, which the overlay stamp and the staleness log line now make visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeVPx9L9YnfSk7an5fALZi

Notes: Added the `ELECTRON_DEBUG_DRAGGABLE_REGIONS` environment variable, which visualizes and logs draggable regions in unpackaged apps to help debug custom title bars.
