### PR TITLE
test: use mock keychain on macOS to avoid dialog timeouts

### DIFF
--- a/spec/chromium-spec.ts
+++ b/spec/chromium-spec.ts
@@ -576,6 +576,7 @@ describe('command line switches', () => {
       if (printEnv) {
         args.push('--print-env');
       }
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
       appProcess = ChildProcess.spawn(process.execPath, args);
 
       let output = '';
@@ -621,7 +622,9 @@ describe('command line switches', () => {
   describe('--remote-debugging-pipe switch', () => {
     it('should expose CDP via pipe', async () => {
       const electronPath = process.execPath;
-      appProcess = ChildProcess.spawn(electronPath, ['--remote-debugging-pipe'], {
+      const args = ['--remote-debugging-pipe'];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      appProcess = ChildProcess.spawn(electronPath, args, {
         stdio: ['inherit', 'inherit', 'inherit', 'pipe', 'pipe']
       }) as ChildProcess.ChildProcessWithoutNullStreams;
       const stdio = appProcess.stdio as unknown as [
@@ -643,7 +646,9 @@ describe('command line switches', () => {
     });
     it('should override --remote-debugging-port switch', async () => {
       const electronPath = process.execPath;
-      appProcess = ChildProcess.spawn(electronPath, ['--remote-debugging-pipe', '--remote-debugging-port=0'], {
+      const args = ['--remote-debugging-pipe', '--remote-debugging-port=0'];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      appProcess = ChildProcess.spawn(electronPath, args, {
         stdio: ['inherit', 'inherit', 'pipe', 'pipe', 'pipe']
       }) as ChildProcess.ChildProcessWithoutNullStreams;
       let stderr = '';
@@ -668,7 +673,9 @@ describe('command line switches', () => {
     });
     it('should shut down Electron upon Browser.close CDP command', async () => {
       const electronPath = process.execPath;
-      appProcess = ChildProcess.spawn(electronPath, ['--remote-debugging-pipe'], {
+      const args = ['--remote-debugging-pipe'];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      appProcess = ChildProcess.spawn(electronPath, args, {
         stdio: ['inherit', 'inherit', 'inherit', 'pipe', 'pipe']
       }) as ChildProcess.ChildProcessWithoutNullStreams;
       const stdio = appProcess.stdio as unknown as [
@@ -688,7 +695,9 @@ describe('command line switches', () => {
     it('should display the discovery page', (done) => {
       const electronPath = process.execPath;
       let output = '';
-      appProcess = ChildProcess.spawn(electronPath, ['--remote-debugging-port=']);
+      const args = ['--remote-debugging-port='];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      appProcess = ChildProcess.spawn(electronPath, args);
       appProcess.stdout.on('data', (data) => {
         console.log(data);
       });
@@ -946,7 +955,9 @@ describe('chromium features', () => {
 
     it('loads first party sets', async () => {
       const appPath = path.join(fixturesPath, 'api', 'first-party-sets', 'base');
-      const fpsProcess = ChildProcess.spawn(process.execPath, [appPath]);
+      const args = [appPath];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      const fpsProcess = ChildProcess.spawn(process.execPath, args);
 
       let output = '';
       fpsProcess.stdout.on('data', (data) => {
@@ -960,6 +971,7 @@ describe('chromium features', () => {
     it('loads sets from the command line', async () => {
       const appPath = path.join(fixturesPath, 'api', 'first-party-sets', 'command-line');
       const args = [appPath, `--use-first-party-set=${fps}`];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
       const fpsProcess = ChildProcess.spawn(process.execPath, args);
 
       let output = '';
@@ -2004,7 +2016,9 @@ describe('chromium features', () => {
     it('Worker with nodeIntegrationInWorker has access to self.module.paths', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'apps', 'self-module-paths');
 
-      appProcess = ChildProcess.spawn(process.execPath, [appPath]);
+      const args = [appPath];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      appProcess = ChildProcess.spawn(process.execPath, args);
 
       const [code] = await once(appProcess, 'exit');
       expect(code).to.equal(0);

--- a/spec/crash-spec.ts
+++ b/spec/crash-spec.ts
@@ -13,7 +13,8 @@ let children: cp.ChildProcessWithoutNullStreams[] = [];
 
 const runFixtureAndEnsureCleanExit = async (args: string[], customEnv: NodeJS.ProcessEnv) => {
   let out = '';
-  const child = cp.spawn(process.execPath, args, {
+  const spawnArgs = process.platform === 'darwin' ? [...args, '--use-mock-keychain'] : args;
+  const child = cp.spawn(process.execPath, spawnArgs, {
     env: {
       ...process.env,
       ...customEnv

--- a/spec/esm-spec.ts
+++ b/spec/esm-spec.ts
@@ -13,7 +13,9 @@ const fixtureTimeout = 20000;
 const fixtureKillTimeout = 5000;
 
 const runFixture = async (appPath: string, args: string[] = []) => {
-  return await spawnAndWait(process.execPath, [appPath, ...args], {
+  const spawnArgs = [appPath, ...args];
+  if (process.platform === 'darwin') spawnArgs.push('--use-mock-keychain');
+  return await spawnAndWait(process.execPath, spawnArgs, {
     timeout: fixtureTimeout,
     killTimeout: fixtureKillTimeout,
     stripOutput: true

--- a/spec/extensions-spec.ts
+++ b/spec/extensions-spec.ts
@@ -1702,7 +1702,9 @@ describe('chrome extensions', () => {
 
   describe('custom protocol', () => {
     async function runFixture(name: string) {
-      const appProcess = spawn(process.execPath, [path.join(fixtures, 'extensions', name, 'main.js')]);
+      const args = [path.join(fixtures, 'extensions', name, 'main.js')];
+      if (process.platform === 'darwin') args.push('--use-mock-keychain');
+      const appProcess = spawn(process.execPath, args);
 
       let output = '';
       appProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
#### Description of Change

Upstreamed from the Microsoft build, patch by @deepak1556. CC @mlaurencin 

On macOS, when running tests that involve spawning Electron app processes, we can encounter test timeouts due to keychain access prompts from app not being signed. The prompt itself is triggered by the network service to read the encryption key from the keychain for cookie handling. `--use-mock-keychain` is meant to be used for such cases.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none