### PR TITLE
fix: don't collect Dawn info for app.getGPUInfo('complete')

### DIFF
--- a/shell/browser/api/gpuinfo_manager.cc
+++ b/shell/browser/api/gpuinfo_manager.cc
@@ -51,8 +51,14 @@ void GPUInfoManager::OnGpuInfoUpdate() {
 void GPUInfoManager::CompleteInfoFetcher(
     gin_helper::Promise<base::Value> promise) {
   complete_info_promise_set_.emplace_back(std::move(promise));
-  gpu_data_manager_->RequestGpuInfoIfNeeded(
-      content::GpuDataManagerImpl::kGpuInfoRequestAll, /* delayed */ false);
+  // Dawn info is deliberately not requested: it isn't part of gpu::GPUInfo
+  // (so it never reaches the result) and collecting it enumerates every Dawn
+  // adapter on the GPU main thread, which can stall compositing for seconds.
+  constexpr auto kRequest =
+      static_cast<content::GpuDataManagerImpl::GpuInfoRequest>(
+          content::GpuDataManagerImpl::kGpuInfoRequestDirectX |
+          content::GpuDataManagerImpl::kGpuInfoRequestVideo);
+  gpu_data_manager_->RequestGpuInfoIfNeeded(kRequest, /* delayed */ false);
 }
 
 void GPUInfoManager::FetchCompleteInfo(


### PR DESCRIPTION
#### Description of Change

Closes #53140.

`app.getGPUInfo('complete')` requested `kGpuInfoRequestAll`, which includes Dawn adapter enumeration. That runs on the GPU process main thread (Chromium pauses the GPU watchdog around it because it is known to be slow) and on some Windows machines stalls compositing for 10+ seconds, freezing every visible `webContents`. The Dawn data isn't part of `gpu::GPUInfo`, so it never appeared in the returned object anyway.

Only request the DirectX and video capability info, which is what actually feeds the result.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes

#### Release Notes

Notes: Fixed `app.getGPUInfo('complete')` stalling the GPU process for several seconds on some Windows systems.
