### PR TITLE
ci: re-enable Dependabot security updates for release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
-    target-branch: 33-x-y
+    target-branch: 45-x-y
   - package-ecosystem: npm
     directories:
       - /
@@ -51,7 +51,7 @@ updates:
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
-    target-branch: 32-x-y
+    target-branch: 44-x-y
   - package-ecosystem: npm
     directories:
       - /
@@ -64,7 +64,7 @@ updates:
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
-    target-branch: 31-x-y
+    target-branch: 43-x-y
   - package-ecosystem: npm
     directories:
       - /
@@ -77,4 +77,4 @@ updates:
     labels:
       - "backport-check-skip"
     open-pull-requests-limit: 0
-    target-branch: 30-x-y
+    target-branch: 42-x-y


### PR DESCRIPTION
#### Description of Change

Apparently, we never updated the list past Electron 33.

We'll need some automation or task as part of our release process where we update the set of branches whenever a new release is cut.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none