### PR TITLE
fix: require a registered source id for webContents capture via getUserMedia

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -2325,6 +2325,10 @@ Setting the WebRTC UDP Port Range allows you to restrict the udp port range used
 Returns `string` - The identifier of a WebContents stream. This identifier can be used
 with `navigator.mediaDevices.getUserMedia` using a `chromeMediaSource` of `tab`.
 The identifier is restricted to the web contents that it is registered to and is only valid for 10 seconds.
+The `desktop` source only accepts screen and window identifiers from
+[`desktopCapturer.getSources`](desktop-capturer.md#desktopcapturergetsourcesoptions);
+to capture a WebContents use this identifier with the `tab` source, or
+[`ses.setDisplayMediaRequestHandler`](session.md#sessetdisplaymediarequesthandlerhandler-opts).
 
 #### `contents.getOrCreateDevToolsTargetId()`
 

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -119,9 +119,14 @@ void HandleUserMediaRequest(const content::MediaStreamRequest& request,
         blink::MediaStreamDevice(request.video_type, "", "");
   } else if (request.video_type == MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE) {
     // If the DesktopMediaID can't be successfully parsed, throw an
-    // Invalid state error to match upstream.
+    // Invalid state error to match upstream. The `desktop` source only names
+    // screens and windows (ids from desktopCapturer.getSources()); a
+    // WebContents is captured through the `tab` source with an id from
+    // webContents.getMediaSourceId(), which is bound to the requesting
+    // contents, or through getDisplayMedia().
     auto dm_id = GetScreenId(request.requested_video_device_ids);
-    if (dm_id.is_null()) {
+    if (dm_id.is_null() ||
+        dm_id.type == content::DesktopMediaID::TYPE_WEB_CONTENTS) {
       std::move(callback).Run(blink::mojom::StreamDevicesSet(),
                               MediaStreamRequestResult::INVALID_STATE, nullptr);
       return;

--- a/spec/api-media-handler-spec.ts
+++ b/spec/api-media-handler-spec.ts
@@ -513,6 +513,22 @@ describe('setDisplayMediaRequestHandler', () => {
     expect(videoTrackCount).to.equal(1);
   });
 
+  it('does not capture a webContents through the desktop source with a raw web-contents id', async () => {
+    const sourceWindow = new BrowserWindow({ show: false });
+    const requestingWindow = new BrowserWindow({ show: false });
+    await Promise.all([sourceWindow.loadURL(serverUrl), requestingWindow.loadURL(serverUrl)]);
+    const { processId, routingId } = sourceWindow.webContents.mainFrame;
+    const rawId = `web-contents-media-stream://${processId}:${routingId}`;
+    const { ok, message } = await requestingWindow.webContents.executeJavaScript(`
+      navigator.mediaDevices.getUserMedia({
+        video: { mandatory: { chromeMediaSource: 'desktop', chromeMediaSourceId: ${JSON.stringify(rawId)} } }
+      }).then((stream) => { stream.getTracks().forEach((t) => t.stop()); return { ok: true }; },
+              (e) => ({ ok: false, message: e.message }))
+    `);
+    expect(ok).to.be.false();
+    expect(message).to.equal('Invalid state');
+  });
+
   it('rejects a tab source id when used from a different requesting webContents', async () => {
     const sourceWindow = new BrowserWindow({ show: false });
     const registeredRequesterWindow = new BrowserWindow({ show: false });


### PR DESCRIPTION
- The legacy `chromeMediaSource: 'desktop'` `getUserMedia` constraint accepts screen and window source ids only; a `web-contents-media-stream://` id there is rejected with "Invalid state".
- Capturing a WebContents keeps working through `chromeMediaSource: 'tab'` with an id from `webContents.getMediaSourceId()` (bound to the requesting contents) and through `setDisplayMediaRequestHandler`.
- Spec and a `getMediaSourceId` doc note.

Notes: `getUserMedia` with `chromeMediaSource: 'desktop'` no longer accepts WebContents source ids; use `chromeMediaSource: 'tab'` with `webContents.getMediaSourceId()` or `setDisplayMediaRequestHandler` to capture a WebContents.
