### PR TITLE
build: keep CI test-shard weights per test job

### DIFF
--- a/script/gen-spec-weights.js
+++ b/script/gen-spec-weights.js
@@ -1,14 +1,15 @@
-// Regenerates script/spec-weights.json (per-platform seconds per spec file,
-// used by script/split-tests.js) from the spec-timings.json files that CI test
-// jobs upload in their test_artifacts_* bundles.
+// Regenerates script/spec-weights.json (seconds per spec file for each CI
+// test job, used by script/split-tests.js) from the spec-timings.json files
+// the test jobs upload in their test_artifacts_* bundles.
 //
-// Usage, from a recent green build.yml run on main:
-//   gh run download <run-id> --repo electron/electron -D /tmp/spec-timings \
-//     -p 'test_artifacts_darwin_x64_*' -p 'test_artifacts_linux_x64_x11_*' -p 'test_artifacts_win_x64_*'
+// Usage, from a recent green build.yml run on the branch:
+//   gh run download <run-id> --repo electron/electron -D /tmp/spec-timings -p 'test_artifacts_*'
 //   node script/gen-spec-weights.js /tmp/spec-timings
 //
-// Where several artifacts cover the same platform (arches, mas/darwin, shards)
-// the largest time seen for a file wins.
+// Each job gets its own table, keyed as its artifact is named:
+// `<build type>_<arch>[_<sanitizer>]`. Where several shards of one job cover
+// a file (a retry) the largest time wins. The Wayland job runs an allowlist
+// and is left out.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -28,15 +29,28 @@ const findTimings = (dir, found = []) => {
   return found;
 };
 
+const BUILD_TYPES = { darwin: 'darwin', linux: 'linux', win32: 'win' };
+
+// `darwin_x64`, `mas_arm64`, `linux_x64_asan`, ... - what split-tests.js reads
+// from ARTIFACT_KEY in CI. Older timing files carry no sanitizer field; for
+// those the artifact directory name says which job wrote them.
+const jobKeyOf = (timings, file) => {
+  const buildType = timings.mas ? 'mas' : (BUILD_TYPES[timings.platform] ?? timings.platform);
+  const sanitizer = timings.sanitizer ?? (/_(asan|ubsan)_/.exec(file)?.[1] || null);
+  return `${buildType}_${timings.arch}${sanitizer ? `_${sanitizer}` : ''}`;
+};
+
 const weights = {};
 let inputs = 0;
 for (const root of roots) {
   for (const file of findTimings(root)) {
-    const { platform, files } = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (/_wayland_/.test(file)) continue;
+    const timings = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const key = jobKeyOf(timings, file);
     inputs++;
-    weights[platform] ??= {};
-    for (const [spec, seconds] of Object.entries(files)) {
-      weights[platform][spec] = Math.max(weights[platform][spec] ?? 0, Math.round(seconds));
+    weights[key] ??= {};
+    for (const [spec, seconds] of Object.entries(timings.files)) {
+      weights[key][spec] = Math.max(weights[key][spec] ?? 0, Math.round(seconds));
     }
   }
 }
@@ -47,8 +61,8 @@ if (!inputs) {
 }
 
 const sorted = {};
-for (const platform of Object.keys(weights).sort()) {
-  sorted[platform] = Object.fromEntries(Object.entries(weights[platform]).sort(([a], [b]) => a.localeCompare(b)));
+for (const key of Object.keys(weights).sort()) {
+  sorted[key] = Object.fromEntries(Object.entries(weights[key]).sort(([a], [b]) => a.localeCompare(b)));
 }
 
 const outPath = path.resolve(__dirname, 'spec-weights.json');
@@ -56,6 +70,6 @@ fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2) + '\n');
 console.log(
   `Wrote ${outPath} from ${inputs} timing files:`,
   Object.entries(sorted)
-    .map(([p, f]) => `${p} ${Object.keys(f).length} specs`)
+    .map(([key, f]) => `${key} ${Object.keys(f).length} specs`)
     .join(', ')
 );

--- a/script/split-tests.js
+++ b/script/split-tests.js
@@ -2,9 +2,19 @@
 //
 // Prints the spec files that belong to <shard> (1-based). Files are packed
 // into shards by expected duration, largest first into the currently lightest
-// shard, using script/spec-weights.json (seconds per file for this platform,
-// regenerate with script/gen-spec-weights.js). Files without a weight get the
-// median of the known ones; with no weights at all we fall back to `it(` count.
+// shard, using script/spec-weights.json (seconds per file, regenerate with
+// script/gen-spec-weights.js). Files without a weight get the median of the
+// known ones; with no weights at all we fall back to `it(` count.
+//
+// The weights are kept per CI test job, keyed the way CI names the job's
+// test_artifacts_* upload: `<build type>_<arch>[_<sanitizer>]`, e.g.
+// `darwin_x64`, `mas_arm64`, `linux_x64_asan`, `win_x64`. Jobs differ by
+// more than a constant factor - MAS builds skip the updater specs, ASan
+// slows native-heavy specs 7x and others not at all, arm64 is faster in
+// some files than others - so one table per platform packs the other jobs'
+// shards unevenly. CI passes the job's key as ARTIFACT_KEY; elsewhere the
+// host's platform and arch are used, and a missing table falls back to the
+// nearest one.
 
 const glob = require('glob');
 
@@ -16,13 +26,37 @@ const shardCount = parseInt(process.argv[3], 10);
 
 const specFiles = glob.sync('spec/*-spec.ts').map((f) => path.normalize(f));
 
+const BUILD_TYPES = { darwin: 'darwin', linux: 'linux', win32: 'win' };
+
+const jobKey = () => process.env.ARTIFACT_KEY || `${BUILD_TYPES[process.platform] ?? process.platform}_${process.arch}`;
+
+// The table for this job, else the nearest one of the same build type (MAS
+// falls back to darwin): same arch first, then the plainest, else a legacy
+// per-platform table, else anything.
+const pickTable = (all, key) => {
+  if (all[key]) return all[key];
+  const [buildType, arch] = key.split('_');
+  const family = buildType === 'mas' ? ['mas', 'darwin'] : [buildType];
+  for (const type of family) {
+    const nearest = Object.keys(all)
+      .filter((k) => k.startsWith(`${type}_`))
+      .sort(
+        (a, b) =>
+          (a.split('_')[1] === arch ? 0 : 1) - (b.split('_')[1] === arch ? 0 : 1) ||
+          a.split('_').length - b.split('_').length ||
+          a.localeCompare(b)
+      )[0];
+    if (nearest) return all[nearest];
+  }
+  return all[process.platform] ?? all.darwin_x64 ?? all.darwin ?? Object.values(all)[0] ?? {};
+};
+
 const loadWeights = () => {
   const weightsPath = path.resolve(__dirname, 'spec-weights.json');
   if (!fs.existsSync(weightsPath)) return {};
   const all = JSON.parse(fs.readFileSync(weightsPath, 'utf8'));
-  const forPlatform = all[process.platform] ?? all.darwin ?? Object.values(all)[0] ?? {};
   const weights = {};
-  for (const [file, seconds] of Object.entries(forPlatform)) {
+  for (const [file, seconds] of Object.entries(pickTable(all, jobKey()))) {
     weights[path.normalize(file)] = seconds;
   }
   return weights;

--- a/spec/index.js
+++ b/spec/index.js
@@ -360,7 +360,13 @@ app
         fs.writeFileSync(
           path.join(artifactsDir, 'spec-timings.json'),
           JSON.stringify(
-            { platform: process.platform, arch: process.arch, mas: !!process.mas, files: timings },
+            {
+              platform: process.platform,
+              arch: process.arch,
+              mas: !!process.mas,
+              sanitizer: process.env.IS_ASAN === 'true' ? 'asan' : process.env.IS_UBSAN === 'true' ? 'ubsan' : null,
+              files: timings
+            },
             null,
             2
           )


### PR DESCRIPTION
Backport of #53737.

See that PR for details. Scripts only: this branch's `spec-weights.json` keeps its current per-platform tables (the sharder falls back to them) until the spec-weights roller regenerates it from this branch's own CI runs.

Notes: none
