### PR TITLE
fix: crash when a node-integrated iframe is removed before its loop starts

### DIFF
--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -60,7 +60,9 @@ template <typename T,
               std::is_same<T, uv_udp_t>::value>::type* = nullptr>
 class UvHandle {
  public:
-  UvHandle() : t_{new T} {}
+  // Value-initialized so a handle that never reaches uv_*_init() reads as
+  // UV_UNKNOWN_HANDLE instead of garbage.
+  UvHandle() : t_{new T{}} {}
   ~UvHandle() { reset(); }
 
   explicit UvHandle(UvHandle&& that) {
@@ -91,8 +93,15 @@ class UvHandle {
   void reset() {
     auto* h = handle();
     if (h != nullptr) {
-      DCHECK_EQ(0, uv_is_closing(h));
-      uv_close(h, OnClosed);
+      if (uv_handle_get_type(h) == UV_UNKNOWN_HANDLE) {
+        // Never initialized, so it is on no loop and there is nothing to
+        // close, e.g. NodeBindings::dummy_uv_handle_ when a frame goes away
+        // before PrepareEmbedThread() runs.
+        delete t_;
+      } else {
+        DCHECK_EQ(0, uv_is_closing(h));
+        uv_close(h, OnClosed);
+      }
       t_ = nullptr;
     }
   }

--- a/spec/fixtures/module/preload-remove-own-frame.js
+++ b/spec/fixtures/module/preload-remove-own-frame.js
@@ -1,0 +1,6 @@
+// Removes its own subframe from a task queued while the frame's Node.js
+// environment is being created, so the environment is torn down before the
+// task that first runs its loop.
+if (window !== window.top) {
+  setTimeout(() => window.frameElement.remove(), 0);
+}

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -591,6 +591,33 @@ describe('node feature', () => {
       }
       expect(errors).to.deep.equal([]);
     });
+
+    // Regression test for https://github.com/electron/electron/issues/53789.
+    it('does not crash when a node-integrated iframe is removed before its loop first runs', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: false,
+          nodeIntegrationInSubFrames: true,
+          preload: path.join(fixtures, 'module', 'preload-remove-own-frame.js')
+        }
+      });
+      const gone = once(w.webContents, 'render-process-gone') as Promise<
+        [Electron.Event, Electron.RenderProcessGoneDetails]
+      >;
+      await w.loadFile(path.join(fixtures, 'pages', 'blank.html'));
+      const removed = w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const frames = Array.from({ length: 10 }, () => {
+          const frame = document.createElement('iframe');
+          frame.src = 'base-page.html';
+          return document.body.appendChild(frame);
+        });
+        const check = () => frames.some((frame) => frame.isConnected) ? setTimeout(check, 10) : resolve(frames.length);
+        check();
+      })`);
+      const result = await Promise.race([removed, gone.then(([, details]) => `render process ${details.reason}`)]);
+      expect(result).to.equal(10);
+    });
   });
 
   describe('native addons', () => {


### PR DESCRIPTION
Fixes #53789.

#52964 gave each `nodeIntegrationInSubFrames` frame its own `NodeBindings`, whose `dummy_uv_handle_` is only initialized by the task that first runs the frame's loop. A frame removed before that task runs (Meta Pixel's hidden form POST iframes hit this) destroyed a `uv_async_t` that never went through `uv_async_init()`, so `uv_close()` ran on uninitialized memory: a DCHECK in testing builds, heap corruption and an eventual renderer crash in release.

- `UvHandle` value-initializes its handle, and `reset()` frees one that was never initialized (still `UV_UNKNOWN_HANDLE`) instead of closing it.
- New spec: the preload removes its own frame from a task queued while the frame's environment is created, which always lands before the loop's first run. It failed 21/21 without the fix (on an older nightly and on current main) and passes 10/10 with it.

Notes: Fixed a renderer crash when an iframe was removed right after loading with `nodeIntegrationInSubFrames` enabled and `sandbox` disabled, e.g. on pages that embed Meta Pixel.
