### PR TITLE
fix: don't expose chrome.webstorePrivate to web pages

### DIFF
--- a/shell/browser/extensions/electron_extensions_browser_api_provider.cc
+++ b/shell/browser/extensions/electron_extensions_browser_api_provider.cc
@@ -4,13 +4,72 @@
 
 #include "shell/browser/extensions/electron_extensions_browser_api_provider.h"
 
+#include <string>
+
+#include "base/strings/strcat.h"
 #include "extensions/browser/api/i18n/i18n_api.h"
+#include "extensions/browser/extension_function.h"
+#include "extensions/browser/extension_function_histogram_value.h"
 #include "extensions/browser/extension_function_registry.h"
 #include "shell/browser/extensions/api/extension_action/extension_action_api.h"
 #include "shell/browser/extensions/api/generated_api_registration.h"
 #include "shell/browser/extensions/api/tabs/tabs_api.h"
 
 namespace extensions {
+
+namespace {
+
+// An ExtensionFunction that always fails. Used to replace core-registered
+// functions for APIs that Electron does not support.
+class UnsupportedFunction : public ExtensionFunction {
+ public:
+  UnsupportedFunction() = default;
+
+ protected:
+  ~UnsupportedFunction() override = default;
+
+  // ExtensionFunction:
+  ResponseAction Run() override {
+    return RespondNow(
+        Error(base::StrCat({name(), " is not supported in Electron"})));
+  }
+};
+
+// chrome.webstorePrivate is implemented in //extensions and registered by
+// CoreExtensionsBrowserAPIProvider, but every function assumes an
+// embedder-provided WebstorePrivateAPIDelegate, which Electron does not have.
+// The API is made unavailable to all contexts via the "webstorePrivate" entry
+// in shell/common/extensions/api/_api_features.json, so these should never be
+// dispatched; replace them anyway so that a request that does reach the
+// browser fails with an error rather than dereferencing a null delegate.
+constexpr const char* kUnsupportedWebstorePrivateFunctions[] = {
+    "webstorePrivate.beginInstallWithManifest3",
+    "webstorePrivate.completeInstall",
+    "webstorePrivate.enableAppLauncher",
+    "webstorePrivate.getBrowserLogin",
+    "webstorePrivate.getExtensionStatus",
+    "webstorePrivate.getFullChromeVersion",
+    "webstorePrivate.getIsLauncherEnabled",
+    "webstorePrivate.getMV2DeprecationStatus",
+    "webstorePrivate.getReferrerChain",
+    "webstorePrivate.getStoreLogin",
+    "webstorePrivate.getWebGLStatus",
+    "webstorePrivate.isInIncognitoMode",
+    "webstorePrivate.isPendingCustodianApproval",
+    "webstorePrivate.logEnterprisePromoShown",
+    "webstorePrivate.onEnterprisePromoClick",
+    "webstorePrivate.setStoreLogin",
+    "webstorePrivate.shouldShowEnterprisePromotionBanner",
+};
+
+void OverrideUnsupportedFunctions(ExtensionFunctionRegistry* registry) {
+  for (const char* name : kUnsupportedWebstorePrivateFunctions) {
+    registry->Register(ExtensionFunctionRegistry::FactoryEntry(
+        &NewExtensionFunction<UnsupportedFunction>, name, functions::UNKNOWN));
+  }
+}
+
+}  // namespace
 
 ElectronExtensionsBrowserAPIProvider::ElectronExtensionsBrowserAPIProvider() =
     default;
@@ -21,6 +80,10 @@ void ElectronExtensionsBrowserAPIProvider::RegisterExtensionFunctions(
     ExtensionFunctionRegistry* registry) {
   // Generated APIs from Electron.
   api::ElectronGeneratedFunctionRegistry::RegisterAll(registry);
+
+  // This provider is added after CoreExtensionsBrowserAPIProvider, so this
+  // replaces the core registrations.
+  OverrideUnsupportedFunctions(registry);
 }
 
 }  // namespace extensions

--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -78,5 +78,23 @@
   },
   "tabs.removeCSS": {
     "max_manifest_version": 2
+  },
+  // Electron does not support chrome.webstorePrivate. The core definition in
+  // //extensions/common/api/_api_features.json exposes it to web pages on the
+  // Chrome Web Store origin, but the browser-side implementation requires an
+  // embedder-provided WebstorePrivateAPIDelegate that Electron does not have.
+  //
+  // This entry replaces the core one (ElectronExtensionsAPIProvider is added
+  // after CoreExtensionsAPIProvider and FeatureProvider::AddFeature() is
+  // last-writer-wins). It matches the core entry except that it also requires
+  // a delegated availability check; Electron never registers a handler for
+  // one, so the feature fails closed (kMissingDelegatedAvailabilityCheck) in
+  // every context in both the renderer and the browser. Do not remove this
+  // without providing a WebstorePrivateAPIDelegate.
+  "webstorePrivate": {
+    "channel": "stable",
+    "contexts": ["web_page"],
+    "matches": ["https://chromewebstore.google.com/*"],
+    "requires_delegated_availability_check": true
   }
 }

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -89,6 +89,57 @@ describe('chrome extensions', () => {
     ).to.eventually.have.property('id');
   });
 
+  describe('Chrome Web Store origin', () => {
+    // The core //extensions feature files expose some APIs to web pages on the
+    // Chrome Web Store origin. Electron does not support chrome.webstorePrivate
+    // and overrides it to be unavailable everywhere; make sure that sticks.
+    const webstoreUrl = 'https://chromewebstore.google.com/category/extensions';
+    let customSession: Session;
+    let w: BrowserWindow;
+
+    beforeEach(() => {
+      customSession = session.fromPartition(`webstore-${randomUUID()}`);
+      // Serve the origin locally so the test does not touch the network.
+      customSession.protocol.handle(
+        'https',
+        () => new Response(emptyPage, { headers: { 'content-type': 'text/html' } })
+      );
+      w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
+    });
+
+    afterEach(async () => {
+      customSession.protocol.unhandle('https');
+      await closeAllWindows();
+    });
+
+    it('does not expose chrome.webstorePrivate to web pages', async () => {
+      await w.loadURL(webstoreUrl);
+      const type = await w.webContents.executeJavaScript(
+        "typeof chrome === 'undefined' ? 'undefined' : typeof chrome.webstorePrivate"
+      );
+      expect(type).to.equal('undefined');
+    });
+
+    it('does not crash if the page tries to call chrome.webstorePrivate', async () => {
+      await w.loadURL(webstoreUrl);
+      // If bindings were ever exposed again this would reach the browser process,
+      // which must respond with an error rather than crash.
+      const result = await w.webContents.executeJavaScript(`new Promise((resolve) => {
+        try {
+          chrome.webstorePrivate.getReferrerChain(() => resolve(chrome.runtime.lastError ? chrome.runtime.lastError.message : 'ok'));
+        } catch (e) {
+          resolve('threw: ' + e.message);
+        }
+      })`);
+      expect(result)
+        .to.be.a('string')
+        .and.match(/^threw: |not supported/);
+      expect(w.webContents.isCrashed()).to.be.false();
+      // The browser process is still alive if we get here; do a round trip to be sure.
+      expect(await w.webContents.executeJavaScript('1 + 1')).to.equal(2);
+    });
+  });
+
   describe('host_permissions', async () => {
     let customSession: Session;
     let w: BrowserWindow;


### PR DESCRIPTION
#### Description of Change

Since the Chromium 152 roll (#52446), the `webstorePrivate` extension API lives in `//extensions` instead of `//chrome` ([CL 7874276](https://chromium-review.googlesource.com/c/chromium/src/+/7874276)). As a result, Electron now compiles and registers every `webstorePrivate.*` function through the core generated registry. It also ships the core `_api_features.json` entry, which exposes the API to regular web pages on `https://chromewebstore.google.com/*`.

`ElectronExtensionsAPIClient` doesn't provide a `WebstorePrivateAPIDelegate`, and most of the browser-side functions dereference it without checking for null. If an app's `webContents` navigates to the Chrome Web Store, the page gets real `chrome.webstorePrivate` bindings in the main world, and the first call the store page makes crashes the browser process.

#52446 added `fix_guard_webstoreprivateapi_factory_against_null_delegate.patch` to fix the startup crash caused by the same missing delegate, but it left the API exposed. This issue only affects 44-x-y and later; 43-x-y predates the roll.

This PR restores the pre-152 behavior (the API isn't exposed anywhere) without adding a patch.

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a crash when a webContents navigated to the Chrome Web Store and the page invoked the unsupported `chrome.webstorePrivate` API.
