### PR TITLE
fix: cppgc object lifetime follow-ups

### DIFF
--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -173,6 +173,13 @@ Menu.prototype.insert = function (pos, item) {
   // insert item depending on its type
   insertItemByType.call(this, item, pos);
 
+  // Make menu accessible to items.
+  item.overrideReadOnlyProperty('menu', this);
+
+  // Remember the item before the setters below, which can throw.
+  this.items.splice(pos, 0, item);
+  this.commandsMap[item.commandId] = item;
+
   // set item properties
   if (item.toolTip) this.setToolTip(pos, item.toolTip);
   if (item.icon) this.setIcon(pos, item.icon);
@@ -183,13 +190,6 @@ Menu.prototype.insert = function (pos, item) {
   if (process.platform === 'darwin' && item.badge) {
     this.setBadge(pos, item.badge);
   }
-
-  // Make menu accessible to items.
-  item.overrideReadOnlyProperty('menu', this);
-
-  // Remember the items.
-  this.items.splice(pos, 0, item);
-  this.commandsMap[item.commandId] = item;
 };
 
 Menu.prototype._callMenuWillShow = function () {

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -157,7 +157,10 @@ DataPipeHolder::DataPipeHolder(const network::DataElement& element)
       element.As<network::DataElementDataPipe>().CloneDataPipeGetter());
 }
 
-DataPipeHolder::~DataPipeHolder() = default;
+DataPipeHolder::~DataPipeHolder() {
+  // Off-heap registry; safe to touch from the finalizer.
+  AllDataPipeHolders().erase(id_);
+}
 
 v8::Local<v8::Promise> DataPipeHolder::ReadAll(v8::Isolate* isolate) {
   gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);

--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -33,7 +33,12 @@ gin::WrapperInfo Debugger::kWrapperInfo =
 Debugger::Debugger(content::WebContents* web_contents)
     : content::WebContentsObserver{web_contents} {}
 
-Debugger::~Debugger() = default;
+Debugger::~Debugger() {
+  // The host holds a raw client pointer to us. Clear |agent_host_| first so
+  // messages dispatched during detach are dropped, not emitted from a dtor.
+  if (scoped_refptr<DevToolsAgentHost> agent_host = std::move(agent_host_))
+    agent_host->DetachClient(this);
+}
 
 void Debugger::AgentHostClosed(DevToolsAgentHost* agent_host) {
   DCHECK(agent_host == agent_host_);
@@ -44,7 +49,9 @@ void Debugger::AgentHostClosed(DevToolsAgentHost* agent_host) {
 
 void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
                                        base::span<const uint8_t> message) {
-  DCHECK(agent_host == agent_host_);
+  // Null while detaching from the destructor; see ~Debugger().
+  if (agent_host != agent_host_)
+    return;
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -9,6 +9,7 @@
 
 #include "base/containers/map_util.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "components/prefs/pref_service.h"
@@ -48,6 +49,34 @@ bool MapHasMediaKeys(
       accelerator_map, [](const auto& ac) { return ac.first.IsMediaKey(); });
 }
 #endif
+
+// xdg GlobalShortcuts portal session key; persisted so a later session can
+// pick up shortcuts already registered with the portal.
+std::string GetPortalProfileId() {
+  auto* context = electron::ElectronBrowserContext::GetDefaultBrowserContext();
+  PrefService* prefs = context->prefs();
+  std::string profile_id =
+      prefs->GetString(electron::kElectronGlobalShortcutsUuid);
+  if (profile_id.empty()) {
+    profile_id = base::Uuid::GenerateRandomV4().AsLowercaseString();
+    prefs->SetString(electron::kElectronGlobalShortcutsUuid, profile_id);
+  }
+  return profile_id;
+}
+
+// See the fake extension id note in GlobalShortcut::Register().
+std::string GetPortalExtensionId(const std::string& command_str,
+                                 const std::string& profile_id) {
+  return command_str + "+" + profile_id;
+}
+
+void ClearPortalCommand(ui::GlobalAcceleratorListener* instance,
+                        const std::string& command_str,
+                        const std::string& profile_id) {
+  instance->OnCommandsChanged(GetPortalExtensionId(command_str, profile_id),
+                              profile_id, ui::CommandMap(),
+                              gfx::kNullAcceleratedWidget, base::DoNothing());
+}
 
 }  // namespace
 
@@ -91,14 +120,9 @@ void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
 
 void GlobalShortcut::ExecuteCommand(const extensions::ExtensionId& extension_id,
                                     const std::string& command_id) {
+  // May arrive after the command was unregistered; ignore it then.
   if (auto* cb = base::FindOrNull(command_callback_map_, command_id)) {
     cb->Run();
-  } else {
-    // This should never occur, because if it does, GlobalAcceleratorListener
-    // notifies us with wrong command.
-    if (!is_disposed_) {
-      NOTREACHED();
-    }
   }
 }
 
@@ -149,18 +173,7 @@ bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
   }
 
   if (instance->IsRegistrationHandledExternally()) {
-    auto* context = ElectronBrowserContext::GetDefaultBrowserContext();
-    PrefService* prefs = context->prefs();
-
-    // Need a unique profile id. Set one if not generated yet, otherwise re-use
-    // the same so that the session for the globalShortcuts is able to get
-    // already registered shortcuts from the previous session. This will be used
-    // by GlobalAcceleratorListenerLinux as a session key.
-    std::string profile_id = prefs->GetString(kElectronGlobalShortcutsUuid);
-    if (profile_id.empty()) {
-      profile_id = base::Uuid::GenerateRandomV4().AsLowercaseString();
-      prefs->SetString(kElectronGlobalShortcutsUuid, profile_id);
-    }
+    const std::string profile_id = GetPortalProfileId();
 
     // There is no way to get command id for the accelerator as it's extensions'
     // thing. Instead, we can convert it to string in a following example form
@@ -184,9 +197,9 @@ bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
     // Alt+Shift+M will trigger global shortcuts, but the command id that is
     // received by GlobalShortcut will correspond to Alt+Shift+K as our command
     // id is basically a stringified accelerator.
-    const std::string fake_extension_id = command_str + "+" + profile_id;
     instance->OnCommandsChanged(
-        fake_extension_id, profile_id, commands, gfx::kNullAcceleratedWidget,
+        GetPortalExtensionId(command_str, profile_id), profile_id, commands,
+        gfx::kNullAcceleratedWidget,
         base::BindRepeating(
             &GlobalShortcut::ExecuteCommand,
             gin::WrapPersistent(weak_factory_.GetWeakCell(
@@ -208,12 +221,22 @@ void GlobalShortcut::Unregister(const ui::Accelerator& accelerator) {
         .ThrowError("globalShortcut cannot be used before the app is ready");
     return;
   }
+  auto* instance = ui::GlobalAcceleratorListener::GetInstance();
+  if (instance && instance->IsRegistrationHandledExternally()) {
+    const std::string command_str =
+        extensions::Command::AcceleratorToString(accelerator);
+    if (!command_callback_map_.contains(command_str))
+      return;
+    ClearPortalCommand(instance, command_str, GetPortalProfileId());
+    command_callback_map_.erase(command_str);
+    return;
+  }
+
   if (!accelerator_callback_map_.contains(accelerator))
     return;
 
-  if (ui::GlobalAcceleratorListener::GetInstance()) {
-    ui::GlobalAcceleratorListener::GetInstance()->UnregisterAccelerator(
-        accelerator, this);
+  if (instance) {
+    instance->UnregisterAccelerator(accelerator, this);
   }
 
   // Remove from local callback map after unregistering from UI listener to
@@ -254,8 +277,16 @@ void GlobalShortcut::UnregisterAll() {
 }
 
 void GlobalShortcut::UnregisterAllInternal() {
-  if (ui::GlobalAcceleratorListener::GetInstance()) {
-    ui::GlobalAcceleratorListener::GetInstance()->UnregisterAccelerators(this);
+  if (auto* instance = ui::GlobalAcceleratorListener::GetInstance()) {
+    instance->UnregisterAccelerators(this);
+    // Portal commands are not in the listener's accelerator map; Dispose()
+    // has already pruned them via the invalidated WeakCell.
+    if (!is_disposed_ && instance->IsRegistrationHandledExternally() &&
+        !command_callback_map_.empty()) {
+      const std::string profile_id = GetPortalProfileId();
+      for (const auto& [command_str, _] : command_callback_map_)
+        ClearPortalCommand(instance, command_str, profile_id);
+    }
   }
   accelerator_callback_map_.clear();
   command_callback_map_.clear();

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -47,12 +47,8 @@ class MenuMac : public Menu {
   std::u16string GetAcceleratorTextAtForTesting(int index) const override;
 
  private:
-  friend class Menu;
-
   void ClosePopupOnUI(int32_t window_id);
   void OnClosed(int32_t window_id, base::OnceClosure callback);
-
-  ElectronMenuController* __strong menu_controller_;
 
   // window ID -> open context menu
   std::map<int32_t, ElectronMenuController*> popup_controllers_;

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -22,9 +22,17 @@
 #include "v8/include/cppgc/allocation.h"
 #include "v8/include/v8-cppgc.h"
 
+// Roots the Menu whose NSMenu is (or is about to become) [NSApp mainMenu];
+// ElectronMenuController only holds a weak reference to the model.
+@interface ElectronApplicationMenuHolder : NSObject
+- (instancetype)initWithMenu:(electron::api::Menu*)menu;
+- (void)install;
+@end
+
 namespace {
 
-static NSMenu* __strong applicationMenu_;
+ElectronApplicationMenuHolder* __strong g_pending_application_menu = nil;
+ElectronApplicationMenuHolder* __strong g_installed_application_menu = nil;
 
 ui::Accelerator GetAcceleratorFromKeyEquivalentAndModifierMask(
     NSString* key_equivalent,
@@ -46,13 +54,35 @@ ui::Accelerator GetAcceleratorFromKeyEquivalentAndModifierMask(
 
 }  // namespace
 
+@implementation ElectronApplicationMenuHolder {
+  cppgc::Persistent<electron::api::Menu> _menu;
+  ElectronMenuController* __strong _controller;
+}
+
+- (instancetype)initWithMenu:(electron::api::Menu*)menu {
+  if ((self = [super init])) {
+    _menu = menu;
+    _controller = [[ElectronMenuController alloc] initWithModel:menu->model()
+                                          useDefaultAccelerator:YES];
+  }
+  return self;
+}
+
+- (void)install {
+  [NSApp setMainMenu:[_controller menu]];
+  // Drops the previous holder and its reference to the old Menu.
+  g_installed_application_menu = self;
+}
+
+@end
+
 namespace electron::api {
 
 MenuMac::MenuMac(gin::Arguments* args) : Menu{args} {}
 
 MenuMac::~MenuMac() {
-  // Must remove observer before destroying menu_controller_, which holds
-  // a weak reference to model_
+  // Must remove observer before destroying popup_controllers_, which hold
+  // weak references to model_
   RemoveModelObserver();
 }
 
@@ -294,25 +324,24 @@ void MenuMac::OnClosed(int32_t window_id, base::OnceClosure callback) {
 }
 
 // static
-void Menu::SetApplicationMenu(Menu* base_menu) {
-  MenuMac* menu = static_cast<MenuMac*>(base_menu);
-  ElectronMenuController* menu_controller =
-      [[ElectronMenuController alloc] initWithModel:menu->model_.get()
-                              useDefaultAccelerator:YES];
+void Menu::SetApplicationMenu(Menu* menu) {
+  ElectronApplicationMenuHolder* holder =
+      [[ElectronApplicationMenuHolder alloc] initWithMenu:menu];
 
+  // Install in the default run loop mode so the main menu is not swapped
+  // while a menu is open; the installed holder keeps its Menu alive till then.
   NSRunLoop* currentRunLoop = [NSRunLoop currentRunLoop];
-  [currentRunLoop cancelPerformSelector:@selector(setMainMenu:)
-                                 target:NSApp
-                               argument:applicationMenu_];
-  applicationMenu_ = [menu_controller menu];
-  [[NSRunLoop currentRunLoop]
-      performSelector:@selector(setMainMenu:)
-               target:NSApp
-             argument:applicationMenu_
+  if (g_pending_application_menu) {
+    [currentRunLoop
+        cancelPerformSelectorsWithTarget:g_pending_application_menu];
+  }
+  g_pending_application_menu = holder;
+  [currentRunLoop
+      performSelector:@selector(install)
+               target:holder
+             argument:nil
                 order:0
                 modes:[NSArray arrayWithObject:NSDefaultRunLoopMode]];
-
-  menu->menu_controller_ = menu_controller;
 }
 
 // static

--- a/shell/browser/api/electron_api_menu_views.cc
+++ b/shell/browser/api/electron_api_menu_views.cc
@@ -67,11 +67,20 @@ void MenuViews::PopupAt(BaseWindow* window,
                      gin::WrapPersistent(weak_cell_factory_.GetWeakCell(
                          isolate->GetCppHeap()->GetAllocationHandle())),
                      window_id, std::move(callback_with_ref)));
-  auto& runner = menu_runners_[window_id] =
-      std::make_unique<MenuRunner>(model(), flags, std::move(close_callback));
-  runner->RunMenuAt(native_window->widget(), nullptr,
-                    gfx::Rect{location, gfx::Size{}},
-                    views::MenuAnchorPosition::kTopLeft, source_type);
+  auto runner = std::make_unique<MenuRunner>(model(), flags, close_callback);
+  auto* const runner_ptr = runner.get();
+  menu_runners_[window_id] = std::move(runner);
+  runner_ptr->RunMenuAt(native_window->widget(), nullptr,
+                        gfx::Rect{location, gfx::Size{}},
+                        views::MenuAnchorPosition::kTopLeft, source_type);
+
+  // MenuRunner silently no-ops if another menu is active and never runs the
+  // close callback; treat that as an immediate close so nothing leaks.
+  if (auto iter = menu_runners_.find(window_id);
+      iter != menu_runners_.end() && iter->second.get() == runner_ptr &&
+      !runner_ptr->IsRunning()) {
+    close_callback.Run();
+  }
 }
 
 void MenuViews::ClosePopupAt(int32_t window_id) {

--- a/shell/browser/api/electron_api_msix_updater.cc
+++ b/shell/browser/api/electron_api_msix_updater.cc
@@ -8,10 +8,11 @@
 #include <string_view>
 #include "base/environment.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
-#include "base/task/single_thread_task_runner.h"
+#include "base/task/bind_post_task.h"
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -231,10 +232,27 @@ HRESULT GetCurrentPackage(ComPtr<IPackage>* package) {
   return package_statics->get_Current(package->GetAddressOf());
 }
 
+// Bound to the UI thread so the promise (a cppgc handle) is only touched
+// there; the callback itself may be run or dropped on any thread.
+using SettleCallback = base::OnceCallback<void(std::string error)>;
+
+void SettlePromise(gin_helper::Promise<void> promise, std::string error) {
+  if (error.empty()) {
+    promise.Resolve();
+  } else {
+    promise.RejectWithErrorMessage(error);
+  }
+}
+
+// Must be called on the UI thread.
+SettleCallback MakeSettleCallback(gin_helper::Promise<void> promise) {
+  return base::BindPostTaskToCurrentDefault(
+      base::BindOnce(&SettlePromise, std::move(promise)));
+}
+
 // Structure to hold callback data for async operations
 struct DeploymentCallbackData {
-  scoped_refptr<base::SingleThreadTaskRunner> reply_runner;
-  gin_helper::Promise<void> promise;
+  SettleCallback settle;
   bool fire_and_forget;
   ComPtr<DeploymentAsyncOp> async_op;  // Keep async_op alive
   std::string operation_name;  // "Deployment" or "Registration" for logs
@@ -254,11 +272,7 @@ void OnDeploymentCompleted(std::unique_ptr<DeploymentCallbackData> data,
            "Good bye!";
     DebugLog(oss.str());
     // Don't wait for result in fire-and-forget mode
-    data->reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise) { promise.Resolve(); },
-            std::move(data->promise)));
+    std::move(data->settle).Run(std::string());
     return;
   }
 
@@ -309,23 +323,13 @@ void OnDeploymentCompleted(std::unique_ptr<DeploymentCallbackData> data,
   }
 
   // Post result back to UI thread
-  data->reply_runner->PostTask(
-      FROM_HERE, base::BindOnce(
-                     [](gin_helper::Promise<void> promise, std::string error) {
-                       if (error.empty()) {
-                         promise.Resolve();
-                       } else {
-                         promise.RejectWithErrorMessage(error);
-                       }
-                     },
-                     std::move(data->promise), std::move(error)));
+  std::move(data->settle).Run(std::move(error));
 }
 
 // Performs MSIX update on IO thread
 void DoUpdateMsix(const std::string& package_uri,
                   UpdateMsixOptions opts,
-                  scoped_refptr<base::SingleThreadTaskRunner> reply_runner,
-                  gin_helper::Promise<void> promise) {
+                  SettleCallback settle) {
   DebugLog("DoUpdateMsix: Starting");
   std::string error;
 
@@ -334,13 +338,7 @@ void DoUpdateMsix(const std::string& package_uri,
   HRESULT hr = CreatePackageManager(&package_manager);
   if (FAILED(hr)) {
     error = "Failed to create PackageManager";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -349,13 +347,7 @@ void DoUpdateMsix(const std::string& package_uri,
   hr = package_manager.As(&package_manager9);
   if (FAILED(hr)) {
     error = "Failed to get IPackageManager9 interface";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -365,13 +357,7 @@ void DoUpdateMsix(const std::string& package_uri,
   hr = CreateUri(uri_wstring, &uri);
   if (FAILED(hr)) {
     error = "Failed to create URI";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -380,13 +366,7 @@ void DoUpdateMsix(const std::string& package_uri,
   hr = CreateAddPackageOptions(opts, &package_options);
   if (FAILED(hr)) {
     error = "Failed to create AddPackageOptions";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -415,52 +395,38 @@ void DoUpdateMsix(const std::string& package_uri,
     error =
         "Deployment is NULL. See "
         "http://go.microsoft.com/fwlink/?LinkId=235160 for diagnosing.";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
   // Set up callback data
   auto callback_data = std::make_unique<DeploymentCallbackData>();
-  callback_data->reply_runner = reply_runner;
-  callback_data->promise = std::move(promise);
+  callback_data->settle = std::move(settle);
   callback_data->fire_and_forget =
       opts.force_shutdown || opts.force_target_shutdown;
   callback_data->async_op = async_op;  // Keep async_op alive
   callback_data->operation_name = "Deployment";
 
-  // Register completion handler
+  // Register completion handler; |handler| keeps |raw_data| alive below.
   DeploymentCallbackData* raw_data = callback_data.get();
-  hr = async_op->put_Completed(
-      Callback<DeploymentCompletedHandler>([data = std::move(callback_data)](
-                                               DeploymentAsyncOp* op,
-                                               AsyncStatus status) mutable {
+  auto handler = Callback<DeploymentCompletedHandler>(
+      [data = std::move(callback_data)](DeploymentAsyncOp* op,
+                                        AsyncStatus status) mutable {
         OnDeploymentCompleted(std::move(data), op, status);
         return S_OK;
-      }).Get());
+      });
+  hr = async_op->put_Completed(handler.Get());
 
   if (FAILED(hr)) {
     DebugLog("Failed to register completion handler");
-    raw_data->reply_runner->PostTask(
-        FROM_HERE, base::BindOnce(
-                       [](gin_helper::Promise<void> promise) {
-                         promise.RejectWithErrorMessage(
-                             "Failed to register completion handler");
-                       },
-                       std::move(raw_data->promise)));
+    std::move(raw_data->settle).Run("Failed to register completion handler");
   }
 }
 
 // Performs package registration on IO thread
 void DoRegisterPackage(const std::string& family_name,
                        RegisterPackageOptions opts,
-                       scoped_refptr<base::SingleThreadTaskRunner> reply_runner,
-                       gin_helper::Promise<void> promise) {
+                       SettleCallback settle) {
   DebugLog("DoRegisterPackage: Starting");
   std::string error;
 
@@ -469,13 +435,7 @@ void DoRegisterPackage(const std::string& family_name,
   HRESULT hr = CreatePackageManager(&package_manager);
   if (FAILED(hr)) {
     error = "Failed to create PackageManager";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -484,13 +444,7 @@ void DoRegisterPackage(const std::string& family_name,
   hr = package_manager.As(&package_manager5);
   if (FAILED(hr)) {
     error = "Failed to get IPackageManager5 interface";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -514,13 +468,7 @@ void DoRegisterPackage(const std::string& family_name,
       base::win::ScopedHString::Create(family_name);
   if (!family_name_hstring.is_valid()) {
     error = "Failed to create family name string";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
@@ -553,44 +501,31 @@ void DoRegisterPackage(const std::string& family_name,
     error =
         "Deployment is NULL. See "
         "http://go.microsoft.com/fwlink/?LinkId=235160 for diagnosing.";
-    reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(
-            [](gin_helper::Promise<void> promise, std::string error) {
-              promise.RejectWithErrorMessage(error);
-            },
-            std::move(promise), std::move(error)));
+    std::move(settle).Run(std::move(error));
     return;
   }
 
   // Set up callback data
   auto callback_data = std::make_unique<DeploymentCallbackData>();
-  callback_data->reply_runner = reply_runner;
-  callback_data->promise = std::move(promise);
+  callback_data->settle = std::move(settle);
   callback_data->fire_and_forget =
       opts.force_shutdown || opts.force_target_shutdown;
   callback_data->async_op = async_op;  // Keep async_op alive
   callback_data->operation_name = "Registration";
 
-  // Register completion handler
+  // Register completion handler; |handler| keeps |raw_data| alive below.
   DeploymentCallbackData* raw_data = callback_data.get();
-  hr = async_op->put_Completed(
-      Callback<DeploymentCompletedHandler>([data = std::move(callback_data)](
-                                               DeploymentAsyncOp* op,
-                                               AsyncStatus status) mutable {
+  auto handler = Callback<DeploymentCompletedHandler>(
+      [data = std::move(callback_data)](DeploymentAsyncOp* op,
+                                        AsyncStatus status) mutable {
         OnDeploymentCompleted(std::move(data), op, status);
         return S_OK;
-      }).Get());
+      });
+  hr = async_op->put_Completed(handler.Get());
 
   if (FAILED(hr)) {
     DebugLog("Failed to register completion handler");
-    raw_data->reply_runner->PostTask(
-        FROM_HERE, base::BindOnce(
-                       [](gin_helper::Promise<void> promise) {
-                         promise.RejectWithErrorMessage(
-                             "Failed to register completion handler");
-                       },
-                       std::move(raw_data->promise)));
+    std::move(raw_data->settle).Run("Failed to register completion handler");
   }
 }
 #endif
@@ -635,10 +570,8 @@ v8::Local<v8::Promise> UpdateMsix(const std::string& package_uri,
 
   // Post to IO thread
   content::GetIOThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(&DoUpdateMsix, package_uri, opts,
-                     base::SingleThreadTaskRunner::GetCurrentDefault(),
-                     std::move(promise)));
+      FROM_HERE, base::BindOnce(&DoUpdateMsix, package_uri, opts,
+                                MakeSettleCallback(std::move(promise))));
 #else
   promise.RejectWithErrorMessage(
       "MSIX updates are only supported on Windows with identity.");
@@ -685,10 +618,8 @@ v8::Local<v8::Promise> RegisterPackage(const std::string& family_name,
 
   // Post to IO thread with POD options (no V8 objects)
   content::GetIOThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(&DoRegisterPackage, family_name, opts,
-                     base::SingleThreadTaskRunner::GetCurrentDefault(),
-                     std::move(promise)));
+      FROM_HERE, base::BindOnce(&DoRegisterPackage, family_name, opts,
+                                MakeSettleCallback(std::move(promise))));
 #else
   promise.RejectWithErrorMessage(
       "MSIX package registration is only supported on Windows.");

--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -17,6 +17,8 @@
 #include "electron/electron_version.h"
 #include "gin/object_template_builder.h"
 #include "gin/persistent.h"
+#include "mojo/public/cpp/bindings/callback_helpers.h"
+#include "net/base/net_errors.h"
 #include "net/log/file_net_log_observer.h"
 #include "net/log/net_log_capture_mode.h"
 #include "shell/browser/electron_browser_context.h"
@@ -208,14 +210,17 @@ v8::Local<v8::Promise> NetLog::StopLogging(v8::Isolate* const isolate) {
     // Move the net_log_exporter_ into the callback to ensure that the mojo
     // pointer lives long enough to resolve the promise. Moving it into the
     // callback will cause the instance variable to become empty.
+    // If the pipe disconnects the reply is dropped; still settle the promise.
     net_log_exporter_->Stop(
         base::DictValue(),
-        base::BindOnce(
-            [](mojo::Remote<network::mojom::NetLogExporter>,
-               gin_helper::Promise<void> promise, int32_t error) {
-              ResolvePromiseWithNetError(std::move(promise), error);
-            },
-            std::move(net_log_exporter_), std::move(promise)));
+        mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+            base::BindOnce(
+                [](mojo::Remote<network::mojom::NetLogExporter>,
+                   gin_helper::Promise<void> promise, int32_t error) {
+                  ResolvePromiseWithNetError(std::move(promise), error);
+                },
+                std::move(net_log_exporter_), std::move(promise)),
+            static_cast<int32_t>(net::ERR_FAILED)));
   } else {
     promise.RejectWithErrorMessage("No net log in progress");
   }

--- a/shell/browser/api/electron_api_notification.cc
+++ b/shell/browser/api/electron_api_notification.cc
@@ -349,7 +349,9 @@ void Notification::Close() {
   } else {
     notification->Dismiss();
   }
-  notification->set_delegate(nullptr);
+  // Dismiss() may run JS ('close' is emitted synchronously on some platforms).
+  if (notification)
+    notification->set_delegate(nullptr);
 }
 
 // Showing notifications
@@ -360,6 +362,9 @@ void Notification::Show() {
     return;
 
   Close();
+  // A 'close' listener may have re-entered Show() and already created one.
+  if (notification_)
+    return;
   if (presenter_) {
     notification_ = presenter_->CreateNotification(delegate_.get(), id_);
     if (notification_) {

--- a/shell/browser/api/electron_api_service_worker_main.cc
+++ b/shell/browser/api/electron_api_service_worker_main.cc
@@ -102,6 +102,8 @@ ServiceWorkerMain::~ServiceWorkerMain() {
 }
 
 void ServiceWorkerMain::Destroy() {
+  if (version_destroyed_)
+    return;
   version_destroyed_ = true;
   InvalidateVersionInfo();
   MaybeDisconnectRemote();
@@ -181,6 +183,14 @@ void ServiceWorkerMain::OnVersionRedundant() {
   // ServiceWorkerMain will need to be created.
   // Set internal state to mark it for deletion once it has fully stopped.
   redundant_ = true;
+
+  // content only broadcasts OnStopped for versions that reached RUNNING;
+  // anything else gets no further running status change, so destroy now.
+  auto* version = GetLiveVersion(service_worker_context_, version_id_);
+  if (!version ||
+      version->running_status() != blink::EmbeddedWorkerStatus::kRunning) {
+    Destroy();
+  }
 }
 
 bool ServiceWorkerMain::IsDestroyed() const {
@@ -236,6 +246,12 @@ void ServiceWorkerMain::FinishExternalRequest(v8::Isolate* isolate,
   content::ServiceWorkerExternalRequestResult result =
       service_worker_context_->FinishedExternalRequest(version_id_,
                                                        request_uuid);
+  // Still release the request above so a doomed worker can stop.
+  if (version_destroyed_) {
+    isolate->ThrowException(v8::Exception::TypeError(
+        gin::StringToV8(isolate, "ServiceWorkerMain is destroyed")));
+    return;
+  }
 
   std::string error;
   switch (result) {

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -15,9 +15,11 @@
 #include "base/apple/scoped_cftyperef.h"
 #include "base/check_op.h"
 #include "base/containers/flat_map.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
 #include "base/no_destructor.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/task/sequenced_task_runner.h"
+#include "base/task/bind_post_task.h"
 #include "base/values.h"
 #include "chrome/browser/media/webrtc/system_media_capture_permissions_mac.h"
 #include "net/base/apple/url_conversions.h"
@@ -492,32 +494,28 @@ v8::Local<v8::Promise> SystemPreferences::PromptTouchID(
               kSecAccessControlPrivateKeyUsage | kSecAccessControlUserPresence,
               nullptr));
 
-  scoped_refptr<base::SequencedTaskRunner> runner =
-      base::SequencedTaskRunner::GetCurrentDefault();
-
-  __block gin_helper::Promise<void> p = std::move(promise);
+  // The reply runs on a LocalAuthentication queue; keep the cppgc-backed
+  // promise inside a UI-sequence-bound callback.
+  __block auto callback = base::BindPostTaskToCurrentDefault(base::BindOnce(
+      [](gin_helper::Promise<void> promise, bool success, std::string err_msg) {
+        if (success) {
+          promise.Resolve();
+        } else {
+          promise.RejectWithErrorMessage(err_msg);
+        }
+      },
+      std::move(promise)));
   [context
       evaluateAccessControl:access_control.get()
                   operation:LAAccessControlOperationUseKeySign
             localizedReason:localized_reason
                       reply:^(BOOL success, NSError* error) {
-                        // NOLINTBEGIN(bugprone-use-after-move)
+                        std::string err_msg;
                         if (!success) {
-                          std::string err_msg = base::SysNSStringToUTF8(
+                          err_msg = base::SysNSStringToUTF8(
                               error.localizedDescription);
-                          runner->PostTask(
-                              FROM_HERE,
-                              base::BindOnce(
-                                  gin_helper::Promise<void>::RejectPromise,
-                                  std::move(p), std::move(err_msg)));
-                        } else {
-                          runner->PostTask(
-                              FROM_HERE,
-                              base::BindOnce(
-                                  gin_helper::Promise<void>::ResolvePromise,
-                                  std::move(p)));
                         }
-                        // NOLINTEND(bugprone-use-after-move)
+                        std::move(callback).Run(success, std::move(err_msg));
                       }];
 
   return handle;
@@ -631,12 +629,15 @@ v8::Local<v8::Promise> SystemPreferences::AskForMediaAccess(
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (auto type = ParseMediaType(media_type)) {
-    __block gin_helper::Promise<bool> p = std::move(promise);
+    // The handler runs on an arbitrary queue; keep the cppgc-backed promise
+    // inside a UI-sequence-bound callback.
+    __block auto callback = base::BindPostTaskToCurrentDefault(
+        base::BindOnce([](gin_helper::Promise<bool> promise,
+                          bool granted) { promise.Resolve(granted); },
+                       std::move(promise)));
     [AVCaptureDevice requestAccessForMediaType:type
                              completionHandler:^(BOOL granted) {
-                               dispatch_async(dispatch_get_main_queue(), ^{
-                                 p.Resolve(!!granted);
-                               });
+                               std::move(callback).Run(!!granted);
                              }];
   } else {
     promise.RejectWithErrorMessage("Invalid media type");

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include "base/containers/fixed_flat_map.h"
+#include "base/functional/callback_helpers.h"
 #include "gin/dictionary.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/api/electron_api_menu.h"
@@ -24,6 +25,7 @@
 #include "shell/common/gin_helper/wrappable_pointer_tags.h"
 #include "shell/common/node_includes.h"
 #include "v8/include/cppgc/allocation.h"
+#include "v8/include/cppgc/persistent.h"
 #include "v8/include/v8-cppgc.h"
 
 namespace gin {
@@ -88,7 +90,8 @@ Tray* Tray::New(gin_helper::ErrorThrower thrower,
   Tray* tray = cppgc::MakeGarbageCollected<Tray>(
       isolate->GetCppHeap()->GetAllocationHandle(), isolate, image, guid);
   if (try_catch.HasCaught()) {
-    tray->keep_alive_.Clear();
+    // Remove the already-created OS icon now, not at eventual collection.
+    tray->Destroy();
     try_catch.ReThrow();
     return {};
   }
@@ -327,6 +330,8 @@ void Tray::DisplayBalloon(gin_helper::ErrorThrower thrower,
 #endif
   }
 
+  if (!CheckAlive())
+    return;
   tray_icon_->DisplayBalloon(balloon_options);
 }
 
@@ -363,8 +368,18 @@ void Tray::PopUpContextMenu(gin::Arguments* args) {
     }
   }
 
+  // Converting the arguments can run JS that destroys the tray.
+  if (!CheckAlive())
+    return;
+  // Root |menu| until the platform is done with its model; JS may not hold it.
+  base::ScopedClosureRunner retain_menu;
+  if (menu) {
+    retain_menu.ReplaceClosure(base::BindOnce([](cppgc::Persistent<Menu>) {},
+                                              cppgc::Persistent<Menu>(menu)));
+  }
   tray_icon_->PopUpContextMenu(pos,
-                               menu ? menu->model()->GetWeakPtr() : nullptr);
+                               menu ? menu->model()->GetWeakPtr() : nullptr,
+                               std::move(retain_menu));
 }
 
 void Tray::CloseContextMenu() {

--- a/shell/browser/api/electron_api_utility_process.cc
+++ b/shell/browser/api/electron_api_utility_process.cc
@@ -10,10 +10,12 @@
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "base/location.h"
 #include "base/no_destructor.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
 #include "base/process/process.h"
+#include "base/task/single_thread_task_runner.h"
 #include "chrome/browser/browser_process.h"
 #include "content/browser/network_service_instance_impl.h"  // nogncheck
 #include "content/public/browser/child_process_data.h"
@@ -49,6 +51,8 @@
 #include "v8/include/cppgc/allocation.h"
 
 #if BUILDFLAG(IS_POSIX)
+#include <unistd.h>
+
 #include "base/posix/eintr_wrapper.h"
 #endif
 
@@ -88,6 +92,8 @@ UtilityProcessRegistry& GetAllUtilityProcessWrappers() {
   return *registry;
 }
 
+constexpr uint32_t kLaunchFailureExitCode = 1;
+
 }  // namespace
 
 namespace api {
@@ -114,6 +120,21 @@ UtilityProcessWrapper::UtilityProcessWrapper(
 #elif BUILDFLAG(IS_POSIX)
   base::FileHandleMappingVector fds_to_remap;
 #endif
+  // Nothing else calls HandleTermination() if we bail before launch; post it
+  // so 'exit' fires after JS has attached its listeners.
+  auto fail_launch = [&] {
+#if BUILDFLAG(IS_POSIX)
+    for (const auto& [fd, _] : fds_to_remap)
+      close(fd);
+#endif
+    CloseStdioReadFds();
+    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(
+            &UtilityProcessWrapper::HandleTermination,
+            gin::WrapPersistent(weak_factory_.GetWeakCell(allocation_handle)),
+            kLaunchFailureExitCode));
+  };
   for (const auto& [io_handle, io_type] : stdio) {
     if (io_handle == IOHandle::STDIN)
       continue;
@@ -134,6 +155,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
       // https://source.chromium.org/chromium/chromium/src/+/main:base/process/launch_win.cc;l=303-332
       if (!::CreatePipe(&read, &write, nullptr, 0)) {
         PLOG(ERROR) << "pipe creation failed";
+        fail_launch();
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -151,6 +173,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
       int pipe_fd[2];
       if (HANDLE_EINTR(pipe(pipe_fd)) < 0) {
         PLOG(ERROR) << "pipe creation failed";
+        fail_launch();
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -169,7 +192,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
                       OPEN_EXISTING, 0, nullptr);
       if (handle == INVALID_HANDLE_VALUE) {
         PLOG(ERROR) << "Failed to create null handle";
-        Emit("error", "Failed to create null handle for ignoring stdio");
+        fail_launch();
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -181,6 +204,7 @@ UtilityProcessWrapper::UtilityProcessWrapper(
       int devnull = open("/dev/null", O_WRONLY);
       if (devnull < 0) {
         PLOG(ERROR) << "failed to open /dev/null";
+        fail_launch();
         return;
       }
       if (io_handle == IOHandle::STDOUT) {
@@ -269,13 +293,16 @@ UtilityProcessWrapper::~UtilityProcessWrapper() {
 
 void UtilityProcessWrapper::OnServiceProcessLaunch(
     const base::Process& process) {
+  if (terminated_)
+    return;
   DCHECK(node_service_remote_.is_connected());
   pid_ = process.Pid();
   GetAllUtilityProcessWrappers().Add(pid_, this);
+  // JS wraps these in net.Socket and owns them from here on.
   if (stdout_read_fd_ != -1)
-    EmitWithoutEvent("stdout", stdout_read_fd_);
+    EmitWithoutEvent("stdout", std::exchange(stdout_read_fd_, -1));
   if (stderr_read_fd_ != -1)
-    EmitWithoutEvent("stderr", stderr_read_fd_);
+    EmitWithoutEvent("stderr", std::exchange(stderr_read_fd_, -1));
   if (url_loader_network_observer_) {
     url_loader_network_observer_->set_process_id(pid_);
   }
@@ -296,6 +323,7 @@ void UtilityProcessWrapper::HandleTermination(uint32_t exit_code) {
   content::ServiceProcessHost::RemoveObserver(this);
   content::BrowserChildProcessObserver::Remove(this);
   CloseConnectorPort();
+  CloseStdioReadFds();
   if (killed_) {
 #if BUILDFLAG(IS_POSIX)
     // UtilityProcessWrapper::Kill relies on base::Process::Terminate
@@ -322,6 +350,10 @@ void UtilityProcessWrapper::OnServiceProcessDisconnected(
     const std::string& description) {
   if (description == "process_exit_termination") {
     HandleTermination(exit_code);
+  } else if (pid_ == base::kNullProcessId) {
+    // Pipe dropped before launch means the child failed to launch; the host
+    // is deleted without notifying observers, so this is the only signal.
+    HandleTermination(kLaunchFailureExitCode);
   }
 }
 
@@ -358,8 +390,22 @@ void UtilityProcessWrapper::BrowserChildProcessKilled(
     HandleTermination(info.exit_code);
 }
 
+void UtilityProcessWrapper::CloseStdioReadFds() {
+  // Read ends not yet handed to JS; on Windows the CRT fd owns the HANDLE.
+  for (int* fd : {&stdout_read_fd_, &stderr_read_fd_}) {
+    if (*fd == -1)
+      continue;
+#if BUILDFLAG(IS_WIN)
+    _close(*fd);
+#else
+    close(*fd);
+#endif
+    *fd = -1;
+  }
+}
+
 void UtilityProcessWrapper::CloseConnectorPort() {
-  if (!connector_closed_ && connector_->is_valid()) {
+  if (!connector_closed_ && connector_ && connector_->is_valid()) {
     host_port_.GiveDisentangledHandle(connector_->PassMessagePipe());
     connector_ = nullptr;
     host_port_.Reset();

--- a/shell/browser/api/electron_api_utility_process.h
+++ b/shell/browser/api/electron_api_utility_process.h
@@ -98,6 +98,7 @@ class UtilityProcessWrapper final
  private:
   void OnServiceProcessLaunch(const base::Process& process);
   void CloseConnectorPort();
+  void CloseStdioReadFds();
 
   void HandleTermination(uint32_t exit_code);
   bool IsThisProcess(const content::ChildProcessData& data) const;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2791,6 +2791,11 @@ void WebContents::WebContentsDestroyed() {
   // Drop this instance's contribution to the process-wide caret browsing count.
   ReconcileCaretBrowsingCount(false);
 
+  // For a content::WebContents we do not own (guest, background page), frames
+  // outlive us but no longer get lifecycle notifications; dispose them now.
+  if (web_contents())
+    WebFrameMain::DestroyAllForWebContents(web_contents());
+
   // The underlying content::WebContents is gone, let the wrapper be collected.
   Unpin();
 

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -17,6 +17,7 @@
 #include "content/browser/renderer_host/render_process_host_impl.h"  // nogncheck
 #include "content/public/browser/frame_tree_node_id.h"
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/isolated_world_ids.h"
 #include "gin/object_template_builder.h"
 #include "gin/persistent.h"
@@ -79,7 +80,11 @@ using LifecycleState = content::RenderFrameHostImpl::LifecycleStateImpl;
   // FrameTreeNode with a new RFH. In these cases, it's marked for
   // deletion. As this pending deletion RFH won't be following future
   // swaps, we need to indicate that its been detached.
-  return GetLifecycleState(rfh) == LifecycleState::kRunningUnloadHandlers;
+  // Also covers CommitPending: the old RFH is no longer current but still
+  // kActive, and embedder callbacks (focus/blur) can run in that window.
+  const auto* rfh_impl = static_cast<const content::RenderFrameHostImpl*>(rfh);
+  return GetLifecycleState(rfh) == LifecycleState::kRunningUnloadHandlers ||
+         rfh_impl->frame_tree_node()->current_frame_host() != rfh_impl;
 }
 
 }  // namespace
@@ -174,8 +179,12 @@ WebFrameMain::WebFrameMain(content::RenderFrameHost* rfh)
     auto& map = GetFrameTreeNodeIdMap();
     auto [it, inserted] = map.try_emplace(frame_tree_node_id_, this);
     if (!inserted) {
-      CHECK(!it->second);
+      WebFrameMain* stale = it->second.Get();
       it->second = this;
+      // A live entry here was never told its frame went away; dispose it
+      // rather than leave two live instances for one node.
+      if (stale)
+        stale->MarkRenderFrameDisposed();
     }
   }
 
@@ -200,6 +209,24 @@ void WebFrameMain::Destroyed() {
   MarkRenderFrameDisposed();
 }
 
+// static
+void WebFrameMain::DestroyAllForWebContents(
+    content::WebContents* web_contents) {
+  // The token map covers every live instance (the FTN-id map does not).
+  // Collect first; Destroyed() mutates both maps.
+  std::vector<content::GlobalRenderFrameHostToken> tokens;
+  for (const auto& [token, web_frame] : GetFrameTokenMap()) {
+    if (web_frame && content::WebContents::FromFrameTreeNodeId(
+                         web_frame->frame_tree_node_id_) == web_contents) {
+      tokens.push_back(token);
+    }
+  }
+  for (const auto& token : tokens) {
+    if (WebFrameMain* web_frame = FromFrameToken(token))
+      web_frame->Destroyed();
+  }
+}
+
 void WebFrameMain::MarkRenderFrameDisposed() {
   render_frame_detached_ = true;
   render_frame_disposed_ = true;
@@ -214,6 +241,10 @@ void WebFrameMain::MarkRenderFrameDisposed() {
 
 // Should only be called when swapping frames.
 void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
+  // From() may already have adopted |rfh| before RenderFrameHostChanged ran.
+  if (!render_frame_disposed_ && frame_token_ == rfh->GetGlobalFrameToken())
+    return;
+
   GetFrameTokenMap().erase(frame_token_);
 
   // Ensure that RFH being swapped in doesn't already exist as its own
@@ -649,6 +680,13 @@ WebFrameMain* WebFrameMain::From(v8::Isolate* isolate,
       // RFH is already assigned to the FrameTreeNode and can safely be looked
       // up directly.
       web_frame = FromRenderFrameHost(rfh);
+      if (!web_frame && !IsDetachedFrameHost(rfh)) {
+        // content makes the new RFH current before RenderFrameHostChanged
+        // re-keys the existing instance; adopt it rather than make a second.
+        web_frame = FromFrameTreeNodeId(rfh->GetFrameTreeNodeId());
+        if (web_frame)
+          web_frame->UpdateRenderFrameHost(rfh);
+      }
       break;
     case LifecycleState::kRunningUnloadHandlers:
       // Event/IPC emitted for a frame running unload handlers. Return the exact

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -30,7 +30,8 @@ class GURL;
 
 namespace content {
 class RenderFrameHost;
-}
+class WebContents;
+}  // namespace content
 
 namespace gin {
 class Arguments;
@@ -87,6 +88,10 @@ class WebFrameMain final : public gin::Wrappable<WebFrameMain>,
 
   // Called when FrameTreeNode is deleted.
   void Destroyed();
+
+  // Calls Destroyed() on every instance belonging to |web_contents|; used when
+  // api::WebContents stops observing a WebContents it does not own.
+  static void DestroyAllForWebContents(content::WebContents* web_contents);
 
   // Mark RenderFrameHost as disposed and to no longer access it. This can
   // happen when the WebFrameMain v8-forward.handle is GC'd or when a

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -83,6 +83,10 @@ void MessagePort::PostMessage(gin::Arguments* args) {
     }
   }
 
+  // Serialization above can run JS that transfers or closes this port.
+  if (!IsEntangled())
+    return;
+
   bool threw_exception = false;
   transferable_message.ports = MessagePort::DisentanglePorts(
       args->isolate(), wrapped_ports, &threw_exception, this);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1477,21 +1477,29 @@ bool NativeWindowViews::IsFocusable() const {
 void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
 #if BUILDFLAG(IS_LINUX)
   // Remove global menu bar.
+  bool try_global_menu_bar = true;
   if (global_menu_bar_ && menu_model == nullptr) {
+    const bool used_global_menu_bar = global_menu_bar_->IsServerStarted();
     global_menu_bar_.reset();
     root_view_.UnregisterAcceleratorsWithFocusManager();
-    return;
+    if (used_global_menu_bar)
+      return;
+    // No global menu server: the menu went in-window; fall through to clear.
+    try_global_menu_bar = false;
   }
 
   // Use global application menu bar when possible.
   const bool can_use_global_menus = ui::OzonePlatform::GetInstance()
                                         ->GetPlatformRuntimeProperties()
                                         .supports_global_application_menus;
-  if (can_use_global_menus && ShouldUseGlobalMenuBar()) {
+  if (try_global_menu_bar && can_use_global_menus && ShouldUseGlobalMenuBar()) {
     if (!global_menu_bar_)
       global_menu_bar_ =
           std::make_unique<GlobalMenuBarX11>(GetAcceleratedWidget());
     if (global_menu_bar_->IsServerStarted()) {
+      // The registrar can appear between calls; drop any in-window bar.
+      if (root_view_.HasMenu())
+        SetRootViewMenu(nullptr);
       root_view_.RegisterAcceleratorsWithFocusManager(menu_model);
       global_menu_bar_->SetMenu(menu_model);
       return;
@@ -1499,6 +1507,10 @@ void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
   }
 #endif
 
+  SetRootViewMenu(menu_model);
+}
+
+void NativeWindowViews::SetRootViewMenu(ElectronMenuModel* menu_model) {
   // Should reset content size when setting menu.
   gfx::Size content_size = GetContentSize();
   bool should_reset_size = use_content_size_ && has_frame() &&

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -215,6 +215,8 @@ class NativeWindowViews : public NativeWindow,
   [[nodiscard]] bool has_rounded_corners() const { return rounded_corner_; }
 
  private:
+  // Applies |menu_model| to the in-window menu bar.
+  void SetRootViewMenu(ElectronMenuModel* menu_model);
   void set_overlay_button_color(std::optional<SkColor> color) {
     overlay_button_color_ = color;
   }

--- a/shell/browser/ui/status_icon_gtk.cc
+++ b/shell/browser/ui/status_icon_gtk.cc
@@ -48,8 +48,8 @@ void StatusIconGtk::SetToolTip(const std::u16string& tool_tip) {
 }
 
 void StatusIconGtk::UpdatePlatformContextMenu(ui::MenuModel* model) {
-  if (model)
-    menu_ = std::make_unique<gtkui::MenuGtk>(model);
+  // MenuGtk holds a bare model pointer the caller may be about to destroy.
+  menu_ = model ? std::make_unique<gtkui::MenuGtk>(model) : nullptr;
 }
 
 void StatusIconGtk::RefreshPlatformContextMenu() {

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -92,9 +93,11 @@ class TrayIcon {
   // Returns focus to the taskbar notification area.
   virtual void Focus() {}
 
-  // Popups the menu.
+  // Popups the menu. |retain_menu| keeps the model's owner alive and is
+  // released once the platform no longer needs |menu_model|.
   virtual void PopUpContextMenu(const gfx::Point& pos,
-                                base::WeakPtr<ElectronMenuModel> menu_model) {}
+                                base::WeakPtr<ElectronMenuModel> menu_model,
+                                base::ScopedClosureRunner retain_menu) {}
 
   virtual void CloseContextMenu() {}
 

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -29,9 +29,11 @@ class TrayIconCocoa : public TrayIcon {
   std::string GetTitle() override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;
-  void PopUpOnUI(base::WeakPtr<ElectronMenuModel> menu_model);
+  void PopUpOnUI(base::WeakPtr<ElectronMenuModel> menu_model,
+                 base::ScopedClosureRunner retain_menu);
   void PopUpContextMenu(const gfx::Point& pos,
-                        base::WeakPtr<ElectronMenuModel> menu_model) override;
+                        base::WeakPtr<ElectronMenuModel> menu_model,
+                        base::ScopedClosureRunner retain_menu) override;
   void CloseContextMenu() override;
   void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -394,16 +394,21 @@ bool TrayIconCocoa::GetIgnoreDoubleClickEvents() {
   return [status_item_view_ getIgnoreDoubleClickEvents];
 }
 
-void TrayIconCocoa::PopUpOnUI(base::WeakPtr<ElectronMenuModel> menu_model) {
+void TrayIconCocoa::PopUpOnUI(base::WeakPtr<ElectronMenuModel> menu_model,
+                              base::ScopedClosureRunner retain_menu) {
+  // -popUpContextMenu: spins a nested loop until the menu closes, so
+  // |retain_menu| covers the whole time the model is in use.
   [status_item_view_ popUpContextMenu:menu_model.get()];
 }
 
 void TrayIconCocoa::PopUpContextMenu(
     const gfx::Point& pos,
-    base::WeakPtr<ElectronMenuModel> menu_model) {
+    base::WeakPtr<ElectronMenuModel> menu_model,
+    base::ScopedClosureRunner retain_menu) {
   content::GetUIThreadTaskRunner({})->PostTask(
-      FROM_HERE, base::BindOnce(&TrayIconCocoa::PopUpOnUI,
-                                weak_factory_.GetWeakPtr(), menu_model));
+      FROM_HERE,
+      base::BindOnce(&TrayIconCocoa::PopUpOnUI, weak_factory_.GetWeakPtr(),
+                     menu_model, std::move(retain_menu)));
 }
 
 void TrayIconCocoa::CloseContextMenu() {

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -85,7 +85,7 @@ void NotifyIcon::HandleClickEvent(int modifiers,
     NotifyMiddleClicked(bounds, modifiers);
   } else if (!double_button_click) {  // single right click
     if (menu_model_)
-      PopUpContextMenu(gfx::Point(), menu_model_->GetWeakPtr());
+      PopUpContextMenu(gfx::Point(), menu_model_->GetWeakPtr(), {});
     else
       NotifyRightClicked(bounds, modifiers);
   }
@@ -209,7 +209,8 @@ void NotifyIcon::Focus() {
 }
 
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
-                                  base::WeakPtr<ElectronMenuModel> menu_model) {
+                                  base::WeakPtr<ElectronMenuModel> menu_model,
+                                  base::ScopedClosureRunner retain_menu) {
   // Returns if context menu isn't set.
   if (menu_model == nullptr && menu_model_ == nullptr)
     return;
@@ -228,9 +229,11 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
     rect.set_origin(display::Screen::Get()->GetCursorScreenPoint());
 
   if (menu_model) {
+    popup_menu_retain_ = std::move(retain_menu);
     menu_runner_ = std::make_unique<views::MenuRunner>(
         menu_model.get(), views::MenuRunner::HAS_MNEMONICS);
   } else {
+    popup_menu_retain_.RunAndReset();
     menu_runner_ = std::make_unique<views::MenuRunner>(
         menu_model_, views::MenuRunner::HAS_MNEMONICS);
   }

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 
+#include "base/functional/callback_helpers.h"
 #include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
@@ -68,7 +69,8 @@ class NotifyIcon : public TrayIcon {
   void RemoveBalloon() override;
   void Focus() override;
   void PopUpContextMenu(const gfx::Point& pos,
-                        base::WeakPtr<ElectronMenuModel> menu_model) override;
+                        base::WeakPtr<ElectronMenuModel> menu_model,
+                        base::ScopedClosureRunner retain_menu) override;
   void CloseContextMenu() override;
   void SetContextMenu(raw_ptr<ElectronMenuModel> menu_model) override;
   gfx::Rect GetBounds() override;
@@ -104,6 +106,8 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
+  // Keeps the popped-up menu's owner alive while |menu_runner_| uses it.
+  base::ScopedClosureRunner popup_menu_retain_;
 
   base::WeakPtrFactory<NotifyIcon> weak_factory_{this};
 };

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -180,6 +180,7 @@ NativeImage* NativeImage::CreateFromNamedImage(gin::Arguments* args,
         if (!deprecated_warning_issued) {
           deprecated_warning_issued = true;
           util::EmitDeprecationWarning(
+              args->isolate(),
               "createFromNamedImage(name, hslShift) is deprecated, use "
               "createFromNamedImage(name, { hslShift }) instead.");
         }

--- a/shell/common/api/electron_api_shared_texture.cc
+++ b/shell/common/api/electron_api_shared_texture.cc
@@ -9,7 +9,11 @@
 
 #include "base/base64.h"
 #include "base/command_line.h"
+#include "base/memory/ref_counted_delete_on_sequence.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/numerics/byte_conversions.h"
+#include "base/task/bind_post_task.h"
+#include "base/task/sequenced_task_runner.h"
 #include "content/browser/compositor/image_transport_factory.h"  // nogncheck
 #include "gpu/command_buffer/client/context_support.h"
 #include "gpu/ipc/client/client_shared_image_interface.h"
@@ -152,13 +156,19 @@ std::string TransferVideoPixelFormatToString(media::VideoPixelFormat format) {
   }
 }
 
+// VideoFrames holding a reference may die on any thread, but the GPU helpers
+// and cppgc-backed |release_callback| are sequence-affine; delete on sequence.
 struct ImportedSharedTexture
-    : base::RefCountedThreadSafe<ImportedSharedTexture> {
+    : base::RefCountedDeleteOnSequence<ImportedSharedTexture> {
+  ImportedSharedTexture()
+      : base::RefCountedDeleteOnSequence<ImportedSharedTexture>(
+            base::SequencedTaskRunner::GetCurrentDefault()) {}
+
   // Metadata
   gfx::Size coded_size;
   gfx::Rect visible_rect;
-  int64_t timestamp;
-  media::VideoPixelFormat pixel_format;
+  int64_t timestamp = 0;
+  media::VideoPixelFormat pixel_format = media::PIXEL_FORMAT_UNKNOWN;
 
   // Holds a reference to prevent it from being destroyed.
   scoped_refptr<gpu::ClientSharedImage> client_shared_image;
@@ -172,6 +182,10 @@ struct ImportedSharedTexture
 
   void UpdateReleaseSyncToken(const gpu::SyncToken& token);
   void SetupReleaseSyncTokenCallback();
+
+  // Safe to run or destroy on any thread; forwards the release sync token to
+  // UpdateReleaseSyncToken() on the owning sequence.
+  media::VideoFrame::ReleaseMailboxCB CreateFrameReleaseCallback();
 
   // Transfer to other Chromium processes.
   v8::Local<v8::Value> StartTransferSharedTexture(v8::Isolate* isolate);
@@ -196,7 +210,8 @@ struct ImportedSharedTexture
 
   // The cleanup happens at destructor.
  private:
-  friend class base::RefCountedThreadSafe<ImportedSharedTexture>;
+  friend class base::RefCountedDeleteOnSequence<ImportedSharedTexture>;
+  friend class base::DeleteHelper<ImportedSharedTexture>;
   ~ImportedSharedTexture();
 };
 
@@ -234,11 +249,12 @@ void ImportedSharedTextureWrapper::ReleaseReference() {
   ist.reset();
 }
 
-// This function will be called when the VideoFrame is destructed.
-void OnVideoFrameMailboxReleased(
-    const scoped_refptr<ImportedSharedTexture>& ist,
-    const gpu::SyncToken& sync_token) {
-  ist->UpdateReleaseSyncToken(sync_token);
+media::VideoFrame::ReleaseMailboxCB
+ImportedSharedTexture::CreateFrameReleaseCallback() {
+  return base::BindPostTask(
+      base::WrapRefCounted(owning_task_runner()),
+      base::BindOnce(&ImportedSharedTexture::UpdateReleaseSyncToken,
+                     base::WrapRefCounted(this)));
 }
 
 v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
@@ -248,7 +264,7 @@ v8::Local<v8::Value> ImportedSharedTextureWrapper::CreateVideoFrame(
       blink::ToExecutionContext(current_script_state);
 
   auto si = ist->client_shared_image;
-  auto cb = base::BindOnce(OnVideoFrameMailboxReleased, ist);
+  auto cb = ist->CreateFrameReleaseCallback();
 
   scoped_refptr<media::VideoFrame> raw_frame =
       media::VideoFrame::WrapSharedImage(

--- a/shell/common/api/electron_api_url_loader.cc
+++ b/shell/common/api/electron_api_url_loader.cc
@@ -257,6 +257,12 @@ class JSChunkedDataPipeGetter final
       // Drop the handle on the floor.
       return;
     }
+    if (data_producer_) {
+      // The network stack wants the body again (e.g. a 307/308 redirect or a
+      // retry) but a JS stream cannot be replayed; fail the upload instead.
+      Abort();
+      return;
+    }
     data_producer_ = std::make_unique<mojo::DataPipeProducer>(std::move(pipe));
 
     v8::HandleScope handle_scope(isolate_);

--- a/shell/common/gin_helper/destroyable.cc
+++ b/shell/common/gin_helper/destroyable.cc
@@ -6,6 +6,7 @@
 
 #include "base/no_destructor.h"
 #include "gin/converter.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/wrappable_base.h"
 #include "v8/include/v8-function.h"
 #include "v8/include/v8-object.h"
@@ -40,6 +41,14 @@ void DestroyFunc(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
   if (IsCppHeapWrappable(holder))
     return;
+
+  // Only gin_helper::Wrappable stores a WrappableBase* in field 0 of a
+  // single-field wrapper; reject foreign receivers like FromV8Impl does.
+  if (holder->InternalFieldCount() != 1) {
+    gin_helper::ErrorThrower(info.GetIsolate())
+        .ThrowTypeError("Illegal invocation");
+    return;
+  }
 
   // TODO(zcbenz): gin_helper::Wrappable will be removed.
   delete static_cast<gin_helper::WrappableBase*>(

--- a/shell/common/gin_helper/reply_channel.cc
+++ b/shell/common/gin_helper/reply_channel.cc
@@ -36,19 +36,23 @@ void ReplyChannel::SendError(v8::Isolate* isolate,
   if (isolate->GetCurrentContext().IsEmpty())
     return;
 
-  SendReplyImpl(isolate, std::move(callback),
+  SendReplyImpl(isolate, callback,
                 gin::DataObjectBuilder(isolate).Set("error", errmsg).Build());
 }
 
 // static
 bool ReplyChannel::SendReplyImpl(v8::Isolate* isolate,
-                                 InvokeCallback callback,
+                                 InvokeCallback& callback,
                                  v8::Local<v8::Value> arg) {
   if (!callback)
     return false;
 
+  // Serialize first so a failed conversion leaves |callback| usable.
   electron::SerializedValue msg;
   if (!gin::ConvertFromV8(isolate, arg, &msg))
+    return false;
+  // Serialization can run JS that replied re-entrantly.
+  if (!callback)
     return false;
 
   std::move(callback).Run(std::move(msg));
@@ -78,7 +82,7 @@ gin::ObjectTemplateBuilder ReplyChannel::GetObjectTemplateBuilder(
 }
 
 bool ReplyChannel::SendReply(v8::Isolate* isolate, v8::Local<v8::Value> arg) {
-  return SendReplyImpl(isolate, std::move(callback_), std::move(arg));
+  return SendReplyImpl(isolate, callback_, std::move(arg));
 }
 
 void ReplyChannel::EnsureReplySent() {

--- a/shell/common/gin_helper/reply_channel.h
+++ b/shell/common/gin_helper/reply_channel.h
@@ -54,8 +54,9 @@ class ReplyChannel : public gin::Wrappable<ReplyChannel> {
   void EnsureReplySent();
 
  private:
+  // |callback| is left untouched if |arg| cannot be serialized.
   static bool SendReplyImpl(v8::Isolate* isolate,
-                            InvokeCallback callback,
+                            InvokeCallback& callback,
                             v8::Local<v8::Value> arg);
 
   bool SendReply(v8::Isolate* isolate, v8::Local<v8::Value> arg);

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -14,7 +14,6 @@
 #include "base/threading/thread_local.h"
 #include "base/values.h"
 #include "gin/converter.h"
-#include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/node_natives_code_cache.h"
@@ -97,13 +96,15 @@ void InstallProcessCodeCache() {
 
 void EmitWarning(const std::string_view warning_msg,
                  const std::string_view warning_type) {
-  EmitWarning(JavascriptEnvironment::GetIsolate(), warning_msg, warning_type);
+  // Reachable from renderers, where there is no JavascriptEnvironment.
+  EmitWarning(v8::Isolate::TryGetCurrent(), warning_msg, warning_type);
 }
 
 void EmitWarning(v8::Isolate* isolate,
                  const std::string_view warning_msg,
                  const std::string_view warning_type) {
-  node::Environment* env = node::Environment::GetCurrent(isolate);
+  node::Environment* env =
+      isolate ? node::Environment::GetCurrent(isolate) : nullptr;
   if (!env) {
     // No Node.js environment available, fall back to console logging.
     LOG(WARNING) << "[" << warning_type << "] " << warning_msg;
@@ -114,14 +115,15 @@ void EmitWarning(v8::Isolate* isolate,
 
 void EmitDeprecationWarning(const std::string_view warning_msg,
                             const std::string_view deprecation_code) {
-  EmitDeprecationWarning(JavascriptEnvironment::GetIsolate(), warning_msg,
+  EmitDeprecationWarning(v8::Isolate::TryGetCurrent(), warning_msg,
                          deprecation_code);
 }
 
 void EmitDeprecationWarning(v8::Isolate* isolate,
                             const std::string_view warning_msg,
                             const std::string_view deprecation_code) {
-  node::Environment* env = node::Environment::GetCurrent(isolate);
+  node::Environment* env =
+      isolate ? node::Environment::GetCurrent(isolate) : nullptr;
   if (!env) {
     // No Node.js environment available, fall back to console logging.
     LOG(WARNING) << "[DeprecationWarning] " << warning_msg

--- a/shell/common/node_util.h
+++ b/shell/common/node_util.h
@@ -30,8 +30,8 @@ void EmitWarning(v8::Isolate* isolate,
                  std::string_view warning_msg,
                  std::string_view warning_type);
 
-// Emit a warning via node's process.emitWarning(),
-// using JavascriptEnvironment's isolate
+// Emit a warning via node's process.emitWarning() on the currently entered
+// isolate, or log it if there is no isolate / Node.js environment.
 void EmitWarning(std::string_view warning_msg, std::string_view warning_type);
 
 // Emit a deprecation warning via node's process.emitWarning()
@@ -39,8 +39,8 @@ void EmitDeprecationWarning(v8::Isolate* isolate,
                             std::string_view warning_msg,
                             std::string_view deprecation_code = "");
 
-// Emit a deprecation warning via node's process.emitWarning(),
-// using JavascriptEnvironment's isolate
+// Emit a deprecation warning via node's process.emitWarning() on the current
+// isolate, or log it if there is no isolate / Node.js environment.
 void EmitDeprecationWarning(std::string_view warning_msg,
                             std::string_view deprecation_code = "");
 

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -330,8 +330,11 @@ bool XDGUtil(const std::vector<std::string>& argv,
   options.environment["MM_NOTTTY"] = "1";
 
   base::Process process = base::LaunchProcess(argv, options);
-  if (!process.IsValid())
+  if (!process.IsValid()) {
+    if (!callback.is_null())
+      std::move(callback).Run("Failed to launch " + argv[0]);
     return false;
+  }
 
   if (wait_for_exit) {
     base::ScopedAllowBaseSyncPrimitivesForTesting
@@ -344,6 +347,9 @@ bool XDGUtil(const std::vector<std::string>& argv,
   }
 
   base::EnsureProcessGetsReaped(std::move(process));
+  // Not waiting for the exit code, so report success once it has launched.
+  if (!callback.is_null())
+    std::move(callback).Run("");
   return true;
 }
 

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -574,6 +574,10 @@ class WebFrameRenderer final
       return;
     }
 
+    // Reading |provider| may run script that detaches the frame; do it first.
+    auto spell_check_client =
+        std::make_unique<SpellCheckClient>(language, isolate, provider);
+
     // Remove the old client.
     content::RenderFrame* render_frame;
     if (!MaybeGetRenderFrame(isolate, "setSpellCheckProvider", &render_frame))
@@ -585,8 +589,6 @@ class WebFrameRenderer final
 
     // Set spellchecker for all live frames in the same process or
     // in the sandbox mode for all live sub frames to this WebFrame.
-    auto spell_check_client =
-        std::make_unique<SpellCheckClient>(language, isolate, provider);
     FrameSetSpellChecker spell_checker(spell_check_client.get(), render_frame);
 
     // Attach the spell checker to RenderFrame.
@@ -719,14 +721,6 @@ class WebFrameRenderer final
     }
     const int world_id = world_id_value.As<v8::Int32>()->Value();
 
-    content::RenderFrame* render_frame;
-    std::string error_msg;
-    if (!MaybeGetRenderFrame(&error_msg, "executeJavaScriptInIsolatedWorld",
-                             &render_frame)) {
-      promise.RejectWithErrorMessage(error_msg);
-      return handle;
-    }
-
     bool has_user_gesture = false;
     if (auto next = args->PeekNext(); !next.IsEmpty() && next->IsBoolean()) {
       args->GetNext(&has_user_gesture);
@@ -759,6 +753,15 @@ class WebFrameRenderer final
 
       sources.emplace_back(blink::WebString::FromUtf16(code),
                            blink::WebURL(GURL(url)));
+    }
+
+    // Only now: the |scripts| getters above may have detached the frame.
+    content::RenderFrame* render_frame;
+    std::string error_msg;
+    if (!MaybeGetRenderFrame(&error_msg, "executeJavaScriptInIsolatedWorld",
+                             &render_frame)) {
+      promise.RejectWithErrorMessage(error_msg);
+      return handle;
     }
 
     // Deletes itself.

--- a/shell/services/node/node_service.cc
+++ b/shell/services/node/node_service.cc
@@ -14,7 +14,6 @@
 #include "electron/buildflags/buildflags.h"
 #include "electron/fuses.h"
 #include "electron/mas.h"
-#include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/host_resolver.mojom.h"
@@ -115,6 +114,9 @@ NodeService::NodeService(
 NodeService::~NodeService() {
 #if BUILDFLAG(ENABLE_PROMPT_API)
   electron::api::local_ai_handler::SetHandlerChangedCallback({});
+  // Tear down the AI receivers while the isolate is still alive; their
+  // destructors call into V8.
+  ai_managers_.Clear();
 #endif
   if (!node_env_stopped_) {
     node_env_->set_trace_sync_io(false);
@@ -289,17 +291,16 @@ void NodeService::BindAIManager(
     return;
   }
 
-  mojo::MakeSelfOwnedReceiver(
-      std::make_unique<UtilityAIManager>(
-          params->web_contents_id, params->security_origin, params->frame_token,
-          params->render_process_id),
-      std::move(ai_manager));
+  ai_managers_.Add(std::make_unique<UtilityAIManager>(
+                       params->web_contents_id, params->security_origin,
+                       params->frame_token, params->render_process_id),
+                   std::move(ai_manager));
 }
 
 void NodeService::FlushPendingAIManagerBindings() {
   auto pending = std::move(pending_ai_manager_bindings_);
   for (auto& binding : pending) {
-    mojo::MakeSelfOwnedReceiver(
+    ai_managers_.Add(
         std::make_unique<UtilityAIManager>(
             binding.params->web_contents_id, binding.params->security_origin,
             binding.params->frame_token, binding.params->render_process_id),

--- a/shell/services/node/node_service.h
+++ b/shell/services/node/node_service.h
@@ -14,12 +14,17 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "mojo/public/cpp/bindings/unique_receiver_set.h"
 #include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/mojom/host_resolver.mojom.h"
 #include "services/network/public/mojom/url_loader_factory.mojom-forward.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/services/node/public/mojom/node_service.mojom.h"
+
+#if BUILDFLAG(ENABLE_PROMPT_API)
+#include "third_party/blink/public/mojom/ai/ai_manager.mojom.h"
+#endif  // BUILDFLAG(ENABLE_PROMPT_API)
 
 namespace node {
 
@@ -116,6 +121,11 @@ class NodeService : public node::mojom::NodeService {
   std::shared_ptr<node::Environment> node_env_;
 
   std::unique_ptr<net::NetworkChangeNotifier> network_change_notifier_;
+
+#if BUILDFLAG(ENABLE_PROMPT_API)
+  // depends-on: js_env_'s isolate; cleared explicitly in the destructor.
+  mojo::UniqueReceiverSet<blink::mojom::AIManager> ai_managers_;
+#endif  // BUILDFLAG(ENABLE_PROMPT_API)
 };
 
 }  // namespace electron

--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -351,6 +351,40 @@ describe('webFrameMain module', () => {
       expect(mainFrame.url).to.equal(server.crossOriginUrl);
     });
 
+    it('keeps a single instance when mainFrame is touched from focus/blur during a cross-origin swap', async () => {
+      // The swap re-focuses the view before RenderFrameHostChanged, so these
+      // handlers see the new RFH first; they must get the existing object.
+      const win = new BrowserWindow({ show: true });
+      await win.loadURL(server.url);
+      win.focus();
+      win.webContents.focus();
+      const { mainFrame } = win.webContents;
+      let navigating = false;
+      const seen: { event: string; navigating: boolean; frame: Electron.WebFrameMain }[] = [];
+      win.webContents.on('did-start-navigation', (e) => {
+        if (e.isMainFrame) navigating = true;
+      });
+      win.webContents.on('did-navigate', () => {
+        navigating = false;
+      });
+      const record = (event: 'focus' | 'blur') => () => {
+        seen.push({ event, navigating, frame: win.webContents.mainFrame });
+      };
+      win.webContents.on('focus', record('focus'));
+      win.webContents.on('blur', record('blur'));
+      await win.loadURL(server.crossOriginUrl);
+      win.webContents.removeAllListeners('focus');
+      win.webContents.removeAllListeners('blur');
+      const duringSwap = seen.filter((s) => s.navigating);
+      expect(duringSwap, 'expected focus/blur to fire during the swap').to.not.be.empty();
+      for (const s of duringSwap) {
+        expect(s.frame).to.equal(mainFrame);
+      }
+      expect(win.webContents.mainFrame).to.equal(mainFrame);
+      expect(mainFrame.url).to.equal(server.crossOriginUrl);
+      expect(mainFrame.framesInSubtree).to.have.lengthOf(1);
+    });
+
     it('recovers from renderer crash on same-origin', async () => {
       // Keep reference to mainFrame alive throughout crash and recovery.
       const { mainFrame } = w.webContents;


### PR DESCRIPTION
#### Description of Change

Follow-ups from an audit of the cppgc-managed API objects. One commit per fix; tests to follow.

- `Debugger`: detach from the `DevToolsAgentHost` when collected
- `DataPipeHolder`: prune the id registry on collection
- `ReplyChannel`: keep the invoke callback when a handler result can't be serialized
- `node_util`: don't `CHECK` when emitting a warning from a renderer
- `shell.openPath()`: settle the promise on Linux
- `ServiceWorkerMain`: only erase its own registry entry; destroy stopped redundant versions
- `utilityProcess`: release wrappers whose child never launches
- `globalShortcut`: unregister portal shortcuts on Linux; ignore stale activations
- `Notification`: don't orphan a platform notification created by a re-entrant `show()`
- `webFrame`: look up the `RenderFrame` after reading arguments
- `WebFrameMain`: adopt a newly committed RFH in `From()`; dispose frames of released guest/background-page WebContents
- `systemPreferences` / MSIX updater: keep `gin_helper::Promise` on the UI thread
- `sharedTexture`: release imported textures on their owning sequence
- `Menu` / `Tray`: keep the `Menu` alive while native code still references its model
- `net.request`: fail a chunked upload the network stack asks to replay instead of re-entering the JS body
- `MessagePortMain`: re-check entanglement after serializing the message
- `netLog`: settle the `stopLogging()` promise if the exporter pipe disconnects
- `Destroyable`: reject foreign receivers in `destroy()`
- utility process: tear down AI receivers before the isolate

The `NativeImage` / `EventEmitterMixin` per-context template duplication is left to #53678.

cc @deepak1556

#### Checklist

- [x] PR description included

#### Release Notes

Notes: Fixed several object lifetime issues in `Debugger`, `Menu`, `Tray`, `Notification`, `globalShortcut`, `utilityProcess`, `ServiceWorkerMain`, `WebFrameMain`, `webFrame`, `sharedTexture`, `systemPreferences`, `netLog`, `MessagePortMain`, `net.request` and `shell.openPath()`.
