### PR TITLE
chore: deprecate synchronous safeStorage methods

### DIFF
--- a/docs/api/safe-storage.md
+++ b/docs/api/safe-storage.md
@@ -8,9 +8,9 @@ This module adds extra protection to data being stored on disk by using OS-provi
 security semantics for each platform are outlined below.
 
 > [!NOTE]
-> We recommend using the asynchronous API (`encryptStringAsync`/`decryptStringAsync`) over the synchronous API.
-> The async API is non-blocking, supports key rotation, and handles temporary unavailability gracefully.
-> The synchronous API may be deprecated in a future version of Electron.
+> The synchronous API (`isEncryptionAvailable`/`encryptString`/`decryptString`) is deprecated and will be
+> removed in Electron 46. Use the asynchronous API (`isAsyncEncryptionAvailable`/`encryptStringAsync`/`decryptStringAsync`),
+> which is non-blocking, supports key rotation, and handles temporary unavailability gracefully.
 
 ## Platform-Specific Key Providers
 
@@ -55,13 +55,23 @@ The `safeStorage` module emits the following events:
 
 The `safeStorage` module has the following methods:
 
-### `safeStorage.isEncryptionAvailable()`
+### `safeStorage.isEncryptionAvailable()` _Deprecated_
+
+<!--
+```YAML history
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/53670
+    breaking-changes-header: deprecated-safestorageisencryptionavailable-safestorageencryptstring-and-safestoragedecryptstring
+```
+-->
 
 Returns `boolean` - Whether encryption is available.
 
 On Linux, returns true if the app has emitted the `ready` event and the secret key is available.
 On MacOS, returns true if Keychain is available.
 On Windows, returns true once the app has emitted the `ready` event.
+
+**Deprecated:** Use [`safeStorage.isAsyncEncryptionAvailable()`](#safestorageisasyncencryptionavailable) instead.
 
 ### `safeStorage.isAsyncEncryptionAvailable()`
 
@@ -72,7 +82,15 @@ The asynchronous encryptor is initialized lazily the first time this method,
 `encryptStringAsync`, or `decryptStringAsync` is called after the app is ready.
 The returned promise resolves once initialization completes.
 
-### `safeStorage.encryptString(plainText)`
+### `safeStorage.encryptString(plainText)` _Deprecated_
+
+<!--
+```YAML history
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/53670
+    breaking-changes-header: deprecated-safestorageisencryptionavailable-safestorageencryptstring-and-safestoragedecryptstring
+```
+-->
 
 * `plainText` string
 
@@ -80,12 +98,25 @@ Returns `Buffer` -  An array of bytes representing the encrypted string.
 
 This function will throw an error if encryption fails.
 
-### `safeStorage.decryptString(encrypted)`
+**Deprecated:** Use [`safeStorage.encryptStringAsync(plainText)`](#safestorageencryptstringasyncplaintext) instead.
+
+### `safeStorage.decryptString(encrypted)` _Deprecated_
+
+<!--
+```YAML history
+deprecated:
+  - pr-url: https://github.com/electron/electron/pull/53670
+    breaking-changes-header: deprecated-safestorageisencryptionavailable-safestorageencryptstring-and-safestoragedecryptstring
+```
+-->
 
 * `encrypted` Buffer
 
 Returns `string` - the decrypted string. Decrypts the encrypted buffer
 obtained  with `safeStorage.encryptString` back into a string.
+
+**Deprecated:** Use [`safeStorage.decryptStringAsync(encrypted)`](#safestoragedecryptstringasyncencrypted) instead.
+Data encrypted with `safeStorage.encryptString` can be decrypted with `safeStorage.decryptStringAsync`.
 
 ### `safeStorage.encryptStringAsync(plainText)`
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -121,6 +121,28 @@ win.webContents.setWindowOpenHandler(() => ({
 Setting `nodeIntegration: true` in the override also makes the child unsandboxed and has
 the same effect.
 
+### Deprecated: `safeStorage.isEncryptionAvailable()`, `safeStorage.encryptString()` and `safeStorage.decryptString()`
+
+The synchronous `safeStorage` methods are deprecated and will be removed in
+Electron 46, following Chromium's removal of the synchronous OSCrypt backend
+they are built on. Use the asynchronous methods instead, which use the same
+per-platform key stores. Data encrypted with `safeStorage.encryptString()` can
+be decrypted with `safeStorage.decryptStringAsync()`.
+
+```js
+// Deprecated
+if (safeStorage.isEncryptionAvailable()) {
+  const encrypted = safeStorage.encryptString('secret')
+  const decrypted = safeStorage.decryptString(encrypted)
+}
+
+// Replace with
+if (await safeStorage.isAsyncEncryptionAvailable()) {
+  const encrypted = await safeStorage.encryptStringAsync('secret')
+  const { result: decrypted } = await safeStorage.decryptStringAsync(encrypted)
+}
+```
+
 ## Breaking API Changes (44.0)
 
 ### Behavior Changed: `webContents` may be `null` in `select-client-certificate`

--- a/lib/browser/api/safe-storage.ts
+++ b/lib/browser/api/safe-storage.ts
@@ -1,3 +1,29 @@
+import * as deprecate from '@electron/internal/common/deprecate';
+
 const { safeStorage } = process._linkedBinding('electron_browser_safe_storage');
+
+const isEncryptionAvailableDeprecated = deprecate.warnOnce(
+  'safeStorage.isEncryptionAvailable',
+  'safeStorage.isAsyncEncryptionAvailable'
+);
+const isEncryptionAvailable = safeStorage.isEncryptionAvailable.bind(safeStorage);
+safeStorage.isEncryptionAvailable = () => {
+  isEncryptionAvailableDeprecated();
+  return isEncryptionAvailable();
+};
+
+const encryptStringDeprecated = deprecate.warnOnce('safeStorage.encryptString', 'safeStorage.encryptStringAsync');
+const encryptString = safeStorage.encryptString.bind(safeStorage);
+safeStorage.encryptString = (plainText: string) => {
+  encryptStringDeprecated();
+  return encryptString(plainText);
+};
+
+const decryptStringDeprecated = deprecate.warnOnce('safeStorage.decryptString', 'safeStorage.decryptStringAsync');
+const decryptString = safeStorage.decryptString.bind(safeStorage);
+safeStorage.decryptString = (encrypted: Buffer) => {
+  decryptStringDeprecated();
+  return decryptString(encrypted);
+};
 
 export default safeStorage;

--- a/spec/api-safe-storage-spec.ts
+++ b/spec/api-safe-storage-spec.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { ifdescribe } from './lib/spec-helpers';
+import { expectWarningMessages } from './lib/warning-helpers';
 
 chai.use(chaiAsPromised);
 
@@ -25,6 +26,18 @@ describe('safeStorage module', () => {
     if (fs.existsSync(pathToEncryptedString)) {
       await fs.promises.rm(pathToEncryptedString, { force: true, recursive: true });
     }
+  });
+
+  it('emits deprecation warnings for the synchronous methods', async () => {
+    await expectWarningMessages(
+      () => {
+        safeStorage.isEncryptionAvailable();
+        safeStorage.decryptString(safeStorage.encryptString('plaintext'));
+      },
+      "(electron) 'safeStorage.isEncryptionAvailable' is deprecated and will be removed. Please use 'safeStorage.isAsyncEncryptionAvailable' instead.",
+      "(electron) 'safeStorage.encryptString' is deprecated and will be removed. Please use 'safeStorage.encryptStringAsync' instead.",
+      "(electron) 'safeStorage.decryptString' is deprecated and will be removed. Please use 'safeStorage.decryptStringAsync' instead."
+    );
   });
 
   describe('SafeStorage.isEncryptionAvailable()', () => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/51301

Chromium removed the synchronous OSCrypt backend in https://chromium-review.googlesource.com/c/chromium/src/+/7765593, which `safeStorage.isEncryptionAvailable()`, `encryptString()` and `decryptString()` sit on, and we currently carry a ~6.5k line revert to keep them working. Per https://github.com/electron/electron/pull/53662#issuecomment-5567985558 this deprecates the three synchronous methods in 45 so that they, and the revert patch, can be removed in 46 (#53662).

The methods keep working and log a one-time deprecation warning pointing at `isAsyncEncryptionAvailable()` / `encryptStringAsync()` / `decryptStringAsync()`. Data written with `encryptString()` decrypts with `decryptStringAsync()`, so apps can switch without re-encrypting anything. `setUsePlainTextEncryption()` and `getSelectedStorageBackend()` are unchanged.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Deprecated the synchronous `safeStorage.isEncryptionAvailable()`, `safeStorage.encryptString()` and `safeStorage.decryptString()` in favor of `isAsyncEncryptionAvailable()`, `encryptStringAsync()` and `decryptStringAsync()`.
