### PR TITLE
fix: crash when a preload removes its own iframe asynchronously

### DIFF
--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -60,7 +60,9 @@ template <typename T,
               std::is_same<T, uv_udp_t>::value>::type* = nullptr>
 class UvHandle {
  public:
-  UvHandle() : t_{new T} {}
+  // Value-initialized so a handle that never reaches uv_*_init() reads as
+  // UV_UNKNOWN_HANDLE instead of garbage.
+  UvHandle() : t_{new T{}} {}
   ~UvHandle() { reset(); }
 
   explicit UvHandle(UvHandle&& that) {
@@ -91,8 +93,15 @@ class UvHandle {
   void reset() {
     auto* h = handle();
     if (h != nullptr) {
-      DCHECK_EQ(0, uv_is_closing(h));
-      uv_close(h, OnClosed);
+      if (uv_handle_get_type(h) == UV_UNKNOWN_HANDLE) {
+        // Never initialized, so it is on no loop and there is nothing to
+        // close, e.g. NodeBindings::dummy_uv_handle_ when a frame goes away
+        // before PrepareEmbedThread() runs.
+        delete t_;
+      } else {
+        DCHECK_EQ(0, uv_is_closing(h));
+        uv_close(h, OnClosed);
+      }
       t_ = nullptr;
     }
   }

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -9,10 +9,12 @@
 #include <vector>
 
 #include "base/memory/ref_counted_memory.h"
+#include "base/memory/stack_allocated.h"
 #include "content/public/renderer/render_frame.h"
 #include "net/base/module/net_module.h"
 #include "net/grit/net_resources.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
+#include "shell/common/node_util.h"
 #include "shell/common/web_contents_utility.mojom.h"
 #include "shell/common/world_ids.h"
 #include "shell/renderer/renderer_client_base.h"
@@ -24,6 +26,8 @@
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
 #include "third_party/blink/public/web/web_view.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"  // nogncheck
+#include "third_party/blink/renderer/core/frame/local_frame.h"  // nogncheck
 #include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"  // nogncheck
 #include "ui/base/resource/resource_bundle.h"
 
@@ -46,6 +50,27 @@ scoped_refptr<base::RefCountedMemory> NetResourceProvider(int key) {
 [[nodiscard]] constexpr bool is_isolated_world(int world_id) {
   return world_id == WorldIDs::ISOLATED_WORLD_ID;
 }
+
+// Preload scripts run from DidClearWindowObject() and
+// DidInstallConditionalFeatures(), which Blink and content call while they are
+// still setting up the frame's script contexts. A microtask checkpoint there
+// runs whatever the preload queued underneath them, and one that removes this
+// frame frees the RenderFrame and window proxy they return to. Hold off every
+// checkpoint, Node.js's explicit ones included, until the outermost of these
+// callbacks returns; the queue drains at the next checkpoint after that.
+class DeferMicrotasksScope {
+  STACK_ALLOCATED();
+
+ public:
+  DeferMicrotasksScope(v8::Isolate* isolate, v8::MicrotaskQueue* queue)
+      : explicit_policy_(queue),
+        depth_(isolate, queue, v8::MicrotasksScope::kRunMicrotasks) {}
+
+ private:
+  // Outlives |depth_|, so leaving that scope does not checkpoint either.
+  util::ExplicitMicrotasksScope explicit_policy_;
+  v8::MicrotasksScope depth_;
+};
 
 }  // namespace
 
@@ -73,13 +98,16 @@ void ElectronRenderFrameObserver::SetIsolatedWorldCreatedCallback(
 }
 
 void ElectronRenderFrameObserver::DidClearWindowObject() {
-  // Do a delayed Node.js initialization for child window.
-  // Check DidInstallConditionalFeatures below for the background.
   auto* web_frame =
       static_cast<blink::WebLocalFrameImpl*>(render_frame_->GetWebFrame());
+  v8::Isolate* isolate = web_frame->GetAgentGroupScheduler()->Isolate();
+  DeferMicrotasksScope defer_microtasks(
+      isolate, web_frame->GetFrame()->DomWindow()->GetMicrotaskQueue());
+
+  // Do a delayed Node.js initialization for child window.
+  // Check DidInstallConditionalFeatures below for the background.
   if (has_delayed_node_initialization_ &&
       !web_frame->IsOnInitialEmptyDocument()) {
-    v8::Isolate* isolate = web_frame->GetAgentGroupScheduler()->Isolate();
     v8::HandleScope handle_scope{isolate};
     v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
     v8::MicrotasksScope microtasks_scope(
@@ -95,6 +123,9 @@ void ElectronRenderFrameObserver::DidClearWindowObject() {
 void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
     v8::Local<v8::Context> context,
     int world_id) {
+  DeferMicrotasksScope defer_microtasks(v8::Isolate::GetCurrent(),
+                                        context->GetMicrotaskQueue());
+
   if (electron::is_main_world(world_id)) {
     // Start each document with a clean slate before preload has a chance to
     // subscribe for current-document isolated world creation.

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -4,6 +4,8 @@
 
 #include "shell/renderer/electron_renderer_client.h"
 
+#include <utility>
+
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/task/sequenced_task_runner.h"
@@ -56,6 +58,9 @@ struct ElectronRendererClient::FrameEnvironment {
   // The world of |environment|'s context, recorded while Blink can still map
   // the context to its frame.
   int world_id = 0;
+  // Set once the frame's context is released; the environment may outlive
+  // that briefly (see WillReleaseScriptContext) but must not run again.
+  bool released = false;
   base::WeakPtrFactory<FrameEnvironment> weak_factory{this};
 };
 
@@ -182,14 +187,31 @@ void ElectronRendererClient::DidCreateScriptContext(
       frame_env->weak_factory.GetWeakPtr();
   environments_[render_frame] = std::move(frame_env);
 
-  node_bindings->LoadEnvironment(env.get());
+  {
+    // Node.js runs the process.nextTick() callbacks queued during bootstrap,
+    // the preload's included, when bootstrap's callback scope closes. That is
+    // still inside Blink's context setup, where one that removes this frame
+    // frees it underneath Blink, so keep them queued here instead.
+    v8::Context::Scope context_scope(renderer_context);
+    node::InternalCallbackScope keep_ticks_queued(
+        env.get(), v8::Object::New(isolate), {0, 0},
+        node::InternalCallbackScope::kSkipAsyncHooks |
+            node::InternalCallbackScope::kSkipTaskQueues);
+    node_bindings->LoadEnvironment(env.get());
+  }
+  // Run them from a microtask, which the frame observer holds until that setup
+  // has returned. Queued behind the preload's own promise reactions, which
+  // have always run first.
+  renderer_context->GetMicrotaskQueue()->EnqueueMicrotask(
+      isolate, &ElectronRendererClient::RunTicksQueuedDuringSetup,
+      new base::WeakPtr<FrameEnvironment>(weak_frame_env));
 
   // This context may have been created from inside a script (e.g. the opener's
   // window.open() call), so give the loop its first run from a fresh task.
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE, base::BindOnce(
                      [](base::WeakPtr<FrameEnvironment> frame_env) {
-                       if (!frame_env)
+                       if (!frame_env || frame_env->released)
                          return;
                        frame_env->node_bindings->PrepareEmbedThread();
                        frame_env->node_bindings->StartPolling();
@@ -209,14 +231,60 @@ void ElectronRendererClient::WillReleaseScriptContext(
   auto iter = environments_.find(render_frame);
   std::unique_ptr<FrameEnvironment> frame_env = std::move(iter->second);
   environments_.erase(iter);
-
-  // Park the embed thread so FreeEnvironment's uv_run is the loop's only user.
+  frame_env->released = true;
   frame_env->node_bindings->set_uv_env(nullptr);
+
+  // The frame can go away from inside one of its own Node.js callbacks, e.g.
+  // an iframe removing itself from a setImmediate(). Freeing the environment
+  // and its loop there frees them underneath that callback, so stop the
+  // environment calling back into JS and free it from a fresh task. A main
+  // frame on the process-wide loop is still freed here: another environment
+  // may take that loop over before the task runs.
+  if (frame_env->own_node_bindings && env->async_callback_scope_depth() > 0) {
+    env->set_can_call_into_js(false);
+    released_environments_.push_back(std::move(frame_env));
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(&ElectronRendererClient::FreeReleasedEnvironments,
+                       base::Unretained(this)));
+    return;
+  }
+  FreeFrameEnvironment(std::move(frame_env));
+}
+
+void ElectronRendererClient::FreeReleasedEnvironments() {
+  for (auto& frame_env : std::exchange(released_environments_, {}))
+    FreeFrameEnvironment(std::move(frame_env));
+}
+
+// static
+void ElectronRendererClient::FreeFrameEnvironment(
+    std::unique_ptr<FrameEnvironment> frame_env) {
+  node::Environment* const env = frame_env->environment.get();
+  // Park the embed thread so FreeEnvironment's uv_run is the loop's only user.
   frame_env->node_bindings->StopPolling();
   frame_env->electron_bindings->EnvironmentDestroyed(env);
+  v8::Isolate* const isolate = env->isolate();
+  v8::HandleScope handle_scope{isolate};
   // Freeing the environment runs its loop, i.e. enters Node.js.
-  util::ExplicitMicrotasksScope microtasks_scope(context->GetMicrotaskQueue());
+  util::ExplicitMicrotasksScope microtasks_scope(
+      env->context()->GetMicrotaskQueue());
   frame_env->environment.reset();
+}
+
+// static
+void ElectronRendererClient::RunTicksQueuedDuringSetup(void* data) {
+  const std::unique_ptr<base::WeakPtr<FrameEnvironment>> weak_frame_env{
+      static_cast<base::WeakPtr<FrameEnvironment>*>(data)};
+  FrameEnvironment* const frame_env = weak_frame_env->get();
+  if (!frame_env || frame_env->released)
+    return;
+  node::Environment* const env = frame_env->environment.get();
+  v8::Isolate* const isolate = env->isolate();
+  v8::HandleScope handle_scope{isolate};
+  v8::Context::Scope context_scope{env->context()};
+  // Closing the scope runs them.
+  node::CallbackScope callback_scope{isolate, v8::Object::New(isolate), {0, 0}};
 }
 
 namespace {

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include "base/containers/flat_map.h"
 #include "shell/renderer/renderer_client_base.h"
@@ -63,6 +64,14 @@ class ElectronRendererClient : public RendererClientBase {
 
   node::Environment* GetEnvironment(content::RenderFrame* frame) const;
 
+  // Microtask running the process.nextTick() callbacks queued while a frame's
+  // environment was set up. |data| is a heap-allocated
+  // base::WeakPtr<FrameEnvironment>, freed here.
+  static void RunTicksQueuedDuringSetup(void* data);
+
+  static void FreeFrameEnvironment(std::unique_ptr<FrameEnvironment> frame_env);
+  void FreeReleasedEnvironments();
+
   // Whether the node integration has been initialized.
   bool node_integration_initialized_ = false;
 
@@ -73,6 +82,10 @@ class ElectronRendererClient : public RendererClientBase {
 
   base::flat_map<content::RenderFrame*, std::unique_ptr<FrameEnvironment>>
       environments_;
+
+  // Environments released from inside one of their own Node.js callbacks,
+  // waiting for a fresh task to be freed.
+  std::vector<std::unique_ptr<FrameEnvironment>> released_environments_;
 };
 
 }  // namespace electron

--- a/spec/fixtures/module/preload-remove-own-frame.js
+++ b/spec/fixtures/module/preload-remove-own-frame.js
@@ -1,0 +1,6 @@
+// Removes its own subframe from a task queued while the frame's Node.js
+// environment is being created, so the environment is torn down before the
+// task that first runs its loop.
+if (window !== window.top) {
+  setTimeout(() => window.frameElement.remove(), 0);
+}

--- a/spec/fixtures/module/preload-remove-own-frame.js
+++ b/spec/fixtures/module/preload-remove-own-frame.js
@@ -1,6 +1,19 @@
-// Removes its own subframe from a task queued while the frame's Node.js
-// environment is being created, so the environment is torn down before the
-// task that first runs its loop.
+// Removes its own subframe while or right after the frame's Node.js
+// environment is being created. --remove-own-frame-via picks how; by default
+// it's a task queued while the environment is created, so the environment is
+// torn down before the task that first runs its loop.
 if (window !== window.top) {
-  setTimeout(() => window.frameElement.remove(), 0);
+  const via = process.argv.find((arg) => arg.startsWith('--remove-own-frame-via='))?.split('=')[1];
+  const remove = () => window.frameElement.remove();
+  if (via === 'queueMicrotask') {
+    queueMicrotask(remove);
+  } else if (via === 'nextTick') {
+    process.nextTick(remove);
+  } else if (via === 'setImmediate') {
+    setImmediate(remove);
+  } else if (via === 'fs-callback') {
+    require('node:fs').readFile(__filename, remove);
+  } else {
+    setTimeout(remove, 0);
+  }
 }

--- a/spec/fixtures/module/preload-task-order.js
+++ b/spec/fixtures/module/preload-task-order.js
@@ -1,0 +1,3 @@
+window.taskOrder = ['preload'];
+Promise.resolve().then(() => window.taskOrder.push('microtask'));
+process.nextTick(() => window.taskOrder.push('nextTick'));

--- a/spec/fixtures/pages/task-order.html
+++ b/spec/fixtures/pages/task-order.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      window.taskOrder.push('page');
+    </script>
+  </body>
+</html>

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -591,6 +591,33 @@ describe('node feature', () => {
       }
       expect(errors).to.deep.equal([]);
     });
+
+    // Regression test for https://github.com/electron/electron/issues/53789.
+    it('does not crash when a node-integrated iframe is removed before its loop first runs', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: false,
+          nodeIntegrationInSubFrames: true,
+          preload: path.join(fixtures, 'module', 'preload-remove-own-frame.js')
+        }
+      });
+      const gone = once(w.webContents, 'render-process-gone') as Promise<
+        [Electron.Event, Electron.RenderProcessGoneDetails]
+      >;
+      await w.loadFile(path.join(fixtures, 'pages', 'blank.html'));
+      const removed = w.webContents.executeJavaScript(`new Promise((resolve) => {
+        const frames = Array.from({ length: 10 }, () => {
+          const frame = document.createElement('iframe');
+          frame.src = 'base-page.html';
+          return document.body.appendChild(frame);
+        });
+        const check = () => frames.some((frame) => frame.isConnected) ? setTimeout(check, 10) : resolve(frames.length);
+        check();
+      })`);
+      const result = await Promise.race([removed, gone.then(([, details]) => `render process ${details.reason}`)]);
+      expect(result).to.equal(10);
+    });
   });
 
   describe('native addons', () => {

--- a/spec/node-spec.ts
+++ b/spec/node-spec.ts
@@ -618,6 +618,56 @@ describe('node feature', () => {
       const result = await Promise.race([removed, gone.then(([, details]) => `render process ${details.reason}`)]);
       expect(result).to.equal(10);
     });
+
+    // A preload that removes its own frame asynchronously must not have that
+    // run underneath Blink's context creation or one of the frame's own Node.js
+    // callbacks.
+    for (const via of ['queueMicrotask', 'nextTick', 'setImmediate', 'fs-callback']) {
+      it(`does not crash when a preload removes its own iframe from ${via}`, async () => {
+        const w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            sandbox: false,
+            nodeIntegrationInSubFrames: true,
+            preload: path.join(fixtures, 'module', 'preload-remove-own-frame.js'),
+            additionalArguments: [`--remove-own-frame-via=${via}`]
+          }
+        });
+        const gone = once(w.webContents, 'render-process-gone') as Promise<
+          [Electron.Event, Electron.RenderProcessGoneDetails]
+        >;
+        await w.loadFile(path.join(fixtures, 'pages', 'blank.html'));
+        const removed = w.webContents.executeJavaScript(`new Promise((resolve) => {
+          const frames = Array.from({ length: 10 }, () => {
+            const frame = document.createElement('iframe');
+            frame.src = 'base-page.html';
+            return document.body.appendChild(frame);
+          });
+          const check = () => frames.some((frame) => frame.isConnected) ? setTimeout(check, 10) : resolve(frames.length);
+          check();
+        })`);
+        const result = await Promise.race([removed, gone.then(([, details]) => `render process ${details.reason}`)]);
+        expect(result).to.equal(10);
+      });
+    }
+
+    it('runs preload promise reactions and nextTick callbacks before page scripts', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: false,
+          contextIsolation: false,
+          preload: path.join(fixtures, 'module', 'preload-task-order.js')
+        }
+      });
+      await w.loadFile(path.join(fixtures, 'pages', 'task-order.html'));
+      expect(await w.webContents.executeJavaScript('window.taskOrder')).to.deep.equal([
+        'preload',
+        'microtask',
+        'nextTick',
+        'page'
+      ]);
+    });
   });
 
   describe('native addons', () => {


### PR DESCRIPTION
Follow-up to #53833, and based on it.

An iframe with `nodeIntegrationInSubFrames` whose preload removed its own frame asynchronously crashed the renderer, whether the removal ran from a promise reaction, `process.nextTick()`, `setImmediate()` or another Node.js callback. This predates #52964: 42.3.1 crashes the same way.

- The frame observer holds off microtask checkpoints, Node.js's explicit ones included, while Blink and content are inside `DidClearWindowObject()` / `DidInstallConditionalFeatures()`. A preload's promise reactions used to run from any native call it made, underneath those callbacks, and one that detached the frame freed the `RenderFrame` and window proxy they return to. They now run once those callbacks return, still before page scripts.
- `process.nextTick()` callbacks queued during bootstrap no longer run as bootstrap's callback scope closes, for the same reason. A microtask queued behind the preload's own promise reactions runs them, keeping the existing order.
- A frame released from inside one of its own Node.js callbacks has its environment and loop freed from a fresh task instead of underneath that callback, and cannot call back into JS in between.
- New specs cover removal from each of those, and the order of preload promise reactions, `nextTick` callbacks and page scripts.

A preload that removes its own frame synchronously still crashes: that runs inside the same Blink and content callbacks and needs a different fix.

Notes: Fixed a renderer crash when a `nodeIntegrationInSubFrames` preload removed its own iframe from a promise, `process.nextTick()` or other Node.js callback.
