### PR TITLE
fix: route modifier-click and OpenURLFromTab popups through the window-open policy (44-x-y)

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -214,7 +214,9 @@ value will fail with a DOM exception.
 ```
 
 A `boolean`. When this attribute is present the guest page will be allowed to open new
-windows. Popups are disabled by default.
+windows, whether through `window.open()` or a link opened into a new window
+(for example a modifier-clicked or `target="_blank"` link). Popups are
+disabled by default.
 
 ### `webpreferences`
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -603,45 +603,49 @@ WebContents.prototype._init = function () {
 
   if (this.getType() !== 'remote') {
     // Make new windows requested by links behave like "window.open".
-    this.on('-new-window', (event, url, frameName, disposition, rawFeatures, referrer, postData, sandboxFlags) => {
-      const postBody = postData
-        ? {
-            data: postData,
-            ...parseContentTypeFormat(postData)
-          }
-        : undefined;
-      const details: Electron.HandlerDetails = {
-        url,
-        frameName,
-        features: rawFeatures,
-        referrer,
-        postBody,
-        disposition
-      };
-
-      let result: ReturnType<typeof this._callWindowOpenHandler>;
-      try {
-        result = this._callWindowOpenHandler(event, details);
-      } catch (err) {
-        event.preventDefault();
-        throw err;
-      }
-
-      const options = result.browserWindowConstructorOptions;
-      if (!event.defaultPrevented) {
-        openGuestWindow({
-          embedder: this,
-          disposition,
+    this.on(
+      '-new-window',
+      (event, url, frameName, disposition, rawFeatures, referrer, postData, sandboxFlags, navigate) => {
+        const postBody = postData
+          ? {
+              data: postData,
+              ...parseContentTypeFormat(postData)
+            }
+          : undefined;
+        const details: Electron.HandlerDetails = {
+          url,
+          frameName,
+          features: rawFeatures,
           referrer,
-          postData,
-          overrideBrowserWindowOptions: options || {},
-          windowOpenArgs: details,
-          outlivesOpener: result.outlivesOpener,
-          createWindow: result.createWindow,
-          inheritedSandboxFlags: sandboxFlags
-        });
+          postBody,
+          disposition
+        };
+
+        let result: ReturnType<typeof this._callWindowOpenHandler>;
+        try {
+          result = this._callWindowOpenHandler(event, details);
+        } catch (err) {
+          event.preventDefault();
+          throw err;
+        }
+
+        const options = result.browserWindowConstructorOptions;
+        if (!event.defaultPrevented) {
+          openGuestWindow({
+            embedder: this,
+            disposition,
+            referrer,
+            postData,
+            overrideBrowserWindowOptions: options || {},
+            windowOpenArgs: details,
+            outlivesOpener: result.outlivesOpener,
+            createWindow: result.createWindow,
+            inheritedSandboxFlags: sandboxFlags,
+            navigate
+          });
+        }
       }
-    });
+    );
 
     let windowOpenOverriddenOptions: BrowserWindowConstructorOptions | null = null;
     let windowOpenOutlivesOpenerOption: boolean = false;

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -31,7 +31,8 @@ export function openGuestWindow({
   windowOpenArgs,
   outlivesOpener,
   createWindow,
-  inheritedSandboxFlags
+  inheritedSandboxFlags,
+  navigate
 }: {
   embedder: WebContents;
   guest?: WebContents;
@@ -43,6 +44,9 @@ export function openGuestWindow({
   outlivesOpener: boolean;
   createWindow?: Electron.CreateWindowFunction;
   inheritedSandboxFlags?: number;
+  // For windows opened from a link (OpenURLFromTab): starts the navigation in
+  // the new webContents with the initiating frame's identity preserved.
+  navigate?: (webContents: WebContents) => void;
 }): void {
   const { url, frameName, features } = windowOpenArgs;
   const { options: parsedOptions } = parseFeatures(features);
@@ -94,13 +98,17 @@ export function openGuestWindow({
     // When we open a new window from a link (via OpenURLFromTab),
     // the browser process is responsible for initiating navigation
     // in the new window.
-    window.loadURL(url, {
-      httpReferrer: referrer,
-      ...(postData && {
-        postData,
-        extraHeaders: formatPostDataHeaders(postData as Electron.UploadRawData[])
-      })
-    });
+    if (navigate) {
+      navigate(window.webContents);
+    } else {
+      window.loadURL(url, {
+        httpReferrer: referrer,
+        ...(postData && {
+          postData,
+          extraHeaders: formatPostDataHeaders(postData as Electron.UploadRawData[])
+        })
+      });
+    }
   }
 
   handleWindowLifecycleEvents({ embedder, guest: window.webContents, outlivesOpener });

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -62,6 +62,7 @@
 #include "content/public/browser/favicon_status.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_entry_restore_context.h"
@@ -1509,6 +1510,14 @@ content::WebContents* WebContents::OpenURLFromTab(
         navigation_handle_callback) {
   auto weak_this = GetWeakPtr();
   if (params.disposition != WindowOpenDisposition::CURRENT_TAB) {
+    // A link opened into a new window (modifier-click, middle-click,
+    // target=_blank form post routed here, ...) is a popup like window.open()
+    // and is subject to the same embedder policy; see
+    // ElectronBrowserClient::CanCreateWindow.
+    auto* source_preferences = WebContentsPreferences::From(source);
+    if (source_preferences && source_preferences->ShouldDisablePopups())
+      return nullptr;
+
     using SandboxFlags = network::mojom::WebSandboxFlags;
     SandboxFlags inherited_sandbox_flags = SandboxFlags::kNone;
     // For non-CURRENT_TAB dispositions params.frame_tree_node_id refers to
@@ -1541,8 +1550,31 @@ content::WebContents* WebContents::OpenURLFromTab(
         inherited_sandbox_flags = flags;
       }
     }
+    // The new window's first navigation keeps the initiator's identity
+    // (origin, frame, site instance, user gesture) instead of being re-issued
+    // as a browser-initiated load, so Sec-Fetch-Site / SameSite, external
+    // protocol attribution and navigation events describe who asked for it.
+    auto navigate = base::BindRepeating(
+        [](const content::OpenURLParams& params, content::WebContents* target) {
+          if (!target)
+            return;
+          content::NavigationController::LoadURLParams load_params(params);
+          // The initiator may live in a different session than the window the
+          // app created; a SiteInstance cannot cross browser contexts.
+          if (load_params.source_site_instance &&
+              load_params.source_site_instance->GetBrowserContext() !=
+                  target->GetBrowserContext()) {
+            load_params.source_site_instance = nullptr;
+          }
+          load_params.frame_tree_node_id = {};
+          load_params.override_user_agent =
+              content::NavigationController::UA_OVERRIDE_INHERIT;
+          target->GetController().LoadURLWithParams(load_params);
+        },
+        params);
     Emit("-new-window", params.url, "", params.disposition, "", params.referrer,
-         params.post_data, static_cast<uint32_t>(inherited_sandbox_flags));
+         params.post_data, static_cast<uint32_t>(inherited_sandbox_flags),
+         navigate);
     return nullptr;
   }
 

--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -5331,6 +5331,59 @@ describe('iframe sandbox external protocols', () => {
   });
 });
 
+describe('links opened into a new window', () => {
+  // A modifier-clicked link goes through OpenURLFromTab. The window the app
+  // creates for it must start its navigation as the clicking document did
+  // (renderer-initiated, with that document as initiator), not as a fresh
+  // browser-initiated load.
+  let server: http.Server;
+  let serverUrl: string;
+  const requests: Record<string, http.IncomingHttpHeaders> = {};
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      requests[req.url!] = req.headers;
+      res.setHeader('Content-Type', 'text/html');
+      if (req.url === '/popup') {
+        res.end('<p>popup</p>');
+        return;
+      }
+      res.end(`<a id="a" href="/popup" target="_blank">link</a><script>
+        window.clickLink = () => document.getElementById('a').dispatchEvent(new MouseEvent('click', {
+          ctrlKey: true, metaKey: true, bubbles: true, cancelable: true, view: window
+        }));
+      </script>`);
+    });
+    serverUrl = (await listen(server)).url;
+  });
+  after(() => server.close());
+  afterEach(closeAllWindows);
+
+  it('navigates the new window as the initiating document', async () => {
+    const w = new BrowserWindow({ show: false });
+    w.webContents.setWindowOpenHandler(() => ({ action: 'allow', overrideBrowserWindowOptions: { show: false } }));
+    await w.loadURL(`${serverUrl}/opener`);
+    // The navigation starts before did-create-window is emitted, so hook the
+    // new webContents as soon as it exists.
+    const started = new Promise<any>((resolve) => {
+      app.once('web-contents-created', (_event, contents) => {
+        contents.once('did-start-navigation', (details: any) => resolve(details));
+      });
+    });
+    const created = once(w.webContents, 'did-create-window') as Promise<[BrowserWindow, any]>;
+    await w.webContents.executeJavaScript('window.clickLink(); true');
+    const [child] = await created;
+    const details = await started;
+    if (child.webContents.isLoading()) await once(child.webContents, 'did-finish-load');
+    expect(details.url).to.equal(`${serverUrl}/popup`);
+    // The clicking document is the initiator...
+    expect(details.initiator).to.exist();
+    expect(details.initiator.routingId).to.equal(w.webContents.mainFrame.routingId);
+    // ...so the request is same-origin rather than a browser-typed load.
+    expect(requests['/popup']['sec-fetch-site']).to.equal('same-origin');
+  });
+});
+
 describe('iframe sandbox popups', () => {
   let server: http.Server;
   let serverUrl: string;

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1549,6 +1549,50 @@ describe('<webview> tag', function () {
 
       generateSpecs('without sandbox');
       generateSpecs('with sandbox', 'sandbox=yes');
+
+      describe('links opened into a new window', () => {
+        // A modifier-clicked link is a popup like window.open() and is subject
+        // to allowpopups too. The click is synthesised by the guest itself, so
+        // no user gesture is involved.
+        const linkPage = (href: string) =>
+          'data:text/html,' +
+          encodeURIComponent(`<a id="a" href="${href}" target="_blank">link</a><script>
+            onload = () => {
+              document.getElementById('a').dispatchEvent(new MouseEvent('click', {
+                ctrlKey: true, metaKey: true, bubbles: true, cancelable: true, view: window
+              }));
+              console.log('clicked');
+            };
+          </script>`);
+
+        const countNewWindows = async (attributes: Record<string, string>) => {
+          let created = 0;
+          const onCreated = (_e: unknown, bw: BrowserWindow) => {
+            created++;
+            // Not synchronously: this fires while the window is still being
+            // constructed.
+            setImmediate(() => {
+              if (!bw.isDestroyed()) bw.destroy();
+            });
+          };
+          app.on('browser-window-created', onCreated);
+          try {
+            await loadWebViewAndWaitForMessage(w, { ...attributes, src: linkPage('about:blank#popup') });
+            await setTimeout(1000);
+          } finally {
+            app.removeListener('browser-window-created', onCreated);
+          }
+          return created;
+        };
+
+        it('does not open a new window when allowpopups is not set', async () => {
+          expect(await countNewWindows({})).to.equal(0);
+        });
+
+        it('opens a new window when allowpopups is set', async () => {
+          expect(await countNewWindows({ allowpopups: 'on' })).to.equal(1);
+        });
+      });
     });
 
     describe('webpreferences attribute', () => {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -277,7 +277,8 @@ declare namespace Electron {
         rawFeatures: string,
         referrer: Electron.Referrer,
         postData: LoadURLOptions['postData'],
-        inheritedSandboxFlags: number
+        inheritedSandboxFlags: number,
+        navigate: (webContents: Electron.WebContents) => void
       ) => void
     ): this;
     on(


### PR DESCRIPTION
Backport of #53683

See that PR for details. Only conflict was spec context from #53682, whose 44-x-y backport (#53699) has not landed yet.

Notes: `<webview>` without `allowpopups` also blocks links opened into a new window by modifier-click, and such windows navigate as the clicking document rather than as a browser-initiated load.
