### PR TITLE
fix: scope File System Access grants to the requesting document (43-x-y)

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -149,6 +149,14 @@ initialized to support the start of the extension's background page.
 
 #### Event: 'file-system-access-restricted'
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53666
+    description: "Added `details.frame` and `details.webContents`; emitted once per requesting document instead of once per path."
+```
+-->
+
 Returns:
 
 * `event` Event
@@ -156,6 +164,8 @@ Returns:
   * `origin` string - The origin that initiated access to the blocked path.
   * `isDirectory` boolean - Whether or not the path is a directory.
   * `path` string - The blocked path attempting to be accessed.
+  * `frame` [WebFrameMain](web-frame-main.md) | null - The frame that initiated access. May be `null` if the frame has since been destroyed.
+  * `webContents` [WebContents](web-contents.md) | null - The WebContents that contains `frame`.
 * `callback` Function
   * `action` string - The action to take as a result of the restricted path access attempt.
     * `allow` - This will allow `path` to be accessed despite restricted status.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -113,6 +113,7 @@
 #include "shell/browser/electron_navigation_throttle.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/file_select_helper.h"
+#include "shell/browser/file_system_access/file_system_access_web_contents_helper.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/osr/osr_render_widget_host_view.h"
 #include "shell/browser/osr/osr_web_contents_view.h"
@@ -1141,6 +1142,7 @@ void WebContents::InitWithWebContents(
   // As the delegate we route permission checks through this helper, so every
   // adopted WebContents (including extension background pages) needs one.
   WebContentsPermissionHelper::CreateForWebContents(web_contents.get());
+  FileSystemAccessWebContentsHelper::CreateForWebContents(web_contents.get());
 
   // A <webview> guest is created with a copy of its embedder's renderer
   // preferences, so caret browsing may already be enabled. Every path that

--- a/shell/browser/file_system_access/file_system_access_permission_context.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context.cc
@@ -32,10 +32,13 @@
 #include "content/public/browser/web_contents.h"
 #include "gin/data_object_builder.h"
 #include "shell/browser/api/electron_api_session.h"
+#include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/electron_permission_manager.h"
 #include "shell/browser/web_contents_permission_helper.h"
 #include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_converters/frame_converter.h"
 #include "third_party/blink/public/common/features_generated.h"
 #include "third_party/blink/public/mojom/file_system_access/file_system_access_manager.mojom.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -345,12 +348,16 @@ class FileSystemAccessPermissionContext::PermissionGrantImpl
       return;
     }
 
-    auto origin = rfh->GetLastCommittedOrigin().GetURL();
-    if (url::Origin::Create(origin) != origin_) {
-      // Third party iframes are not allowed to request more permissions.
+    // Third party iframes are not allowed to request more permissions: the
+    // grant belongs to |origin_|, and only a top-level document of that origin
+    // may ask to widen it.
+    const url::Origin embedding_origin =
+        rfh->GetMainFrame()->GetLastCommittedOrigin();
+    if (embedding_origin != origin_) {
       std::move(callback).Run(PermissionRequestOutcome::kThirdPartyContext);
       return;
     }
+    auto origin = rfh->GetLastCommittedOrigin().GetURL();
 
     auto* permission_manager =
         static_cast<electron::ElectronPermissionManager*>(
@@ -698,14 +705,15 @@ void FileSystemAccessPermissionContext::ConfirmSensitiveEntryAccess(
     base::OnceCallback<void(SensitiveEntryResult)> callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
-  auto [it, inserted] = callback_map_.try_emplace(path_info.path);
-  it->second.push_back(std::move(callback));
-  if (!inserted)
-    return;
-
+  // Every request is checked and, if needed, confirmed with the app on its
+  // own, so the app sees each requesting origin/frame and one requester's
+  // answer is never applied to another's.
+  const int request_id = next_restricted_path_request_id_++;
+  restricted_path_callbacks_.emplace(request_id, std::move(callback));
   auto after_blocklist_check_callback = base::BindOnce(
       &FileSystemAccessPermissionContext::DidCheckPathAgainstBlocklist,
-      GetWeakPtr(), origin, path_info, handle_type, user_action, frame_id);
+      GetWeakPtr(), request_id, origin, path_info, handle_type, user_action,
+      frame_id);
   CheckPathAgainstBlocklist(path_info, handle_type,
                             std::move(after_blocklist_check_callback));
 }
@@ -771,24 +779,23 @@ void FileSystemAccessPermissionContext::PerformAfterWriteChecks(
 }
 
 void FileSystemAccessPermissionContext::RunRestrictedPathCallback(
-    const base::FilePath& file_path,
+    int request_id,
     SensitiveEntryResult result) {
-  if (auto val = callback_map_.extract(file_path)) {
-    for (auto& callback : val.mapped()) {
-      std::move(callback).Run(result);
-    }
+  if (auto node = restricted_path_callbacks_.extract(request_id)) {
+    std::move(node.mapped()).Run(result);
   }
 }
 
 void FileSystemAccessPermissionContext::OnRestrictedPathResult(
-    const base::FilePath& file_path,
+    int request_id,
     gin::Arguments* args) {
   SensitiveEntryResult result = SensitiveEntryResult::kAbort;
   args->GetNext(&result);
-  RunRestrictedPathCallback(file_path, result);
+  RunRestrictedPathCallback(request_id, result);
 }
 
 void FileSystemAccessPermissionContext::DidCheckPathAgainstBlocklist(
+    int request_id,
     const url::Origin& origin,
     const content::PathInfo& path_info,
     HandleType handle_type,
@@ -800,7 +807,7 @@ void FileSystemAccessPermissionContext::DidCheckPathAgainstBlocklist(
   if (user_action == UserAction::kNone) {
     auto result = should_block ? SensitiveEntryResult::kAbort
                                : SensitiveEntryResult::kAllowed;
-    RunRestrictedPathCallback(path_info.path, result);
+    RunRestrictedPathCallback(request_id, result);
     return;
   }
 
@@ -810,22 +817,30 @@ void FileSystemAccessPermissionContext::DidCheckPathAgainstBlocklist(
     if (session && session->Get()) {
       v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
       v8::HandleScope scope(isolate);
+      content::RenderFrameHost* rfh =
+          content::RenderFrameHost::FromID(frame_id);
       v8::Local<v8::Object> details =
           gin::DataObjectBuilder(isolate)
               .Set("origin", origin.GetURL().spec())
               .Set("isDirectory", handle_type == HandleType::kDirectory)
               .Set("path", path_info.path)
+              .Set("frame", rfh)
+              .Set("webContents",
+                   rfh ? content::WebContents::FromRenderFrameHost(rfh)
+                       : nullptr)
               .Build();
       session->Get()->Emit(
           "file-system-access-restricted", details,
           base::BindRepeating(
               &FileSystemAccessPermissionContext::OnRestrictedPathResult,
-              weak_factory_.GetWeakPtr(), path_info.path));
+              weak_factory_.GetWeakPtr(), request_id));
+    } else {
+      RunRestrictedPathCallback(request_id, SensitiveEntryResult::kAbort);
     }
     return;
   }
 
-  RunRestrictedPathCallback(path_info.path, SensitiveEntryResult::kAllowed);
+  RunRestrictedPathCallback(request_id, SensitiveEntryResult::kAllowed);
 }
 
 void FileSystemAccessPermissionContext::MaybeEvictEntries(
@@ -1150,6 +1165,18 @@ void FileSystemAccessPermissionContext::NavigatedAwayFromOrigin(
 void FileSystemAccessPermissionContext::CleanupPermissions(
     const url::Origin& origin) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  // Keep the grants while any top-level document of |origin| is still open in
+  // this session.
+  for (api::WebContents* api_web_contents :
+       api::WebContents::GetWebContentsList()) {
+    content::WebContents* web_contents = api_web_contents->web_contents();
+    if (web_contents && !web_contents->IsBeingDestroyed() &&
+        web_contents->GetBrowserContext() == browser_context() &&
+        web_contents->GetPrimaryMainFrame()->GetLastCommittedOrigin() ==
+            origin) {
+      return;
+    }
+  }
   RevokeActiveGrants(origin);
 }
 

--- a/shell/browser/file_system_access/file_system_access_permission_context.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context.h
@@ -152,18 +152,17 @@ class FileSystemAccessPermissionContext
   void CheckPathAgainstBlocklist(const content::PathInfo& path,
                                  HandleType handle_type,
                                  base::OnceCallback<void(bool)> callback);
-  void DidCheckPathAgainstBlocklist(const url::Origin& origin,
+  void DidCheckPathAgainstBlocklist(int request_id,
+                                    const url::Origin& origin,
                                     const content::PathInfo& path,
                                     HandleType handle_type,
                                     UserAction user_action,
                                     content::GlobalRenderFrameHostId frame_id,
                                     bool should_block);
 
-  void RunRestrictedPathCallback(const base::FilePath& file_path,
-                                 SensitiveEntryResult result);
+  void RunRestrictedPathCallback(int request_id, SensitiveEntryResult result);
 
-  void OnRestrictedPathResult(const base::FilePath& file_path,
-                              gin::Arguments* args);
+  void OnRestrictedPathResult(int request_id, gin::Arguments* args);
 
   void MaybeEvictEntries(base::DictValue& dict);
 
@@ -192,9 +191,11 @@ class FileSystemAccessPermissionContext
 
   std::map<url::Origin, base::DictValue> id_pathinfo_map_;
 
-  std::map<base::FilePath,
-           std::vector<base::OnceCallback<void(SensitiveEntryResult)>>>
-      callback_map_;
+  // Restricted-path confirmations waiting on the app's
+  // `file-system-access-restricted` handler, one per request.
+  int next_restricted_path_request_id_ = 0;
+  std::map<int, base::OnceCallback<void(SensitiveEntryResult)>>
+      restricted_path_callbacks_;
 
   std::unique_ptr<ChromeFileSystemAccessPermissionContext::BlockPathRules>
       block_path_rules_;

--- a/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
+++ b/shell/browser/file_system_access/file_system_access_permission_context_factory.cc
@@ -35,6 +35,16 @@ FileSystemAccessPermissionContextFactory::
 FileSystemAccessPermissionContextFactory::
     ~FileSystemAccessPermissionContextFactory() = default;
 
+// In-memory partitions report themselves as off-the-record, which the base
+// class maps to "no service"; without a permission context content denies all
+// write access and never consults the app. Every Electron session gets its own
+// context.
+content::BrowserContext*
+FileSystemAccessPermissionContextFactory::GetBrowserContextToUse(
+    content::BrowserContext* context) const {
+  return context;
+}
+
 std::unique_ptr<KeyedService>
 FileSystemAccessPermissionContextFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {

--- a/shell/browser/file_system_access/file_system_access_permission_context_factory.h
+++ b/shell/browser/file_system_access/file_system_access_permission_context_factory.h
@@ -32,6 +32,8 @@ class FileSystemAccessPermissionContextFactory
   ~FileSystemAccessPermissionContextFactory() override;
 
   // BrowserContextKeyedServiceFactory:
+  content::BrowserContext* GetBrowserContextToUse(
+      content::BrowserContext* context) const override;
   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
 };

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { AddressInfo } from 'node:net';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import * as url from 'node:url';
@@ -1825,6 +1826,175 @@ describe('chromium features', () => {
         w.webContents.focus();
         w.webContents.paste();
       });
+    });
+  });
+
+  describe('File System Access permission scope', () => {
+    // Pages obtain FileSystemHandles by pasting a file:// URI, the same way the
+    // tests above do, so no picker is needed.
+    const handlePage = `<!doctype html><body contenteditable tabindex="0">fsa<script>
+      window.gotHandle = false; window.handle = null; window.handleError = null;
+      document.onpaste = (event) => {
+        event.preventDefault();
+        event.clipboardData.items[0].getAsFileSystemHandle().then(
+          (h) => { window.handle = h; window.gotHandle = true; },
+          (e) => { window.handleError = String(e); window.gotHandle = true; });
+      };
+    </script></body>`;
+    let serverA: http.Server;
+    let serverB: http.Server;
+    let urlA: string;
+    let urlB: string;
+    before(async () => {
+      const handler = (_req: http.IncomingMessage, res: http.ServerResponse) => {
+        res.setHeader('content-type', 'text/html');
+        res.end(handlePage);
+      };
+      serverA = http.createServer(handler);
+      serverB = http.createServer(handler);
+      urlA = (await listen(serverA)).url;
+      urlB = (await listen(serverB)).url;
+    });
+    after(() => {
+      serverA.close();
+      serverB.close();
+    });
+    afterEach(closeAllWindows);
+
+    const pasteHandle = async (w: BrowserWindow, frame: Electron.WebFrameMain, dirOrFile: string) => {
+      // @ts-expect-error Undocumented testing method.
+      clipboard._writeFilesForTesting([dirOrFile]);
+      if (!w.webContents.isFocused()) {
+        const focused = once(w.webContents, 'focus');
+        w.webContents.focus();
+        await focused;
+      }
+      await frame.executeJavaScript('window.focus(); document.body.focus(); window.gotHandle = false; true');
+      w.webContents.paste();
+    };
+    const waitForHandle = (frame: Electron.WebFrameMain) =>
+      waitUntil(async () => (await frame.executeJavaScript('window.gotHandle')) === true);
+
+    it('does not let a cross-origin iframe request more access than it was granted', async () => {
+      const ses = session.fromPartition(`fsa-scope-${Math.random()}`);
+      const w = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await w.loadURL(urlA);
+      await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = ${JSON.stringify(urlB)};
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = w.webContents.mainFrame.frames[0];
+      const requests: any[] = [];
+      ses.setPermissionRequestHandler((_wc, permission, callback, details) => {
+        if (permission === 'fileSystem') requests.push(details);
+        callback(true);
+      });
+      const testFile = path.join(fixturesPath, 'file-system', 'test.txt');
+      await pasteHandle(w, iframe, testFile);
+      await waitForHandle(iframe);
+      expect(await iframe.executeJavaScript('window.handle && window.handle.kind')).to.equal('file');
+      // Matches Chrome: a third-party iframe cannot ask for more than it has.
+      const status = await iframe.executeJavaScript(
+        "window.handle.requestPermission({ mode: 'readwrite' }).catch((e) => e.name)",
+        true
+      );
+      expect(status).to.equal('SecurityError');
+      expect(requests).to.be.empty();
+
+      // The same request from the top-level document reaches the handler.
+      await pasteHandle(w, w.webContents.mainFrame, testFile);
+      await waitForHandle(w.webContents.mainFrame);
+      const topStatus = await w.webContents.mainFrame.executeJavaScript(
+        "window.handle.requestPermission({ mode: 'readwrite' })",
+        true
+      );
+      expect(topStatus).to.equal('granted');
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].isMainFrame).to.equal(true);
+    });
+
+    it("asks about a restricted path once per requester, with that requester's identity", async () => {
+      const ses = session.fromPartition(`fsa-scope-${Math.random()}`);
+      const events: { details: any; callback: (action: 'allow' | 'deny' | 'tryAgain') => void }[] = [];
+      ses.on('file-system-access-restricted', (_e, details, callback) => {
+        events.push({ details, callback });
+      });
+      const wa = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await wa.loadURL(urlA);
+      const wb = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await wb.loadURL(urlB);
+      const restricted = os.homedir();
+
+      await pasteHandle(wa, wa.webContents.mainFrame, restricted);
+      await waitUntil(() => events.length === 1);
+      await pasteHandle(wb, wb.webContents.mainFrame, restricted);
+      await waitUntil(() => events.length === 2);
+
+      expect(events[0].details.origin).to.equal(`${urlA}/`);
+      expect(events[0].details.webContents).to.equal(wa.webContents);
+      expect(events[0].details.frame).to.equal(wa.webContents.mainFrame);
+      expect(events[1].details.origin).to.equal(`${urlB}/`);
+      expect(events[1].details.webContents).to.equal(wb.webContents);
+      expect(events[1].details.frame).to.equal(wb.webContents.mainFrame);
+
+      // Answers are independent.
+      events[1].callback('allow');
+      events[0].callback('deny');
+      await waitForHandle(wb.webContents.mainFrame);
+      await waitForHandle(wa.webContents.mainFrame);
+      expect(await wb.webContents.executeJavaScript('window.handle && window.handle.kind')).to.equal('directory');
+      expect(await wa.webContents.executeJavaScript('window.handle')).to.equal(null);
+    });
+
+    it('revokes active grants once no top-level document of the origin remains', async function () {
+      this.timeout(60000);
+      const ses = session.fromPartition(`fsa-scope-${Math.random()}`);
+      ses.setPermissionRequestHandler((_wc, _permission, callback) => callback(true));
+      const testFile = path.join(fixturesPath, 'file-system', 'test.txt');
+
+      // A top-level document of origin A obtains read/write access to the file.
+      const top = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await top.loadURL(urlA);
+      await pasteHandle(top, top.webContents.mainFrame, testFile);
+      await waitForHandle(top.webContents.mainFrame);
+      expect(
+        await top.webContents.mainFrame.executeJavaScript(
+          "window.handle.requestPermission({ mode: 'readwrite' })",
+          true
+        )
+      ).to.equal('granted');
+
+      // An origin-A iframe inside an origin-B page holds a handle to the same
+      // file and shares that grant.
+      const host = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await host.loadURL(urlB);
+      await host.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = ${JSON.stringify(urlA)};
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = host.webContents.mainFrame.frames[0];
+      await pasteHandle(host, iframe, testFile);
+      await waitForHandle(iframe);
+      const query = () => iframe.executeJavaScript("window.handle.queryPermission({ mode: 'readwrite' })");
+      expect(await query()).to.equal('granted');
+
+      // While another top-level origin-A document exists the grant survives the
+      // first one closing...
+      const otherTop = new BrowserWindow({ show: true, webPreferences: { session: ses } });
+      await otherTop.loadURL(urlA);
+      top.close();
+      await setTimeout(6000);
+      expect(await query()).to.equal('granted');
+
+      // ...and once the last one is gone it is revoked, so the embedded frame
+      // can no longer write without the app being asked again.
+      otherTop.close();
+      await setTimeout(6000);
+      expect(await query()).to.equal('prompt');
     });
   });
 


### PR DESCRIPTION
Backport of #53666

See that PR for details. The new specs use this branch's `clipboard._writeFilesForTesting()` helper to place a file on the clipboard.

Notes: File System Access permission requests and the `file-system-access-restricted` event are scoped to the requesting document, grants are reset when the origin's last page closes, and write access works in in-memory sessions.
