### PR TITLE
fix: don't start an app instance when a helper is executed without --type

### DIFF
--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -30,8 +30,8 @@ on Windows).
 **@electron/fuses:** `FuseV1Options.RunAsNode`
 
 The `runAsNode` fuse toggles whether the [`ELECTRON_RUN_AS_NODE`](../api/environment-variables.md)
-environment variable is respected or not. With this fuse disabled, [`child_process.fork`](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) in the main process will not function
-as expected, as it depends on this environment variable to function. Instead, we recommend that you
+environment variable is respected or not. With this fuse disabled, [`child_process.fork`](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) throws,
+as it depends on this environment variable to function. Instead, we recommend that you
 use [Utility Processes](../api/utility-process.md), which work for many use cases where you need a
 standalone Node.js process (e.g. a SQLite server process).
 

--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -28,7 +28,9 @@ cp.fork = (modulePath, args?, options?: cp.ForkOptions) => {
   // disabled that environment is ignored and the child would start another
   // copy of the app instead, so refuse up front.
   if (!process._linkedBinding('electron_common_features').isRunAsNodeEnabled()) {
-    throw new Error('child_process.fork() is not supported when the runAsNode fuse is disabled; use utilityProcess.fork() instead');
+    throw new Error(
+      'child_process.fork() is not supported when the runAsNode fuse is disabled; use utilityProcess.fork() instead'
+    );
   }
   options = options ?? {};
   options.env = Object.create(options.env || process.env);

--- a/lib/node/init.ts
+++ b/lib/node/init.ts
@@ -24,7 +24,12 @@ cp.fork = (modulePath, args?, options?: cp.ForkOptions) => {
     return originalFork(modulePath, args, options);
   }
   // When forking a child script, we setup a special environment to make
-  // the electron binary run like upstream Node.js.
+  // the electron binary run like upstream Node.js. With the runAsNode fuse
+  // disabled that environment is ignored and the child would start another
+  // copy of the app instead, so refuse up front.
+  if (!process._linkedBinding('electron_common_features').isRunAsNodeEnabled()) {
+    throw new Error('child_process.fork() is not supported when the runAsNode fuse is disabled; use utilityProcess.fork() instead');
+  }
   options = options ?? {};
   options.env = Object.create(options.env || process.env);
   options.env!.ELECTRON_RUN_AS_NODE = '1';

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -2,10 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <sysexits.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include "base/strings/cstring_view.h"
 #include "electron/fuses.h"
@@ -35,6 +38,21 @@ namespace {
   return indicator && *indicator;
 }
 
+#if defined(HELPER_EXECUTABLE)
+// Helper apps only ever host child processes, which are always launched with
+// --type. Started bare (for example by child_process.fork() while the
+// runAsNode fuse is disabled) a helper would otherwise boot a second browser
+// process out of the helper bundle, whose own children then fail to launch.
+[[nodiscard]] bool HasProcessType(int argc, char* argv[]) {
+  constexpr std::string_view kProcessType = "--type=";
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i]).starts_with(kProcessType))
+      return true;
+  }
+  return false;
+}
+#endif
+
 #if defined(HELPER_EXECUTABLE) && !IS_MAS_BUILD()
 [[noreturn]] void FatalError(const std::string errmsg) {
   if (!errmsg.empty()) {
@@ -53,6 +71,16 @@ int main(int argc, char* argv[]) {
   if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet(electron::kRunAsNode)) {
     return ElectronInitializeICUandStartNode(argc, argv);
   }
+
+#if defined(HELPER_EXECUTABLE)
+  if (!HasProcessType(argc, argv)) {
+    std::cerr << argv[0]
+              << " is a helper executable and cannot be launched directly; "
+                 "it requires a --type argument from the browser process."
+              << std::endl;
+    return EX_USAGE;
+  }
+#endif
 
 #if defined(HELPER_EXECUTABLE) && !IS_MAS_BUILD()
   uint32_t exec_path_size = 0;

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 
+#include "base/compiler_specific.h"
 #include "base/strings/cstring_view.h"
 #include "electron/fuses.h"
 #include "electron/mas.h"
@@ -46,7 +47,8 @@ namespace {
 [[nodiscard]] bool HasProcessType(int argc, char* argv[]) {
   constexpr std::string_view kProcessType = "--type=";
   for (int i = 1; i < argc; ++i) {
-    if (std::string_view(argv[i]).starts_with(kProcessType))
+    // SAFETY: the OS guarantees that argv holds argc entries.
+    if (std::string_view(UNSAFE_BUFFERS(argv[i])).starts_with(kProcessType))
       return true;
   }
   return false;
@@ -74,8 +76,7 @@ int main(int argc, char* argv[]) {
 
 #if defined(HELPER_EXECUTABLE)
   if (!HasProcessType(argc, argv)) {
-    std::cerr << argv[0]
-              << " is a helper executable and cannot be launched directly; "
+    std::cerr << "This is a helper executable and cannot be launched directly; "
                  "it requires a --type argument from the browser process."
               << std::endl;
     return EX_USAGE;

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "printing/buildflags/buildflags.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
@@ -33,6 +34,10 @@ bool IsExtensionsEnabled() {
   return BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS);
 }
 
+bool IsRunAsNodeEnabled() {
+  return electron::fuses::IsRunAsNodeEnabled();
+}
+
 bool IsComponentBuild() {
 #if defined(COMPONENT_BUILD)
   return true;
@@ -54,6 +59,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPrintingEnabled", &IsPrintingEnabled);
   dict.SetMethod("isPromptAPIEnabled", &IsPromptAPIEnabled);
   dict.SetMethod("isComponentBuild", &IsComponentBuild);
+  dict.SetMethod("isRunAsNodeEnabled", &IsRunAsNodeEnabled);
   dict.SetMethod("isExtensionsEnabled", &IsExtensionsEnabled);
 }
 

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -31,14 +31,17 @@ describe('fuses', () => {
 
   it('makes child_process.fork throw when run_as_node is 0', async () => {
     const rc = await startRemoteControlApp(['--set-fuse-run_as_node=0']);
-    const message = await rc.remotely((fixture: string) => {
-      try {
-        require('node:child_process').fork(fixture);
-        return 'forked';
-      } catch (error) {
-        return (error as Error).message;
-      }
-    }, path.join(__dirname, 'fixtures', 'module', 'noop.js'));
+    const message = await rc.remotely(
+      (fixture: string) => {
+        try {
+          require('node:child_process').fork(fixture);
+          return 'forked';
+        } catch (error) {
+          return (error as Error).message;
+        }
+      },
+      path.join(__dirname, 'fixtures', 'module', 'noop.js')
+    );
     expect(message).to.include('runAsNode fuse is disabled');
   });
 

--- a/spec/fuses-spec.ts
+++ b/spec/fuses-spec.ts
@@ -29,6 +29,19 @@ describe('fuses', () => {
     expect(status).to.equal(0);
   });
 
+  it('makes child_process.fork throw when run_as_node is 0', async () => {
+    const rc = await startRemoteControlApp(['--set-fuse-run_as_node=0']);
+    const message = await rc.remotely((fixture: string) => {
+      try {
+        require('node:child_process').fork(fixture);
+        return 'forked';
+      } catch (error) {
+        return (error as Error).message;
+      }
+    }, path.join(__dirname, 'fixtures', 'module', 'noop.js'));
+    expect(message).to.include('runAsNode fuse is disabled');
+  });
+
   it('disables fetching file:// URLs when grant_file_protocol_extra_privileges is 0', async () => {
     const rc = await startRemoteControlApp(['--set-fuse-grant_file_protocol_extra_privileges=0']);
     await expect(

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -50,14 +50,21 @@ describe('node feature', () => {
         expect(msg.length).to.equal(2);
       });
 
-      ifit(process.platform === 'darwin')('does not start an app instance when the helper is executed without a process type', () => {
-        const { status, stderr } = childProcess.spawnSync(process.helperExecPath, [path.join(fixtures, 'module', 'ping.js')], {
-          encoding: 'utf-8',
-          timeout: 20000
-        });
-        expect(status).to.equal(64);
-        expect(stderr).to.include('requires a --type argument');
-      });
+      ifit(process.platform === 'darwin')(
+        'does not start an app instance when the helper is executed without a process type',
+        () => {
+          const { status, stderr } = childProcess.spawnSync(
+            process.helperExecPath,
+            [path.join(fixtures, 'module', 'ping.js')],
+            {
+              encoding: 'utf-8',
+              timeout: 20000
+            }
+          );
+          expect(status).to.equal(64);
+          expect(stderr).to.include('requires a --type argument');
+        }
+      );
     });
   });
 

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -49,6 +49,15 @@ describe('node feature', () => {
         const [msg] = await once(child, 'message');
         expect(msg.length).to.equal(2);
       });
+
+      ifit(process.platform === 'darwin')('does not start an app instance when the helper is executed without a process type', () => {
+        const { status, stderr } = childProcess.spawnSync(process.helperExecPath, [path.join(fixtures, 'module', 'ping.js')], {
+          encoding: 'utf-8',
+          timeout: 20000
+        });
+        expect(status).to.equal(64);
+        expect(stderr).to.include('requires a --type argument');
+      });
     });
   });
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -27,6 +27,7 @@ declare namespace NodeJS {
     isPromptAPIEnabled(): boolean;
     isExtensionsEnabled(): boolean;
     isComponentBuild(): boolean;
+    isRunAsNodeEnabled(): boolean;
   }
 
   interface IpcRendererImpl {


### PR DESCRIPTION
#### Description of Change

On macOS the helper executables link the same framework as the main binary, so running one without a `--type` argument boots it as a full browser process from inside the helper bundle. That process derives its child helper paths from its own name (`App Helper (Plugin) (GPU).app`, ...), so its GPU and renderer launches fail and its sandboxed utilities abort in `OverrideChildProcessPath` with "Unable to find helper app", relaunching in a loop. The easiest way to get there today is `child_process.fork()` in an app that has the `runAsNode` fuse disabled: the fork wrapper points `execPath` at the helper and sets `ELECTRON_RUN_AS_NODE=1`, the fuse ignores the variable, and the helper starts as an app.

Two changes:
* Helper executables now exit with `EX_USAGE` and a message when started without `--type`, the same guard Chrome has in `ChromeMainDelegate` ("Helper application requires --type"). Every legitimate helper launch from content carries `--type`.
* `child_process.fork()` throws when the `runAsNode` fuse is disabled instead of spawning a process that cannot work. The fuses tutorial already said fork "will not function as expected" in that configuration; it now says it throws.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed helper executables on macOS starting a second app instance when launched without a process type, for example through `child_process.fork()` with the `runAsNode` fuse disabled; `fork()` now throws in that configuration.
