### PR TITLE
chore: remove Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Discord Chat
-    url: https://discord.gg/APGC3k5yaH
-    about: Have questions? Try asking on our Discord - this issue tracker is for reporting bugs or feature requests only
   - name: Open Collective
     url: https://opencollective.com/electron
     about: Help support Electron by contributing to our Open Collective

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)
 
 [![GitHub Actions Build Status](https://github.com/electron/electron/actions/workflows/build.yml/badge.svg)](https://github.com/electron/electron/actions/workflows/build.yml)
-[![Electron Discord Invite](https://img.shields.io/discord/745037351163527189?color=%237289DA&label=chat&logo=discord&logoColor=white)](https://discord.gg/electronjs)
 
 :memo: Available Translations: 🇨🇳 🇧🇷 🇪🇸 🇯🇵 🇷🇺 🇫🇷 🇺🇸 🇩🇪.
 View these docs in other languages on our [Crowdin](https://crowdin.com/project/electron) project.

--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -31,12 +31,6 @@ app.whenReady().then(() => {
         }
       },
       {
-        label: 'Community Discussions',
-        click: async () => {
-          await shell.openExternal('https://discord.gg/electronjs');
-        }
-      },
-      {
         label: 'Search Issues',
         click: async () => {
           await shell.openExternal('https://github.com/electron/electron/issues');

--- a/docs/tutorial/examples.md
+++ b/docs/tutorial/examples.md
@@ -39,12 +39,9 @@ guide!).
 
 ## How to...?
 
-You can find the full list of "How to?" in the sidebar. If there is
-something that you would like to do that is not documented, please join
-our [Discord server][discord] and let us know!
+You can find the full list of "How to?" in the sidebar.
 
 [app]: ../api/app.md
-[discord]: https://discord.gg/electronjs
 [fiddle]: https://www.electronjs.org/fiddle
 [Message ports]: ./message-ports.md
 [Device access]: ./devices.md

--- a/docs/tutorial/forge-overview.md
+++ b/docs/tutorial/forge-overview.md
@@ -51,13 +51,11 @@ For beginners, we recommend following through Electron's [tutorial][] to develop
 package and publish your first Electron app. If you have already developed an app on your machine
 and want to start on packaging and distribution, start from [step 5][] of the tutorial.
 
-## Getting help
+## Found a bug in Forge?
 
-- If you need help with developing your app, our [community Discord server][discord] is a great place
-  to get advice from other Electron app developers.
-- If you suspect you're running into a bug with Forge, please check the [GitHub issue tracker][]
-  to see if any existing issues match your problem. If not, feel free to fill out our bug report
-  template and submit a new issue.
+If you suspect you're running into a bug with Forge, please check the [GitHub issue tracker][]
+to see if any existing issues match your problem. If not, feel free to fill out our bug report
+template and submit a new issue.
 
 [Electron Forge Docs]: https://www.electronforge.io/
 [step 5]: ./tutorial-5-packaging.md
@@ -65,5 +63,4 @@ and want to start on packaging and distribution, start from [step 5][] of the tu
 [(make)]: https://www.electronforge.io/cli#make
 [(publish)]: https://www.electronforge.io/cli#publish
 [GitHub issue tracker]: https://github.com/electron/forge/issues
-[discord]: https://discord.gg/APGC3k5yaH
 [tutorial]: ./tutorial-1-prerequisites.md

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -53,22 +53,17 @@ are the different categories and what you can expect on each one:
 - **Contributing**: Compiling Electron and making contributions can be daunting.
   We try to make it easier in this section.
 
-## Getting help
+## Found a bug in Electron?
 
-Are you getting stuck anywhere? Here are a few links to places to look:
-
-- If you need help with developing your app, our [community Discord server][discord]
-  is a great place to get advice from other Electron app developers.
-- If you suspect you're running into a bug with the `electron` package, please check
-  the [GitHub issue tracker][issue-tracker] to see if any existing issues match your
-  problem. If not, feel free to fill out our bug report template and submit a new issue.
+If you suspect you're running into a bug with the `electron` package, please check
+the [GitHub issue tracker][issue-tracker] to see if any existing issues match your
+problem. If not, feel free to fill out our bug report template and submit a new issue.
 
 <!-- Links -->
 
 [tutorial]: tutorial-1-prerequisites.md
 [api documentation]: ../api/app.md
 [chromium]: https://www.chromium.org/
-[discord]: https://discord.gg/electronjs
 [examples]: examples.md
 [fiddle]: https://www.electronjs.org/fiddle
 [issue-tracker]: https://github.com/electron/electron/issues

--- a/docs/tutorial/tutorial-4-adding-features.md
+++ b/docs/tutorial/tutorial-4-adding-features.md
@@ -49,8 +49,7 @@ and deeper operating system integrations. To get started, check out the
 
 :::note Let us know if something is missing!
 
-If you can't find what you are looking for, please let us know on [GitHub][] or in
-our [Discord server][discord]!
+If you can't find what you are looking for, please let us know on [GitHub][]!
 
 :::
 
@@ -62,7 +61,6 @@ into end users' hands.
 
 <!-- Link labels -->
 
-[discord]: https://discord.gg/electronjs
 [github]: https://github.com/electron/website/issues/new
 [how-to]: ./examples.md
 

--- a/docs/tutorial/tutorial-6-publishing-updating.md
+++ b/docs/tutorial/tutorial-6-publishing-updating.md
@@ -213,14 +213,12 @@ own update server and configure the autoUpdater module yourself.
 :::info 🌟 You're done!
 
 From here, you have officially completed our tutorial to Electron. Feel free to explore the
-rest of our docs and happy developing! If you have questions, please stop by our community
-[Discord server][].
+rest of our docs and happy developing!
 
 :::
 
 [autoupdater]: ../api/auto-updater.md
 [code-signed]: ./code-signing.md
-[discord server]: https://discord.gg/electronjs
 [electron fiddle]: https://www.electronjs.org/fiddle
 [fiddle-build]: https://github.com/electron/fiddle/blob/main/.circleci/config.yml
 [fiddle-forge-config]: https://github.com/electron/fiddle/blob/main/forge.config.ts


### PR DESCRIPTION
#### Description of Change

As discussed at the Summit.

Backport labels applied to update the docs on our website as well as on https://www.npmjs.com/package/electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
