### PR TITLE
fix: gate preload and worker Node integration on the creating frame (42-x-y)

### DIFF
--- a/docs/api/structures/web-preferences.md
+++ b/docs/api/structures/web-preferences.md
@@ -4,7 +4,9 @@
 * `nodeIntegration` boolean (optional) - Whether node integration is enabled.
   Default is `false`.
 * `nodeIntegrationInWorker` boolean (optional) - Whether node integration is
-  enabled in web workers. Default is `false`. More about this can be found
+  enabled in web workers. Default is `false`. Only workers created by a frame
+  that itself has access to Node.js (the main frame, or any frame when
+  `nodeIntegrationInSubFrames` is enabled) get it. More about this can be found
   in [Multithreading](../../tutorial/multithreading.md).
 * `nodeIntegrationInSubFrames` boolean (optional) - Experimental option for
   enabling Node.js support in sub-frames such as iframes and child windows. All your preloads will load for

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -14,6 +14,22 @@ This document uses the following convention to categorize breaking changes:
 
 ## Planned Breaking API Changes (42.0)
 
+### Behavior Changed: workers created by subframes need `nodeIntegrationInSubFrames` for Node.js integration
+
+With `nodeIntegrationInWorker: true`, a `Worker` created from an `<iframe>` in
+the same process as the main frame used to get Node.js integration even though
+the iframe itself had none. Workers now only get Node.js integration when the
+frame that creates them has it: the main frame, or any frame when
+`nodeIntegrationInSubFrames` is enabled.
+
+### Behavior Changed: preload scripts only run in DevTools extension frames hosted by DevTools
+
+A `chrome-extension://` document used to receive the window's preload script
+(and session preload scripts) wherever it was embedded. It now only does so
+when it is a top-level frame or is hosted inside the DevTools front-end (a
+`devtools_page` or panel); an extension frame embedded in an ordinary page is
+treated like any other subframe and follows `nodeIntegrationInSubFrames`.
+
 ### Behavior Changed: macOS notifications now use `UNNotification` API
 
 Electron has migrated from the deprecated `NSUserNotification` API to the

--- a/docs/tutorial/multithreading.md
+++ b/docs/tutorial/multithreading.md
@@ -17,6 +17,9 @@ const win = new BrowserWindow({
 })
 ```
 
+Workers created by an `<iframe>` only get Node.js integration when the frame
+itself has it, i.e. when `nodeIntegrationInSubFrames` is also enabled.
+
 The `nodeIntegrationInWorker` can be used independent of `nodeIntegration`, but
 `sandbox` must not be set to `true`.
 

--- a/patches/chromium/feat_plumb_node_integration_in_worker_through_workersettings.patch
+++ b/patches/chromium/feat_plumb_node_integration_in_worker_through_workersettings.patch
@@ -7,10 +7,12 @@ Copy the node_integration_in_worker flag from the initiating frame's
 WebPreferences into WorkerSettings at dedicated worker creation time,
 so the value is readable per-worker on the worker thread rather than
 relying on a process-wide command line switch. The value is also
-propagated to nested workers via WorkerSettings::Copy.
+propagated to nested workers via WorkerSettings::Copy. Only frames that
+would themselves get Node integration (the main frame, or any frame with
+node_integration_in_sub_frames) hand it to their workers.
 
 diff --git a/third_party/blink/renderer/core/workers/dedicated_worker.cc b/third_party/blink/renderer/core/workers/dedicated_worker.cc
-index 7ea6daec53a497bf867d799e041bf6ae7191ef7b..15940624940d5c629c40319f45c59282713bec17 100644
+index 7ea6daec53a497bf867d799e041bf6ae7191ef7b..b573aef5f95f00c4b49f2de66482838014aa0fbe 100644
 --- a/third_party/blink/renderer/core/workers/dedicated_worker.cc
 +++ b/third_party/blink/renderer/core/workers/dedicated_worker.cc
 @@ -37,6 +37,7 @@
@@ -21,21 +23,26 @@ index 7ea6daec53a497bf867d799e041bf6ae7191ef7b..15940624940d5c629c40319f45c59282
  #include "third_party/blink/renderer/core/inspector/inspector_trace_events.h"
  #include "third_party/blink/renderer/core/inspector/main_thread_debugger.h"
  #include "third_party/blink/renderer/core/loader/document_loader.h"
-@@ -572,6 +573,12 @@ DedicatedWorker::CreateGlobalScopeCreationParams(
+@@ -572,6 +573,17 @@ DedicatedWorker::CreateGlobalScopeCreationParams(
      auto* frame = window->GetFrame();
      parent_devtools_token = frame->GetDevToolsFrameToken();
      settings = std::make_unique<WorkerSettings>(frame->GetSettings());
 +    if (auto* web_local_frame = WebLocalFrameImpl::FromFrame(frame)) {
 +      if (auto* web_view = web_local_frame->ViewImpl()) {
++        // Only frames that themselves get Node integration (the main frame,
++        // or any frame when nodeIntegrationInSubFrames is on) pass it on to
++        // the workers they create.
++        const auto& prefs = web_view->GetWebPreferences();
 +        settings->SetNodeIntegrationInWorker(
-+            web_view->GetWebPreferences().node_integration_in_worker);
++            prefs.node_integration_in_worker &&
++            (frame->IsMainFrame() || prefs.node_integration_in_sub_frames));
 +      }
 +    }
      agent_group_scheduler_compositor_task_runner =
          execution_context->GetScheduler()
              ->ToFrameScheduler()
 diff --git a/third_party/blink/renderer/core/workers/threaded_worklet_messaging_proxy.cc b/third_party/blink/renderer/core/workers/threaded_worklet_messaging_proxy.cc
-index 936f5ebe28caa993ed5de0f7de3613fa338e263f..961ac8091aa82128e1cfb8800a7efcb80d100a05 100644
+index 936f5ebe28caa993ed5de0f7de3613fa338e263f..7f5e2bf1662f812f6d0a830640e32ac865000bbe 100644
 --- a/third_party/blink/renderer/core/workers/threaded_worklet_messaging_proxy.cc
 +++ b/third_party/blink/renderer/core/workers/threaded_worklet_messaging_proxy.cc
 @@ -13,10 +13,12 @@
@@ -51,7 +58,7 @@ index 936f5ebe28caa993ed5de0f7de3613fa338e263f..961ac8091aa82128e1cfb8800a7efcb8
  #include "third_party/blink/renderer/core/inspector/thread_debugger_common_impl.h"
  #include "third_party/blink/renderer/core/loader/worker_fetch_context.h"
  #include "third_party/blink/renderer/core/origin_trials/origin_trial_context.h"
-@@ -135,6 +137,14 @@ void ThreadedWorkletMessagingProxy::Initialize(
+@@ -135,6 +137,17 @@ void ThreadedWorkletMessagingProxy::Initialize(
    DCHECK(csp);
  
    LocalFrameClient* frame_client = window->GetFrame()->Client();
@@ -59,14 +66,17 @@ index 936f5ebe28caa993ed5de0f7de3613fa338e263f..961ac8091aa82128e1cfb8800a7efcb8
 +      std::make_unique<WorkerSettings>(window->GetFrame()->GetSettings());
 +  if (auto* web_local_frame = WebLocalFrameImpl::FromFrame(window->GetFrame())) {
 +    if (auto* web_view = web_local_frame->ViewImpl()) {
++      const auto& prefs = web_view->GetWebPreferences();
 +      worklet_settings->SetNodeIntegrationInWorker(
-+          web_view->GetWebPreferences().node_integration_in_worker);
++          prefs.node_integration_in_worker &&
++          (window->GetFrame()->IsMainFrame() ||
++           prefs.node_integration_in_sub_frames));
 +    }
 +  }
    auto global_scope_creation_params =
        std::make_unique<GlobalScopeCreationParams>(
            window->Url(), mojom::blink::ScriptType::kModule, global_scope_name,
-@@ -147,8 +157,7 @@ void ThreadedWorkletMessagingProxy::Initialize(
+@@ -147,8 +160,7 @@ void ThreadedWorkletMessagingProxy::Initialize(
            window->GetHttpsState(), worker_clients,
            frame_client->CreateWorkerContentSettingsClient(),
            OriginTrialContext::GetInheritedTrialFeatures(window).get(),

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2306,17 +2306,22 @@ void WebContents::MaybeSendRendererStartupData(
 
   // Match RendererClientBase::ShouldLoadPreload() — only push for documents
   // that will actually compile the sandbox bundle.
+  content::RenderFrameHost* rfh = navigation_handle->GetRenderFrameHost();
+  if (!rfh || !rfh->IsRenderFrameLive())
+    return;
+
   const GURL& url = navigation_handle->GetURL();
   bool main_frame = navigation_handle->IsInMainFrame();
   bool allow_subframes =
       web_prefs && web_prefs->AllowsNodeIntegrationInSubFrames();
+  // DevTools itself, or an extension document hosted inside the DevTools
+  // front-end (a devtools_page / panel). An extension frame embedded in an
+  // ordinary page is treated like any other subframe.
   bool is_devtools_like =
-      url.SchemeIs("devtools") || url.SchemeIs("chrome-extension");
+      url.SchemeIs("devtools") ||
+      (url.SchemeIs("chrome-extension") && !main_frame &&
+       rfh->GetMainFrame()->GetLastCommittedURL().SchemeIs("devtools"));
   if (!main_frame && !allow_subframes && !is_devtools_like)
-    return;
-
-  content::RenderFrameHost* rfh = navigation_handle->GetRenderFrameHost();
-  if (!rfh || !rfh->IsRenderFrameLive())
     return;
 
   mojom::RendererStartupDataPtr data;

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -43,8 +43,11 @@
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 #include "third_party/blink/public/platform/web_runtime_features.h"
+#include "third_party/blink/public/platform/web_security_origin.h"
+#include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/blink/public/web/web_custom_element.h"  // NOLINT(build/include_alpha)
+#include "third_party/blink/public/web/web_frame.h"
 #include "third_party/blink/public/web/web_frame_widget.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_plugin_params.h"
@@ -132,9 +135,16 @@ bool IsDevTools(content::RenderFrame* render_frame) {
       "devtools");
 }
 
+// A DevTools extension panel or devtools_page: an extension document hosted
+// inside the DevTools front-end. A chrome-extension:// frame embedded anywhere
+// else (e.g. a web-accessible resource inside a regular page) is not one.
 bool IsDevToolsExtension(content::RenderFrame* render_frame) {
-  return render_frame->GetWebFrame()->GetDocument().Url().ProtocolIs(
-      "chrome-extension");
+  blink::WebLocalFrame* frame = render_frame->GetWebFrame();
+  if (!frame->GetDocument().Url().ProtocolIs("chrome-extension"))
+    return false;
+  blink::WebFrame* top = frame->Top();
+  return top && top != frame &&
+         top->GetSecurityOrigin().Protocol() == "devtools";
 }
 
 }  // namespace

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -1926,6 +1926,59 @@ describe('chromium features', () => {
       expect(data).to.equal('object function object function');
     });
 
+    it('only gives node integration to workers created by frames that have it themselves', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegrationInWorker: true,
+          contextIsolation: false
+        }
+      });
+      await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+      const probe = `new Promise((resolve) => {
+        const src = 'postMessage([typeof process, typeof require].join(" "))';
+        const worker = new Worker(URL.createObjectURL(new Blob([src], { type: 'text/javascript' })));
+        worker.onmessage = (e) => { worker.terminate(); resolve(e.data); };
+      })`;
+      // The main frame's workers get Node...
+      expect(await w.webContents.mainFrame.executeJavaScript(probe)).to.equal('object function');
+      // ...a same-origin (same-process) iframe's workers do not, because the
+      // iframe itself has no Node integration (nodeIntegrationInSubFrames is off).
+      await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = location.href;
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = w.webContents.mainFrame.frames[0];
+      expect(await iframe.executeJavaScript(probe)).to.equal('undefined undefined');
+    });
+
+    it('gives node integration to subframe workers when nodeIntegrationInSubFrames is on', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegrationInWorker: true,
+          nodeIntegrationInSubFrames: true,
+          contextIsolation: false
+        }
+      });
+      await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+      await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = location.href;
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = w.webContents.mainFrame.frames[0];
+      const result = await iframe.executeJavaScript(`new Promise((resolve) => {
+        const src = 'postMessage([typeof process, typeof require].join(" "))';
+        const worker = new Worker(URL.createObjectURL(new Blob([src], { type: 'text/javascript' })));
+        worker.onmessage = (e) => { worker.terminate(); resolve(e.data); };
+      })`);
+      expect(result).to.equal('object function');
+    });
+
     it('Worker does not have node integration when nodeIntegrationInWorker is disabled via setWindowOpenHandler', async () => {
       const w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
Backport of #53686

See that PR for details. The `feat_plumb_node_integration_in_worker_through_workersettings.patch` change is regenerated against this branch's Chromium (148.0.7778.280).

Notes: `nodeIntegrationInWorker` now applies only to workers created by frames that themselves have Node integration; enable `nodeIntegrationInSubFrames` to keep Node in workers created by subframes.
