### PR TITLE
fix: capture offscreen pages at the view's device scale factor

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4170,14 +4170,10 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
   const gfx::Size view_size =
       rect.IsEmpty() ? view->GetViewBounds().size() : rect.size();
 
-  // By default, the requested bitmap size is the view size in screen
-  // coordinates.  However, if the view renders with more pixel detail,
-  // increase the requested bitmap size to capture it all. Offscreen views
-  // render at their own scale factor, not the display's.
-  gfx::Size bitmap_size = view_size;
-  const float scale = view->GetDeviceScaleFactor();
-  if (scale > 1.0f)
-    bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
+  // Capture at the view's own scale factor. Offscreen views render at
+  // |offscreen.deviceScaleFactor|, not the display's, and it may be below 1.
+  const gfx::Size bitmap_size =
+      gfx::ScaleToCeiledSize(view_size, view->GetDeviceScaleFactor());
 
   view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
                         base::TimeDelta(),

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -180,7 +180,6 @@
 #include "ui/base/cursor/cursor.h"
 #include "ui/base/cursor/mojom/cursor_type.mojom-shared.h"
 #include "ui/base/mojom/menu_source_type.mojom.h"
-#include "ui/display/screen.h"
 #include "ui/events/base_event_utils.h"
 #include "ui/views/widget/widget.h"
 
@@ -4172,13 +4171,11 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
       rect.IsEmpty() ? view->GetViewBounds().size() : rect.size();
 
   // By default, the requested bitmap size is the view size in screen
-  // coordinates.  However, if there's more pixel detail available on the
-  // current system, increase the requested bitmap size to capture it all.
+  // coordinates.  However, if the view renders with more pixel detail,
+  // increase the requested bitmap size to capture it all. Offscreen views
+  // render at their own scale factor, not the display's.
   gfx::Size bitmap_size = view_size;
-  const gfx::NativeView native_view = view->GetNativeView();
-  const float scale = display::Screen::Get()
-                          ->GetDisplayNearestView(native_view)
-                          .device_scale_factor();
+  const float scale = view->GetDeviceScaleFactor();
   if (scale > 1.0f)
     bitmap_size = gfx::ScaleToCeiledSize(view_size, scale);
 

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7935,6 +7935,26 @@ describe('BrowserWindow module', () => {
       expect(rect.height).to.be.closeTo(50 * scaleFactor, 2);
     });
 
+    it('captures the page at a device scale factor below 1', async () => {
+      const small = new BrowserWindow({
+        width: 100,
+        height: 100,
+        show: false,
+        webPreferences: {
+          backgroundThrottling: false,
+          offscreen: {
+            deviceScaleFactor: 0.5
+          }
+        }
+      });
+      await small.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+      await once(small.webContents, 'paint');
+
+      const full = (await small.webContents.capturePage()).getSize();
+      expect(full.width).to.be.closeTo(50, 2);
+      expect(full.height).to.be.closeTo(50, 2);
+    });
+
     it('has correct screen and window sizes', async () => {
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       await once(w.webContents, 'dom-ready');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7920,6 +7920,20 @@ describe('BrowserWindow module', () => {
       expect(size.height).to.be.closeTo(100 * scaleFactor, 2);
     });
 
+    it('captures the page at the device scale factor', async () => {
+      const paint = once(w.webContents, 'paint');
+      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+      await paint;
+
+      const full = (await w.webContents.capturePage()).getSize();
+      expect(full.width).to.be.closeTo(100 * scaleFactor, 2);
+      expect(full.height).to.be.closeTo(100 * scaleFactor, 2);
+
+      const rect = (await w.webContents.capturePage({ x: 0, y: 0, width: 50, height: 50 })).getSize();
+      expect(rect.width).to.be.closeTo(50 * scaleFactor, 2);
+      expect(rect.height).to.be.closeTo(50 * scaleFactor, 2);
+    });
+
     it('has correct screen and window sizes', async () => {
       w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       await once(w.webContents, 'dom-ready');

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7921,9 +7921,10 @@ describe('BrowserWindow module', () => {
     });
 
     it('captures the page at the device scale factor', async () => {
-      const paint = once(w.webContents, 'paint');
-      w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
-      await paint;
+      // Capture a frame painted after the navigation has committed; the first
+      // paint can precede the surface swap and fail to copy.
+      await w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
+      await once(w.webContents, 'paint');
 
       const full = (await w.webContents.capturePage()).getSize();
       expect(full.width).to.be.closeTo(100 * scaleFactor, 2);


### PR DESCRIPTION
#### Description of Change

`capturePage()` sized its bitmap from the nearest display's scale factor. Offscreen windows render at `webPreferences.offscreen.deviceScaleFactor` (default `1`), so their captures were resampled whenever that differed from the display, e.g. a 1x frame upscaled to 2x on a Retina display.

- Size the capture from `view->GetDeviceScaleFactor()`. Onscreen views already report the display's factor, so onscreen captures are unchanged.
- Add a spec that captures an offscreen window at `deviceScaleFactor: 1.5`.

Fixes #53675

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are changed or added

#### Release Notes

Notes: Fixed `webContents.capturePage()` on offscreen windows returning an image resampled to the display's scale factor instead of rendered at the window's `offscreen.deviceScaleFactor`.
