### PR TITLE
feat: add webContents discard APIs

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1342,6 +1342,28 @@ Navigates to the specified offset from the "current entry".
 
 Returns `boolean` - Whether the renderer process has crashed.
 
+#### `contents.discard()`
+
+Returns `boolean` - Whether the page was accepted for discard.
+
+Discards the page hosted by this `webContents`, terminating its renderer when
+the process is no longer needed by another page. The page must not be visible.
+Calling this method on a visible or already discarded page returns `false` and
+does nothing. A `true` return value means the page was synchronously marked as
+discarded; renderer teardown may complete asynchronously.
+
+Discarding preserves the page's URL and navigation history, but destroys its
+in-memory document and JavaScript state. Making an owning `BrowserWindow`
+visible reloads the page, and [`document.wasDiscarded`](https://developer.mozilla.org/en-US/docs/Web/API/Document/wasDiscarded)
+is `true` in the newly loaded document. Other owners, including a
+`WebContentsView` in a `BaseWindow`, must call `reload()` or navigate explicitly
+to restore discarded contents.
+
+#### `contents.isDiscarded()`
+
+Returns `boolean` - Whether the page has been discarded and is waiting to be
+reloaded.
+
 #### `contents.forcefullyCrashRenderer()`
 
 Forcefully terminates the renderer process that is currently hosting this

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1344,6 +1344,13 @@ Returns `boolean` - Whether the renderer process has crashed.
 
 #### `contents.discard()`
 
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53741
+```
+-->
+
 Returns `boolean` - Whether the page was accepted for discard.
 
 Discards the page hosted by this `webContents`, terminating its renderer when
@@ -1360,6 +1367,13 @@ is `true` in the newly loaded document. Other owners, including a
 to restore discarded contents.
 
 #### `contents.isDiscarded()`
+
+<!--
+```YAML history
+added:
+  - pr-url: https://github.com/electron/electron/pull/53741
+```
+-->
 
 Returns `boolean` - Whether the page has been discarded and is waiting to be
 reloaded.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -21,6 +21,7 @@
 #include "base/containers/flat_set.h"
 #include "base/containers/id_map.h"
 #include "base/containers/map_util.h"
+#include "base/feature_list.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
@@ -77,6 +78,7 @@
 #include "content/public/browser/visibility.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/child_process_id.h"
+#include "content/public/common/content_features.h"
 #include "content/public/common/page_visibility_state.h"
 #include "content/public/common/referrer_type_converters.h"
 #include "content/public/common/result_codes.h"
@@ -3311,6 +3313,29 @@ bool WebContents::IsCrashed() const {
   return web_contents()->IsCrashed();
 }
 
+bool WebContents::Discard() {
+  bool is_visible =
+      web_contents()->GetVisibility() == content::Visibility::VISIBLE;
+  if (auto* window = owner_window()) {
+    is_visible = window->IsVisible() && !window->IsMinimized() &&
+                 inspectable_web_contents()->GetView()->IsDrawn();
+  }
+
+  if (!base::FeatureList::IsEnabled(features::kWebContentsDiscard) ||
+      is_visible || web_contents()->WasDiscarded()) {
+    return false;
+  }
+
+  web_contents()->Discard(base::OnceClosure());
+  // Chromium sets WasDiscarded synchronously when the request is accepted;
+  // renderer teardown may finish later.
+  return web_contents()->WasDiscarded();
+}
+
+bool WebContents::IsDiscarded() const {
+  return web_contents()->WasDiscarded();
+}
+
 void WebContents::ForcefullyCrashRenderer() {
   content::RenderWidgetHostView* view =
       web_contents()->GetRenderWidgetHostView();
@@ -5071,6 +5096,8 @@ void WebContents::FillObjectTemplate(v8::Isolate* isolate,
       .SetMethod("_clearHistory", &WebContents::ClearHistory)
       .SetMethod("_restoreHistory", &WebContents::RestoreHistory)
       .SetMethod("isCrashed", &WebContents::IsCrashed)
+      .SetMethod("discard", &WebContents::Discard)
+      .SetMethod("isDiscarded", &WebContents::IsDiscarded)
       .SetMethod("forcefullyCrashRenderer",
                  &WebContents::ForcefullyCrashRenderer)
       .SetMethod("setUserAgent", &WebContents::SetUserAgent)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -240,6 +240,8 @@ class WebContents final : public ExclusiveAccessContext,
   std::string GetMediaSourceID(content::WebContents* request_web_contents);
   std::string GetOrCreateDevToolsTargetId();
   bool IsCrashed() const;
+  bool Discard();
+  bool IsDiscarded() const;
   void ForcefullyCrashRenderer();
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent();

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -95,6 +95,11 @@ void InitializeFeatureList() {
       std::string(",") + chrome_pdf::features::kPdfUseShowSaveFilePicker.name;
 #endif
 
+  // Electron exposes explicit WebContents lifecycle control to applications.
+  // The Chromium feature is disabled by default on desktop, so enable the
+  // underlying discard mechanism while allowing --disable-features to win.
+  enable_features += std::string(",") + features::kWebContentsDiscard.name;
+
 #if BUILDFLAG(IS_LINUX)
   // Without this, globalShortcut is a silent no-op on GNOME Wayland (the
   // ozone factory returns no listener there). Chromium keeps it off due to

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -3971,6 +3971,90 @@ describe('webContents module', () => {
     });
   }
 
+  describe('discard()', () => {
+    afterEach(closeAllWindows);
+
+    it('honors an explicit WebContentsDiscard feature disable', async () => {
+      const rc = await startRemoteControlApp(['--disable-features=WebContentsDiscard']);
+      const result = await rc.remotely(async () => {
+        const { BrowserWindow } = require('electron');
+        const w = new BrowserWindow({ show: false });
+        await w.loadURL('data:text/html,<title>not-discardable</title>');
+        const result = {
+          discardAccepted: w.webContents.discard(),
+          isDiscarded: w.webContents.isDiscarded()
+        };
+        w.destroy();
+        return result;
+      });
+
+      expect(result).to.deep.equal({
+        discardAccepted: false,
+        isDiscarded: false
+      });
+    });
+
+    it('discards a hidden webContents only once', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('data:text/html,<title>discardable</title>');
+
+      expect(w.webContents.isDiscarded()).to.equal(false);
+      expect(w.webContents.discard()).to.equal(true);
+      expect(w.webContents.isDiscarded()).to.equal(true);
+      expect(w.webContents.discard()).to.equal(false);
+    });
+
+    it('does not discard a visible webContents', async () => {
+      const w = new BrowserWindow({ show: true });
+      await w.loadURL('data:text/html,<title>visible</title>');
+
+      expect(w.webContents.discard()).to.equal(false);
+      expect(w.webContents.isDiscarded()).to.equal(false);
+    });
+
+    it('reloads a discarded webContents when it becomes visible', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadURL('data:text/html,<title>restorable</title>');
+      expect(w.webContents.discard()).to.equal(true);
+
+      const loaded = once(w.webContents, 'did-finish-load');
+      w.show();
+      await loaded;
+
+      const wasDiscarded = await w.webContents.executeJavaScript('document.wasDiscarded');
+      expect(wasDiscarded).to.equal(true);
+      expect(w.webContents.isDiscarded()).to.equal(false);
+      expect(w.webContents.getTitle()).to.equal('restorable');
+    });
+
+    it('discards a hidden WebContentsView in a visible BaseWindow', async () => {
+      const w = new BaseWindow({ show: true, width: 400, height: 300 });
+      const view = new WebContentsView();
+      w.contentView.addChildView(view);
+      view.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+      await view.webContents.loadURL('data:text/html,<title>view-restorable</title>');
+
+      expect(w.isVisible()).to.equal(true);
+      expect(view.getVisible()).to.equal(true);
+      expect(view.webContents.discard()).to.equal(false);
+
+      view.setVisible(false);
+      await setTimeout(0);
+      expect(view.getVisible()).to.equal(false);
+      expect(view.webContents.discard()).to.equal(true);
+      expect(view.webContents.isDiscarded()).to.equal(true);
+
+      const loaded = once(view.webContents, 'did-finish-load');
+      view.webContents.reload();
+      await loaded;
+
+      const wasDiscarded = await view.webContents.executeJavaScript('document.wasDiscarded');
+      expect(wasDiscarded).to.equal(true);
+      expect(view.webContents.isDiscarded()).to.equal(false);
+      expect(view.webContents.getTitle()).to.equal('view-restorable');
+    });
+  });
+
   // Destroying webContents in its event listener is going to crash when
   // Electron is built in Debug mode.
   describe('destroy()', () => {


### PR DESCRIPTION
#### Description of Change

Adds explicit renderer-discard lifecycle control to `WebContents` through:
- `webContents.discard()`, which accepts hidden pages for discard and reports whether Chromium marked the page as discarded.
- `webContents.isDiscarded()`, which reports whether the page is currently discarded and waiting to be reloaded.

This enables Chromium's `WebContentsDiscard` feature by default while preserving the `--disable-features=WebContentsDiscard` override.
Visible pages and already-discarded pages are rejected. Showing a discarded `BrowserWindow` reloads its contents automatically. Other owners, such as `WebContentsView`, can restore discarded contents explicitly using `reload()` or navigation.
Discarding destroys the renderer's in-memory document and JavaScript state. It is therefore intended for applications that can safely restore their state after navigation.

Fixes #38278


Validation performed locally on Windows:
- Fresh `Testing` build completed successfully and linked `electron.exe`.
- Focused `discard()` specification suite passed: 5 tests.
- TypeScript and API definition generation passed.
- JavaScript lint, formatting, documentation checks, API history checks, clang-format, and cpplint passed.
- The full test suite was attempted but stopped on unrelated Windows environment failures involving Recent Documents integration, a missing `ElectronMSIX.exe`, and display-scaled `BaseWindow` bounds. The affected `discard()` specification suite passes independently.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are changed or added
- [x] relevant API documentation, tutorials, and examples are updated
- [x] PR release notes describe the change in a way relevant to app developers

#### Release Notes

Notes: Added `webContents.discard()` and `webContents.isDiscarded()` for explicitly discarding hidden pages.