### PR TITLE
fix: restore the kill ring on non-MAS macOS builds

### DIFF
--- a/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
+++ b/patches/chromium/mas_avoid_private_macos_api_usage.patch.patch
@@ -1816,26 +1816,6 @@ index 86d0cefd4c815d1da2f4bf6e06b5657c1ce04784..47e9e8429f0fd457762ce6cf53c68616
    ]
  
    if (is_mac) {
-diff --git a/third_party/blink/renderer/core/editing/build.gni b/third_party/blink/renderer/core/editing/build.gni
-index cd01cf1da3d1154b88aa1d733c3255923d82876d..720b6955b28cfa4fb296af220b1246368452c9cc 100644
---- a/third_party/blink/renderer/core/editing/build.gni
-+++ b/third_party/blink/renderer/core/editing/build.gni
-@@ -378,10 +378,14 @@ blink_core_sources_editing = [
- if (is_mac) {
-   blink_core_sources_editing += [
-     "commands/smart_replace_cf.cc",
--    "kill_ring_mac.mm",
-     "substring_util.h",
-     "substring_util.mm",
-   ]
-+  if (is_mas_build) {
-+    blink_core_sources_editing += [ "kill_ring_mac.mm" ]
-+  } else {
-+    blink_core_sources_editing += [ "kill_ring_none.cc" ]
-+  }
- } else {
-   blink_core_sources_editing += [ "kill_ring_none.cc" ]
- }
 diff --git a/third_party/blink/renderer/core/editing/kill_ring_mac.mm b/third_party/blink/renderer/core/editing/kill_ring_mac.mm
 index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..3e3aaea0ec6c8fad0d90a931d269af3af01ab73a 100644
 --- a/third_party/blink/renderer/core/editing/kill_ring_mac.mm

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -4160,6 +4160,29 @@ describe('chromium features', () => {
   });
 });
 
+ifdescribe(process.platform === 'darwin' && !process.mas)('kill ring', () => {
+  afterEach(closeAllWindows);
+
+  it('yanks back text killed with Ctrl+K', async () => {
+    const w = new BrowserWindow({ show: true });
+    await w.loadURL('data:text/html,<textarea id="t">kill me</textarea>');
+    w.webContents.focus();
+    await w.webContents.executeJavaScript(
+      'const t = document.getElementById("t"); t.focus(); t.setSelectionRange(0, 0); null'
+    );
+    w.webContents.debugger.attach();
+    const press = async (key: string, code: string, keyCode: number, commands: string[]) => {
+      const base = { key, code, windowsVirtualKeyCode: keyCode, modifiers: 2 };
+      await w.webContents.debugger.sendCommand('Input.dispatchKeyEvent', { ...base, type: 'rawKeyDown', commands });
+      await w.webContents.debugger.sendCommand('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
+    };
+    await press('k', 'KeyK', 75, ['deleteToEndOfParagraph']);
+    expect(await w.webContents.executeJavaScript('t.value')).to.equal('');
+    await press('y', 'KeyY', 89, ['yank']);
+    expect(await w.webContents.executeJavaScript('t.value')).to.equal('kill me');
+  });
+});
+
 describe('font fallback', () => {
   async function getRenderedFonts(html: string) {
     const w = new BrowserWindow({ show: false });


### PR DESCRIPTION
#### Description of Change

The MAS patch's `blink/renderer/core/editing/build.gni` hunk has had its condition inverted since #36368, so regular (non-MAS) macOS builds compiled `kill_ring_none.cc`: Ctrl+K in a text field deleted to the end of the paragraph but Ctrl+Y had nothing to yank. `kill_ring_mac.mm` already stubs itself under `IS_MAS_BUILD()`, so the hunk is simply dropped and the file is always compiled on macOS.

The spec drives the two editing commands through `Input.dispatchKeyEvent` and checks the text comes back (macOS, non-MAS). I checked its mechanics on Linux, where the yank assertion fails exactly as a pre-fix mac build would; the mac jobs here are the check for the fix itself.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: Fixed Ctrl+Y not yanking text killed with Ctrl+K in text fields on macOS.
