### PR TITLE
fix: potential UAF in GetPreferredLanguages on Windows

### DIFF
--- a/shell/common/language_util_win.cc
+++ b/shell/common/language_util_win.cc
@@ -38,12 +38,10 @@ bool GetPreferredLanguagesUsingGlobalization(
     return false;
 
   for (unsigned i = 0; i < size; ++i) {
-    HSTRING hstr;
-    hr = langs->GetAt(i, &hstr);
-    if (SUCCEEDED(hr)) {
-      std::wstring_view str = base::win::ScopedHString(hstr).Get();
-      languages->emplace_back(str.data(), str.size());
-    }
+    base::win::ScopedHString str(nullptr);
+    hr = langs->GetAt(i, base::win::ScopedHString::Receiver(str).get());
+    if (SUCCEEDED(hr))
+      languages->emplace_back(str.Get());
   }
 
   return true;


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md

Using a coding agent / AI? Read the policy: https://github.com/electron/governance/blob/main/policy/ai.md

NOTE: PRs submitted that do not follow this template will be automatically closed.
-->

In practice this hasn't bit us as `langs` is keeping the memory alive, but we can't rely on that, so refactor to remove the latent UAF.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed a potential UAF in `app.getPreferredSystemLanguages()` on Windows
