### PR TITLE
fix: give captured page images their device scale factor

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1256,7 +1256,7 @@ Returns `boolean` - Whether the window's document has been edited.
 
 Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
-Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page. If the page is not visible, `rect` may be empty. The page is considered visible when its browser window is hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
+Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page. If the page is not visible, `rect` may be empty. The page is considered visible when its browser window is hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true. The image has the page's device scale factor (for offscreen rendering, `webPreferences.offscreen.deviceScaleFactor`), so `image.getSize()` is in DIPs and `image.toBitmap()` holds the full-resolution pixels.
 
 #### `win.loadURL(url[, options])`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1249,6 +1249,15 @@ Returns `boolean` - Whether the window's document has been edited.
 
 #### `win.capturePage([rect, opts])`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53813
+    description: "The image now has the page's device scale factor, so `image.getSize()` is in DIPs."
+    breaking-changes-header: behavior-changed-captured-page-images-have-the-pages-scale-factor
+```
+-->
+
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The bounds to capture
 * `opts` Object (optional)
   * `stayHidden` boolean (optional) -  Keep the page hidden instead of visible. Default is `false`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -934,6 +934,8 @@ Returns:
 * `image` [NativeImage](native-image.md) - The image data of the whole frame.
 
 Emitted when a new frame is generated. Only the dirty area is passed in the buffer.
+`image` has the view's device scale factor, so `image.getSize()` is in DIPs, while
+`dirtyRect` is in the pixels of `image.toBitmap()`.
 
 ```js
 const { BrowserWindow } = require('electron')
@@ -1814,6 +1816,7 @@ Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 The page is considered visible when its browser window is hidden and the capturer count is non-zero.
 If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
+The image has the page's device scale factor (for offscreen rendering, `webPreferences.offscreen.deviceScaleFactor`), so `image.getSize()` is in DIPs and `image.toBitmap()` holds the full-resolution pixels.
 
 #### `contents.isBeingCaptured()`
 
@@ -2186,7 +2189,8 @@ will be called with `callback(image, dirtyRect)` when there is a presentation
 event.
 
 The `image` is an instance of [NativeImage](native-image.md) that stores the
-captured frame.
+captured frame. It has the page's device scale factor, so `image.getSize()` is
+in DIPs, while `dirtyRect` is in the pixels of `image.toBitmap()`.
 
 The `dirtyRect` is an object with `x, y, width, height` properties that
 describes which part of the page was repainted. If `onlyDirty` is set to

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -926,6 +926,15 @@ app.whenReady().then(() => {
 
 #### Event: 'paint'
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53813
+    description: "`image` now has the view's device scale factor, so `image.getSize()` is in DIPs."
+    breaking-changes-header: behavior-changed-captured-page-images-have-the-pages-scale-factor
+```
+-->
+
 Returns:
 
 * `details` Event\<\>
@@ -1806,6 +1815,15 @@ console.log(requestId)
 
 #### `contents.capturePage([rect, opts])`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53813
+    description: "The image now has the page's device scale factor, so `image.getSize()` is in DIPs."
+    breaking-changes-header: behavior-changed-captured-page-images-have-the-pages-scale-factor
+```
+-->
+
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 * `opts` Object (optional)
   * `stayHidden` boolean (optional) -  Keep the page hidden instead of visible. Default is `false`.
@@ -2178,6 +2196,15 @@ Sends an input `event` to the page.
 `sendInputEvent()` to work.
 
 #### `contents.beginFrameSubscription([onlyDirty ,]callback)`
+
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53813
+    description: "The image now has the page's device scale factor, so `image.getSize()` is in DIPs."
+    breaking-changes-header: behavior-changed-captured-page-images-have-the-pages-scale-factor
+```
+-->
 
 * `onlyDirty` boolean (optional) - Defaults to `false`.
 * `callback` Function

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -612,6 +612,15 @@ Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options)`.
 
 ### `<webview>.capturePage([rect])`
 
+<!--
+```YAML history
+changes:
+  - pr-url: https://github.com/electron/electron/pull/53813
+    description: "The image now has the page's device scale factor, so `image.getSize()` is in DIPs."
+    breaking-changes-header: behavior-changed-captured-page-images-have-the-pages-scale-factor
+```
+-->
+
 * `rect` [Rectangle](structures/rectangle.md) (optional) - The area of the page to be captured.
 
 Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -617,6 +617,7 @@ Prints `webview`'s web page as PDF, Same as `webContents.printToPDF(options)`.
 Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
+The image has the page's device scale factor (for offscreen rendering, `webPreferences.offscreen.deviceScaleFactor`), so `image.getSize()` is in DIPs and `image.toBitmap()` holds the full-resolution pixels.
 
 ### `<webview>.send(channel, ...args)`
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -16,6 +16,25 @@ This document uses the following convention to categorize breaking changes:
 
 ## Breaking API Changes (46.0)
 
+### Behavior Changed: captured page images have the page's scale factor
+
+The [`NativeImage`](api/native-image.md) returned by `webContents.capturePage()`
+(and `win.capturePage()` / `<webview>.capturePage()`), passed to the offscreen
+`paint` event, and passed to the `webContents.beginFrameSubscription()`
+callback now has the page's device scale factor. These images used to always
+be marked as 1x, so on a HiDPI display, or with
+`webPreferences.offscreen.deviceScaleFactor`, `image.getSize()` returned pixels.
+It now returns DIPs, and `image.crop()` and `image.resize()` take DIPs. The
+pixel data returned by `toBitmap()`, `toPNG()`, `toJPEG()` and `toDataURL()` is
+unchanged.
+
+```js
+const image = await win.webContents.capturePage()
+const [scaleFactor] = image.getScaleFactors()
+const { width, height } = image.getSize() // DIPs
+console.log(width * scaleFactor, height * scaleFactor) // pixels, as before
+```
+
 ### Behavior Changed: workers created by subframes need `nodeIntegrationInSubFrames` for Node.js integration
 
 With `nodeIntegrationInWorker: true`, a `Worker` created from an `<iframe>` in

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -181,6 +181,7 @@
 #include "ui/base/cursor/mojom/cursor_type.mojom-shared.h"
 #include "ui/base/mojom/menu_source_type.mojom.h"
 #include "ui/events/base_event_utils.h"
+#include "ui/gfx/image/image_skia.h"
 #include "ui/views/widget/widget.h"
 
 #if BUILDFLAG(IS_MAC)
@@ -629,12 +630,14 @@ base::IDMap<WebContents*>& GetAllWebContents() {
 
 void OnCapturePageDone(gin_helper::Promise<gfx::Image> promise,
                        base::ScopedClosureRunner capture_handle,
+                       float scale_factor,
                        const content::CopyFromSurfaceResult& result) {
   auto ui_task_runner = content::GetUIThreadTaskRunner({});
   if (!ui_task_runner->RunsTasksInCurrentSequence()) {
     ui_task_runner->PostTask(
-        FROM_HERE, base::BindOnce(&OnCapturePageDone, std::move(promise),
-                                  std::move(capture_handle), result));
+        FROM_HERE,
+        base::BindOnce(&OnCapturePageDone, std::move(promise),
+                       std::move(capture_handle), scale_factor, result));
     return;
   }
 
@@ -645,8 +648,8 @@ void OnCapturePageDone(gin_helper::Promise<gfx::Image> promise,
     return;
   }
 
-  // Hack to enable transparency in captured image
-  promise.Resolve(gfx::Image::CreateFrom1xBitmap(result->bitmap));
+  promise.Resolve(gfx::Image(
+      gfx::ImageSkia::CreateFromBitmap(result->bitmap, scale_factor)));
   capture_handle.RunAndReset();
 }
 
@@ -4172,13 +4175,13 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin::Arguments* args) {
 
   // Capture at the view's own scale factor. Offscreen views render at
   // |offscreen.deviceScaleFactor|, not the display's, and it may be below 1.
-  const gfx::Size bitmap_size =
-      gfx::ScaleToCeiledSize(view_size, view->GetDeviceScaleFactor());
+  const float scale_factor = view->GetDeviceScaleFactor();
+  const gfx::Size bitmap_size = gfx::ScaleToCeiledSize(view_size, scale_factor);
 
-  view->CopyFromSurface(gfx::Rect(rect.origin(), view_size), bitmap_size,
-                        base::TimeDelta(),
-                        base::BindOnce(&OnCapturePageDone, std::move(promise),
-                                       std::move(capture_handle)));
+  view->CopyFromSurface(
+      gfx::Rect(rect.origin(), view_size), bitmap_size, base::TimeDelta(),
+      base::BindOnce(&OnCapturePageDone, std::move(promise),
+                     std::move(capture_handle), scale_factor));
   return handle;
 }
 
@@ -4236,8 +4239,11 @@ void WebContents::OnPaint(const gfx::Rect& dirty_rect,
     dict.Set("texture", tex);
   }
 
-  EmitWithoutEvent("paint", event_object, dirty_rect,
-                   gfx::Image::CreateFrom1xBitmap(bitmap));
+  auto* const view = web_contents()->GetRenderWidgetHostView();
+  const float scale_factor = view ? view->GetDeviceScaleFactor() : 1.0f;
+  EmitWithoutEvent(
+      "paint", event_object, dirty_rect,
+      gfx::Image(gfx::ImageSkia::CreateFromBitmap(bitmap, scale_factor)));
 }
 
 void WebContents::StartPainting() {

--- a/shell/browser/api/frame_subscriber.cc
+++ b/shell/browser/api/frame_subscriber.cc
@@ -17,6 +17,7 @@
 #include "services/viz/privileged/mojom/compositing/frame_sink_video_capture.mojom-shared.h"
 #include "ui/gfx/geometry/size_conversions.h"
 #include "ui/gfx/image/image.h"
+#include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/skbitmap_operations.h"
 
 namespace electron::api {
@@ -164,7 +165,10 @@ void FrameSubscriber::Done(const gfx::Rect& damage, const SkBitmap& frame) {
   bool success = bitmap.peekPixels(&pixmap) && copy.writePixels(pixmap, 0, 0);
   CHECK(success);
 
-  callback_.Run(gfx::Image::CreateFrom1xBitmap(copy), damage);
+  content::RenderWidgetHostView* view = host_->GetView();
+  const float scale_factor = view ? view->GetDeviceScaleFactor() : 1.0f;
+  callback_.Run(
+      gfx::Image(gfx::ImageSkia::CreateFromBitmap(copy, scale_factor)), damage);
 }
 
 gfx::Size FrameSubscriber::GetRenderViewSize() const {

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -297,8 +297,13 @@ v8::Local<v8::Value> NativeImage::ToBitmap(gin::Arguments* args) {
 }
 
 v8::Local<v8::Value> NativeImage::ToJPEG(v8::Isolate* isolate, int quality) {
-  const std::optional<std::vector<uint8_t>> encoded_image =
+  std::optional<std::vector<uint8_t>> encoded_image =
       gfx::JPEG1xEncodedDataFromImage(image_, quality);
+  // Images without a 1x representation are encoded from the closest one.
+  if (!encoded_image && !image_.IsEmpty()) {
+    encoded_image = gfx::JPEGCodec::Encode(
+        image_.AsImageSkia().GetRepresentation(1.0f).GetBitmap(), quality);
+  }
   if (!encoded_image)
     return NewEmptyBuffer(isolate);
   return electron::Buffer::Copy(isolate, *encoded_image).ToLocalChecked();

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -1,3 +1,4 @@
+import { nativeImage } from 'electron/common';
 import {
   app,
   BrowserWindow,
@@ -7967,9 +7968,13 @@ describe('BrowserWindow module', () => {
       const [, , data] = await paint;
       expect(data.constructor.name).to.equal('NativeImage');
       expect(data.isEmpty()).to.be.false('data is empty');
+      expect(data.getScaleFactors()).to.deep.equal([scaleFactor]);
       const size = data.getSize();
-      expect(size.width).to.be.closeTo(100 * scaleFactor, 2);
-      expect(size.height).to.be.closeTo(100 * scaleFactor, 2);
+      expect(size.width).to.be.closeTo(100, 2);
+      expect(size.height).to.be.closeTo(100, 2);
+      const pixels = nativeImage.createFromBuffer(data.toPNG()).getSize();
+      expect(pixels.width).to.be.closeTo(100 * scaleFactor, 2);
+      expect(pixels.height).to.be.closeTo(100 * scaleFactor, 2);
     });
 
     it('captures the page at the device scale factor', async () => {
@@ -7978,13 +7983,21 @@ describe('BrowserWindow module', () => {
       await w.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       await once(w.webContents, 'paint');
 
-      const full = (await w.webContents.capturePage()).getSize();
-      expect(full.width).to.be.closeTo(100 * scaleFactor, 2);
-      expect(full.height).to.be.closeTo(100 * scaleFactor, 2);
+      const full = await w.webContents.capturePage();
+      expect(full.getScaleFactors()).to.deep.equal([scaleFactor]);
+      expect(full.getSize().width).to.be.closeTo(100, 2);
+      expect(full.getSize().height).to.be.closeTo(100, 2);
+      const fullPixels = nativeImage.createFromBuffer(full.toPNG()).getSize();
+      expect(fullPixels.width).to.be.closeTo(100 * scaleFactor, 2);
+      expect(fullPixels.height).to.be.closeTo(100 * scaleFactor, 2);
+      expect(full.toJPEG(90)).to.not.be.empty();
 
-      const rect = (await w.webContents.capturePage({ x: 0, y: 0, width: 50, height: 50 })).getSize();
-      expect(rect.width).to.be.closeTo(50 * scaleFactor, 2);
-      expect(rect.height).to.be.closeTo(50 * scaleFactor, 2);
+      const rect = await w.webContents.capturePage({ x: 0, y: 0, width: 50, height: 50 });
+      expect(rect.getSize().width).to.be.closeTo(50, 2);
+      expect(rect.getSize().height).to.be.closeTo(50, 2);
+      const rectPixels = nativeImage.createFromBuffer(rect.toPNG()).getSize();
+      expect(rectPixels.width).to.be.closeTo(50 * scaleFactor, 2);
+      expect(rectPixels.height).to.be.closeTo(50 * scaleFactor, 2);
     });
 
     it('captures the page at a device scale factor below 1', async () => {
@@ -8002,9 +8015,13 @@ describe('BrowserWindow module', () => {
       await small.loadFile(path.join(fixtures, 'api', 'offscreen-rendering.html'));
       await once(small.webContents, 'paint');
 
-      const full = (await small.webContents.capturePage()).getSize();
-      expect(full.width).to.be.closeTo(50, 2);
-      expect(full.height).to.be.closeTo(50, 2);
+      const full = await small.webContents.capturePage();
+      expect(full.getScaleFactors()).to.deep.equal([0.5]);
+      expect(full.getSize().width).to.be.closeTo(100, 2);
+      expect(full.getSize().height).to.be.closeTo(100, 2);
+      const pixels = nativeImage.createFromBuffer(full.toPNG()).getSize();
+      expect(pixels.width).to.be.closeTo(50, 2);
+      expect(pixels.height).to.be.closeTo(50, 2);
     });
 
     it('has correct screen and window sizes', async () => {

--- a/spec/api-native-image-spec.ts
+++ b/spec/api-native-image-spec.ts
@@ -242,6 +242,19 @@ describe('nativeImage module', () => {
     });
   });
 
+  describe('toJPEG()', () => {
+    it('encodes an image that only has a non-1x representation', () => {
+      const image = nativeImage.createFromBitmap(Buffer.alloc(8 * 6 * 4, 0xff), {
+        width: 8,
+        height: 6,
+        scaleFactor: 2
+      });
+      const jpeg = image.toJPEG(90);
+      expect(jpeg).to.not.be.empty();
+      expect(nativeImage.createFromBuffer(jpeg).getSize()).to.deep.equal({ width: 8, height: 6 });
+    });
+  });
+
   describe('toPNG()', () => {
     it('returns a buffer at 1x scale factor by default', () => {
       const imageData = imageLogo;


### PR DESCRIPTION
#### Description of Change

Stacked on #53810.

`capturePage()`, the offscreen `paint` event and `beginFrameSubscription()` wrapped their bitmaps with `CreateFrom1xBitmap`, so the image always claimed a scale factor of 1. On a HiDPI display, or with `offscreen.deviceScaleFactor`, `getSize()` returned pixels and the image displayed at the wrong size.

- Mark each image with the view's device scale factor. `getSize()`, `crop()` and `resize()` are now in DIPs; `toBitmap()`, `toPNG()`, `toJPEG()` and `toDataURL()` still return every pixel.
- Fix `nativeImage.toJPEG()` returning an empty buffer for images with no 1x representation (already broken for `createFromBitmap(..., { scaleFactor: 2 })`). Separate commit, can be split out and backported.
- Breaking change entry under 46.0.

| 400×300 window on a 2x display | before | after |
|---|---|---|
| `getSize()` | 800×600 | 400×300 |
| `getScaleFactors()` | `[1]` | `[2]` |
| `toPNG()` pixels | 800×600 | 800×600 |

#### Checklist

- [x] PR description included
- [x] I have built and tested this PR
- [x] `npm test` passes
- [x] tests are changed or added
- [x] relevant API documentation is changed or added

#### Release Notes

Notes: `webContents.capturePage()`, the offscreen `paint` event and `webContents.beginFrameSubscription()` now return images with the page's device scale factor, so `image.getSize()` is in DIPs rather than pixels on HiDPI displays. Also fixed `nativeImage.toJPEG()` returning an empty buffer for images without a 1x representation.
