### PR TITLE
fix: report the requesting frame for hid and usb permission checks (44-x-y)

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -991,7 +991,7 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
 #### `ses.setPermissionCheckHandler(handler)`
 
 * `handler` Function\<boolean> | null
-  * `webContents` ([WebContents](web-contents.md) | null) - WebContents checking the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.  All cross origin sub frames making permission checks will pass a `null` webContents to this handler, while certain other permission checks such as `notifications` checks will always pass `null`.  You should use `embeddingOrigin` and `requestingOrigin` to determine what origin the owning frame and the requesting frame are on respectively.
+  * `webContents` ([WebContents](web-contents.md) | null) - WebContents that contains the frame checking the permission. This is `null` when the check is not made on behalf of a document, for example for a service worker or for a `notifications` check. If the check comes from a subframe, `webContents` is the top-level WebContents; use `requestingOrigin`, `requestingUrl` and `isMainFrame` to identify the frame that is asking.
   * `permission` string - Type of permission check. Electron forwards every permission type that Chromium checks, so this list mirrors Chromium's permission types and includes some that have no effect on desktop or are only used by specific platforms or features.
     * `ar` - Access to augmented reality sessions via the [WebXR Device API](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API).
     * `automatic-fullscreen` - Enter fullscreen without a prior user gesture (Chromium's automatic fullscreen content setting).
@@ -1042,10 +1042,10 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
   * `requestingOrigin` string - The origin URL of the permission check
   * `details` Object - Some properties are only available on certain permission types.
     * `embeddingOrigin` string (optional) - The origin of the frame embedding the frame that made the permission check.  Only set for cross-origin sub frames making permission checks.
-    * `securityOrigin` string (optional) - The security origin of the `media` check.
+    * `securityOrigin` string (optional) - The origin of the requesting frame, for `media`, `hid`, `usb` and `serial` checks.
     * `mediaType` string (optional) - The type of media access being requested, can be `video`,
       `audio` or `unknown`.
-    * `requestingUrl` string (optional) - The last URL the requesting frame loaded.  This is not provided for cross-origin sub frames making permission checks.
+    * `requestingUrl` string (optional) - The last URL the requesting frame loaded. Not provided when the check is not made on behalf of a document (for example for a service worker).
     * `isMainFrame` boolean - Whether the frame making the request is the main frame.
     * `filePath` string (optional) - The path of a `fileSystem` request.
     * `isDirectory` boolean (optional) - Whether a `fileSystem` request is a directory.

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -178,3 +178,5 @@ cherry-pick-92e11f6fe0.patch
 cherry-pick-4dfbc081b5.patch
 cherry-pick-4d2a827481.patch
 fix_register_status_icon_with_unique_d-bus_name_when_owning_one.patch
+webhid_webusb_pass_the_frame_to_canrequestdevicepermission.patch
+webhid_webusb_key_document_services_on_the_requesting_frame_s_origin.patch

--- a/patches/chromium/webhid_webusb_key_document_services_on_the_requesting_frame_s_origin.patch
+++ b/patches/chromium/webhid_webusb_key_document_services_on_the_requesting_frame_s_origin.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sam@electronjs.org>
+Date: Mon, 7 Sep 2026 06:09:36 +0000
+Subject: [WebHID][WebUSB] Key document services on the requesting frame's
+ origin
+
+HidService and WebUsbServiceImpl are constructed with the primary main
+frame's origin, which is the principal Chrome grants device permissions
+to (delegation via permissions policy). Electron grants, checks and
+revokes device permissions per requesting document, and reports that
+document to the app. Construct both services with the requesting
+frame's origin so that every delegate call content makes for a document
+(CanRequestDevicePermission, HasDevicePermission,
+RevokeDevicePermission[WebInitiated], IsFidoAllowedForOrigin,
+AdjustProtectedInterfaceClasses) and the OnPermissionRevoked comparison
+use the same origin the grant was stored under.
+
+This is specific to Electron's permission model and is not intended for
+upstream.
+
+diff --git a/content/browser/hid/hid_service.cc b/content/browser/hid/hid_service.cc
+index 12be56457d7df9123aed7194d2c4a4bfe03b07a5..fddd2108d40a896ca0db7524b3b5f798e0dd12fa 100644
+--- a/content/browser/hid/hid_service.cc
++++ b/content/browser/hid/hid_service.cc
+@@ -117,7 +117,7 @@ HidService::HidService(
+ HidService::HidService(RenderFrameHostImpl* render_frame_host)
+     : HidService(render_frame_host,
+                  /*service_worker_version=*/nullptr,
+-                 render_frame_host->GetMainFrame()->GetLastCommittedOrigin()) {}
++                 render_frame_host->GetLastCommittedOrigin()) {}
+ 
+ HidService::HidService(
+     base::WeakPtr<ServiceWorkerVersion> service_worker_version,
+diff --git a/content/browser/usb/web_usb_service_impl.cc b/content/browser/usb/web_usb_service_impl.cc
+index 91822eda5b25a2e696e94326ded5e14df647cadf..6b53067182094da7899f14ac09c3c448035adb81 100644
+--- a/content/browser/usb/web_usb_service_impl.cc
++++ b/content/browser/usb/web_usb_service_impl.cc
+@@ -203,7 +203,7 @@ void WebUsbServiceImpl::Create(
+       std::make_unique<WebUsbServiceImpl>(
+           &render_frame_host,
+           /*service_worker_version=*/nullptr,
+-          render_frame_host.GetMainFrame()->GetLastCommittedOrigin()),
++          render_frame_host.GetLastCommittedOrigin()),
+       render_frame_host, std::move(pending_receiver));
+ }
+ 

--- a/patches/chromium/webhid_webusb_pass_the_frame_to_canrequestdevicepermission.patch
+++ b/patches/chromium/webhid_webusb_pass_the_frame_to_canrequestdevicepermission.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Sun, 6 Sep 2026 17:49:35 +0000
+Subject: [WebHID][WebUSB] Pass the frame to CanRequestDevicePermission()
+
+HidDelegate::CanRequestDevicePermission() and
+UsbDelegate::CanRequestDevicePermission() take only a BrowserContext and
+an origin, while the sibling methods on the same delegates
+(HasDevicePermission(), RevokeDevicePermission(), RunChooser(),
+AdjustProtectedInterfaceClasses()) also receive the RenderFrameHost.
+An embedder that scopes device permission checks to the requesting
+document therefore cannot tell which frame is asking in the "can
+request" step, even though it can in every later step.
+
+Add a RenderFrameHost* parameter to both methods, in the same position
+as in HasDevicePermission(). HidService and WebUsbServiceImpl pass
+their render_frame_host_, which is null for service worker clients, as
+HasDevicePermission() already documents. ChromeHidDelegate and
+ChromeUsbDelegate ignore the new argument and keep evaluating the
+top-level origin they are given, so there is no behavior change in
+Chrome.
+
+Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/8364427;
+remove this patch when it rolls in.
+
+diff --git a/chrome/browser/hid/chrome_hid_delegate.cc b/chrome/browser/hid/chrome_hid_delegate.cc
+index 25e2cdb623a1d9d6aba647b0623f43e6918e871c..f73abd1202f2d4365b367f4aa3b2500679fb662e 100644
+--- a/chrome/browser/hid/chrome_hid_delegate.cc
++++ b/chrome/browser/hid/chrome_hid_delegate.cc
+@@ -236,6 +236,7 @@ std::unique_ptr<content::HidChooser> ChromeHidDelegate::RunChooser(
+ 
+ bool ChromeHidDelegate::CanRequestDevicePermission(
+     content::BrowserContext* browser_context,
++    content::RenderFrameHost* render_frame_host,
+     const url::Origin& origin) {
+   return browser_context &&
+          GetChooserContext(browser_context)->CanRequestObjectPermission(origin);
+@@ -397,7 +398,7 @@ void ChromeHidDelegate::OnWebViewHidPermissionRequestCompleted(
+ 
+   auto* browser_context = render_frame_host->GetBrowserContext();
+   auto origin = render_frame_host->GetMainFrame()->GetLastCommittedOrigin();
+-  if (!CanRequestDevicePermission(browser_context, origin)) {
++  if (!CanRequestDevicePermission(browser_context, render_frame_host, origin)) {
+     std::move(callback).Run(/*devices=*/{});
+     return;
+   }
+diff --git a/chrome/browser/hid/chrome_hid_delegate.h b/chrome/browser/hid/chrome_hid_delegate.h
+index 4e3d99091ee5c0ac5ffd6d76758da6397574cabe..0edc5e93760ce8b4e453dcd63ec9aaa7e27ba67d 100644
+--- a/chrome/browser/hid/chrome_hid_delegate.h
++++ b/chrome/browser/hid/chrome_hid_delegate.h
+@@ -39,6 +39,7 @@ class ChromeHidDelegate : public content::HidDelegate {
+       std::vector<blink::mojom::HidDeviceFilterPtr> exclusion_filters,
+       content::HidChooser::Callback callback) override;
+   bool CanRequestDevicePermission(content::BrowserContext* browser_context,
++                                  content::RenderFrameHost* render_frame_host,
+                                   const url::Origin& origin) override;
+   bool HasDevicePermission(content::BrowserContext* browser_context,
+                            content::RenderFrameHost* render_frame_host,
+diff --git a/chrome/browser/hid/chrome_hid_delegate_unittest.cc b/chrome/browser/hid/chrome_hid_delegate_unittest.cc
+index 1f83bb4359d749d0f2a547d975aa51bd15a2efed..fd1bd69835962b754e6c230cae94aefcda40cb04 100644
+--- a/chrome/browser/hid/chrome_hid_delegate_unittest.cc
++++ b/chrome/browser/hid/chrome_hid_delegate_unittest.cc
+@@ -1284,7 +1284,7 @@ TEST(ChromeHidDelegateBrowserContextTest, BrowserContextIsNull) {
+   ChromeHidDelegate chrome_hid_delegate;
+   url::Origin origin = url::Origin::Create(GURL(kDefaultTestUrl));
+   EXPECT_FALSE(chrome_hid_delegate.CanRequestDevicePermission(
+-      /*browser_context=*/nullptr, origin));
++      /*browser_context=*/nullptr, /*render_frame_host=*/nullptr, origin));
+   EXPECT_FALSE(chrome_hid_delegate.HasDevicePermission(
+       /*browser_context=*/nullptr, /*render_frame_host=*/nullptr, origin,
+       device::mojom::HidDeviceInfo()));
+diff --git a/chrome/browser/usb/chrome_usb_delegate.cc b/chrome/browser/usb/chrome_usb_delegate.cc
+index c34387a5e63299901e6e32e1b5a43e0b08b8d814..f0c2b7398cbec947acb3869b5e8d05e0c921c389 100644
+--- a/chrome/browser/usb/chrome_usb_delegate.cc
++++ b/chrome/browser/usb/chrome_usb_delegate.cc
+@@ -294,6 +294,7 @@ bool ChromeUsbDelegate::PageMayUseUsb(content::Page& page) {
+ 
+ bool ChromeUsbDelegate::CanRequestDevicePermission(
+     content::BrowserContext* browser_context,
++    content::RenderFrameHost* frame,
+     const url::Origin& origin) {
+   return browser_context &&
+          GetChooserContext(browser_context)->CanRequestObjectPermission(origin);
+diff --git a/chrome/browser/usb/chrome_usb_delegate.h b/chrome/browser/usb/chrome_usb_delegate.h
+index 0f8281c843aff6b095eed4176455f4e5c1b3bc97..190c8ad7733aa90dede09551f4ecf18e4cd18466 100644
+--- a/chrome/browser/usb/chrome_usb_delegate.h
++++ b/chrome/browser/usb/chrome_usb_delegate.h
+@@ -39,6 +39,7 @@ class ChromeUsbDelegate : public content::UsbDelegate {
+       blink::mojom::WebUsbService::GetPermissionCallback callback) override;
+   bool PageMayUseUsb(content::Page& page) override;
+   bool CanRequestDevicePermission(content::BrowserContext* browser_context,
++                                  content::RenderFrameHost* frame,
+                                   const url::Origin& origin) override;
+   void RevokeDevicePermissionWebInitiated(
+       content::BrowserContext* browser_context,
+diff --git a/chrome/browser/usb/chrome_usb_delegate_unittest.cc b/chrome/browser/usb/chrome_usb_delegate_unittest.cc
+index 9463c12f2ab56c4bf04f80d0dd4ae7c4bad36891..f13ddc2c177b1d2ee90fd298fe16955364d01d14 100644
+--- a/chrome/browser/usb/chrome_usb_delegate_unittest.cc
++++ b/chrome/browser/usb/chrome_usb_delegate_unittest.cc
+@@ -1057,7 +1057,7 @@ TEST(ChromeUsbDelegateBrowserContextTest, BrowserContextIsNull) {
+   ChromeUsbDelegate chrome_usb_delegate;
+   url::Origin origin = url::Origin::Create(GURL(kDefaultTestUrl));
+   EXPECT_FALSE(chrome_usb_delegate.CanRequestDevicePermission(
+-      /*browser_context=*/nullptr, origin));
++      /*browser_context=*/nullptr, /*frame=*/nullptr, origin));
+   EXPECT_FALSE(chrome_usb_delegate.HasDevicePermission(
+       /*browser_context=*/nullptr, /*frame=*/nullptr, origin,
+       device::mojom::UsbDeviceInfo()));
+diff --git a/content/browser/hid/hid_service.cc b/content/browser/hid/hid_service.cc
+index fe153f8623005d5b093c2532c6b57fe91e24a89c..12be56457d7df9123aed7194d2c4a4bfe03b07a5 100644
+--- a/content/browser/hid/hid_service.cc
++++ b/content/browser/hid/hid_service.cc
+@@ -419,7 +419,8 @@ void HidService::RequestDevice(
+     RequestDeviceCallback callback) {
+   HidDelegate* delegate = GetContentClient()->browser()->GetHidDelegate();
+   if (!render_frame_host_ ||
+-      !delegate->CanRequestDevicePermission(GetBrowserContext(), origin_)) {
++      !delegate->CanRequestDevicePermission(GetBrowserContext(),
++                                            render_frame_host_, origin_)) {
+     std::move(callback).Run(std::vector<device::mojom::HidDeviceInfoPtr>());
+     return;
+   }
+diff --git a/content/browser/hid/hid_test_utils.h b/content/browser/hid/hid_test_utils.h
+index 86db539c1719da7e879f87ec6642de8a02a6f808..c4db21810c0764e76dc338002a969e344ed6499e 100644
+--- a/content/browser/hid/hid_test_utils.h
++++ b/content/browser/hid/hid_test_utils.h
+@@ -56,7 +56,7 @@ class MockHidDelegate : public HidDelegate {
+               ());
+   MOCK_METHOD(bool,
+               CanRequestDevicePermission,
+-              (BrowserContext*, const url::Origin&));
++              (BrowserContext*, RenderFrameHost*, const url::Origin&));
+   MOCK_METHOD(bool,
+               HasDevicePermission,
+               (BrowserContext*,
+diff --git a/content/browser/usb/usb_test_utils.h b/content/browser/usb/usb_test_utils.h
+index 0c6a091a224fcbb26bb134accf69d42e191e6041..f93b6402c1366d8a34da5e5d5e5268a94d99a98c 100644
+--- a/content/browser/usb/usb_test_utils.h
++++ b/content/browser/usb/usb_test_utils.h
+@@ -99,8 +99,8 @@ class MockUsbDelegate : public UsbDelegate {
+                     RenderFrameHost*,
+                     std::vector<uint8_t>&));
+   MOCK_METHOD1(PageMayUseUsb, bool(Page&));
+-  MOCK_METHOD2(CanRequestDevicePermission,
+-               bool(BrowserContext*, const url::Origin&));
++  MOCK_METHOD3(CanRequestDevicePermission,
++               bool(BrowserContext*, RenderFrameHost*, const url::Origin&));
+   MOCK_METHOD3(RevokeDevicePermissionWebInitiated,
+                void(BrowserContext*,
+                     const url::Origin&,
+diff --git a/content/browser/usb/web_usb_service_impl.cc b/content/browser/usb/web_usb_service_impl.cc
+index 389c9cfbe0a55730e2daa191d13a5c5fbda223c0..91822eda5b25a2e696e94326ded5e14df647cadf 100644
+--- a/content/browser/usb/web_usb_service_impl.cc
++++ b/content/browser/usb/web_usb_service_impl.cc
+@@ -333,8 +333,8 @@ void WebUsbServiceImpl::GetPermission(
+     blink::mojom::WebUsbRequestDeviceOptionsPtr options,
+     GetPermissionCallback callback) {
+   auto* delegate = GetContentClient()->browser()->GetUsbDelegate();
+-  if (!delegate ||
+-      !delegate->CanRequestDevicePermission(GetBrowserContext(), origin_)) {
++  if (!delegate || !delegate->CanRequestDevicePermission(
++                       GetBrowserContext(), render_frame_host_, origin_)) {
+     std::move(callback).Run(nullptr);
+     return;
+   }
+diff --git a/content/public/browser/hid_delegate.h b/content/public/browser/hid_delegate.h
+index cb1c313bea2bd7269f9560cd613a09596585fc95..27246a32e71222bb11339e81598a6a48efbfee02 100644
+--- a/content/public/browser/hid_delegate.h
++++ b/content/public/browser/hid_delegate.h
+@@ -57,7 +57,10 @@ class CONTENT_EXPORT HidDelegate {
+       HidChooser::Callback callback) = 0;
+ 
+   // Returns whether `origin` has permission to request access to a device.
++  // `render_frame_host` is the frame making the request, or null when there
++  // is none (for example, for a service worker).
+   virtual bool CanRequestDevicePermission(BrowserContext* browser_context,
++                                          RenderFrameHost* render_frame_host,
+                                           const url::Origin& origin) = 0;
+ 
+   // Returns whether `origin` has permission to access `device`.
+diff --git a/content/public/browser/usb_delegate.h b/content/public/browser/usb_delegate.h
+index fb8aec0347674b349058bf75849abf62a5b39ba9..7621fdcf0b52caaa0b9388826a2c12c018977bca 100644
+--- a/content/public/browser/usb_delegate.h
++++ b/content/public/browser/usb_delegate.h
+@@ -68,8 +68,10 @@ class CONTENT_EXPORT UsbDelegate {
+   virtual bool PageMayUseUsb(Page& page) = 0;
+ 
+   // Returns whether `origin` in `browser_context` has permission to request
+-  // access to a device.
++  // access to a device. `frame` is the frame making the request, or null when
++  // there is none (for example, for a service worker).
+   virtual bool CanRequestDevicePermission(BrowserContext* browser_context,
++                                          RenderFrameHost* frame,
+                                           const url::Origin& origin) = 0;
+ 
+   // Attempts to revoke the permission for `origin` in `browser_context` to

--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -9,6 +9,7 @@
 
 #include "base/scoped_observation.h"
 #include "chrome/common/chrome_features.h"
+#include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/buildflags/buildflags.h"
 #include "services/device/public/cpp/hid/hid_switches.h"
@@ -33,6 +34,14 @@ electron::HidChooserContext* GetChooserContext(
     return nullptr;
   return electron::HidChooserContextFactory::GetForBrowserContext(
       browser_context);
+}
+
+// The origin device permissions are scoped to: the requesting document's, or
+// for a service worker (no frame) the origin content keyed the service on.
+const url::Origin& RequestingOrigin(content::RenderFrameHost* render_frame_host,
+                                    const url::Origin& service_origin) {
+  return render_frame_host ? render_frame_host->GetLastCommittedOrigin()
+                           : service_origin;
 }
 
 }  // namespace
@@ -135,16 +144,20 @@ std::unique_ptr<content::HidChooser> ElectronHidDelegate::RunChooser(
 
 bool ElectronHidDelegate::CanRequestDevicePermission(
     content::BrowserContext* browser_context,
+    content::RenderFrameHost* render_frame_host,
     const url::Origin& origin) {
   if (!browser_context)
     return false;
 
+  const url::Origin& requesting_origin =
+      RequestingOrigin(render_frame_host, origin);
   base::DictValue details;
-  details.Set("securityOrigin", origin.GetURL().spec());
+  details.Set("securityOrigin", requesting_origin.GetURL().spec());
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
       browser_context->GetPermissionControllerDelegate());
   return permission_manager->CheckPermissionWithDetails(
-      blink::PermissionType::HID, nullptr, origin.GetURL(), std::move(details));
+      blink::PermissionType::HID, render_frame_host, requesting_origin.GetURL(),
+      std::move(details));
 }
 
 bool ElectronHidDelegate::HasDevicePermission(
@@ -152,8 +165,10 @@ bool ElectronHidDelegate::HasDevicePermission(
     content::RenderFrameHost* render_frame_host,
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
-  return browser_context && GetChooserContext(browser_context)
-                                ->HasDevicePermission(origin, device);
+  return browser_context &&
+         GetChooserContext(browser_context)
+             ->HasDevicePermission(RequestingOrigin(render_frame_host, origin),
+                                   device);
 }
 
 void ElectronHidDelegate::RevokeDevicePermission(
@@ -162,7 +177,9 @@ void ElectronHidDelegate::RevokeDevicePermission(
     const url::Origin& origin,
     const device::mojom::HidDeviceInfo& device) {
   if (browser_context) {
-    GetChooserContext(browser_context)->RevokeDevicePermission(origin, device);
+    GetChooserContext(browser_context)
+        ->RevokeDevicePermission(RequestingOrigin(render_frame_host, origin),
+                                 device);
   }
 }
 

--- a/shell/browser/hid/electron_hid_delegate.h
+++ b/shell/browser/hid/electron_hid_delegate.h
@@ -40,6 +40,7 @@ class ElectronHidDelegate : public content::HidDelegate {
       std::vector<blink::mojom::HidDeviceFilterPtr> exclusion_filters,
       content::HidChooser::Callback callback) override;
   bool CanRequestDevicePermission(content::BrowserContext* browser_context,
+                                  content::RenderFrameHost* render_frame_host,
                                   const url::Origin& origin) override;
   bool HasDevicePermission(content::BrowserContext* browser_context,
                            content::RenderFrameHost* render_frame_host,

--- a/shell/browser/usb/electron_usb_delegate.cc
+++ b/shell/browser/usb/electron_usb_delegate.cc
@@ -82,6 +82,13 @@ bool IsDevicePermissionAutoGranted(
   return false;
 }
 
+// The origin device permissions are scoped to: the requesting document's, or
+// for a service worker (no frame) the origin content keyed the service on.
+const url::Origin& RequestingOrigin(content::RenderFrameHost* frame,
+                                    const url::Origin& service_origin) {
+  return frame ? frame->GetLastCommittedOrigin() : service_origin;
+}
+
 }  // namespace
 
 namespace electron {
@@ -174,16 +181,19 @@ std::unique_ptr<content::UsbChooser> ElectronUsbDelegate::RunChooser(
 
 bool ElectronUsbDelegate::CanRequestDevicePermission(
     content::BrowserContext* browser_context,
+    content::RenderFrameHost* frame,
     const url::Origin& origin) {
   if (!browser_context)
     return false;
 
+  const url::Origin& requesting_origin = RequestingOrigin(frame, origin);
   base::DictValue details;
-  details.Set("securityOrigin", origin.GetURL().spec());
+  details.Set("securityOrigin", requesting_origin.GetURL().spec());
   auto* permission_manager = static_cast<ElectronPermissionManager*>(
       browser_context->GetPermissionControllerDelegate());
   return permission_manager->CheckPermissionWithDetails(
-      blink::PermissionType::USB, nullptr, origin.GetURL(), std::move(details));
+      blink::PermissionType::USB, frame, requesting_origin.GetURL(),
+      std::move(details));
 }
 
 void ElectronUsbDelegate::RevokeDevicePermissionWebInitiated(
@@ -210,15 +220,13 @@ bool ElectronUsbDelegate::HasDevicePermission(
     content::RenderFrameHost* frame,
     const url::Origin& origin,
     const device::mojom::UsbDeviceInfo& device_info) {
-  if (IsDevicePermissionAutoGranted(origin, device_info))
+  const url::Origin& requesting_origin = RequestingOrigin(frame, origin);
+  if (IsDevicePermissionAutoGranted(requesting_origin, device_info))
     return true;
 
   auto* chooser_context = GetChooserContext(browser_context);
-  if (!chooser_context)
-    return false;
-
-  return GetChooserContext(browser_context)
-      ->HasDevicePermission(origin, device_info);
+  return chooser_context &&
+         chooser_context->HasDevicePermission(requesting_origin, device_info);
 }
 
 void ElectronUsbDelegate::GetDevices(

--- a/shell/browser/usb/electron_usb_delegate.h
+++ b/shell/browser/usb/electron_usb_delegate.h
@@ -53,6 +53,7 @@ class ElectronUsbDelegate : public content::UsbDelegate {
       blink::mojom::WebUsbRequestDeviceOptionsPtr options,
       blink::mojom::WebUsbService::GetPermissionCallback callback) override;
   bool CanRequestDevicePermission(content::BrowserContext* browser_context,
+                                  content::RenderFrameHost* frame,
                                   const url::Origin& origin) override;
   void RevokeDevicePermissionWebInitiated(
       content::BrowserContext* browser_context,

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -2081,6 +2081,58 @@ describe('session module', () => {
         ses.setPermissionCheckHandler(null);
       }
     });
+
+    for (const [permission, api] of [
+      ['hid', 'navigator.hid.requestDevice({ filters: [] })'],
+      ['usb', 'navigator.usb.requestDevice({ filters: [] })']
+    ] as const) {
+      it(`provides iframe origin as requestingOrigin for ${permission} check from cross-origin subFrame`, async () => {
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            partition: `very-temp-permission-handler-${permission}`
+          }
+        });
+        const ses = w.webContents.session;
+        const iframeUrl = 'https://myfakesite/';
+        let captured: { origin: string; webContents: Electron.WebContents | null; details: any } | undefined;
+
+        ses.protocol.interceptStringProtocol('https', (req, cb) => {
+          cb('<html><body>iframe</body></html>');
+        });
+
+        ses.setPermissionCheckHandler((wc, perm, requestingOrigin, details) => {
+          if (perm === permission) {
+            captured = { origin: requestingOrigin, webContents: wc, details };
+          }
+          return false;
+        });
+
+        try {
+          await w.loadFile(path.join(fixtures, 'api', 'blank.html'));
+          w.webContents.executeJavaScript(`
+            var iframe = document.createElement('iframe');
+            iframe.src = '${iframeUrl}';
+            iframe.allow = '${permission}';
+            document.body.appendChild(iframe);
+            null;
+          `);
+          const [, , frameProcessId, frameRoutingId] = await once(w.webContents, 'did-frame-finish-load');
+          const frame = webFrameMain.fromId(frameProcessId, frameRoutingId)!;
+          await frame.executeJavaScript(`${api}.then(() => {}).catch(() => {});`, true);
+
+          expect(captured).to.not.be.undefined();
+          expect(captured!.origin).to.equal(iframeUrl);
+          expect(captured!.webContents).to.equal(w.webContents);
+          expect(captured!.details.isMainFrame).to.be.false();
+          expect(captured!.details.requestingUrl).to.equal(iframeUrl);
+          expect(captured!.details.securityOrigin).to.equal(iframeUrl);
+        } finally {
+          ses.protocol.uninterceptProtocol('https');
+          ses.setPermissionCheckHandler(null);
+        }
+      });
+    }
   });
 
   describe('ses.isPersistent()', () => {


### PR DESCRIPTION
Backport of #53656

See that PR for details. The Chromium patch is regenerated against M152 (`HidService::RequestDevice` differs).

Notes: Fixed `session.setPermissionCheckHandler` receiving the top-level origin and a null `webContents` for `hid` and `usb` checks made from a subframe.
