### PR TITLE
fix: attribute openExternal permission requests to the navigation's initiator

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1054,6 +1054,9 @@ void OnOpenExternal(const GURL& escaped_url, bool allowed) {
 void HandleExternalProtocolInUI(
     const GURL& url,
     content::WeakDocumentPtr document_ptr,
+    const std::optional<WebContentsPermissionHelper::ExternalProtocolRequester>&
+        initiator,
+    const std::optional<url::Origin>& initiating_origin,
     content::WebContents::OnceGetter web_contents_getter,
     bool has_user_gesture,
     bool is_primary_main_frame,
@@ -1067,12 +1070,32 @@ void HandleExternalProtocolInUI(
   if (!permission_helper)
     return;
 
+  // Who is asking to launch |url|:
+  //  * |rfh| is the document that started the navigation, if it still exists;
+  //    it is then the requester, exactly as for any other permission. It can
+  //    be gone by now (the navigation belongs to the navigating frame, e.g. a
+  //    popup, so its initiator can navigate away or be removed while a
+  //    redirect is in flight), and it is null for navigations the browser
+  //    started itself (e.g. webContents.loadURL()).
+  //  * |initiator| is that document's origin and main-frame-ness captured when
+  //    the request reached the browser, for use once the document is gone.
+  //  * |initiating_origin| is what content holds responsible: the origin that
+  //    redirected to |url| if there was a server redirect, otherwise the
+  //    initiator's origin; absent only for direct browser-initiated
+  //    navigations. It is the last resort when neither of the above exists,
+  //    and then isMainFrame describes the navigating frame.
+  // The navigating WebContents' main frame only ever anchors the request in
+  // those fallback cases; it is reported as the requester solely for direct
+  // browser-initiated navigations.
   content::RenderFrameHost* rfh = document_ptr.AsRenderFrameHostIfValid();
+  std::optional<WebContentsPermissionHelper::ExternalProtocolRequester>
+      requester;
   if (!rfh) {
-    // If the render frame host is not valid it means it was a top level
-    // navigation and the frame has already been disposed of.  In this case we
-    // take the current main frame and declare it responsible for the
-    // transition.
+    if (initiator) {
+      requester = initiator;
+    } else if (initiating_origin) {
+      requester.emplace(*initiating_origin, is_primary_main_frame);
+    }
     rfh = web_contents->GetPrimaryMainFrame();
   }
 
@@ -1102,8 +1125,8 @@ void HandleExternalProtocolInUI(
 
   GURL escaped_url(base::EscapeExternalHandlerValue(url.spec()));
   auto callback = base::BindOnce(&OnOpenExternal, escaped_url);
-  permission_helper->RequestOpenExternalPermission(rfh, std::move(callback),
-                                                   has_user_gesture, url);
+  permission_helper->RequestOpenExternalPermission(
+      rfh, std::move(callback), has_user_gesture, url, requester);
 }
 
 }  // namespace
@@ -1124,12 +1147,18 @@ bool ElectronBrowserClient::HandleExternalProtocol(
     mojo::PendingRemote<network::mojom::URLLoaderFactory>* out_factory) {
   content::GetUIThreadTaskRunner({})->PostTask(
       FROM_HERE,
-      base::BindOnce(&HandleExternalProtocolInUI, url,
-                     initiator_document
-                         ? initiator_document->GetWeakDocumentPtr()
-                         : content::WeakDocumentPtr(),
-                     std::move(web_contents_getter), has_user_gesture,
-                     is_primary_main_frame, sandbox_flags));
+      base::BindOnce(
+          &HandleExternalProtocolInUI, url,
+          initiator_document ? initiator_document->GetWeakDocumentPtr()
+                             : content::WeakDocumentPtr(),
+          initiator_document
+              ? std::make_optional<
+                    WebContentsPermissionHelper::ExternalProtocolRequester>(
+                    initiator_document->GetLastCommittedOrigin(),
+                    initiator_document->GetParent() == nullptr)
+              : std::nullopt,
+          initiating_origin, std::move(web_contents_getter), has_user_gesture,
+          is_primary_main_frame, sandbox_flags));
   return true;
 }
 

--- a/shell/browser/electron_permission_manager.cc
+++ b/shell/browser/electron_permission_manager.cc
@@ -255,8 +255,16 @@ void ElectronPermissionManager::RequestPermissionsWithDetails(
   int request_id = pending_requests_.Add(std::make_unique<PendingRequest>(
       render_frame_host, std::move(permissions), std::move(response_callback)));
 
-  details.Set("requestingUrl", render_frame_host->GetLastCommittedURL().spec());
-  details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
+  // The caller may already have attributed the request (see
+  // WebContentsPermissionHelper::RequestOpenExternalPermission); otherwise it
+  // comes from |render_frame_host|.
+  if (!details.Find("requestingUrl")) {
+    details.Set("requestingUrl",
+                render_frame_host->GetLastCommittedURL().spec());
+  }
+  if (!details.Find("isMainFrame")) {
+    details.Set("isMainFrame", render_frame_host->GetParent() == nullptr);
+  }
   base::Value dict_value(std::move(details));
 
   for (size_t i = 0; i < request_description.permissions.size(); ++i) {

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -235,7 +235,7 @@ void WebContentsPermissionHelper::RequestPermission(
   permission_manager->RequestPermissionWithDetails(
       content::PermissionDescriptorUtil::
           CreatePermissionDescriptorForPermissionType(permission),
-      requesting_frame, origin, false, std::move(details),
+      requesting_frame, origin, user_gesture, std::move(details),
       base::BindOnce(&OnPermissionResponse, std::move(callback)));
 }
 
@@ -337,9 +337,26 @@ void WebContentsPermissionHelper::RequestOpenExternalPermission(
     content::RenderFrameHost* requesting_frame,
     base::OnceCallback<void(bool)> callback,
     bool user_gesture,
-    const GURL& url) {
+    const GURL& url,
+    const std::optional<ExternalProtocolRequester>& requester) {
   base::DictValue details;
   details.Set("externalURL", url.spec());
+  if (requester) {
+    // |requesting_frame| only anchors the request; report who content holds
+    // responsible for the launch. An opaque origin is reported as "".
+    details.Set("requestingUrl", requester->origin.GetURL().spec());
+    details.Set("isMainFrame", requester->is_main_frame);
+    auto* permission_manager = static_cast<ElectronPermissionManager*>(
+        web_contents_->GetBrowserContext()->GetPermissionControllerDelegate());
+    permission_manager->RequestPermissionWithDetails(
+        content::PermissionDescriptorUtil::
+            CreatePermissionDescriptorForPermissionType(
+                blink::PermissionType::OPEN_EXTERNAL),
+        requesting_frame, requester->origin.GetURL(), user_gesture,
+        std::move(details),
+        base::BindOnce(&OnPermissionResponse, std::move(callback)));
+    return;
+  }
   RequestPermission(requesting_frame, blink::PermissionType::OPEN_EXTERNAL,
                     std::move(callback), user_gesture, std::move(details));
 }

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -5,11 +5,14 @@
 #ifndef ELECTRON_SHELL_BROWSER_WEB_CONTENTS_PERMISSION_HELPER_H_
 #define ELECTRON_SHELL_BROWSER_WEB_CONTENTS_PERMISSION_HELPER_H_
 
+#include <optional>
+
 #include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "content/public/browser/media_stream_request.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
+#include "url/origin.h"
 
 namespace electron {
 
@@ -40,10 +43,26 @@ class WebContentsPermissionHelper
   void RequestWebNotificationPermission(
       content::RenderFrameHost* requesting_frame,
       base::OnceCallback<void(bool)> callback);
-  void RequestOpenExternalPermission(content::RenderFrameHost* requesting_frame,
-                                     base::OnceCallback<void(bool)> callback,
-                                     bool user_gesture,
-                                     const GURL& url);
+  // Identity to report for an external protocol launch when the initiating
+  // document no longer exists: its origin (or, failing that, the origin
+  // content holds responsible) and whether it was a main frame.
+  struct ExternalProtocolRequester {
+    ExternalProtocolRequester(const url::Origin& origin, bool is_main_frame)
+        : origin(origin), is_main_frame(is_main_frame) {}
+    url::Origin origin;
+    bool is_main_frame;
+  };
+
+  // |requesting_frame| is the initiator document's frame, or the navigating
+  // WebContents' main frame if that document is gone or the browser started
+  // the navigation. With |requester| set, the request is reported with that
+  // origin and main-frame-ness instead of |requesting_frame|'s.
+  void RequestOpenExternalPermission(
+      content::RenderFrameHost* requesting_frame,
+      base::OnceCallback<void(bool)> callback,
+      bool user_gesture,
+      const GURL& url,
+      const std::optional<ExternalProtocolRequester>& requester = std::nullopt);
 
   // Synchronous Checks
   bool CheckMediaAccessPermission(content::RenderFrameHost* requesting_frame,

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -5394,6 +5394,158 @@ describe('iframe sandbox external protocols', () => {
   });
 });
 
+describe('external protocol permission attribution', () => {
+  // The document that starts a navigation to an external protocol can be gone
+  // by the time the browser handles it: the navigation lives in the navigating
+  // frame (here, a popup), not in its initiator. The openExternal permission
+  // request must not be attributed to whatever the popup's WebContents happens
+  // to have committed (here, the trusted top-level origin).
+  let trusted: http.Server;
+  let untrusted: http.Server;
+  let trustedUrl: string;
+  let untrustedUrl: string;
+
+  before(async () => {
+    untrusted = http.createServer((req, res) => {
+      if (req.url!.startsWith('/slow-redirect')) {
+        // Give the initiating iframe time to navigate away first.
+        setTimeout(600).then(() => {
+          res.writeHead(302, { Location: 'magnet:attribution-test' });
+          res.end();
+        });
+        return;
+      }
+      res.setHeader('Content-Type', 'text/html');
+      if (req.url === '/self') {
+        res.end('<script>location.href = "/slow-redirect"</script>');
+        return;
+      }
+      // Cross-origin iframe content: open a popup on the trusted origin, send
+      // it to the slow redirect, then leave.
+      res.end(`<script>
+        (async () => {
+          const trusted = decodeURIComponent(location.hash.slice(1));
+          const w = window.open(trusted + '/blank', 'popup');
+          await new Promise(r => setTimeout(r, 400));
+          w.location = location.origin + '/slow-redirect';
+          await new Promise(r => setTimeout(r, 100));
+          location.href = 'about:blank';
+        })();
+      </script>`);
+    });
+    untrustedUrl = (await listen(untrusted)).url.replace('127.0.0.1', 'localhost');
+    trusted = http.createServer((req, res) => {
+      res.setHeader('Content-Type', 'text/html');
+      if (req.url === '/blank') {
+        res.end('<p>trusted popup</p>');
+      } else {
+        res.end(`<iframe src="${untrustedUrl}/#${encodeURIComponent(trustedUrl)}"></iframe>`);
+      }
+    });
+    trustedUrl = (await listen(trusted)).url;
+  });
+
+  after(() => {
+    trusted.close();
+    untrusted.close();
+  });
+
+  afterEach(() => {
+    session.defaultSession.setPermissionRequestHandler(null);
+    return closeAllWindows();
+  });
+
+  it('does not report the popup main frame as the requester when the initiator is gone', async () => {
+    const w = new BrowserWindow({ show: false });
+    w.webContents.setWindowOpenHandler(() => ({
+      action: 'allow',
+      overrideBrowserWindowOptions: { show: false }
+    }));
+    const request = new Promise<any>((resolve) => {
+      session.defaultSession.setPermissionRequestHandler((_wc, permission, callback, details) => {
+        callback(false);
+        if (permission === 'openExternal') resolve(details);
+      });
+    });
+    await w.loadURL(trustedUrl);
+    const details = await request;
+    expect(details.externalURL).to.equal('magnet:attribution-test');
+    // Before the fix this was the trusted popup's URL with isMainFrame: true.
+    expect(details.requestingUrl).to.not.contain(new URL(trustedUrl).host);
+    expect(details.requestingUrl).to.equal(`${untrustedUrl}/`);
+    expect(details.isMainFrame).to.be.a('boolean');
+  });
+
+  it('keeps attributing a redirected navigation to the live document that started it', async () => {
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(`${trustedUrl}/blank`);
+    const request = new Promise<any>((resolve) => {
+      session.defaultSession.setPermissionRequestHandler((_wc, permission, callback, details) => {
+        callback(false);
+        if (permission === 'openExternal') resolve(details);
+      });
+    });
+    // The trusted main frame navigates itself to an untrusted URL that
+    // redirects to the external protocol; the requester is still that frame.
+    w.webContents.executeJavaScript(`location.href = ${JSON.stringify(untrustedUrl + '/slow-redirect')}; true`);
+    const details = await request;
+    expect(details.externalURL).to.equal('magnet:attribution-test');
+    expect(details.requestingUrl).to.equal(`${trustedUrl}/blank`);
+    expect(details.isMainFrame).to.equal(true);
+  });
+
+  it('attributes a redirected browser-initiated navigation to the redirecting origin', async () => {
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(`${trustedUrl}/blank`);
+    const request = new Promise<any>((resolve) => {
+      session.defaultSession.setPermissionRequestHandler((_wc, permission, callback, details) => {
+        callback(false);
+        if (permission === 'openExternal') resolve(details);
+      });
+    });
+    w.loadURL(`${untrustedUrl}/slow-redirect`).catch(() => {});
+    const details = await request;
+    expect(details.externalURL).to.equal('magnet:attribution-test');
+    // Not the previously committed trusted page.
+    expect(details.requestingUrl).to.equal(`${untrustedUrl}/`);
+    expect(details.isMainFrame).to.equal(true);
+  });
+
+  it('attributes a direct browser-initiated navigation to the navigating main frame', async () => {
+    const w = new BrowserWindow({ show: false });
+    await w.loadURL(`${trustedUrl}/blank`);
+    const request = new Promise<any>((resolve) => {
+      session.defaultSession.setPermissionRequestHandler((wc, permission, callback, details) => {
+        callback(false);
+        if (permission === 'openExternal') resolve({ wc, details });
+      });
+    });
+    w.loadURL('magnet:direct-test').catch(() => {});
+    const { wc, details } = await request;
+    expect(wc).to.equal(w.webContents);
+    expect(details.externalURL).to.equal('magnet:direct-test');
+    expect(details.requestingUrl).to.equal(`${trustedUrl}/blank`);
+    expect(details.isMainFrame).to.equal(true);
+  });
+
+  it('still attributes to the initiating frame while it is alive', async () => {
+    const w = new BrowserWindow({ show: false });
+    const request = new Promise<any>((resolve) => {
+      session.defaultSession.setPermissionRequestHandler((_wc, permission, callback, details) => {
+        callback(false);
+        if (permission === 'openExternal') resolve(details);
+      });
+    });
+    await w.loadURL(`data:text/html,<iframe src="${untrustedUrl}/self"></iframe>`);
+    // The iframe's own document navigates to the redirect and stays alive
+    // until it resolves, so attribution comes from that document.
+    const details = await request;
+    expect(details.externalURL).to.equal('magnet:attribution-test');
+    expect(details.requestingUrl).to.equal(`${untrustedUrl}/self`);
+    expect(details.isMainFrame).to.equal(false);
+  });
+});
+
 describe('iframe sandbox popups', () => {
   let server: http.Server;
   let serverUrl: string;


### PR DESCRIPTION
- When the document that started a navigation to an external protocol no longer exists, the `openExternal` permission request is reported with that document's origin (captured when the request reached the browser) as `requestingUrl`, instead of whatever the navigating WebContents has committed; `isMainFrame` then describes the navigating frame.
- Live initiators and direct browser-initiated navigations are attributed exactly as before; the request's user gesture is now passed through.
- Specs for detached initiators, redirects and browser-initiated navigations.

Notes: `openExternal` permission requests started by a frame that has since gone away are attributed to that frame's origin rather than to the navigating page.
