### PR TITLE
fix: several small memory leaks in Windows code

### DIFF
--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -189,7 +189,7 @@ bool WindowsToastNotification::Initialize() {
   }
 
   if (FAILED(Windows::Foundation::GetActivationFactory(
-          toast_manager_str, toast_manager_->GetAddressOf())))
+          toast_manager_str, toast_manager_->ReleaseAndGetAddressOf())))
     return false;
 
   if (!toast_notifier_) {
@@ -202,15 +202,16 @@ bool WindowsToastNotification::Initialize() {
     // requires us to not give Windows an appUserModelId.
     return SUCCEEDED(
         (*toast_manager_)
-            ->CreateToastNotifier(toast_notifier_->GetAddressOf()));
+            ->CreateToastNotifier(toast_notifier_->ReleaseAndGetAddressOf()));
   } else {
     ScopedHString app_id;
     if (!GetAppUserModelID(&app_id))
       return false;
 
-    return SUCCEEDED((*toast_manager_)
-                         ->CreateToastNotifierWithId(
-                             app_id, toast_notifier_->GetAddressOf()));
+    return SUCCEEDED(
+        (*toast_manager_)
+            ->CreateToastNotifierWithId(
+                app_id, toast_notifier_->ReleaseAndGetAddressOf()));
   }
 }
 

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -186,7 +186,6 @@ static bool ShowOpenDialogSyncWithParent(const DialogSettings& settings,
   if (FAILED(hr))
     return false;
 
-  ATL::CComPtr<IShellItem> item;
   DWORD count = 0;
   hr = items->GetCount(&count);
   if (FAILED(hr))
@@ -194,6 +193,7 @@ static bool ShowOpenDialogSyncWithParent(const DialogSettings& settings,
 
   paths->reserve(count);
   for (DWORD i = 0; i < count; ++i) {
+    ATL::CComPtr<IShellItem> item;
     hr = items->GetItemAt(i, &item);
     if (FAILED(hr))
       return false;

--- a/shell/common/language_util_win.cc
+++ b/shell/common/language_util_win.cc
@@ -27,7 +27,9 @@ bool GetPreferredLanguagesUsingGlobalization(
   if (FAILED(hr))
     return false;
 
-  ABI::Windows::Foundation::Collections::IVectorView<HSTRING>* langs;
+  Microsoft::WRL::ComPtr<
+      ABI::Windows::Foundation::Collections::IVectorView<HSTRING>>
+      langs;
   hr = prefs->get_Languages(&langs);
   if (FAILED(hr))
     return false;


### PR DESCRIPTION
#### Description of Change

Fixes several small memory leaks due to leaking COM references in Windows code.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a memory leak on Windows when `app.getPreferredSystemLanguages()` was called.
Notes: Fixed a memory leak on Windows when selecting multiple files in an open dialog.
Notes: Fixed a memory leak on Windows when notification initialization was retried after a failure.
