### PR TITLE
feat: identify the requesting frame and initiator on network, auth and download events (44-x-y)

### DIFF
--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -139,6 +139,22 @@ Returns `string` - The files mime type.
 
 Returns `boolean` - Whether the download has user gesture.
 
+#### `downloadItem.getInitiatorOrigin()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53685
+```
+-->
+
+Returns `string` - The origin that started the download (for example
+`https://example.com`, or `null` for an opaque origin), or an empty string if
+the download was not started by web content (for example
+`webContents.downloadURL()`). Use this rather than `getURL()` or the
+`webContents` to decide whose download it is: the URL is chosen by the
+initiator and the `webContents` is the whole tab.
+
 #### `downloadItem.getFilename()`
 
 Returns `string` - The file name of the download item.

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -134,6 +134,12 @@ expect streaming responses.
 Register a protocol handler for `scheme`. Requests made to URLs with this
 scheme will delegate to this handler to determine what response should be sent.
 
+In addition to the standard `Request` fields, `request.initiatorOrigin` is set to the
+origin that issued the request (for example `https://example.com`, or `null`
+for an opaque origin) when web content made it; it is absent for requests the
+browser started itself. Unlike `request.referrer` it is not controlled by the
+requesting page, so prefer it when deciding whether to serve a request.
+
 Either a `Response` or a `Promise<Response>` can be returned.
 
 Example:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -90,13 +90,23 @@ The following events are available on instances of `Session`:
 
 #### Event: 'will-download'
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added the trailing `frame` argument."
+```
+-->
+
 Returns:
 
 * `event` Event
 * `item` [DownloadItem](download-item.md)
 * `webContents` [WebContents](web-contents.md)
+* `frame` [WebFrameMain](web-frame-main.md) | null - The frame that started the download, if it still exists.
 
-Emitted when Electron is about to download `item` in `webContents`.
+Emitted when Electron is about to download `item` in `webContents`. See also
+[`item.getInitiatorOrigin()`](download-item.md#downloaditemgetinitiatororigin).
 
 Calling `event.preventDefault()` will cancel the download and `item` will not be
 available from next tick of the process.
@@ -214,6 +224,14 @@ app.on('window-all-closed', function () {
 
 #### Event: 'preconnect'
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added the trailing `frame` argument."
+```
+-->
+
 Returns:
 
 * `event` Event
@@ -222,6 +240,7 @@ Returns:
 * `allowCredentials` boolean - True if the renderer is requesting that the
   connection include credentials (see the
   [spec](https://w3c.github.io/resource-hints/#preconnect) for more details.)
+* `frame` [WebFrameMain](web-frame-main.md) | null - The frame that requested the preconnection, if it still exists.
 
 Emitted when a render process requests preconnection to a URL, generally due to
 a [resource hint](https://w3c.github.io/resource-hints/).

--- a/docs/api/structures/protocol-request.md
+++ b/docs/api/structures/protocol-request.md
@@ -2,6 +2,10 @@
 
 * `url` string
 * `referrer` string
+* `initiatorOrigin` string (optional) - The origin that issued the request (for example
+  `https://example.com`, or `null` for an opaque origin). Absent for requests
+  the browser started itself. Unlike `referrer`, this is not controlled by the
+  requesting page.
 * `method` string
 * `uploadData` [UploadData[]](upload-data.md) (optional)
 * `headers` Record\<string, string\>

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -43,6 +43,14 @@ The following methods are available on instances of `WebRequest`:
 
 #### `webRequest.onBeforeRequest([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -53,6 +61,7 @@ The following methods are available on instances of `WebRequest`:
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -88,6 +97,14 @@ Some examples of valid `urls`:
 
 #### `webRequest.onBeforeSendHeaders([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -98,6 +115,7 @@ Some examples of valid `urls`:
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -117,6 +135,14 @@ The `callback` has to be called with a `response` object.
 
 #### `webRequest.onSendHeaders([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -127,6 +153,7 @@ The `callback` has to be called with a `response` object.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -138,6 +165,14 @@ response are visible by the time this listener is fired.
 
 #### `webRequest.onHeadersReceived([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -148,6 +183,7 @@ response are visible by the time this listener is fired.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -170,6 +206,14 @@ The `callback` has to be called with a `response` object.
 
 #### `webRequest.onResponseStarted([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -180,6 +224,7 @@ The `callback` has to be called with a `response` object.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -195,6 +240,14 @@ and response headers are available.
 
 #### `webRequest.onBeforeRedirect([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -205,6 +258,7 @@ and response headers are available.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -221,6 +275,14 @@ redirect is about to occur.
 
 #### `webRequest.onCompleted([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -231,6 +293,7 @@ redirect is about to occur.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
@@ -245,6 +308,14 @@ completed.
 
 #### `webRequest.onErrorOccurred([filter, ]listener)`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53685
+    description: "Added `details.initiatorOrigin`."
+```
+-->
+
 * `filter` [WebRequestFilter](structures/web-request-filter.md) (optional)
 * `listener` Function | null
   * `details` Object
@@ -255,6 +326,7 @@ completed.
     * `webContents` WebContents (optional)
     * `frame` WebFrameMain | null (optional) - Requesting frame.
       May be `null` if accessed after the frame has either navigated or been destroyed.
+    * `initiatorOrigin` string (optional) - The origin that issued the request (for example `https://example.com`, or `null` for an opaque origin). Kept from the original request across redirects; absent for requests the browser started itself.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -165,6 +165,9 @@ Protocol.prototype.handle = function (
         body,
         duplex: body instanceof ReadableStream ? 'half' : undefined
       } as any);
+      // The origin that issued the request, if web content did; not something
+      // a standard Request can carry, so it is attached as an own property.
+      if (preq.initiatorOrigin !== undefined) (req as any).initiatorOrigin = preq.initiatorOrigin;
       const res = await handler(req);
       if (!validateResponse(res)) {
         return cb({ error: ERR_UNEXPECTED });

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -16,6 +16,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 #include "v8/include/cppgc/allocation.h"
 #include "v8/include/cppgc/persistent.h"
 #include "v8/include/v8-cppgc.h"
@@ -209,6 +210,14 @@ const GURL& DownloadItem::GetURL() const {
   return download_item_->GetURL();
 }
 
+std::string DownloadItem::GetInitiatorOrigin() const {
+  if (!CheckAlive())
+    return {};
+  const std::optional<url::Origin>& initiator =
+      download_item_->GetRequestInitiator();
+  return initiator ? initiator->Serialize() : std::string();
+}
+
 v8::Local<v8::Value> DownloadItem::GetURLChain() const {
   if (!CheckAlive())
     return {};
@@ -283,6 +292,7 @@ gin::ObjectTemplateBuilder DownloadItem::GetObjectTemplateBuilder(
       .SetMethod("getContentDisposition", &DownloadItem::GetContentDisposition)
       .SetMethod("getURL", &DownloadItem::GetURL)
       .SetMethod("getURLChain", &DownloadItem::GetURLChain)
+      .SetMethod("getInitiatorOrigin", &DownloadItem::GetInitiatorOrigin)
       .SetMethod("getState", &DownloadItem::GetState)
       .SetMethod("setSavePath", &DownloadItem::SetSavePath)
       .SetMethod("getSavePath", &DownloadItem::GetSavePath)

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -71,6 +71,7 @@ class DownloadItem final : public gin::Wrappable<DownloadItem>,
   std::string GetContentDisposition() const;
   const GURL& GetURL() const;
   v8::Local<v8::Value> GetURLChain() const;
+  std::string GetInitiatorOrigin() const;
   download::DownloadItem::DownloadState GetState() const;
   void SetSaveDialogOptions(const file_dialog::DialogSettings& options);
   std::string GetLastModifiedTime() const;

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -85,6 +85,7 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/media_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
@@ -618,7 +619,10 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
     handle->SetSavePath(item->GetTargetFilePath());
   content::WebContents* web_contents =
       content::DownloadItemUtils::GetWebContents(item);
-  bool prevent_default = Emit("will-download", handle_object, web_contents);
+  content::RenderFrameHost* frame =
+      content::DownloadItemUtils::GetRenderFrameHost(item);
+  bool prevent_default =
+      Emit("will-download", handle_object, web_contents, frame);
   if (prevent_default) {
     item->Cancel(true);
     item->Remove();

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -119,6 +119,11 @@ void ToDictionary(gin_helper::Dictionary* details,
   details->Set("resourceType", info->web_request_type);
   if (!info->response_ip.empty())
     details->Set("ip", info->response_ip);
+  // The origin that issued the request (Chrome's webRequest `initiator`). It
+  // is kept from the original request across redirects and, unlike
+  // `referrer`, is not under the requesting document's control.
+  if (info->initiator)
+    details->Set("initiatorOrigin", info->initiator->Serialize());
   if (info->response_headers) {
     details->Set("fromCache", info->response_from_cache);
     details->Set("statusLine", info->response_headers->GetStatusLine());

--- a/shell/browser/network_hints_handler_impl.cc
+++ b/shell/browser/network_hints_handler_impl.cc
@@ -12,6 +12,7 @@
 #include "content/public/browser/render_process_host.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "shell/browser/api/electron_api_session.h"
+#include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "v8/include/v8.h"
 
@@ -20,6 +21,7 @@ NetworkHintsHandlerImpl::NetworkHintsHandlerImpl(
     : network_hints::SimpleNetworkHintsHandlerImpl(
           frame_host->GetProcess()->GetDeprecatedID(),
           frame_host->GetRoutingID()),
+      render_frame_host_id_(frame_host->GetGlobalId()),
       browser_context_(frame_host->GetProcess()->GetBrowserContext()) {}
 
 NetworkHintsHandlerImpl::~NetworkHintsHandlerImpl() = default;
@@ -34,7 +36,9 @@ void NetworkHintsHandlerImpl::Preconnect(const url::SchemeHostPort& url,
   gin::WeakCell<electron::api::Session>* session =
       electron::api::Session::FromBrowserContext(browser_context_);
   if (session && session->Get()) {
-    session->Get()->Emit("preconnect", url.GetURL(), allow_credentials);
+    session->Get()->Emit(
+        "preconnect", url.GetURL(), allow_credentials,
+        content::RenderFrameHost::FromID(render_frame_host_id_));
   }
 }
 

--- a/shell/browser/network_hints_handler_impl.h
+++ b/shell/browser/network_hints_handler_impl.h
@@ -7,6 +7,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "components/network_hints/browser/simple_network_hints_handler_impl.h"
+#include "content/public/browser/global_routing_id.h"
 
 namespace content {
 class RenderFrameHost;
@@ -30,6 +31,7 @@ class NetworkHintsHandlerImpl
  private:
   explicit NetworkHintsHandlerImpl(content::RenderFrameHost*);
 
+  const content::GlobalRenderFrameHostId render_frame_host_id_;
   raw_ptr<content::BrowserContext> browser_context_ = nullptr;
 };
 

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -699,6 +699,10 @@ v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
       .Set("headers", val.headers);
   if (val.request_body)
     builder.Set("uploadData", ConvertToV8(isolate, *val.request_body));
+  // The origin that issued the request; absent for requests the browser
+  // started itself. Unlike `referrer` this is not controlled by the page.
+  if (val.request_initiator)
+    builder.Set("initiatorOrigin", val.request_initiator->Serialize());
   return builder.Build();
 }
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -3229,9 +3229,10 @@ describe('BrowserWindow module', () => {
       w = new BrowserWindow({ show: true });
       const p = once(w.webContents.session, 'preconnect');
       w.loadURL(url + '/link');
-      const [, preconnectUrl, allowCredentials] = await p;
+      const [, preconnectUrl, allowCredentials, frame] = await p;
       expect(preconnectUrl).to.equal('http://example.com/');
       expect(allowCredentials).to.be.true('allowCredentials');
+      expect(frame).to.equal(w.webContents.mainFrame);
     });
   });
 

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -1494,6 +1494,29 @@ describe('protocol module', () => {
   describe('handle', () => {
     afterEach(closeAllWindows);
 
+    it('reports the origin that issued the request', async () => {
+      // http-like is registered as standard + fetch-enabled in spec/index.js.
+      const initiators: Record<string, string | undefined> = {};
+      protocol.handle('http-like', (req) => {
+        initiators[new URL(req.url).pathname] = (req as any).initiatorOrigin;
+        return new Response('<p>hi</p>', { headers: { 'content-type': 'text/html' } });
+      });
+      defer(() => {
+        protocol.unhandle('http-like');
+      });
+      const w = new BrowserWindow({ show: false });
+      // Browser-initiated navigation: no initiator.
+      await w.loadURL('http-like://page/');
+      expect(initiators).to.have.property('/');
+      expect(initiators['/']).to.equal(undefined);
+      // A fetch from that document carries the document's origin, even with
+      // no referrer.
+      await w.webContents.executeJavaScript(
+        "fetch('http-like://page/data', { referrerPolicy: 'no-referrer' }).then(r => r.text())"
+      );
+      expect(initiators['/data']).to.equal('http-like://page');
+    });
+
     it('receives requests to a custom scheme', async () => {
       protocol.handle('test-scheme', (req) => new Response('hello ' + req.url));
       defer(() => {

--- a/spec/api-session-spec.ts
+++ b/spec/api-session-spec.ts
@@ -664,6 +664,67 @@ describe('session module', () => {
 
   describe('will-download event', () => {
     afterEach(closeAllWindows);
+    it('identifies the frame and origin that started the download', async () => {
+      const mockFile = Buffer.alloc(16);
+      const downloadServer = http.createServer((req, res) => {
+        if (req.url === '/file') {
+          res.writeHead(200, {
+            'Content-Length': mockFile.length,
+            'Content-Type': 'application/octet-stream',
+            'Content-Disposition': 'attachment; filename="f.bin"'
+          });
+          res.end(mockFile);
+          return;
+        }
+        res.setHeader('Content-Type', 'text/html');
+        res.end('<a id="dl" href="/file" download>dl</a>');
+      });
+      const pageServer = http.createServer((_req, res) => {
+        res.setHeader('Content-Type', 'text/html');
+        res.end('<p>top</p>');
+      });
+      const downloadOrigin = (await listen(downloadServer)).url;
+      const topUrl = (await listen(pageServer)).url;
+      defer(() => {
+        downloadServer.close();
+        pageServer.close();
+      });
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL(topUrl);
+      await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = ${JSON.stringify(downloadOrigin)};
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = w.webContents.mainFrame.frames[0];
+      const willDownload = new Promise<{ item: Electron.DownloadItem; wc: Electron.WebContents; frame: any }>(
+        (resolve) => {
+          w.webContents.session.once('will-download', (e, item, wc, frame) => {
+            e.preventDefault();
+            resolve({ item, wc, frame });
+          });
+        }
+      );
+      await iframe.executeJavaScript("document.getElementById('dl').click()", true);
+      const { item, wc, frame } = await willDownload;
+      expect(wc).to.equal(w.webContents);
+      expect(frame).to.equal(iframe);
+      expect(item.getInitiatorOrigin()).to.equal(downloadOrigin);
+
+      // A download the app starts itself has no initiating origin or frame.
+      const own = new Promise<{ item: Electron.DownloadItem; frame: any }>((resolve) => {
+        w.webContents.session.once('will-download', (e, item, _wc, frame) => {
+          e.preventDefault();
+          resolve({ item, frame });
+        });
+      });
+      w.webContents.session.downloadURL(`${downloadOrigin}/file`);
+      const ownResult = await own;
+      expect(ownResult.item.getInitiatorOrigin()).to.equal('');
+      expect(ownResult.frame).to.equal(null);
+    });
+
     it('can cancel default download behavior', async () => {
       const w = new BrowserWindow({ show: false });
       const mockFile = Buffer.alloc(1024);

--- a/spec/api-web-request-spec.ts
+++ b/spec/api-web-request-spec.ts
@@ -1,4 +1,4 @@
-import { ipcMain, net, protocol, session, WebContents, webContents } from 'electron/main';
+import { BrowserWindow, ipcMain, net, protocol, session, WebContents, webContents } from 'electron/main';
 
 import { expect } from 'chai';
 import * as WebSocket from 'ws';
@@ -91,6 +91,39 @@ describe('webRequest module', () => {
   describe('webRequest.onBeforeRequest', () => {
     afterEach(() => {
       ses.webRequest.onBeforeRequest(null);
+    });
+
+    it('reports the origin that issued the request as details.initiatorOrigin', async () => {
+      const seen: Electron.OnBeforeRequestListenerDetails[] = [];
+      ses.webRequest.onBeforeRequest((details, callback) => {
+        if (details.url.startsWith(defaultURL)) seen.push(details);
+        callback({});
+      });
+      const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+      defer(() => w.destroy());
+      // Top-level navigation started by the browser: no initiator.
+      await w.loadURL(`${defaultURL}top`);
+      const nav = seen.find((d) => d.url === `${defaultURL}top`);
+      expect(nav).to.exist();
+      expect(nav!.initiatorOrigin).to.equal(undefined);
+      // A cross-origin iframe's own subresource request is attributed to the
+      // iframe's origin regardless of referrer policy.
+      const crossOrigin = defaultURL.replace('127.0.0.1', 'localhost');
+      await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = ${JSON.stringify(crossOrigin + 'frame')};
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = w.webContents.mainFrame.frames[0];
+      await iframe.executeJavaScript(
+        `fetch(${JSON.stringify(defaultURL + 'fromframe')}, { referrerPolicy: 'no-referrer', mode: 'no-cors' }).then(() => true)`
+      );
+      const sub = seen.find((d) => d.url === `${defaultURL}fromframe`);
+      expect(sub).to.exist();
+      expect(sub!.initiatorOrigin).to.equal(new URL(crossOrigin).origin);
+      expect(sub!.referrer).to.equal('');
+      expect(sub!.frame).to.equal(iframe);
     });
 
     const cancel = (


### PR DESCRIPTION
Backport of #53685

See that PR for details.

Notes: Added `initiatorOrigin` to webRequest and protocol handler requests, `DownloadItem.getInitiatorOrigin()`, and a trailing `frame` argument to the `will-download` and `preconnect` session events.
