### PR TITLE
fix: check the sending frame for internal guest, window and reply IPCs (43-x-y)

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -962,6 +962,10 @@ Returns:
 * `args` any[]
 
 Fired when the guest page has sent an asynchronous message to embedder page.
+`frameId` does not tell the embedder which document sent the message; when
+that matters, have the guest use `ipcRenderer.send()` and handle the guest
+`webContents`' [`ipc-message`](web-contents.md#event-ipc-message) event in the
+main process, where `event.senderFrame` identifies the sender.
 
 With `sendToHost` method and `ipc-message` event you can communicate
 between guest page and embedder page:

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -771,8 +771,10 @@ ipcMain.handle('get-secrets', (e) => {
 })
 
 function validateSender (frame) {
-  // Validate the host of the URL using an actual URL parser and an allowlist
-  if ((new URL(frame.url)).host === 'electronjs.org') return true
+  // Validate the frame's origin against an allowlist. Use the origin, not the
+  // URL: about:blank, blob: and sandboxed documents have URLs that do not
+  // identify who controls them, and the frame may be null if it has gone away.
+  if (frame && frame.origin === 'https://electronjs.org') return true
   return false
 }
 ```

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -117,13 +117,17 @@ WebContents.prototype._sendInternal = function (channel, ...args) {
 };
 
 function getWebFrame(contents: Electron.WebContents, frame: number | [number, number]) {
+  let webFrame: Electron.WebFrameMain | undefined;
   if (typeof frame === 'number') {
-    return webFrameMain.fromId(contents.mainFrame.processId, frame);
+    webFrame = webFrameMain.fromId(contents.mainFrame.processId, frame);
   } else if (Array.isArray(frame) && frame.length === 2 && frame.every((value) => typeof value === 'number')) {
-    return webFrameMain.fromId(frame[0], frame[1]);
+    webFrame = webFrameMain.fromId(frame[0], frame[1]);
   } else {
     throw new Error('Missing required frame argument (must be number or [processId, frameId])');
   }
+  // Frame ids are global; only address frames that belong to |contents|.
+  if (webFrame && webFrame.top !== contents.mainFrame) return undefined;
+  return webFrame;
 }
 
 WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -16,6 +16,9 @@ interface GuestInstance {
   elementInstanceId: number;
   visibilityState?: DocumentVisibilityState;
   embedder: Electron.WebContents;
+  // The frame in |embedder| that created the <webview>; only it may drive the
+  // guest through the guest-view IPCs.
+  embedderFrame: Electron.WebFrameMain | null;
   guest: Electron.WebContents;
 }
 
@@ -86,6 +89,7 @@ function makeLoadURLOptions(params: Record<string, any>) {
 // Create a new guest instance.
 const createGuest = function (
   embedder: Electron.WebContents,
+  embedderFrame: Electron.WebFrameMain | null,
   embedderFrameToken: string,
   elementInstanceId: number,
   params: Record<string, any>
@@ -116,7 +120,8 @@ const createGuest = function (
   guestInstances.set(guestInstanceId, {
     elementInstanceId,
     guest,
-    embedder
+    embedder,
+    embedderFrame
   });
 
   // Clear the guest from map when it is destroyed.
@@ -298,7 +303,7 @@ const handleMessage = function (channel: string, handler: (event: Electron.IpcMa
 
 const handleMessageSync = function (
   channel: string,
-  handler: (event: { sender: Electron.WebContents }, ...args: any[]) => any
+  handler: (event: { sender: Electron.WebContents; senderFrame?: Electron.WebFrameMain | null }, ...args: any[]) => any
 ) {
   ipcMainUtils.handleSync(channel, makeSafeHandler(channel, handler));
 };
@@ -306,11 +311,12 @@ const handleMessageSync = function (
 handleMessage(
   IPC_MESSAGES.GUEST_VIEW_MANAGER_CREATE_AND_ATTACH_GUEST,
   function (event, embedderFrameToken: string, elementInstanceId: number, params) {
-    return createGuest(event.sender, embedderFrameToken, elementInstanceId, params);
+    return createGuest(event.sender, event.senderFrame ?? null, embedderFrameToken, elementInstanceId, params);
   }
 );
 
 handleMessageSync(IPC_MESSAGES.GUEST_VIEW_MANAGER_DETACH_GUEST, function (event, guestInstanceId: number) {
+  getGuestForFrame(guestInstanceId, event);
   return detachGuest(event.sender, guestInstanceId);
 });
 
@@ -324,7 +330,7 @@ ipcMainInternal.on(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, function (event
 handleMessage(
   IPC_MESSAGES.GUEST_VIEW_MANAGER_CALL,
   function (event, guestInstanceId: number, method: string, args: any[]) {
-    const guest = getGuestForWebContents(guestInstanceId, event.sender);
+    const guest = getGuestForFrame(guestInstanceId, event);
     if (!asyncMethods.has(method)) {
       throw new Error(`Invalid method: ${method}`);
     }
@@ -336,7 +342,7 @@ handleMessage(
 handleMessageSync(
   IPC_MESSAGES.GUEST_VIEW_MANAGER_CALL,
   function (event, guestInstanceId: number, method: string, args: any[]) {
-    const guest = getGuestForWebContents(guestInstanceId, event.sender);
+    const guest = getGuestForFrame(guestInstanceId, event);
     if (!syncMethods.has(method)) {
       throw new Error(`Invalid method: ${method}`);
     }
@@ -356,7 +362,7 @@ handleMessageSync(
 handleMessageSync(
   IPC_MESSAGES.GUEST_VIEW_MANAGER_PROPERTY_GET,
   function (event, guestInstanceId: number, property: string) {
-    const guest = getGuestForWebContents(guestInstanceId, event.sender);
+    const guest = getGuestForFrame(guestInstanceId, event);
     if (!properties.has(property)) {
       throw new Error(`Invalid property: ${property}`);
     }
@@ -368,7 +374,7 @@ handleMessageSync(
 handleMessageSync(
   IPC_MESSAGES.GUEST_VIEW_MANAGER_PROPERTY_SET,
   function (event, guestInstanceId: number, property: string, val: any) {
-    const guest = getGuestForWebContents(guestInstanceId, event.sender);
+    const guest = getGuestForFrame(guestInstanceId, event);
     if (!properties.has(property)) {
       throw new Error(`Invalid property: ${property}`);
     }
@@ -377,13 +383,20 @@ handleMessageSync(
   }
 );
 
-// Returns WebContents from its guest id hosted in given webContents.
-const getGuestForWebContents = function (guestInstanceId: number, contents: Electron.WebContents) {
+// Returns the guest WebContents for |guestInstanceId| if the IPC came from the
+// frame that created it (not merely from the same WebContents).
+const getGuestForFrame = function (
+  guestInstanceId: number,
+  event: { sender: Electron.WebContents; senderFrame?: Electron.WebFrameMain | null }
+) {
   const guestInstance = guestInstances.get(guestInstanceId);
   if (!guestInstance) {
     throw new Error(`Invalid guestInstanceId: ${guestInstanceId}`);
   }
-  if (guestInstance.guest.hostWebContents !== contents) {
+  if (
+    guestInstance.guest.hostWebContents !== event.sender ||
+    (guestInstance.embedderFrame && event.senderFrame !== guestInstance.embedderFrame)
+  ) {
     throw new Error(`Access denied to guestInstanceId: ${guestInstanceId}`);
   }
   return guestInstance.guest;

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -18,8 +18,10 @@ export function invokeInWebContents<T>(sender: Electron.WebContents, command: st
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
+    // The request goes to the main frame; only the main frame may answer it.
+    const frameTreeNodeId = sender.mainFrame.frameTreeNodeId;
     ipcMainInternal.on(channel, function handler(event, error: Error, result: any) {
-      if (event.type !== 'frame' || event.sender !== sender) {
+      if (event.type !== 'frame' || event.sender !== sender || event.frameTreeNodeId !== frameTreeNodeId) {
         console.error(`Reply to ${command} sent by unexpected sender`);
         return;
       }

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -7,15 +7,18 @@ import { webFrameMain } from 'electron/main';
 
 import * as path from 'path';
 
-// Implements window.close()
+// Implements window.close(). Only the top-level document may close its
+// window, as in the HTML spec; the renderer override is installed for the main
+// frame only, and the request is ignored here if it comes from anywhere else.
 ipcMainInternal.on(IPC_MESSAGES.BROWSER_WINDOW_CLOSE, function (event) {
+  event.returnValue = null;
   if (event.type !== 'frame') return;
+  if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) return;
 
   const window = event.sender.getOwnerBrowserWindow();
   if (window) {
     window.close();
   }
-  event.returnValue = null;
 });
 
 ipcMainInternal.handle(IPC_MESSAGES.BROWSER_GET_LAST_WEB_PREFERENCES, function (event) {
@@ -25,7 +28,9 @@ ipcMainInternal.handle(IPC_MESSAGES.BROWSER_GET_LAST_WEB_PREFERENCES, function (
 
 ipcMainInternal.handle(IPC_MESSAGES.BROWSER_GET_PROCESS_MEMORY_INFO, function (event) {
   if (event.type !== 'frame') return;
-  return event.sender._getProcessMemoryInfo();
+  // Report the calling frame's own renderer process, which for an
+  // out-of-process iframe is not the main frame's.
+  return event.sender._getProcessMemoryInfo(event.processId);
 });
 
 // Methods not listed in this set are called directly in the renderer process.

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -5,8 +5,9 @@ import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-in
 const { contextIsolationEnabled } = internalContextBridge;
 
 export const windowSetup = (isWebView: boolean, isHiddenPage: boolean) => {
-  if (!process.sandboxed && !isWebView) {
-    // Override default window.close.
+  if (!process.sandboxed && !isWebView && process.isMainFrame) {
+    // Override default window.close for the top-level document; frames keep
+    // Blink's behaviour (a nested browsing context cannot close the window).
     window.close = function () {
       ipcRendererInternal.send(IPC_MESSAGES.BROWSER_WINDOW_CLOSE);
     };

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4385,17 +4385,30 @@ void WebContents::CancelDialogs(content::WebContents* web_contents,
       gin::DataObjectBuilder(isolate).Set("resetState", reset_state).Build());
 }
 
-v8::Local<v8::Promise> WebContents::GetProcessMemoryInfo(v8::Isolate* isolate) {
+v8::Local<v8::Promise> WebContents::GetProcessMemoryInfo(gin::Arguments* args) {
+  v8::Isolate* isolate = args->isolate();
   gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
-  auto* frame_host = web_contents()->GetPrimaryMainFrame();
-  if (!frame_host) {
+  // With a renderer process id, report that process, provided it hosts a frame
+  // of this WebContents; otherwise the primary main frame's process.
+  content::RenderProcessHost* process = nullptr;
+  int32_t process_id = 0;
+  if (args->GetNext(&process_id)) {
+    web_contents()->GetPrimaryMainFrame()->ForEachRenderFrameHost(
+        [&](content::RenderFrameHost* rfh) {
+          if (!process && rfh->GetProcess()->GetDeprecatedID() == process_id)
+            process = rfh->GetProcess();
+        });
+  } else if (auto* frame_host = web_contents()->GetPrimaryMainFrame()) {
+    process = frame_host->GetProcess();
+  }
+  if (!process || !process->GetProcess().IsValid()) {
     promise.RejectWithErrorMessage("Failed to create memory dump");
     return handle;
   }
 
-  auto pid = frame_host->GetProcess()->GetProcess().Pid();
+  auto pid = process->GetProcess().Pid();
   v8::Global<v8::Context> context(isolate, isolate->GetCurrentContext());
   memory_instrumentation::MemoryInstrumentation::GetInstance()
       ->RequestGlobalDumpForPid(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -369,7 +369,7 @@ class WebContents final : public ExclusiveAccessContext,
 
   v8::Local<v8::Promise> TakeHeapSnapshot(v8::Isolate* isolate,
                                           const base::FilePath& file_path);
-  v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
+  v8::Local<v8::Promise> GetProcessMemoryInfo(gin::Arguments* args);
 
   // content::WebContentsDelegate:
   bool HandleContextMenu(content::RenderFrameHost& render_frame_host,

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -325,6 +325,36 @@ describe('BrowserWindow module', () => {
       w.webContents.executeJavaScript('window.close()', true);
       await once(w.webContents, '-before-unload-fired');
     });
+
+    it('is ignored when called from an iframe', async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader('content-type', 'text/html');
+        res.end('<!doctype html><body>frame</body>');
+      });
+      defer(() => server.close());
+      const crossOriginUrl = (await listen(server)).url;
+      const win = new BrowserWindow({
+        show: false,
+        webPreferences: { sandbox: false, nodeIntegrationInSubFrames: true, contextIsolation: true }
+      });
+      defer(() => win.isDestroyed() || win.destroy());
+      await win.loadFile(path.join(fixtures, 'pages', 'blank.html'));
+      await win.webContents.executeJavaScript(`new Promise((resolve) => {
+        const f = document.createElement('iframe');
+        f.src = ${JSON.stringify(crossOriginUrl)};
+        f.onload = resolve;
+        document.body.appendChild(f);
+      })`);
+      const iframe = win.webContents.mainFrame.frames[0];
+      let closed = false;
+      win.on('closed', () => {
+        closed = true;
+      });
+      await iframe.executeJavaScript('window.close(); true', true);
+      await setTimeout(500);
+      expect(closed).to.equal(false);
+      expect(win.isDestroyed()).to.equal(false);
+    });
   });
 
   describe('BrowserWindow.destroy()', () => {

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -205,6 +205,35 @@ describe('webContents module', () => {
     });
   });
 
+  describe('webContents.sendToFrame(frameId, channel, args...)', () => {
+    afterEach(closeAllWindows);
+    it('only addresses frames that belong to this webContents', async () => {
+      const preload = path.join(fixturesPath, 'module', 'preload-ipc-ping-pong.js');
+      const w1 = new BrowserWindow({
+        show: false,
+        webPreferences: { preload, sandbox: false, contextIsolation: false }
+      });
+      const w2 = new BrowserWindow({
+        show: false,
+        webPreferences: { preload, sandbox: false, contextIsolation: false }
+      });
+      await w1.loadURL('about:blank');
+      await w2.loadURL('about:blank');
+      const received: number[] = [];
+      ipcMain.on('pong', (e) => {
+        received.push(e.sender.id);
+      });
+      defer(() => ipcMain.removeAllListeners('pong'));
+      const other = w2.webContents.mainFrame;
+      expect(w1.webContents.sendToFrame([other.processId, other.routingId], 'ping')).to.equal(false);
+      const own = w1.webContents.mainFrame;
+      expect(w1.webContents.sendToFrame([own.processId, own.routingId], 'ping')).to.equal(true);
+      await waitUntil(() => received.length > 0);
+      await setTimeout(200);
+      expect(received).to.deep.equal([w1.webContents.id]);
+    });
+  });
+
   describe('webContents.send(channel, args...)', () => {
     afterEach(closeAllWindows);
     it('throws an error when the channel is missing', () => {

--- a/spec/fixtures/module/preload-ipc-ping-pong.js
+++ b/spec/fixtures/module/preload-ipc-ping-pong.js
@@ -1,0 +1,5 @@
+const { ipcRenderer } = require('electron');
+
+ipcRenderer.on('ping', () => {
+  ipcRenderer.send('pong');
+});

--- a/spec/webview-spec.ts
+++ b/spec/webview-spec.ts
@@ -1665,6 +1665,57 @@ describe('<webview> tag', function () {
       });
     });
 
+    describe('guest-view IPCs', () => {
+      let server: http.Server;
+      let crossOriginUrl: string;
+      before(async () => {
+        server = http.createServer((_req, res) => {
+          res.setHeader('content-type', 'text/html');
+          res.end('<!doctype html><body>frame</body>');
+        });
+        crossOriginUrl = (await listen(server)).url;
+      });
+      after(() => server.close());
+
+      it('are only honoured from the frame that created the <webview>', async () => {
+        const embedder = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            webviewTag: true,
+            nodeIntegration: true,
+            nodeIntegrationInSubFrames: true,
+            contextIsolation: false,
+            // A fresh partition so the cross-origin iframe below gets its own
+            // renderer rather than one an earlier test started without
+            // subframe node integration.
+            partition: 'guest-view-ipc-spec'
+          }
+        });
+        await embedder.loadURL(`file://${fixtures}/pages/blank.html`);
+        await loadWebView(embedder.webContents, { src: `file://${fixtures}/pages/a.html` });
+        const guestId = await embedder.webContents.executeJavaScript(
+          "document.querySelector('webview').getWebContentsId()"
+        );
+        await embedder.webContents.executeJavaScript(`new Promise((resolve) => {
+          const f = document.createElement('iframe');
+          f.src = ${JSON.stringify(crossOriginUrl)};
+          f.onload = resolve;
+          document.body.appendChild(f);
+        })`);
+        const iframe = embedder.webContents.mainFrame.frames.find((f) => f.url.startsWith('http'))!;
+        // The iframe shares the embedder WebContents but did not create the
+        // <webview>; it must not be able to drive it through the internal IPC.
+        const call = (frame: Electron.WebFrameMain) =>
+          frame.executeJavaScript(`(async () => {
+            const { ipc } = { ipc: process._linkedBinding('electron_renderer_ipc').createForRenderFrame() };
+            const { error, result } = await ipc.invoke(true, 'GUEST_VIEW_MANAGER_CALL', [${guestId}, 'executeJavaScript', ['6 * 7']]);
+            return error ? 'error:' + error : result;
+          })()`);
+        expect(await call(iframe)).to.match(/^error:.*Access denied/);
+        expect(await call(embedder.webContents.mainFrame)).to.equal(42);
+      });
+    });
+
     describe('page-title-updated event', () => {
       it('emits when title is set', async () => {
         const { title, explicitSet } = await loadWebViewAndWaitForEvent(

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -101,7 +101,7 @@ declare namespace Electron {
     _setConsoleMessageObserved(observed: boolean): void;
     getOwnerBrowserWindow(): Electron.BrowserWindow | null;
     getLastWebPreferences(): Electron.WebPreferences | null;
-    _getProcessMemoryInfo(): Electron.ProcessMemoryInfo;
+    _getProcessMemoryInfo(processId?: number): Electron.ProcessMemoryInfo;
     _getPreloadScript(): Electron.PreloadScript | null;
     browserWindowOptions: BrowserWindowConstructorOptions;
     _windowOpenHandler: ((details: Electron.HandlerDetails) => any) | null;


### PR DESCRIPTION
Backport of #53684

See that PR for details.

Notes: Internal `<webview>`, `window.close()` and `executeJavaScript` reply IPCs are validated against the sending frame.
