### PR TITLE
chore: keep data: URLs out of the non-standard scheme origin patch

### DIFF
--- a/patches/chromium/fix_constrain_allowuniversalaccessfromfileurls_to_file_origins_in.patch
+++ b/patches/chromium/fix_constrain_allowuniversalaccessfromfileurls_to_file_origins_in.patch
@@ -101,7 +101,7 @@ index b5464975a3c365a29e342b0dd57a8a73a311924a..72ebd275330e61a8abebfe6d2c06f425
    // universal access privilege.
    WeakMember<WindowAgent> universal_access_agent_;
 diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
-index b903edd51f46454f41ac4be2c15662e0ce2d61e9..066d1887aebf3d67cad1e4c95f727739b5fb6cf9 100644
+index 010af87938deea58a81e71afb2b9b4e396067668..738f7de404d4598d585c5f8389de7e7978d49dc7 100644
 --- a/third_party/blink/renderer/core/loader/document_loader.cc
 +++ b/third_party/blink/renderer/core/loader/document_loader.cc
 @@ -2706,22 +2706,16 @@ bool ShouldReuseDOMWindow(LocalDOMWindow* window,

--- a/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
+++ b/patches/chromium/fix_crash_loading_non-standard_schemes_in_iframes.patch
@@ -16,7 +16,9 @@ This patch adjusts the origin calculation for subframe non-standard schemes in
 When top level frame navigates to non-standard scheme url, the origin is calculated
 as `null` without any derivation. It is only in cases where there is a `initiator_origin`
 then the origin is derived from it, which is usually the case for renderer initiated
-navigations and iframes are no exceptions from this rule.
+navigations and iframes are no exceptions from this rule. data: URLs are also
+non-standard but are left to the upstream paths, which keep a stable nonce for
+the navigation and the initiator as precursor.
 
 The patch should be removed in favor of either:
   - Remove support for non-standard custom schemes
@@ -28,23 +30,24 @@ The patch should be removed in favor of either:
 Upstream bug https://bugs.chromium.org/p/chromium/issues/detail?id=1081397.
 
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index 3d46f9e7d35332f594f46cb50c93a072bc5b8208..14397a927dac55e9925a5404ad9912ff16bec785 100644
+index 3d46f9e7d35332f594f46cb50c93a072bc5b8208..e4c94de4cda68267adf542a4c2a329733c22bffb 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
-@@ -12646,6 +12646,11 @@ url::Origin NavigationRequest::GetOriginForURLLoaderFactoryUnchecked() {
+@@ -12646,6 +12646,12 @@ url::Origin NavigationRequest::GetOriginForURLLoaderFactoryUnchecked() {
              target_rph_id);
    }
  
-+  if (!common_params().url.IsStandard() && !common_params().url.IsAboutBlank()) {
-+    return url::Origin::Resolve(common_params().url,
-+                                url::Origin());
++  if (!common_params().url.IsStandard() &&
++      !common_params().url.IsAboutBlank() &&
++      !common_params().url.SchemeIs(url::kDataScheme)) {
++    return url::Origin::Resolve(common_params().url, url::Origin());
 +  }
 +
    // In cases not covered above, URLLoaderFactory should be associated with the
    // origin of |common_params.url| and/or |common_params.initiator_origin|.
    url::Origin resolved_origin = url::Origin::Resolve(
 diff --git a/third_party/blink/renderer/core/loader/document_loader.cc b/third_party/blink/renderer/core/loader/document_loader.cc
-index 22974735c7a2f25c962a5f2b4b8b3f12fe52df51..b903edd51f46454f41ac4be2c15662e0ce2d61e9 100644
+index 22974735c7a2f25c962a5f2b4b8b3f12fe52df51..010af87938deea58a81e71afb2b9b4e396067668 100644
 --- a/third_party/blink/renderer/core/loader/document_loader.cc
 +++ b/third_party/blink/renderer/core/loader/document_loader.cc
 @@ -2460,6 +2460,7 @@ Frame* DocumentLoader::CalculateOwnerFrame() {
@@ -59,8 +62,8 @@ index 22974735c7a2f25c962a5f2b4b8b3f12fe52df51..b903edd51f46454f41ac4be2c15662e0
      // non-renderer only origin bits will be the same, which will be asserted at
      // the end of this function.
      origin = origin_to_commit_;
-+  } else if (!SecurityOrigin::ShouldUseInnerURL(url_) &&
-+             !is_standard) {
++  } else if (!SecurityOrigin::ShouldUseInnerURL(url_) && !is_standard &&
++             !url_.ProtocolIsData()) {
 +    origin = SecurityOrigin::Create(url_);
    } else {
      // Otherwise, create an origin that propagates precursor information


### PR DESCRIPTION
#### Description of Change

`fix_crash_loading_non-standard_schemes_in_iframes.patch` short-circuits origin computation for every non-standard URL, in `NavigationRequest::GetOriginForURLLoaderFactoryUnchecked` and in `DocumentLoader::CalculateOrigin`, so that subframes on embedder-registered custom schemes do not trip `CanAccessDataForOrigin`. `data:` is also a non-standard scheme, so every `data:` navigation was taking that branch as well and skipping what Chromium does for `data:` right below it: reusing the nonce cached in `tentative_data_origin_to_commit_` (crrev.com/c/4902624) and resolving the opaque origin against the initiator so it carries a precursor.

This excludes `data:` from both hunks so those navigations stay on Chromium's path in the browser and the renderer alike, and notes that in the patch description. The `about:blank` carve-out added in #45694 stays as is.

Verified on Linux with a testing (DCHECK) build: `data:` and custom non-standard-scheme iframes under an http parent, browser- and renderer-initiated, commit without origin-mismatch checks firing; blob URL fetches from the `data:` frame work; spec/api-protocol-spec.ts (178) and the frame-related subset of spec/chromium-spec.ts pass. I did not find an app-observable difference from the old behavior in that probing; the point is to stop diverging from upstream for a scheme the patch was never about.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)

#### Release Notes

Notes: none
