### PR TITLE
perf: build the draggable region by recursive halving

### DIFF
--- a/shell/browser/ui/drag_util.cc
+++ b/shell/browser/ui/drag_util.cc
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "base/containers/span.h"
 #include "third_party/blink/public/mojom/page/draggable_region.mojom.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkRegion.h"
@@ -13,33 +14,89 @@
 
 namespace electron {
 
-// Convert draggable regions in raw format to SkRegion format.
+namespace {
+
+// TODO(MarshallOfSound): this is a copy of content::DraggableRegionsToSkRegion
+// from https://chromium-review.googlesource.com/c/chromium/src/+/8360195.
+// Once that lands and rolls into Electron, delete everything in this
+// namespace and make DraggableRegionsToSkRegion() below a call to
+// content::DraggableRegionsToSkRegion(regions).
+
+SkIRect ToSkIRect(const gfx::Rect& rect) {
+  return SkIRect::MakeLTRB(rect.x(), rect.y(), rect.right(), rect.bottom());
+}
+
+// The renderer sends an ordered list of rects. A draggable rect adds its area
+// to the region and a non-draggable rect removes its area. Where rects
+// overlap, the later rect wins, so a point ends up draggable exactly when the
+// last rect in the list that contains it is draggable.
 //
-// The regions arrive in document order and later ones win, so a `no-drag`
-// rect punches a hole in the `drag` rects before it and a later `drag` rect
-// can fill it again. Applying them one SkRegion::op() at a time is quadratic in
-// the number of rects (each op is linear in the region built so far), which
-// stalls the UI thread for ~100 ms at 10k rects. Instead, union each run of
-// consecutive same-kind rects with SkRegion::setRects(), which is
-// divide-and-conquer, and fold the runs in order; the result is identical.
+// A SequenceRegion describes one contiguous part of the list. `result` is the
+// region that part produces when applied in order to an empty region.
+// `covered` is the union of all its rects, draggable or not; `result` always
+// lies inside `covered`. If every rect in the part is draggable the two are
+// equal, so only `result` is stored and Covered() returns it.
+//
+// Applying the first half and then the second half of a list: a point outside
+// every rect of the second half is draggable exactly when it is in
+// `first.result`; a point inside a rect of the second half is draggable
+// exactly when it is in `second.result`. So the whole is `first.result`, minus
+// `second.covered`, plus `second.result`, and each half can be built on its
+// own. That is O(n log n) region operations however draggable and
+// non-draggable rects interleave, where one SkRegion::op() per rect is O(n^2)
+// because each op walks the whole region built so far.
+struct SequenceRegion {
+  const SkRegion& Covered() const { return all_draggable ? result : covered; }
+
+  SkRegion result;
+  SkRegion covered;
+  bool all_draggable = false;
+};
+
+SequenceRegion Build(
+    base::span<const blink::mojom::DraggableRegionPtr> regions) {
+  SequenceRegion out;
+  if (regions.size() == 1) {
+    const SkIRect rect = ToSkIRect(regions[0]->bounds);
+    if (regions[0]->draggable) {
+      out.result.setRect(rect);
+      out.all_draggable = true;
+    } else {
+      out.covered.setRect(rect);
+    }
+    return out;
+  }
+
+  const size_t mid = regions.size() / 2;
+  const SequenceRegion first = Build(regions.first(mid));
+  const SequenceRegion second = Build(regions.subspan(mid));
+  if (first.all_draggable && second.all_draggable) {
+    out.result.op(first.result, second.result, SkRegion::kUnion_Op);
+    out.all_draggable = true;
+    return out;
+  }
+  if (second.result.isEmpty()) {
+    out.result.op(first.result, second.Covered(), SkRegion::kDifference_Op);
+  } else if (second.all_draggable) {
+    out.result.op(first.result, second.result, SkRegion::kUnion_Op);
+  } else {
+    SkRegion first_outside_second;
+    first_outside_second.op(first.result, second.covered,
+                            SkRegion::kDifference_Op);
+    out.result.op(first_outside_second, second.result, SkRegion::kUnion_Op);
+  }
+  out.covered.op(first.Covered(), second.Covered(), SkRegion::kUnion_Op);
+  return out;
+}
+
+}  // namespace
+
 SkRegion DraggableRegionsToSkRegion(
     const std::vector<blink::mojom::DraggableRegionPtr>& regions) {
-  SkRegion sk_region;
-  std::vector<SkIRect> run;
-  for (size_t i = 0; i < regions.size();) {
-    const bool draggable = regions[i]->draggable;
-    run.clear();
-    for (; i < regions.size() && regions[i]->draggable == draggable; ++i) {
-      const gfx::Rect& bounds = regions[i]->bounds;
-      run.push_back(SkIRect::MakeLTRB(bounds.x(), bounds.y(), bounds.right(),
-                                      bounds.bottom()));
-    }
-    SkRegion run_region;
-    run_region.setRects(run);
-    sk_region.op(run_region,
-                 draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
+  if (regions.empty()) {
+    return SkRegion();
   }
-  return sk_region;
+  return Build(regions).result;
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Follow-up to #53595, adopting the approach from https://crrev.com/c/8360195 (`content::DraggableRegionsToSkRegion`).

- #53595 unions each run of consecutive same-kind rects with `setRects()` and folds the runs in order. That is O(n log n) only while drag/no-drag rects arrive in long runs; when they interleave (a `drag` card containing a `no-drag` button, repeated N times) every run is a single rect and the fold is quadratic again.
- This splits the list in halves, builds each half recursively, and combines them as `first.result − second.covered + second.result` (a point covered by any rect in the second half is decided by the second half alone). Later rects still win; the region is identical to the original sequential loop (checked on 20k randomized inputs), and the cost is O(n log n) region ops however the kinds interleave.
- The helper is a verbatim copy of the one in the CL, with a TODO to replace it with a call to `content::DraggableRegionsToSkRegion()` once that rolls in.

Release Skia, building the region once from 10k rects:

| input | sequential (pre‑#53595) | runs (#53595) | halving (this PR) |
|---|---:|---:|---:|
| disjoint drag tiles / 1 drag + 9,999 no‑drag holes | 106–114 ms | 0.74 ms | ~1 ms |
| strictly alternating drag/no‑drag tiles | — | — | 1.4 ms |
| random overlapping, 80% drag / 20% no‑drag | 475 ms | 202 ms | 26 ms |

#### Checklist

- [x] PR description included
- [x] `npm test` passes

#### Release Notes

Notes: none
