### PR TITLE
fix: report renderer hangs independently of system sleep and window visibility (44-x-y)

### DIFF
--- a/patches/chromium/refactor_unfilter_unresponsive_events.patch
+++ b/patches/chromium/refactor_unfilter_unresponsive_events.patch
@@ -14,6 +14,68 @@ RendererUnresponsive events are filtered out when
 This CL removes these filters so the unresponsive event can still be
 accessed from our JS event. The filtering is moved into Electron's code.
 
+It also stops RenderWidgetHostImpl::WasHidden() from declaring a hung
+renderer responsive: StopInputEventAckTimeout() calls
+RendererIsResponsive(), so hiding a hung widget emitted `responsive`
+without any recovery and cleared is_unresponsive_, and the real recovery
+then emitted nothing. WasHidden() now uses a PauseInputEventAckTimeout()
+that only stops the timer; WasShown() re-arms it and a real input ack
+still goes through RendererIsResponsive(). Chrome relies on the old
+behavior only to dismiss its hung-page dialog on tab backgrounding, which
+Electron does not build. This part is proposed upstream at
+https://chromium-review.googlesource.com/c/chromium/src/+/8360632 and
+can be dropped from this patch once it rolls in.
+
+diff --git a/components/input/render_input_router.cc b/components/input/render_input_router.cc
+index 2cffb3a8812bd9c107f59c90481d4a35718d9a5f..abafa454cebab2063673b8f83dbce2d7f08dd2dc 100644
+--- a/components/input/render_input_router.cc
++++ b/components/input/render_input_router.cc
+@@ -391,9 +391,13 @@ void RenderInputRouter::StartInputEventAckTimeout() {
+ }
+ 
+ void RenderInputRouter::StopInputEventAckTimeout() {
++  PauseInputEventAckTimeout();
++  delegate_->RendererIsResponsive();
++}
++
++void RenderInputRouter::PauseInputEventAckTimeout() {
+   input_event_ack_timeout_.Stop();
+   hang_monitor_timer_state_ = HangMonitorTimerState::kStopped;  // Reset state
+-  delegate_->RendererIsResponsive();
+ }
+ 
+ void RenderInputRouter::RestartInputEventAckTimeoutIfNecessary() {
+diff --git a/components/input/render_input_router.h b/components/input/render_input_router.h
+index 3e47a795e9f4d1e25fab5fefb3addf1ff3911f7c..55e19177b71b7dd157540eda6ce208feac8eda46 100644
+--- a/components/input/render_input_router.h
++++ b/components/input/render_input_router.h
+@@ -220,6 +220,9 @@ class COMPONENT_EXPORT(INPUT) RenderInputRouter
+   // Stops all existing hang monitor timeouts and assumes the renderer is
+   // responsive.
+   void StopInputEventAckTimeout();
++  // Stops the timeout without treating the renderer as responsive; used while
++  // the widget is hidden, when a missing ack says nothing either way.
++  void PauseInputEventAckTimeout();
+   void RestartInputEventAckTimeoutIfNecessary();
+ 
+   void StartInputEventAckTimeoutForTesting() { StartInputEventAckTimeout(); }
+diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
+index c4cc713dc414007e309234b09274b59dc86781af..827fe79b39e47fe2361f7b6eea96cb4ab4570b94 100644
+--- a/content/browser/renderer_host/render_widget_host_impl.cc
++++ b/content/browser/renderer_host/render_widget_host_impl.cc
+@@ -865,8 +865,10 @@ void RenderWidgetHostImpl::WasHidden() {
+   // show goes through immediately.
+   visual_properties_ack_pending_ = false;
+ 
+-  // Don't bother reporting hung state when we aren't active.
+-  GetRenderInputRouter()->StopInputEventAckTimeout();
++  // Don't report hung state when we aren't active, but don't take hiding as
++  // proof of recovery either: a hung widget stays unresponsive until its
++  // input is acked, and WasShown() re-arms the timeout.
++  GetRenderInputRouter()->PauseInputEventAckTimeout();
+ 
+   // Show/Hide state is not sent to the renderer when it has requested for us to
+   // wait until it requests them via Init().
 diff --git a/content/browser/web_contents/web_contents_impl.cc b/content/browser/web_contents/web_contents_impl.cc
 index 6c640b449c06309a9f54949fb45e960ded2ec48c..ec9ccb0b174d4e3b781067065509d6326886e886 100644
 --- a/content/browser/web_contents/web_contents_impl.cc

--- a/patches/chromium/revert_partial_remove_unused_prehandlemouseevent.patch
+++ b/patches/chromium/revert_partial_remove_unused_prehandlemouseevent.patch
@@ -42,7 +42,7 @@ diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/
 index 827fe79b39e47fe2361f7b6eea96cb4ab4570b94..5024a05f7cc2b2b0ca22e32952d1aef72e147ef4 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
-@@ -1630,6 +1630,10 @@ void RenderWidgetHostImpl::ForwardMouseEventWithLatencyInfo(
+@@ -1632,6 +1632,10 @@ void RenderWidgetHostImpl::ForwardMouseEventWithLatencyInfo(
    CHECK_GE(mouse_event.GetType(), WebInputEvent::Type::kMouseTypeFirst);
    CHECK_LE(mouse_event.GetType(), WebInputEvent::Type::kMouseTypeLast);
  

--- a/patches/chromium/revert_partial_remove_unused_prehandlemouseevent.patch
+++ b/patches/chromium/revert_partial_remove_unused_prehandlemouseevent.patch
@@ -39,7 +39,7 @@ index 57a9f0227b847f608a2a90de3491323f23c844f4..b6341ff8dc1e26dfcffa3a5110e4b556
    // event before sending it to the renderer. See enum for details on return
    // value.
 diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
-index c4cc713dc414007e309234b09274b59dc86781af..193b6c317588d3f20fab9d828d2d955de87e46ba 100644
+index 827fe79b39e47fe2361f7b6eea96cb4ab4570b94..5024a05f7cc2b2b0ca22e32952d1aef72e147ef4 100644
 --- a/content/browser/renderer_host/render_widget_host_impl.cc
 +++ b/content/browser/renderer_host/render_widget_host_impl.cc
 @@ -1630,6 +1630,10 @@ void RenderWidgetHostImpl::ForwardMouseEventWithLatencyInfo(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -25,6 +25,7 @@
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
+#include "base/power_monitor/power_monitor.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
@@ -40,6 +41,7 @@
 #include "chrome/browser/ui/views/eye_dropper/eye_dropper.h"
 #include "chrome/common/pref_names.h"
 #include "components/embedder_support/user_agent_utils.h"
+#include "components/input/input_constants.h"
 #include "components/input/native_web_keyboard_event.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -1824,6 +1826,18 @@ void WebContents::RendererUnresponsive(
     content::WebContents* source,
     content::RenderWidgetHost* render_widget_host,
     base::RepeatingClosure hang_monitor_restarter) {
+  // The hang monitor's timer keeps counting through system sleep on Windows,
+  // so a timeout that lands while suspended or right after waking says nothing
+  // about the renderer; give it a full delay from the wake instead.
+  const base::TimeTicks last_resume =
+      base::PowerMonitor::GetInstance()->GetLastSystemResumeTime();
+  if (last_resume.is_max() ||
+      (!last_resume.is_null() &&
+       base::TimeTicks::Now() - last_resume < input::kHungRendererDelay)) {
+    hang_monitor_restarter.Run();
+    return;
+  }
+
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
   gin_helper::internal::Event* event =

--- a/shell/common/api/electron_api_testing.cc
+++ b/shell/common/api/electron_api_testing.cc
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include <optional>
+#include <string>
 
 #include "base/command_line.h"
 #include "base/dcheck_is_on.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
+#include "base/power_monitor/power_monitor_source.h"
 #include "chrome/browser/browser_process.h"
 #include "components/prefs/pref_service.h"
 #include "content/browser/network_service_instance_impl.h"  // nogncheck
@@ -18,6 +20,7 @@
 #include "shell/common/callback_util.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
 #include "ui/accessibility/platform/ax_platform.h"
@@ -240,6 +243,21 @@ void ClearHeldPromiseForTesting() {
   GetHeldPromise().reset();
 }
 
+// Reaches the protected PowerMonitorSource::ProcessPowerEvent().
+struct PowerEventInjector : base::PowerMonitorSource {
+  static void Inject(PowerEvent event) { ProcessPowerEvent(event); }
+};
+
+void SimulatePowerEvent(gin_helper::ErrorThrower thrower,
+                        const std::string& event) {
+  if (event == "suspend")
+    PowerEventInjector::Inject(base::PowerMonitorSource::SUSPEND_EVENT);
+  else if (event == "resume")
+    PowerEventInjector::Inject(base::PowerMonitorSource::RESUME_EVENT);
+  else
+    thrower.ThrowTypeError("unknown power event");
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
@@ -251,6 +269,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPlatformCaretBrowsingEnabled",
                  &IsPlatformCaretBrowsingEnabled);
   dict.SetMethod("simulateNetworkServiceCrash", &SimulateNetworkServiceCrash);
+  dict.SetMethod("simulatePowerEvent", &SimulatePowerEvent);
   dict.SetMethod("holdRepeatingCallbackForTesting",
                  &HoldRepeatingCallbackForTesting);
   dict.SetMethod("copyHeldRepeatingCallbackForTesting",

--- a/spec/api-web-contents-spec.ts
+++ b/spec/api-web-contents-spec.ts
@@ -3744,6 +3744,66 @@ describe('webContents module', () => {
     });
   });
 
+  describe('unresponsive event', () => {
+    afterEach(closeAllWindows);
+    const testing = () => process._linkedBinding('electron_common_testing');
+    // The hang monitor reports after kHungRendererDelay (15 s) plus a 1 s ping.
+    const hangAndPoke = async (w: BrowserWindow, ms = 0) => {
+      w.webContents
+        .executeJavaScript(ms ? `{ const end = Date.now() + ${ms}; while (Date.now() < end) {} }` : 'while (true) {}')
+        .catch(() => {});
+      await setTimeout(200);
+      w.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'A' });
+    };
+
+    ifit(isTestingBindingAvailable())('is not emitted within a hang delay of a system resume', async function () {
+      this.timeout(70000);
+      const w = new BrowserWindow({ show: true });
+      await w.loadURL('about:blank');
+      let unresponsiveAt = 0;
+      w.webContents.once('unresponsive', () => {
+        unresponsiveAt = Date.now();
+      });
+      await hangAndPoke(w);
+      // Sleep and wake while the timeout is pending; it would fire ~6 s after
+      // this resume, which says nothing about the renderer.
+      await setTimeout(10000);
+      testing().simulatePowerEvent('suspend');
+      testing().simulatePowerEvent('resume');
+      const resumedAt = Date.now();
+      await once(w.webContents, 'unresponsive');
+      expect(unresponsiveAt - resumedAt).to.be.greaterThan(15000);
+    });
+
+    it('is not followed by responsive just because the window is hidden', async function () {
+      this.timeout(90000);
+      const w = new BrowserWindow({ show: true });
+      await w.loadURL('about:blank');
+      await hangAndPoke(w, 40000);
+      await once(w.webContents, 'unresponsive');
+      const events: string[] = [];
+      w.webContents.on('responsive', () => events.push('responsive'));
+      w.webContents.on('unresponsive', () => events.push('unresponsive'));
+      w.hide();
+      await setTimeout(2000);
+      expect(events, 'after hide').to.deep.equal([]);
+      w.show();
+      // Still hung and visible again: reported again after one delay.
+      await once(w.webContents, 'unresponsive');
+      // The spin ends ~40 s in; the pending key event is then acked.
+      await once(w.webContents, 'responsive');
+      expect(events).to.deep.equal(['unresponsive', 'responsive']);
+    });
+
+    it('is emitted for a hang with no suspend involved', async function () {
+      this.timeout(40000);
+      const w = new BrowserWindow({ show: true });
+      await w.loadURL('about:blank');
+      await hangAndPoke(w);
+      await once(w.webContents, 'unresponsive');
+    });
+  });
+
   describe('render view deleted events', () => {
     let server: http.Server;
     let serverUrl: string;


### PR DESCRIPTION
Backport of #53529

See that PR for details.

Notes: Fixed `webContents` emitting `unresponsive` right after the system wakes from sleep on Windows, and emitting `responsive` when a hung window was hidden rather than when it recovered.
