### PR TITLE
build: remove git add from lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,8 +115,7 @@
     ],
     "docs/api/**/*.md": [
       "ts-node script/gen-filenames.ts",
-      "markdownlint-cli2 --config .autofix.markdownlint-cli2.jsonc --fix",
-      "git add filenames.auto.gni"
+      "markdownlint-cli2 --config .autofix.markdownlint-cli2.jsonc --fix"
     ],
     "{*.patch,.patches}": [
       "node script/lint.js --patches --only --",
@@ -125,12 +124,10 @@
     "DEPS": [
       "node script/gen-hunspell-filenames.js",
       "node script/gen-libc++-filenames.js",
-      "node script/gen-siso-revision.js",
-      "git add build/siso_revision"
+      "node script/gen-siso-revision.js"
     ],
     ".github/workflows/pipeline-segment-electron-build.yml": [
-      "node script/copy-pipeline-segment-publish.js",
-      "git add .github/workflows/pipeline-segment-electron-publish.yml"
+      "node script/copy-pipeline-segment-publish.js"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
#### Description of Change

According to a logged warning message, these have been redundant since `lint-staged` [v10.0.0](https://github.com/lint-staged/lint-staged/releases/tag/v10.0.0), when `lint-staged` started automatically adding changes during these tasks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description

#### Release Notes

Notes: none
