### PR TITLE
feat: expose WebAuthn hybrid transport via 'webauthn-hybrid-request'

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -742,6 +742,94 @@ app.whenReady().then(() => {
 })
 ```
 
+#### Event: 'webauthn-hybrid-request'
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53733
+```
+-->
+
+Returns:
+
+* `event` Event
+* `details` Object
+  * `relyingPartyId` string - The relying party identifier from the WebAuthn request.
+  * `requestType` string - `'create'` for `navigator.credentials.create()` or
+    `'get'` for `navigator.credentials.get()`.
+  * `qrCode` string - The `FIDO:/` URL to encode in a QR code. Scanning it with a
+    phone starts the hybrid (cross-device) passkey flow.
+  * `frame` [WebFrameMain](web-frame-main.md) | null - The frame initiating this event.
+      May be `null` if accessed after the frame has either navigated or been destroyed.
+
+Emitted at the start of every WebAuthn request that can use hybrid transport,
+the FIDO cross-device flow where a phone holding the passkey scans a QR code
+and proves proximity over Bluetooth Low Energy. Electron does not draw any UI
+for this flow. The app renders `details.qrCode` as a QR code and shows it to
+the user. Once the phone connects, the ceremony completes on the phone and the
+page's `navigator.credentials` promise resolves as usual.
+
+Hybrid transport is only enabled for a request when at least one listener is
+registered for this event. Without a listener the request behaves exactly as
+before and is served by the remaining authenticators (USB security keys and
+platform authenticators). Every request receives a fresh single-use QR code.
+
+Listen for [`webauthn-hybrid-request-completed`](#event-webauthn-hybrid-request-completed)
+to know when to dismiss the QR code.
+
+On macOS the app's `Info.plist` must include `NSBluetoothAlwaysUsageDescription`
+so the system Bluetooth permission prompt can be shown the first time the
+phone is discovered. The app must also be launched from Finder or with the app
+bundle as the responsible process; when launched from a terminal, macOS
+attributes Bluetooth use to the terminal and Chromium disables hybrid transport.
+
+This event is not emitted on Windows 11 and later, where the operating system
+implements hybrid transport and shows its own QR code, or on systems without
+Bluetooth Low Energy support.
+
+```js
+const { BrowserWindow } = require('electron')
+
+const win = new BrowserWindow()
+
+win.webContents.session.on('webauthn-hybrid-request', (event, details) => {
+  // Render details.qrCode with a QR code library and show it to the user,
+  // for example in a small dialog window.
+  win.webContents.send('show-passkey-qr-code', {
+    qrCode: details.qrCode,
+    relyingPartyId: details.relyingPartyId
+  })
+})
+
+win.webContents.session.on('webauthn-hybrid-request-completed', () => {
+  win.webContents.send('hide-passkey-qr-code')
+})
+```
+
+#### Event: 'webauthn-hybrid-request-completed'
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53733
+```
+-->
+
+Returns:
+
+* `event` Event
+* `details` Object
+  * `relyingPartyId` string - The relying party identifier from the WebAuthn request.
+  * `frame` [WebFrameMain](web-frame-main.md) | null - The frame initiating this event.
+      May be `null` if accessed after the frame has either navigated or been destroyed.
+
+Emitted when a WebAuthn request that was offered hybrid transport through
+[`webauthn-hybrid-request`](#event-webauthn-hybrid-request) has finished,
+whether it succeeded, failed, timed out, or was cancelled by the page. Use it
+to dismiss the QR code. This event is not emitted for requests that had no
+`webauthn-hybrid-request` listener.
+
 ### Instance Methods
 
 The following methods are available on instances of `Session`:

--- a/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
+++ b/shell/browser/webauthn/electron_authenticator_request_client_delegate.cc
@@ -5,35 +5,51 @@
 #include "shell/browser/webauthn/electron_authenticator_request_client_delegate.h"
 
 #include <algorithm>
+#include <array>
 #include <string>
 #include <utility>
 
 #include "base/base64url.h"
 #include "base/containers/span.h"
 #include "base/functional/bind.h"
+#include "base/notreached.h"
+#include "components/device_event_log/device_event_log.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
+#include "crypto/random.h"
+#include "device/bluetooth/bluetooth_adapter_factory.h"
 #include "device/fido/authenticator_get_assertion_response.h"
+#include "device/fido/cable/v2_constants.h"
+#include "device/fido/cable/v2_handshake.h"
 #include "device/fido/fido_authenticator.h"
+#include "device/fido/fido_discovery_factory.h"
 #include "device/fido/public/fido_types.h"
 #include "device/fido/public/public_key_credential_descriptor.h"
 #include "device/fido/public/public_key_credential_user_entity.h"
 #include "gin/arguments.h"
 #include "gin/converter.h"
 #include "gin/data_object_builder.h"
+#include "services/network/public/mojom/network_context.mojom-forward.h"
 #include "shell/browser/api/electron_api_session.h"
+#include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
+#include "url/origin.h"
 
 #if BUILDFLAG(IS_MAC)
 #include "shell/browser/webauthn/electron_authenticator_request_delegate.h"
 #include "shell/browser/webauthn/electron_platform_passkeys_discovery.h"
 #include "third_party/blink/public/mojom/devtools/console_message.mojom.h"
-#include "url/origin.h"
+#endif
+
+#if BUILDFLAG(IS_WIN)
+#include "device/fido/win/webauthn_api.h"
 #endif
 
 namespace electron {
@@ -55,6 +71,97 @@ std::string CredentialIdFor(
     return Base64UrlEncodeNoPad(response.credential->id);
   }
   return {};
+}
+
+gin::WeakCell<api::Session>* SessionFor(
+    content::GlobalRenderFrameHostId render_frame_host_id) {
+  content::RenderFrameHost* rfh =
+      content::RenderFrameHost::FromID(render_frame_host_id);
+  content::WebContents* web_contents =
+      rfh ? content::WebContents::FromRenderFrameHost(rfh) : nullptr;
+  return web_contents ? api::Session::FromBrowserContext(
+                            web_contents->GetBrowserContext())
+                      : nullptr;
+}
+
+// Hybrid transport tunnels to the phone over a WebSocket, which needs a
+// network context. Use the one belonging to the requesting session so proxy
+// and certificate settings match the page that made the request. The request
+// handler that owns the discovery is torn down with the frame, before the
+// browser context, so the context is live for every call made during a
+// request.
+network::mojom::NetworkContext* NetworkContextFor(
+    base::WeakPtr<ElectronBrowserContext> browser_context) {
+  if (!browser_context) {
+    return nullptr;
+  }
+  return browser_context->GetDefaultStoragePartition()->GetNetworkContext();
+}
+
+// True when Chromium would actually create a hybrid discovery for this
+// process. Mirrors the checks in FidoDiscoveryFactory::Create(kHybrid) so the
+// app is not asked to show a QR code that can never be scanned.
+bool HybridTransportAvailable() {
+  if (!device::BluetoothAdapterFactory::Get()->IsLowEnergySupported()) {
+    return false;
+  }
+#if BUILDFLAG(IS_WIN)
+  // Windows 11 implements hybrid natively and shows its own QR code.
+  device::WinWebAuthnApi* const webauthn_api =
+      device::WinWebAuthnApi::GetDefault();
+  if (webauthn_api && webauthn_api->SupportsHybrid()) {
+    return false;
+  }
+#endif
+  return true;
+}
+
+const char* RequestTypeName(device::FidoRequestType request_type) {
+  switch (request_type) {
+    case device::FidoRequestType::kMakeCredential:
+      return "create";
+    case device::FidoRequestType::kGetAssertion:
+      return "get";
+  }
+  NOTREACHED();
+}
+
+// Completion of a WebAuthn request is signalled by //content destroying the
+// delegate, so this runs from a task posted by the destructor rather than
+// re-entering JavaScript from inside teardown. The frame is often already
+// gone at that point (navigation is the usual reason a request ends early),
+// so the session is resolved from the browser context instead.
+void EmitHybridRequestCompleted(
+    base::WeakPtr<ElectronBrowserContext> browser_context,
+    content::GlobalRenderFrameHostId render_frame_host_id,
+    std::string relying_party_id) {
+  gin::WeakCell<api::Session>* session =
+      browser_context ? api::Session::FromBrowserContext(browser_context.get())
+                      : nullptr;
+  if (!session || !session->Get()) {
+    return;
+  }
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+
+  v8::Local<v8::Object> session_wrapper;
+  if (!session->Get()->GetWrapper(isolate).ToLocal(&session_wrapper)) {
+    return;
+  }
+
+  v8::Local<v8::Object> details =
+      gin::DataObjectBuilder(isolate)
+          .Set("relyingPartyId", relying_party_id)
+          .Set("frame", content::RenderFrameHost::FromID(render_frame_host_id))
+          .Build();
+
+  v8::Local<v8::Object> event_object = gin_helper::internal::Event::New(isolate)
+                                           ->GetWrapper(isolate)
+                                           .ToLocalChecked();
+  gin_helper::EmitEvent(isolate, session_wrapper,
+                        "webauthn-hybrid-request-completed", event_object,
+                        details);
 }
 
 #if BUILDFLAG(IS_MAC)
@@ -79,11 +186,118 @@ ElectronAuthenticatorRequestClientDelegate::
     : render_frame_host_id_(render_frame_host->GetGlobalId()) {}
 
 ElectronAuthenticatorRequestClientDelegate::
-    ~ElectronAuthenticatorRequestClientDelegate() = default;
+    ~ElectronAuthenticatorRequestClientDelegate() {
+  if (hybrid_browser_context_) {
+    // During browser shutdown the task runner may refuse the task; the app is
+    // going away with it, so the dropped event is harmless.
+    content::GetUIThreadTaskRunner({})->PostTask(
+        FROM_HERE,
+        base::BindOnce(&EmitHybridRequestCompleted, hybrid_browser_context_,
+                       render_frame_host_id_, relying_party_id_));
+  }
+}
 
 void ElectronAuthenticatorRequestClientDelegate::SetRelyingPartyId(
     const std::string& rp_id) {
   relying_party_id_ = rp_id;
+}
+
+void ElectronAuthenticatorRequestClientDelegate::SetUIPresentation(
+    UIPresentation ui_presentation) {
+  ui_presentation_ = ui_presentation;
+}
+
+void ElectronAuthenticatorRequestClientDelegate::ConfigureDiscoveries(
+    const url::Origin& origin,
+    const std::string& rp_id,
+    RequestSource request_source,
+    device::FidoRequestType request_type,
+    std::optional<device::ResidentKeyRequirement> resident_key_requirement,
+    device::UserVerificationRequirement user_verification_requirement,
+    bool cmtg_key_requested,
+    std::optional<std::string_view> user_name,
+    bool is_enclave_authenticator_available,
+    device::FidoDiscoveryFactory* fido_discovery_factory) {
+  // A null factory means the request is for passwords only. Conditional
+  // (autofill) and passkey-upgrade requests show no UI in Chromium either, so
+  // a QR code must not appear for them.
+  if (!fido_discovery_factory ||
+      request_source != RequestSource::kWebAuthentication ||
+      ui_presentation_ != UIPresentation::kModal ||
+      !HybridTransportAvailable()) {
+    return;
+  }
+
+  content::RenderFrameHost* rfh =
+      content::RenderFrameHost::FromID(render_frame_host_id_);
+  if (!rfh) {
+    return;
+  }
+  base::WeakPtr<ElectronBrowserContext> browser_context =
+      static_cast<ElectronBrowserContext*>(rfh->GetBrowserContext())
+          ->GetWeakPtr();
+
+  // Chromium adds kHybrid to every request's transport set but only creates
+  // the hybrid discovery once a QR generator key is configured. Without one
+  // the request has no hybrid authenticator and never completes on that
+  // transport.
+  std::array<uint8_t, device::cablev2::kQRKeySize> qr_generator_key;
+  crypto::RandBytes(qr_generator_key);
+  const std::string qr_code =
+      device::cablev2::qr::Encode(qr_generator_key, request_type);
+
+  // The app renders the QR code, so hybrid is only useful when a listener
+  // exists. Without one, leave the transport unconfigured so the remaining
+  // authenticators behave exactly as before.
+  base::WeakPtr<ElectronAuthenticatorRequestClientDelegate> weak_this =
+      weak_factory_.GetWeakPtr();
+  if (!EmitHybridRequestEvent(request_type, qr_code) || !weak_this) {
+    return;
+  }
+
+  hybrid_browser_context_ = browser_context;
+  fido_discovery_factory->set_cable_data(request_type, qr_generator_key);
+  fido_discovery_factory->set_network_context_factory(
+      base::BindRepeating(&NetworkContextFor, browser_context));
+}
+
+bool ElectronAuthenticatorRequestClientDelegate::EmitHybridRequestEvent(
+    device::FidoRequestType request_type,
+    const std::string& qr_code) {
+  gin::WeakCell<api::Session>* session = SessionFor(render_frame_host_id_);
+  if (!session || !session->Get()) {
+    return false;
+  }
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+
+  v8::Local<v8::Object> session_wrapper;
+  if (!session->Get()->GetWrapper(isolate).ToLocal(&session_wrapper)) {
+    return false;
+  }
+
+  v8::Local<v8::Object> details =
+      gin::DataObjectBuilder(isolate)
+          .Set("relyingPartyId", relying_party_id_)
+          .Set("requestType", RequestTypeName(request_type))
+          .Set("qrCode", qr_code)
+          .Set("frame", content::RenderFrameHost::FromID(render_frame_host_id_))
+          .Build();
+
+  v8::Local<v8::Object> event_object = gin_helper::internal::Event::New(isolate)
+                                           ->GetWrapper(isolate)
+                                           .ToLocalChecked();
+
+  v8::Local<v8::Value> emit_result =
+      gin_helper::EmitEvent(isolate, session_wrapper, "webauthn-hybrid-request",
+                            event_object, details);
+
+  // EventEmitter.prototype.emit() returns true iff there was at least one
+  // listener.
+  bool had_listener = false;
+  return gin::ConvertFromV8(isolate, emit_result, &had_listener) &&
+         had_listener;
 }
 
 void ElectronAuthenticatorRequestClientDelegate::StartObserving(
@@ -110,6 +324,9 @@ void ElectronAuthenticatorRequestClientDelegate::RegisterActionCallbacks(
         request_ble_permission_callback) {
   cancel_callback_ = std::move(cancel_callback);
   request_callback_ = std::move(request_callback);
+  bluetooth_adapter_power_on_callback_ =
+      std::move(bluetooth_adapter_power_on_callback);
+  request_ble_permission_callback_ = std::move(request_ble_permission_callback);
 }
 
 void ElectronAuthenticatorRequestClientDelegate::SelectAccount(
@@ -286,9 +503,40 @@ void ElectronAuthenticatorRequestClientDelegate::FidoAuthenticatorAdded(
 void ElectronAuthenticatorRequestClientDelegate::
     OnTransportAvailabilityEnumerated(
         device::FidoRequestHandlerBase::TransportAvailabilityInfo data) {
+  // Hybrid discovery listens for the phone's BLE advertisement, which on
+  // macOS needs the Bluetooth permission. Ask for it now rather than letting
+  // the request sit until the OS prompt happens to appear.
+  can_power_on_ble_adapter_ = data.can_power_on_ble_adapter;
+  if (hybrid_browser_context_ && request_ble_permission_callback_ &&
+      data.ble_status == device::FidoRequestHandlerBase::BleStatus::
+                             kPendingPermissionRequest) {
+    request_ble_permission_callback_.Run(
+        base::BindOnce(&ElectronAuthenticatorRequestClientDelegate::OnBleStatus,
+                       weak_factory_.GetWeakPtr()));
+  }
+
   if (!controls_dispatch_ || pending_authenticators_.empty())
     return;
   MaybeEmitSelectAuthenticatorEvent();
+}
+
+void ElectronAuthenticatorRequestClientDelegate::OnBleStatus(
+    device::FidoRequestHandlerBase::BleStatus status) {
+  switch (status) {
+    case device::FidoRequestHandlerBase::BleStatus::kOn:
+      break;
+    case device::FidoRequestHandlerBase::BleStatus::kOff:
+      if (can_power_on_ble_adapter_ && bluetooth_adapter_power_on_callback_) {
+        bluetooth_adapter_power_on_callback_.Run();
+      }
+      break;
+    case device::FidoRequestHandlerBase::BleStatus::kPermissionDenied:
+      FIDO_LOG(ERROR) << "Bluetooth permission denied; hybrid transport "
+                         "cannot discover the phone.";
+      break;
+    case device::FidoRequestHandlerBase::BleStatus::kPendingPermissionRequest:
+      break;
+  }
 }
 
 void ElectronAuthenticatorRequestClientDelegate::

--- a/shell/browser/webauthn/electron_authenticator_request_client_delegate.h
+++ b/shell/browser/webauthn/electron_authenticator_request_client_delegate.h
@@ -6,7 +6,9 @@
 #define ELECTRON_SHELL_BROWSER_WEBAUTHN_ELECTRON_AUTHENTICATOR_REQUEST_CLIENT_DELEGATE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
@@ -16,6 +18,7 @@
 #include "content/public/browser/global_routing_id.h"
 #include "device/fido/fido_discovery_base.h"
 #include "device/fido/fido_request_handler_base.h"
+#include "device/fido/public/fido_constants.h"
 
 namespace content {
 class RenderFrameHost;
@@ -26,6 +29,8 @@ class Arguments;
 }
 
 namespace electron {
+
+class ElectronBrowserContext;
 
 class ElectronAuthenticatorRequestClientDelegate
     : public content::AuthenticatorRequestClientDelegate {
@@ -42,6 +47,18 @@ class ElectronAuthenticatorRequestClientDelegate
 
   // content::AuthenticatorRequestClientDelegate:
   void SetRelyingPartyId(const std::string& rp_id) override;
+  void SetUIPresentation(UIPresentation ui_presentation) override;
+  void ConfigureDiscoveries(
+      const url::Origin& origin,
+      const std::string& rp_id,
+      RequestSource request_source,
+      device::FidoRequestType request_type,
+      std::optional<device::ResidentKeyRequirement> resident_key_requirement,
+      device::UserVerificationRequirement user_verification_requirement,
+      bool cmtg_key_requested,
+      std::optional<std::string_view> user_name,
+      bool is_enclave_authenticator_available,
+      device::FidoDiscoveryFactory* fido_discovery_factory) override;
   void StartObserving(device::FidoRequestHandlerBase* request_handler) override;
   void StopObserving(device::FidoRequestHandlerBase* request_handler) override;
   void RegisterActionCallbacks(
@@ -79,14 +96,31 @@ class ElectronAuthenticatorRequestClientDelegate
 
   void OnAccountSelected(gin::Arguments* args);
   void CancelPendingAccountSelection();
+  // Emits 'webauthn-hybrid-request' on the session. Returns true iff at least
+  // one listener received the event.
+  bool EmitHybridRequestEvent(device::FidoRequestType request_type,
+                              const std::string& qr_code);
+  void OnBleStatus(device::FidoRequestHandlerBase::BleStatus status);
   void MaybeEmitSelectAuthenticatorEvent();
   void DispatchDefaultAuthenticator();
   void OnAuthenticatorSelected(gin::Arguments* args);
 
   const content::GlobalRenderFrameHostId render_frame_host_id_;
   std::string relying_party_id_;
+  UIPresentation ui_presentation_ = UIPresentation::kModal;
   base::OnceClosure cancel_callback_;
   device::FidoRequestHandlerBase::RequestCallback request_callback_;
+  base::RepeatingClosure bluetooth_adapter_power_on_callback_;
+  base::RepeatingCallback<void(
+      device::FidoRequestHandlerBase::BlePermissionCallback)>
+      request_ble_permission_callback_;
+
+  // Set once an app listener accepted the 'webauthn-hybrid-request' event
+  // and hybrid (caBLE v2) discovery was configured for this request. The
+  // browser context outlives the request; the frame may not, so the
+  // completion event is delivered through this handle.
+  base::WeakPtr<ElectronBrowserContext> hybrid_browser_context_;
+  bool can_power_on_ble_adapter_ = false;
 
   base::ScopedObservation<device::FidoRequestHandlerBase,
                           device::FidoRequestHandlerBase::Observer>

--- a/spec/api-web-authn-spec.ts
+++ b/spec/api-web-authn-spec.ts
@@ -491,3 +491,172 @@ describe("session 'select-webauthn-account' event", () => {
     expect(result.name).to.equal('NotAllowedError');
   });
 });
+
+// Windows 11 serves hybrid transport natively, so Electron does not offer it
+// there and the event is not emitted.
+ifdescribe(process.platform !== 'win32')("session 'webauthn-hybrid-request' event", () => {
+  let server: http.Server;
+  let serverUrl: string;
+  let w: BrowserWindow;
+
+  before(async () => {
+    server = http.createServer((req, res) => {
+      res.setHeader('Content-Type', 'text/html');
+      res.end('<!doctype html><title>webauthn</title>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, 'localhost', resolve));
+    const { port } = server.address() as AddressInfo;
+    serverUrl = `http://localhost:${port}/`;
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  beforeEach(async () => {
+    w = new BrowserWindow({ show: false });
+    await w.loadURL(serverUrl);
+    w.webContents.debugger.attach();
+    await w.webContents.debugger.sendCommand('WebAuthn.enable');
+    // A virtual authenticator lets the ceremony complete on CI machines that
+    // have no Bluetooth adapter. The hybrid event fires before any
+    // authenticator is consulted, so it is observable either way.
+    await w.webContents.debugger.sendCommand('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true
+      }
+    });
+  });
+
+  afterEach(async () => {
+    session.defaultSession.removeAllListeners('webauthn-hybrid-request');
+    session.defaultSession.removeAllListeners('webauthn-hybrid-request-completed');
+    try {
+      w.webContents.debugger.detach();
+    } catch {}
+    await closeAllWindows();
+  });
+
+  function makeCredential() {
+    return w.webContents.executeJavaScript(`
+      navigator.credentials.create({
+        publicKey: {
+          rp: { id: 'localhost', name: 'Electron Spec' },
+          user: {
+            id: new TextEncoder().encode('user-1'),
+            name: 'alice@example.com',
+            displayName: 'Alice'
+          },
+          challenge: new Uint8Array(32),
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          authenticatorSelection: {
+            residentKey: 'required',
+            userVerification: 'required'
+          }
+        }
+      }).then(
+        c => ({ ok: true, id: c.id }),
+        e => ({ ok: false, name: e.name, message: e.message })
+      )
+    `);
+  }
+
+  function getAssertion() {
+    return w.webContents.executeJavaScript(`
+      navigator.credentials.get({
+        publicKey: {
+          challenge: new Uint8Array(32),
+          rpId: 'localhost',
+          userVerification: 'required'
+        }
+      }).then(
+        c => ({ ok: true, id: c.id }),
+        e => ({ ok: false, name: e.name, message: e.message })
+      )
+    `);
+  }
+
+  it('fires for navigator.credentials.create() with a FIDO QR code', async () => {
+    let received: any;
+    (w.webContents.session as NodeJS.EventEmitter).on('webauthn-hybrid-request', (event, details) => {
+      received = details;
+    });
+
+    const result = await makeCredential();
+    expect(result.ok).to.be.true();
+
+    expect(received).to.exist();
+    expect(received.relyingPartyId).to.equal('localhost');
+    expect(received.requestType).to.equal('create');
+    // caBLE v2 QR payloads are the "FIDO:/" prefix followed by base-10 digits.
+    expect(received.qrCode).to.match(/^FIDO:\/\d+$/);
+    expect(received.frame).to.equal(w.webContents.mainFrame);
+  });
+
+  it('fires for navigator.credentials.get() and emits a completion event', async () => {
+    await makeCredential();
+
+    const requests: any[] = [];
+    (w.webContents.session as NodeJS.EventEmitter).on('webauthn-hybrid-request', (event, details) => {
+      requests.push(details);
+    });
+    const completed = new Promise<any>((resolve) => {
+      (w.webContents.session as NodeJS.EventEmitter).once('webauthn-hybrid-request-completed', (event, details) => {
+        resolve(details);
+      });
+    });
+
+    const result = await getAssertion();
+    expect(result.ok).to.be.true();
+
+    const getRequest = requests.find((r) => r.requestType === 'get');
+    expect(getRequest).to.exist();
+    expect(getRequest.qrCode).to.match(/^FIDO:\/\d+$/);
+
+    const details = await completed;
+    expect(details.relyingPartyId).to.equal('localhost');
+    expect(details.frame).to.equal(w.webContents.mainFrame);
+  });
+
+  it('generates a fresh QR code for every request', async () => {
+    const codes: string[] = [];
+    (w.webContents.session as NodeJS.EventEmitter).on('webauthn-hybrid-request', (event, details) => {
+      codes.push(details.qrCode);
+    });
+
+    await makeCredential();
+    await getAssertion();
+
+    expect(codes).to.have.lengthOf(2);
+    expect(codes[0]).to.not.equal(codes[1]);
+  });
+
+  it('leaves other authenticators working when no listener is registered', async () => {
+    expect(w.webContents.session.listenerCount('webauthn-hybrid-request')).to.equal(0);
+
+    const created = await makeCredential();
+    expect(created.ok).to.be.true();
+
+    const asserted = await getAssertion();
+    expect(asserted.ok).to.be.true();
+    expect(asserted.id).to.equal(created.id);
+  });
+
+  it('does not emit a completion event when no listener accepted the request', async () => {
+    let completions = 0;
+    (w.webContents.session as NodeJS.EventEmitter).on('webauthn-hybrid-request-completed', () => {
+      completions++;
+    });
+
+    const result = await makeCredential();
+    expect(result.ok).to.be.true();
+    // The completion task is posted to the UI thread; give it a turn to run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(completions).to.equal(0);
+  });
+});


### PR DESCRIPTION
#### Description of Change

Chromium adds the hybrid (caBLE v2, "use a passkey from your phone") transport to every WebAuthn request, but only creates the discovery once the embedder configures a QR generator key in `AuthenticatorRequestClientDelegate::ConfigureDiscoveries`. Electron never overrode that method, so a `navigator.credentials.get()` or `create()` that a site expects to serve over hybrid transport sits forever with no UI and no error. This is the cause of reports like pingdotgg/t3code#5665 (passkey sign-in in an embedded browser hangs) and is the missing piece behind #24573 for cross-device passkeys.

This PR adds the minimal embedder support without pulling any `chrome/browser` UI into Electron:

- `ElectronAuthenticatorRequestClientDelegate::ConfigureDiscoveries` generates the caBLE v2 QR key, encodes it with `device::cablev2::qr::Encode`, and emits a new session event **`webauthn-hybrid-request`** with `{ relyingPartyId, requestType, qrCode, frame }`. The app renders the `FIDO:/` string as a QR code.
- Hybrid discovery is configured (`set_cable_data` + a storage-partition network context factory) **only when a listener received the event**. With no listener, behaviour is unchanged.
- The Bluetooth callbacks passed to `RegisterActionCallbacks`, previously discarded, are stored. When transport enumeration reports the Bluetooth permission as pending, it is requested so the macOS prompt appears.
- A second event, **`webauthn-hybrid-request-completed`**, fires when the request ends so the app can dismiss the QR code. It is posted from the delegate destructor (how //content signals completion) and resolves the session via the browser context, since the frame is often already gone.
- Requests are skipped when the UI presentation is not `kModal` (conditional/autofill and passkey-upgrade requests show no UI in Chromium either), when BLE is unsupported, and on Windows 11 where the OS implements hybrid natively and shows its own QR.

Docs are added to `docs/api/session.md`; typings are generated from them. Spec tests cover: the event fires for `create()` and `get()` with a `FIDO:/` payload, a fresh code per request, the completion event, and that requests without a listener still succeed via other authenticators.

Verification status: this was authored without a local Chromium build. All Chromium symbols were checked against the pinned `155.0.8038.2` source. `npm run lint:docs` passes locally apart from the `pr-url` placeholder, which I will update with this PR's number. I am relying on CI for compilation and the spec run, and will test the real phone flow on macOS against the CI artifact. Opening as a draft until CI is green.

Known follow-ups (out of scope here): surfacing `cablev2::Event::kPhoneConnected` so apps can switch from "scan this" to "continue on your phone", and persistent phone pairing (`set_cable_pairing_callback`).

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Added the `webauthn-hybrid-request` and `webauthn-hybrid-request-completed` session events so apps can offer WebAuthn hybrid (cross-device, QR code) passkey sign-in.
