### PR TITLE
fix: deliver Window Controls Overlay geometry to WebContentsViews

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -211,11 +211,6 @@ void BrowserWindow::OnWindowLeaveFullScreen() {
   BaseWindow::OnWindowLeaveFullScreen();
 }
 
-void BrowserWindow::UpdateWindowControlsOverlay(
-    const gfx::Rect& bounding_rect) {
-  web_contents()->UpdateWindowControlsOverlay(bounding_rect);
-}
-
 void BrowserWindow::CloseImmediately() {
   // Close all child windows before closing current window.
   for (BaseWindow* child : GetChildWindows())

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -53,7 +53,6 @@ class BrowserWindow : public BaseWindow,
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
   void OnWindowIsKeyChanged(bool is_key) override;
-  void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
 
   // BaseWindow:
   void OnWindowBlur() override;

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -62,14 +62,14 @@ class View : public gin_helper::EventEmitter<View>,
   // Should delete the |view_| in destructor.
   void set_delete_view(bool should) { delete_view_ = should; }
 
+ private:
+  using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
+
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;
   void OnChildViewRemoved(views::View* observed_view,
                           views::View* child) override;
-
- private:
-  using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
 
   ui::Layer* GetLayer();
   void ApplyBorderRadius();

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -62,14 +62,14 @@ class View : public gin_helper::EventEmitter<View>,
   // Should delete the |view_| in destructor.
   void set_delete_view(bool should) { delete_view_ = should; }
 
- private:
-  using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
-
   // views::ViewObserver
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewIsDeleting(views::View* observed_view) override;
   void OnChildViewRemoved(views::View* observed_view,
                           views::View* child) override;
+
+ private:
+  using ChildPair = std::pair<raw_ptr<views::View>, v8::Global<v8::Object>>;
 
   ui::Layer* GetLayer();
   void ApplyBorderRadius();

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -6,6 +6,7 @@
 
 #include "base/no_destructor.h"
 #include "base/timer/elapsed_timer.h"
+#include "content/public/browser/render_frame_host.h"
 #include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/browser.h"
@@ -46,6 +47,7 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
 }
 
 WebContentsView::~WebContentsView() {
+  StopObservingWindow();
   if (api_web_contents_)  // destroy() called without closing WebContents
     api_web_contents_->Destroy();
 }
@@ -135,17 +137,62 @@ void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
   // because that's handled in the WebContents dtor called prior.
   api_web_contents_->SetOwnerWindow(native_window);
   native_window->AddDraggableRegionProvider(this);
+  StopObservingWindow();
+  observed_window_ = native_window->GetWeakPtr();
+  native_window->AddObserver(this);
   ApplyBorderRadius();
+  MaybeUpdateWindowControlsOverlay();
 }
 
 void WebContentsView::OnViewRemovedFromWidget(views::View* observed_view) {
   DCHECK_EQ(observed_view, view());
+
+  StopObservingWindow();
 
   NativeWindow* native_window = NativeWindow::FromWidget(view()->GetWidget());
   if (!native_window)
     return;
 
   native_window->RemoveDraggableRegionProvider(this);
+}
+
+void WebContentsView::OnViewBoundsChanged(views::View* observed_view) {
+  View::OnViewBoundsChanged(observed_view);
+  MaybeUpdateWindowControlsOverlay();
+}
+
+// Re-sends the window's current overlay rect if a page is already live. Before
+// the first navigation there is nothing to update; the window notifies us again
+// from WebContents::DidFinishNavigation.
+void WebContentsView::MaybeUpdateWindowControlsOverlay() {
+  if (!observed_window_ || !web_contents() ||
+      !web_contents()->GetPrimaryMainFrame()->IsRenderFrameLive())
+    return;
+  if (const auto overlay = observed_window_->GetWindowControlsOverlayRect())
+    UpdateWindowControlsOverlay(*overlay);
+}
+
+// The overlay rect is relative to the window's content area. Translate it
+// into this view's coordinates so that views which only partially cover (or
+// don't cover) the titlebar report the right env(titlebar-area-*) values.
+void WebContentsView::UpdateWindowControlsOverlay(
+    const gfx::Rect& bounding_rect) {
+  if (!api_web_contents_ || !observed_window_)
+    return;
+  views::View* window_view = observed_window_->GetContentsView();
+  if (!window_view || !window_view->Contains(view()))
+    return;
+
+  gfx::Rect local_rect =
+      views::View::ConvertRectToTarget(window_view, view(), bounding_rect);
+  local_rect.Intersect(view()->GetLocalBounds());
+  web_contents()->UpdateWindowControlsOverlay(local_rect);
+}
+
+void WebContentsView::StopObservingWindow() {
+  if (observed_window_)
+    observed_window_->RemoveObserver(this);
+  observed_window_ = nullptr;
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -4,7 +4,9 @@
 
 #include "shell/browser/api/electron_api_web_contents_view.h"
 
+#include "base/functional/bind.h"
 #include "base/no_destructor.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/timer/elapsed_timer.h"
 #include "content/public/browser/render_frame_host.h"
 #include "gin/data_object_builder.h"
@@ -39,6 +41,10 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
       web_contents_(isolate, web_contents.ToV8()),
       api_web_contents_(web_contents->GetWeakPtr()) {
   set_delete_view(false);
+  // See OnContentsBoundsChanging().
+  web_contents->inspectable_web_contents()->GetView()->SetBoundsChangedCallback(
+      base::BindRepeating(&WebContentsView::OnContentsBoundsChanging,
+                          weak_factory_.GetWeakPtr()));
   view()->SetProperty(
       views::kFlexBehaviorKey,
       views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToMinimum,
@@ -141,7 +147,8 @@ void WebContentsView::OnViewAddedToWidget(views::View* observed_view) {
   observed_window_ = native_window->GetWeakPtr();
   native_window->AddObserver(this);
   ApplyBorderRadius();
-  MaybeUpdateWindowControlsOverlay();
+  if (HasLivePage())
+    ScheduleWindowControlsOverlayUpdate();
 }
 
 void WebContentsView::OnViewRemovedFromWidget(views::View* observed_view) {
@@ -156,35 +163,55 @@ void WebContentsView::OnViewRemovedFromWidget(views::View* observed_view) {
   native_window->RemoveDraggableRegionProvider(this);
 }
 
-void WebContentsView::OnViewBoundsChanged(views::View* observed_view) {
-  View::OnViewBoundsChanged(observed_view);
-  MaybeUpdateWindowControlsOverlay();
+// Our bounds changed and the RenderWidgetHostView is about to be resized to
+// match. Push the re-clipped overlay rect now so that it rides along with the
+// resize in a single VisualProperties update, rather than trailing it (where it
+// could sit behind the resize's pending ack).
+void WebContentsView::OnContentsBoundsChanging() {
+  if (HasLivePage())
+    SendWindowControlsOverlay();
 }
 
-// Re-sends the window's current overlay rect if a page is already live. Before
-// the first navigation there is nothing to update; the window notifies us again
-// from WebContents::DidFinishNavigation.
-void WebContentsView::MaybeUpdateWindowControlsOverlay() {
-  if (!observed_window_ || !web_contents() ||
-      !web_contents()->GetPrimaryMainFrame()->IsRenderFrameLive())
+bool WebContentsView::HasLivePage() {
+  // Before the first navigation there is nothing to update; the window
+  // notifies us again from WebContents::DidFinishNavigation.
+  return observed_window_ && web_contents() &&
+         web_contents()->GetPrimaryMainFrame()->IsRenderFrameLive();
+}
+
+// NativeWindowObserver. This fires from inside the frame view's layout, before
+// the client area (and so this view) has been laid out, so defer until the
+// current layout pass has finished to avoid clipping against stale bounds.
+void WebContentsView::UpdateWindowControlsOverlay(
+    const gfx::Rect& bounding_rect) {
+  ScheduleWindowControlsOverlayUpdate();
+}
+
+void WebContentsView::ScheduleWindowControlsOverlayUpdate() {
+  if (window_controls_overlay_update_pending_)
     return;
-  if (const auto overlay = observed_window_->GetWindowControlsOverlayRect())
-    UpdateWindowControlsOverlay(*overlay);
+  window_controls_overlay_update_pending_ = true;
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&WebContentsView::SendWindowControlsOverlay,
+                                weak_factory_.GetWeakPtr()));
 }
 
 // The overlay rect is relative to the window's content area. Translate it
 // into this view's coordinates so that views which only partially cover (or
 // don't cover) the titlebar report the right env(titlebar-area-*) values.
-void WebContentsView::UpdateWindowControlsOverlay(
-    const gfx::Rect& bounding_rect) {
+void WebContentsView::SendWindowControlsOverlay() {
+  window_controls_overlay_update_pending_ = false;
   if (!api_web_contents_ || !observed_window_)
+    return;
+  const auto bounding_rect = observed_window_->GetWindowControlsOverlayRect();
+  if (!bounding_rect)
     return;
   views::View* window_view = observed_window_->GetContentsView();
   if (!window_view || !window_view->Contains(view()))
     return;
 
   gfx::Rect local_rect =
-      views::View::ConvertRectToTarget(window_view, view(), bounding_rect);
+      views::View::ConvertRectToTarget(window_view, view(), *bounding_rect);
   local_rect.Intersect(view()->GetLocalBounds());
   web_contents()->UpdateWindowControlsOverlay(local_rect);
 }

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -61,7 +61,6 @@ class WebContentsView : public View,
   // views::ViewObserver
   void OnViewAddedToWidget(views::View* view) override;
   void OnViewRemovedFromWidget(views::View* view) override;
-  void OnViewBoundsChanged(views::View* view) override;
 
   // NativeWindowObserver
   void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
@@ -71,12 +70,18 @@ class WebContentsView : public View,
 
   void ApplyBorderRadius();
   void StopObservingWindow();
-  void MaybeUpdateWindowControlsOverlay();
+  void OnContentsBoundsChanging();
+  bool HasLivePage();
+  void ScheduleWindowControlsOverlayUpdate();
+  void SendWindowControlsOverlay();
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
   base::WeakPtr<api::WebContents> api_web_contents_;
   base::WeakPtr<NativeWindow> observed_window_;
+  bool window_controls_overlay_update_pending_ = false;
+
+  base::WeakPtrFactory<WebContentsView> weak_factory_{this};
 };
 
 }  // namespace electron::api

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -11,9 +11,14 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/browser/api/electron_api_view.h"
 #include "shell/browser/draggable_region_provider.h"
+#include "shell/browser/native_window_observer.h"
 
 namespace gin_helper {
 class Dictionary;
+}
+
+namespace electron {
+class NativeWindow;
 }
 
 namespace electron::api {
@@ -22,6 +27,7 @@ class WebContents;
 
 class WebContentsView : public View,
                         private content::WebContentsObserver,
+                        private NativeWindowObserver,
                         public DraggableRegionProvider {
  public:
   // Create a new instance of WebContentsView.
@@ -55,15 +61,22 @@ class WebContentsView : public View,
   // views::ViewObserver
   void OnViewAddedToWidget(views::View* view) override;
   void OnViewRemovedFromWidget(views::View* view) override;
+  void OnViewBoundsChanged(views::View* view) override;
+
+  // NativeWindowObserver
+  void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
 
  private:
   static gin_helper::WrappableBase* New(gin::Arguments* args);
 
   void ApplyBorderRadius();
+  void StopObservingWindow();
+  void MaybeUpdateWindowControlsOverlay();
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
   base::WeakPtr<api::WebContents> api_web_contents_;
+  base::WeakPtr<NativeWindow> observed_window_;
 };
 
 }  // namespace electron::api

--- a/shell/browser/ui/inspectable_web_contents_view.cc
+++ b/shell/browser/ui/inspectable_web_contents_view.cc
@@ -299,6 +299,12 @@ void InspectableWebContentsView::SetContentsViewBounds(
   }
 }
 
+void InspectableWebContentsView::OnBoundsChanged(
+    const gfx::Rect& previous_bounds) {
+  if (bounds_changed_callback_)
+    bounds_changed_callback_.Run();
+}
+
 void InspectableWebContentsView::Layout(PassKey) {
   if (!devtools_web_view_->GetVisible()) {
     SetContentsViewBounds(GetContentsBounds());

--- a/shell/browser/ui/inspectable_web_contents_view.h
+++ b/shell/browser/ui/inspectable_web_contents_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/devtools/devtools_contents_resizing_strategy.h"
 #include "ui/gfx/geometry/rect.h"
@@ -70,8 +71,15 @@ class InspectableWebContentsView : public views::View {
   // when undocked, otherwise the window containing this view).
   void ShowDevToolsContextMenu(const content::ContextMenuParams& params);
 
+  // Invoked when this view's bounds have changed but before its children (and
+  // therefore the RenderWidgetHostView) have been laid out to match.
+  void SetBoundsChangedCallback(base::RepeatingClosure callback) {
+    bounds_changed_callback_ = std::move(callback);
+  }
+
   // views::View:
   void Layout(PassKey) override;
+  void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
 
   views::View* GetContentsView() const;
 
@@ -97,6 +105,7 @@ class InspectableWebContentsView : public views::View {
   bool devtools_visible_ = false;
   raw_ptr<views::WidgetDelegate> devtools_window_delegate_ = nullptr;
   std::u16string title_;
+  base::RepeatingClosure bounds_changed_callback_;
 };
 
 }  // namespace electron

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3860,10 +3860,13 @@ describe('BrowserWindow module', () => {
       );
 
       // The rect is clipped to the view and follows it when its bounds change.
+      // (Its x depends on which side the window controls are on, so check the
+      // right edge.)
       topView.setBounds({ x: 0, y: 0, width: 150, height: 100 });
-      await waitUntil(
-        async () => (await topView.webContents.executeJavaScript('getJSOverlayProperties()')).width === 150
-      );
+      await waitUntil(async () => {
+        const r = await topView.webContents.executeJavaScript('getJSOverlayProperties()');
+        return r.x + r.width === 150;
+      });
       bottomView.setBounds({ x: 0, y: 20, width: 400, height: 200 });
       await waitUntil(() => bottomView.webContents.executeJavaScript('navigator.windowControlsOverlay.visible'));
       const bottomRect = await bottomView.webContents.executeJavaScript('getJSOverlayProperties()');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3821,6 +3821,45 @@ describe('BrowserWindow module', () => {
     it('sets Window Control Overlay with title bar height of 40', async () => {
       await testWindowsOverlayHeight(40);
     });
+
+    it('propagates the overlay to WebContentsViews in a BaseWindow', async () => {
+      const w = new BaseWindow({
+        show: false,
+        width: 400,
+        height: 400,
+        titleBarStyle: 'hidden',
+        titleBarOverlay: { height: 40 }
+      });
+      const webPreferences = { nodeIntegration: true, contextIsolation: false };
+      const topView = new WebContentsView({ webPreferences });
+      const bottomView = new WebContentsView({ webPreferences });
+      topView.setBounds({ x: 0, y: 0, width: 400, height: 100 });
+      bottomView.setBounds({ x: 0, y: 200, width: 400, height: 200 });
+      w.contentView.addChildView(topView);
+      w.contentView.addChildView(bottomView);
+
+      // On Linux the overlay geometry is only computed once the frame has
+      // been laid out, which for a BaseWindow doesn't happen until it's shown.
+      if (process.platform === 'linux') {
+        const shown = once(w, 'show');
+        w.show();
+        await shown;
+      }
+      const overlayHTML = path.join(__dirname, 'fixtures', 'pages', 'overlay.html');
+      await topView.webContents.loadFile(overlayHTML);
+      await bottomView.webContents.loadFile(overlayHTML);
+
+      await waitUntil(() => topView.webContents.executeJavaScript('navigator.windowControlsOverlay.visible'));
+      const overlayRect = await topView.webContents.executeJavaScript('getJSOverlayProperties()');
+      expect(overlayRect.y).to.equal(0);
+      expect(overlayRect.width).to.be.greaterThan(0);
+      expect(overlayRect.height).to.equal(40);
+
+      // A view that doesn't intersect the titlebar area shouldn't see an overlay.
+      expect(await bottomView.webContents.executeJavaScript('navigator.windowControlsOverlay.visible')).to.be.false(
+        'bottom view overlay visible'
+      );
+    });
   });
 
   ifdescribe(process.platform !== 'darwin')('BrowserWindow.setTitlebarOverlay', () => {

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3838,13 +3838,12 @@ describe('BrowserWindow module', () => {
       w.contentView.addChildView(topView);
       w.contentView.addChildView(bottomView);
 
-      // On Linux the overlay geometry is only computed once the frame has
-      // been laid out, which for a BaseWindow doesn't happen until it's shown.
-      if (process.platform === 'linux') {
-        const shown = once(w, 'show');
-        w.show();
-        await shown;
-      }
+      // The overlay geometry reaches the renderer through visual properties,
+      // which aren't synchronised for an unsized (never shown) child view, and
+      // on Linux the frame isn't laid out until the window is shown either.
+      const shown = once(w, 'show');
+      w.show();
+      await shown;
       const overlayHTML = path.join(__dirname, 'fixtures', 'pages', 'overlay.html');
       await topView.webContents.loadFile(overlayHTML);
       await bottomView.webContents.loadFile(overlayHTML);

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3858,6 +3858,17 @@ describe('BrowserWindow module', () => {
       expect(await bottomView.webContents.executeJavaScript('navigator.windowControlsOverlay.visible')).to.be.false(
         'bottom view overlay visible'
       );
+
+      // The rect is clipped to the view and follows it when its bounds change.
+      topView.setBounds({ x: 0, y: 0, width: 150, height: 100 });
+      await waitUntil(
+        async () => (await topView.webContents.executeJavaScript('getJSOverlayProperties()')).width === 150
+      );
+      bottomView.setBounds({ x: 0, y: 20, width: 400, height: 200 });
+      await waitUntil(() => bottomView.webContents.executeJavaScript('navigator.windowControlsOverlay.visible'));
+      const bottomRect = await bottomView.webContents.executeJavaScript('getJSOverlayProperties()');
+      expect(bottomRect.y).to.equal(0);
+      expect(bottomRect.height).to.equal(20);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Closes #53530.

Window Controls Overlay geometry was only forwarded by `BrowserWindow` to its own `webContents`, so a `WebContentsView` hosted in a `BaseWindow` never got `navigator.windowControlsOverlay.visible === true` or the `titlebar-area-*` CSS env() variables, even though the native overlay was drawn.

`WebContentsView` now observes the window it is attached to and forwards the overlay rect to its own `webContents`, translated into the view's coordinates and clipped to its bounds. A view that covers the top of the window sees the same values a `BrowserWindow` would; a view that doesn't intersect the titlebar reports no overlay. `BrowserWindow` goes through the same path since its content is a `WebContentsView`.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: Fixed Window Controls Overlay CSS environment variables and `navigator.windowControlsOverlay` not being populated for `WebContentsView`s in a `BaseWindow`.
