### PR TITLE
feat: add 'system-audio' to systemPreferences.askForMediaAccess()

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -642,6 +642,10 @@ source_set("electron_lib") {
   }
   if (is_mac) {
     sources += filenames.lib_sources_mac
+    deps += [
+      "//media",
+      "//services/audio/public/cpp",
+    ]
   }
   if (is_posix) {
     sources += filenames.lib_sources_posix

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -350,13 +350,24 @@ It will always return `granted` for `screen` and for all media types on older ve
 
 ### `systemPreferences.askForMediaAccess(mediaType)` _macOS_
 
-* `mediaType` string - the type of media being requested; can be `microphone`, `camera`.
+* `mediaType` string - the type of media being requested; can be `microphone`, `camera` or `system-audio`.
 
 Returns `Promise<boolean>` - A promise that resolves with `true` if consent was granted and `false` if it was denied. If an invalid `mediaType` is passed, the promise will be rejected. If an access request was denied and later is changed through the System Preferences pane, a restart of the app will be required for the new permissions to take effect. If access has already been requested and denied, it _must_ be changed through the preference pane; an alert will not pop up and the promise will resolve with the existing access status.
 
-**Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](../tutorial/application-distribution.md#rebranding-with-downloaded-binaries) for more information about how to set these in the context of Electron.
+**Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription`, `NSCameraUsageDescription` and (for `system-audio`) `NSAudioCaptureUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](../tutorial/application-distribution.md#rebranding-with-downloaded-binaries) for more information about how to set these in the context of Electron.
 
-This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` if your system is running 10.13 High Sierra.
+This user consent was not required until macOS 10.14 Mojave, so this method will always return `true` for `microphone` and `camera` if your system is running 10.13 High Sierra.
+
+`system-audio` covers capturing system audio output (the `loopback` / `loopbackWithMute` audio
+sources used with [`session.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts)).
+macOS offers no API to query this permission directly, so Electron determines it the same way
+Chrome's share picker does: by briefly opening a system-audio capture stream. On macOS 14.2 and
+later that is gated on the "System Audio Recording" privacy permission, and the first call will
+show the system prompt (attributed to the app, or to the terminal/IDE when running unpackaged);
+subsequent calls resolve with the stored decision without prompting. The promise resolves with
+`false` if the stream could not be started for any reason, including on macOS versions that do not
+support system audio capture. There is no corresponding `getMediaAccessStatus` type because the
+status cannot be read without performing this check.
 
 ### `systemPreferences.getAnimationSettings()`
 

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -123,6 +123,9 @@ class SystemAudioAccessProbe : public media::AudioInputIPCDelegate {
   SystemAudioAccessProbe(const SystemAudioAccessProbe&) = delete;
   SystemAudioAccessProbe& operator=(const SystemAudioAccessProbe&) = delete;
 
+  // Public for base::DeleteHelper; use Run().
+  ~SystemAudioAccessProbe() override = default;
+
  private:
   explicit SystemAudioAccessProbe(gin_helper::Promise<bool> promise)
       : promise_(std::move(promise)) {
@@ -140,7 +143,6 @@ class SystemAudioAccessProbe : public media::AudioInputIPCDelegate {
                                960),
         /*automatic_gain_control=*/false, /*total_segments=*/1);
   }
-  ~SystemAudioAccessProbe() override = default;
 
   // media::AudioInputIPCDelegate
   void OnStreamCreated(base::UnsafeSharedMemoryRegion shared_memory_region,

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -20,7 +20,13 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
 #include "chrome/browser/media/webrtc/system_media_capture_permissions_mac.h"
+#include "content/public/browser/audio_service.h"
+#include "media/audio/audio_device_description.h"
+#include "media/base/audio_parameters.h"
+#include "media/mojo/mojom/audio_stream_factory.mojom.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
 #include "net/base/apple/url_conversions.h"
+#include "services/audio/public/cpp/input_ipc.h"
 #include "shell/browser/mac/dict_util.h"
 #include "shell/browser/mac/electron_application.h"
 #include "shell/common/color_util.h"
@@ -101,6 +107,69 @@ AVMediaType ParseMediaType(const std::string& media_type) {
     return nil;
   }
 }
+
+// macOS has no API to query or request the "System Audio Recording"
+// permission that CoreAudio taps are gated on. The only way to surface the
+// prompt (or learn that access was denied) is to try to open a system-audio
+// loopback stream, which is what Chrome's share picker does as well. This asks
+// the audio service for one, resolves the promise with whether it could be
+// created, and tears everything down again. Self-owned.
+class SystemAudioAccessProbe : public media::AudioInputIPCDelegate {
+ public:
+  static void Run(gin_helper::Promise<bool> promise) {
+    new SystemAudioAccessProbe(std::move(promise));
+  }
+
+  SystemAudioAccessProbe(const SystemAudioAccessProbe&) = delete;
+  SystemAudioAccessProbe& operator=(const SystemAudioAccessProbe&) = delete;
+
+ private:
+  explicit SystemAudioAccessProbe(gin_helper::Promise<bool> promise)
+      : promise_(std::move(promise)) {
+    mojo::PendingRemote<media::mojom::AudioStreamFactory> factory;
+    content::GetAudioService().BindStreamFactory(
+        factory.InitWithNewPipeAndPassReceiver());
+    input_ipc_ = std::make_unique<audio::InputIPC>(
+        std::move(factory),
+        media::AudioDeviceDescription::kLoopbackInputDeviceId,
+        /*log=*/mojo::NullRemote());
+    input_ipc_->CreateStream(
+        this,
+        media::AudioParameters(media::AudioParameters::AUDIO_PCM_LOW_LATENCY,
+                               media::ChannelLayoutConfig::Stereo(), 48000,
+                               960),
+        /*automatic_gain_control=*/false, /*total_segments=*/1);
+  }
+  ~SystemAudioAccessProbe() override = default;
+
+  // media::AudioInputIPCDelegate
+  void OnStreamCreated(base::UnsafeSharedMemoryRegion shared_memory_region,
+                       base::SyncSocket::ScopedHandle socket_handle,
+                       bool initially_muted) override {
+    Finish(true);
+  }
+  void OnError(media::AudioCapturerSource::ErrorCode code) override {
+    Finish(false);
+  }
+  void OnMuted(bool is_muted) override {}
+  void OnIPCClosed() override { Finish(false); }
+
+  void Finish(bool granted) {
+    if (finished_)
+      return;
+    finished_ = true;
+    input_ipc_->CloseStream();
+    promise_.Resolve(granted);
+    // We're inside an InputIPC callback; defer destruction.
+    auto task_runner = base::SequencedTaskRunner::GetCurrentDefault();
+    task_runner->DeleteSoon(FROM_HERE, std::move(input_ipc_));
+    task_runner->DeleteSoon(FROM_HERE, this);
+  }
+
+  bool finished_ = false;
+  gin_helper::Promise<bool> promise_;
+  std::unique_ptr<audio::InputIPC> input_ipc_;
+};
 
 std::string ConvertSystemPermission(
     system_permission_settings::SystemPermission value) {
@@ -630,7 +699,9 @@ v8::Local<v8::Promise> SystemPreferences::AskForMediaAccess(
   gin_helper::Promise<bool> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  if (auto type = ParseMediaType(media_type)) {
+  if (media_type == "system-audio") {
+    SystemAudioAccessProbe::Run(std::move(promise));
+  } else if (auto type = ParseMediaType(media_type)) {
     __block gin_helper::Promise<bool> p = std::move(promise);
     [AVCaptureDevice requestAccessForMediaType:type
                              completionHandler:^(BOOL granted) {

--- a/spec/api-system-preferences-spec.ts
+++ b/spec/api-system-preferences-spec.ts
@@ -302,6 +302,21 @@ describe('systemPreferences module', () => {
     }
   );
 
+  ifdescribe(process.platform === 'darwin')('systemPreferences.askForMediaAccess(mediaType)', () => {
+    it('rejects an unknown media type', async () => {
+      await expect(systemPreferences.askForMediaAccess('bogus' as any)).to.eventually.be.rejectedWith(
+        'Invalid media type'
+      );
+    });
+
+    it('resolves with a boolean for system-audio', async function () {
+      // If the OS decides to prompt, CoreAudio waits up to a minute for an answer.
+      this.timeout(90000);
+      const granted = await systemPreferences.askForMediaAccess('system-audio');
+      expect(granted).to.be.a('boolean');
+    });
+  });
+
   describe('systemPreferences.getAnimationSettings()', () => {
     it('returns an object with all properties', () => {
       const settings = systemPreferences.getAnimationSettings();


### PR DESCRIPTION
#### Description of Change

Refs #52738

On macOS 14.2+, system audio capture (`loopback` / `loopbackWithMute`) goes through a CoreAudio process tap, and process taps are gated on the "System Audio Recording" privacy permission.

Apple doesn't provide an API to check or request that permission. The prompt only shows up the first time a tap is opened, and if the user denies it, the stream just fails. That means apps using `setDisplayMediaRequestHandler` with their own picker can't show the prompt ahead of time or detect a denial. They just get an audio track that's `ended` from the start.

Chrome's share picker gets around this with `AudioCapturePermissionCheckerMac`. When "share system audio" is ticked, it briefly opens a loopback stream through the audio service.

This PR adds a `system-audio` media type to `systemPreferences.askForMediaAccess()` that runs the same probe and resolves with whether the stream could be created. Apps can call it before `getDisplayMedia` to trigger the prompt, or to find out the permission was denied and deep-link to System Settings.

_Nota bene: I deliberately didn't add `getMediaAccessStatus('system-audio')`. The only way to find out the permission state is to open that test stream, and opening it shows the prompt if the user hasn't answered it yet. A status check shouldn't prompt the user, so this only makes sense as part of `askForMediaAccess()`._

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added `system-audio` to `systemPreferences.askForMediaAccess()` on macOS so apps can prompt for, or detect denial of, the System Audio Recording permission before starting loopback capture.
