### PR TITLE
perf: build the draggable region in O(n log n) instead of O(n²)

### DIFF
--- a/shell/browser/ui/drag_util.cc
+++ b/shell/browser/ui/drag_util.cc
@@ -4,20 +4,40 @@
 
 #include "shell/browser/ui/drag_util.h"
 
+#include <vector>
+
 #include "third_party/blink/public/mojom/page/draggable_region.mojom.h"
+#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkRegion.h"
+#include "ui/gfx/geometry/rect.h"
 
 namespace electron {
 
 // Convert draggable regions in raw format to SkRegion format.
+//
+// The regions arrive in document order and later ones win, so a `no-drag`
+// rect punches a hole in the `drag` rects before it and a later `drag` rect
+// can fill it again. Applying them one SkRegion::op() at a time is quadratic in
+// the number of rects (each op is linear in the region built so far), which
+// stalls the UI thread for ~100 ms at 10k rects. Instead, union each run of
+// consecutive same-kind rects with SkRegion::setRects(), which is
+// divide-and-conquer, and fold the runs in order; the result is identical.
 std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions) {
   auto sk_region = std::make_unique<SkRegion>();
-  for (const auto& region : regions) {
-    sk_region->op(
-        SkIRect::MakeLTRB(region->bounds.x(), region->bounds.y(),
-                          region->bounds.right(), region->bounds.bottom()),
-        region->draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
+  std::vector<SkIRect> run;
+  for (size_t i = 0; i < regions.size();) {
+    const bool draggable = regions[i]->draggable;
+    run.clear();
+    for (; i < regions.size() && regions[i]->draggable == draggable; ++i) {
+      const gfx::Rect& bounds = regions[i]->bounds;
+      run.push_back(SkIRect::MakeLTRB(bounds.x(), bounds.y(), bounds.right(),
+                                      bounds.bottom()));
+    }
+    SkRegion run_region;
+    run_region.setRects(run);
+    sk_region->op(run_region,
+                  draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
   }
   return sk_region;
 }


### PR DESCRIPTION
Backport of #53595

See that PR for details. `DraggableRegionsToSkRegion` still returns `std::unique_ptr<SkRegion>` on this branch, so the new body is adapted to that signature.

Notes: Fixed the app becoming unresponsive when a page has a very large number of `app-region` draggable elements.
