### PR TITLE
fix: resolve the capturing webContents in setDisplayMediaRequestHandler

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -1187,7 +1187,7 @@ session.fromPartition('some-partition').setPermissionCheckHandler((webContents, 
         a string is specified, can be `loopback` or `loopbackWithMute`.
         Specifying a loopback device will capture system audio, and is
         currently only supported on Windows. If a WebFrameMain is specified,
-        will capture audio from that frame.
+        will capture audio from the `webContents` that contains that frame.
       * `enableLocalEcho` Boolean (optional) - If `audio` is a [WebFrameMain](web-frame-main.md)
          and this is set to `true`, then local playback of audio will not be muted (e.g. using `MediaRecorder`
          to record `WebFrameMain` with this flag set to `true` will allow audio to pass through to the speakers
@@ -1220,14 +1220,22 @@ session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
 ```
 
 Passing a [WebFrameMain](web-frame-main.md) object as a video or audio stream
-will capture the video or audio stream from that frame.
+captures the whole `webContents` that contains that frame (the tab), not just
+the frame: `request.frame` from an `<iframe>` therefore grants that iframe a
+capture of the page that embeds it. Check `request.frame` before using it this
+way, and note that the callback throws if the frame has been destroyed by the
+time it is called.
 
 ```js
 const { session } = require('electron')
 
 session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
-  // Allow the tab to capture itself.
-  callback({ video: request.frame })
+  // Allow a top-level page to capture its own tab.
+  if (request.frame && request.frame === request.frame.top) {
+    callback({ video: request.frame })
+  } else {
+    callback(null)
+  }
 })
 ```
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -143,6 +143,9 @@ media::mojom::CaptureHandlePtr CreateCaptureHandle(
 
   // Observing CaptureHandle when either the capturing or the captured party
   // is incognito is disallowed, except for self-capture.
+  if (!capturer) {
+    return nullptr;
+  }
   if (capturer->GetPrimaryMainFrame() != captured->GetPrimaryMainFrame()) {
     if (capturer->GetBrowserContext()->IsOffTheRecord() ||
         captured->GetBrowserContext()->IsOffTheRecord()) {
@@ -752,6 +755,30 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
                             nullptr);
     return;
   }
+  // The WebContents that called getDisplayMedia(). Capture handles, zoom
+  // level and the incognito check are computed relative to it.
+  content::WebContents* capturer = content::WebContents::FromRenderFrameHost(
+      content::RenderFrameHost::FromID(request.render_process_id,
+                                       request.render_frame_id));
+  if (!capturer) {
+    std::move(callback).Run(
+        blink::mojom::StreamDevicesSet(),
+        blink::mojom::MediaStreamRequestResult::INVALID_STATE, nullptr);
+    return;
+  }
+  const url::Origin capturer_origin =
+      url::Origin::Create(request.security_origin);
+  // A WebFrameMain passed as `video` / `audio` selects the WebContents that
+  // contains it; content captures whole tabs, not individual frames.
+  auto tab_capture_id = [](content::RenderFrameHost* rfh,
+                           bool disable_local_echo = false) {
+    content::RenderFrameHost* main_frame = rfh->GetOutermostMainFrame();
+    return content::WebContentsMediaCaptureId(
+               main_frame->GetProcess()->GetDeprecatedID(),
+               main_frame->GetRoutingID(), disable_local_echo)
+        .ToString();
+  };
+
   stream_devices_set->stream_devices.emplace_back(
       blink::mojom::StreamDevices::New());
   blink::mojom::StreamDevices& devices = *stream_devices_set->stream_devices[0];
@@ -769,19 +796,24 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
         video_dict.Get("name", &name)) {
       blink::MediaStreamDevice video_device(request.video_type, id, name);
       video_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
-          nullptr, url::Origin::Create(request.security_origin),
+          capturer, capturer_origin,
           content::DesktopMediaID::Parse(video_device.id));
       devices.video_device = video_device;
     } else if (result_dict.Get("video", &rfh)) {
-      auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
+      if (!rfh) {
+        args->ThrowTypeError("video refers to a frame that has been destroyed");
+        std::move(callback).Run(blink::mojom::StreamDevicesSet(),
+                                blink::mojom::MediaStreamRequestResult::
+                                    INVALID_DISPLAY_CAPTURE_CONSTRAINTS,
+                                nullptr);
+        return;
+      }
+      auto* captured = content::WebContents::FromRenderFrameHost(rfh);
       blink::MediaStreamDevice video_device(
-          request.video_type,
-          content::WebContentsMediaCaptureId(
-              rfh->GetProcess()->GetDeprecatedID(), rfh->GetRoutingID())
-              .ToString(),
-          base::UTF16ToUTF8(web_contents->GetTitle()));
+          request.video_type, tab_capture_id(rfh),
+          base::UTF16ToUTF8(captured->GetTitle()));
       video_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
-          web_contents, url::Origin::Create(request.security_origin),
+          capturer, capturer_origin,
           content::DesktopMediaID::Parse(video_device.id));
       devices.video_device = video_device;
     } else {
@@ -807,23 +839,26 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
         audio_dict.Get("name", &name)) {
       blink::MediaStreamDevice audio_device(request.audio_type, id, name);
       audio_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
-          nullptr, url::Origin::Create(request.security_origin),
+          capturer, capturer_origin,
           GetAudioDesktopMediaId(request.requested_audio_device_ids));
       devices.audio_device = audio_device;
     } else if (result_dict.Get("audio", &rfh)) {
+      if (!rfh) {
+        args->ThrowTypeError("audio refers to a frame that has been destroyed");
+        std::move(callback).Run(blink::mojom::StreamDevicesSet(),
+                                blink::mojom::MediaStreamRequestResult::
+                                    INVALID_DISPLAY_CAPTURE_CONSTRAINTS,
+                                nullptr);
+        return;
+      }
       const bool enable_local_echo =
           result_dict.ValueOrDefault("enableLocalEcho", false);
-      const bool disable_local_echo = !enable_local_echo;
-      auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
       blink::MediaStreamDevice audio_device(
           request.audio_type,
-          content::WebContentsMediaCaptureId(
-              rfh->GetProcess()->GetDeprecatedID(), rfh->GetRoutingID(),
-              disable_local_echo)
-              .ToString(),
+          tab_capture_id(rfh, /*disable_local_echo=*/!enable_local_echo),
           "Tab audio");
       audio_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
-          web_contents, url::Origin::Create(request.security_origin),
+          capturer, capturer_origin,
           GetAudioDesktopMediaId(request.requested_audio_device_ids));
       devices.audio_device = audio_device;
     } else if (result_dict.Get("audio", &id)) {
@@ -838,7 +873,7 @@ void ElectronBrowserContext::DisplayMediaDeviceChosen(
       blink::MediaStreamDevice audio_device(request.audio_type, id,
                                             "System audio");
       audio_device.display_media_info = DesktopMediaIDToDisplayMediaInformation(
-          nullptr, url::Origin::Create(request.security_origin),
+          capturer, capturer_origin,
           GetAudioDesktopMediaId(request.requested_audio_device_ids));
       devices.audio_device = audio_device;
     } else {

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import * as http from 'node:http';
 
 import { captureWithTabSourceId } from './lib/media-helpers';
-import { ifit, listen } from './lib/spec-helpers';
+import { ifit, listen, waitUntil } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 describe('setDisplayMediaRequestHandler', () => {
@@ -175,6 +175,87 @@ describe('setDisplayMediaRequestHandler', () => {
     expect(captureHandle.handle).to.be.a('string');
     expect(handleID).to.eq(captureHandle.handle);
     expect(message).to.be.null();
+  });
+
+  const addIframe = async (w: BrowserWindow) => {
+    await w.webContents.executeJavaScript(`new Promise((resolve) => {
+      const f = document.createElement('iframe');
+      f.allow = 'display-capture';
+      f.src = ${JSON.stringify(serverUrl)};
+      f.onload = resolve;
+      document.body.appendChild(f);
+    })`);
+    return w.webContents.mainFrame.frames[0];
+  };
+
+  it('does not crash when the requesting frame is gone before the callback', async () => {
+    const ses = session.fromPartition('' + Math.random());
+    const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await w.loadURL(serverUrl);
+    let pending: { request: any; callback: (streams: any) => void } | undefined;
+    ses.setDisplayMediaRequestHandler((request, callback) => {
+      pending = { request, callback };
+    });
+    const iframe = await addIframe(w);
+    iframe.executeJavaScript('navigator.mediaDevices.getDisplayMedia({ video: true }).catch(() => {}); true', true);
+    await waitUntil(() => !!pending);
+    expect(pending!.request.frame).to.equal(iframe);
+    await w.webContents.executeJavaScript("document.querySelector('iframe').remove()");
+    await waitUntil(() => iframe.isDestroyed());
+    pending!.callback({ video: pending!.request.frame });
+    expect(await w.webContents.executeJavaScript('1 + 1')).to.equal(2);
+  });
+
+  it('throws instead of crashing when the granted frame has been destroyed', async () => {
+    const ses = session.fromPartition('' + Math.random());
+    const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await w.loadURL(serverUrl);
+    const iframe = await addIframe(w);
+    await w.webContents.executeJavaScript("document.querySelector('iframe').remove()");
+    await waitUntil(() => iframe.isDestroyed());
+    let error: unknown;
+    ses.setDisplayMediaRequestHandler((_request, callback) => {
+      try {
+        callback({ video: iframe });
+      } catch (e) {
+        error = e;
+      }
+    });
+    const { ok } = await w.webContents.executeJavaScript(
+      'navigator.mediaDevices.getDisplayMedia({ video: true }).then(() => ({ ok: true }), (e) => ({ ok: false, message: e.message }))',
+      true
+    );
+    expect(ok).to.be.false();
+    expect(error).to.match(/destroyed/);
+  });
+
+  it('returns a capture handle when another webContents is granted by id', async () => {
+    // Capture handles are withheld across in-memory (incognito-like) sessions
+    // unless a tab captures itself, so use a persistent partition here.
+    const ses = session.fromPartition('persist:display-media-' + Math.random());
+    const captured = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await captured.loadURL(serverUrl);
+    await captured.webContents.executeJavaScript(`
+      navigator.mediaDevices.setCaptureHandleConfig({
+        handle: 'captured-tab', exposeOrigin: true, permittedOrigins: ['*']
+      }); true`);
+    const capturer = new BrowserWindow({ show: false, webPreferences: { session: ses } });
+    await capturer.loadURL(serverUrl);
+    ses.setDisplayMediaRequestHandler((_request, callback) => {
+      const { processId, routingId } = captured.webContents.mainFrame;
+      callback({ video: { id: `web-contents-media-stream://${processId}:${routingId}`, name: 'captured' } });
+    });
+    const { ok, captureHandle, message } = await capturer.webContents.executeJavaScript(
+      `navigator.mediaDevices.getDisplayMedia({ video: true }).then((stream) => {
+        const [track] = stream.getVideoTracks();
+        return { ok: true, captureHandle: track.getCaptureHandle(), message: null };
+      }, (e) => ({ ok: false, message: e.message }))`,
+      true
+    );
+    expect(message).to.be.null();
+    expect(ok).to.be.true();
+    expect(captureHandle.handle).to.equal('captured-tab');
+    expect(captureHandle.origin).to.equal(new URL(serverUrl).origin);
   });
 
   it('does not crash when providing only audio for a video request', async () => {


### PR DESCRIPTION
- `setDisplayMediaRequestHandler`: capture-handle, zoom and cross-session checks are computed against the WebContents that called `getDisplayMedia()`; previously this could dereference null when granting another tab by id.
- Passing a `WebFrameMain` whose frame has been destroyed as `video` / `audio` throws a `TypeError` instead of crashing; a request whose own frame is gone fails cleanly.
- A `WebFrameMain` grant captures the tab that contains the frame; the docs now say so and the example only self-captures top-level frames.

Notes: Fixed crashes in `setDisplayMediaRequestHandler` when the granted frame had been destroyed or another tab was granted by id.
