### PR TITLE
test: clean up some test flakes with webFrameMain (43-x-y)

### DIFF
--- a/spec/api-web-frame-main-spec.ts
+++ b/spec/api-web-frame-main-spec.ts
@@ -16,6 +16,25 @@ import { closeAllWindows } from './lib/window-helpers';
 
 const features = process._linkedBinding('electron_common_features');
 
+/**
+ * Waits for the 'preload-unload' IPC that sub-frames/preload sends when a
+ * document detaches. Scoped to a single WebContents since windows torn down by
+ * cleanup send it too, and frame properties are read on arrival because they
+ * stop resolving once the frame is disposed.
+ */
+async function onceUnload(webContents: WebContents) {
+  let unload: { senderFrame: WebFrameMain | null; frameProcessId?: number; processId: number } | undefined;
+  const listener = (event: Electron.IpcMainEvent) => {
+    if (event.sender !== webContents) return;
+    const { processId, senderFrame } = event;
+    unload = { senderFrame, frameProcessId: senderFrame?.processId, processId };
+  };
+  ipcMain.on('preload-unload', listener);
+  defer(() => ipcMain.off('preload-unload', listener));
+  await waitUntil(() => unload !== undefined);
+  return unload!;
+}
+
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');
   const subframesPath = path.join(fixtures, 'sub-frames');
@@ -384,21 +403,12 @@ describe('webFrameMain module', () => {
         }
       });
       await w.webContents.loadURL(server.url);
-      const unloadPromise = new Promise<void>((resolve, reject) => {
-        ipcMain.once('preload-unload', (event) => {
-          try {
-            const { senderFrame } = event;
-            expect(senderFrame).to.not.be.null();
-            expect(senderFrame!.detached).to.be.true();
-            expect(senderFrame!.processId).to.equal(event.processId);
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
+      const unloadPromise = onceUnload(w.webContents);
       await w.webContents.loadURL(server.crossOriginUrl);
-      await expect(unloadPromise).to.eventually.be.fulfilled();
+      const { senderFrame, frameProcessId, processId } = await unloadPromise;
+      expect(senderFrame).to.not.be.null();
+      expect(senderFrame!.detached).to.be.true();
+      expect(frameProcessId).to.equal(processId);
     });
 
     it('disposes detached frame after cross-origin navigation', async () => {
@@ -409,23 +419,14 @@ describe('webFrameMain module', () => {
         }
       });
       await w.webContents.loadURL(server.url);
-      // eslint-disable-next-line prefer-const
-      let crossOriginPromise: Promise<void>;
-      const unloadPromise = new Promise<void>((resolve, reject) => {
-        ipcMain.once('preload-unload', async (event) => {
-          try {
-            const { senderFrame } = event;
-            expect(senderFrame!.detached).to.be.true();
-            await crossOriginPromise;
-            expect(() => senderFrame!.url).to.throw(/Render frame was disposed/);
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
-      crossOriginPromise = w.webContents.loadURL(server.crossOriginUrl);
-      await expect(unloadPromise).to.eventually.be.fulfilled();
+      const unloadPromise = onceUnload(w.webContents);
+      const crossOriginPromise = w.webContents.loadURL(server.crossOriginUrl);
+      const { senderFrame } = await unloadPromise;
+      expect(senderFrame!.detached).to.be.true();
+      await crossOriginPromise;
+      // The detached frame is not destroyed immediately, so wait until it is
+      await waitUntil(() => senderFrame!.isDestroyed());
+      expect(() => senderFrame!.url).to.throw(/Render frame was disposed/);
     });
 
     // Skip test as we don't have an offline repro yet


### PR DESCRIPTION
#### Description of Change

Partial backport of #53048 (27ba18401c403f71bb43e723ab7b192959c6bff8) to `43-x-y`.

The original flakes surfaced while working on UBSan builds: instrumented binaries run more slowly, making these lifecycle races occur more often. This backport applies the API-test fixes to reduce the corresponding downstream Electron 43 test flakes.

The changes scope unload IPC to the relevant `WebContents`, capture frame properties before disposal, clean up the IPC listener, and wait for the detached frame to be destroyed after cross-origin navigation.

**Differences from the original PR**

- Only `spec/api-web-frame-main-spec.ts` is included. The helper is inserted in the corresponding location on the release branch, without importing unrelated newer helpers.
- The `spec/cpp-heap-spec.ts` changes are omitted. `43-x-y` has not migrated `WebFrameMain` to cppgc and does not contain the corresponding heap-test suite. No cppgc migration or new heap suite is included.
- This is test-only; there are no runtime or dependency changes.

CC @dsanders11 as the original author and stakeholder
CC @mlaurencin as build stakeholder

#### Validation

- Passed: scoped JavaScript/TypeScript lint and formatting checks for the changed file.
- Passed: an isolated check of the actual helper for window filtering, immediate property capture, and deferred listener cleanup. This does not substitute for Electron runtime tests.
- Pending: the full Linux x64 native build is still running. Earlier attempts encountered stale generated output and remote-worker build failures; the affected targets passed after local workarounds, with no source changes.
- Pending: focused Electron lifecycle tests against the completed release build. The full `npm test` suite has not been run.

#### Checklist

- [ ] I have built and tested this change
- [x] I have filled out the PR description
- [ ] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [ ] `npm test` passes

#### Release Notes

Notes: none
