### PR TITLE
build: run webpack in production mode, minify only release bundles

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -131,12 +131,14 @@ if ((globalThis.process || binding.process).argv.includes("--profile-electron-in
       );
     }
 
-    const production = env.mode === 'production';
+    // GN passes mode=production for official builds; that only decides
+    // whether the output is minified. webpack itself always runs in
+    // production mode (deterministic module ids, scope hoisting, unused-export
+    // removal) so testing builds exercise the same module graph as releases.
+    const minimize = env.mode === 'production';
 
     return {
-      // Production mode gives deterministic numeric module ids, scope hoisting
-      // and dead-export elimination on top of minification.
-      mode: production ? 'production' : 'development',
+      mode: 'production',
       devtool: false,
       entry,
       target: alwaysHasNode ? 'node' : 'web',
@@ -185,7 +187,7 @@ if ((globalThis.process || binding.process).argv.includes("--profile-electron-in
       },
       performance: { hints: false },
       optimization: {
-        minimize: production,
+        minimize,
         // These bundles are Electron's own runtime; leave the app's
         // process.env.NODE_ENV alone.
         nodeEnv: false,

--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -131,8 +131,12 @@ if ((globalThis.process || binding.process).argv.includes("--profile-electron-in
       );
     }
 
+    const production = env.mode === 'production';
+
     return {
-      mode: 'development',
+      // Production mode gives deterministic numeric module ids, scope hoisting
+      // and dead-export elimination on top of minification.
+      mode: production ? 'production' : 'development',
       devtool: false,
       entry,
       target: alwaysHasNode ? 'node' : 'web',
@@ -179,8 +183,12 @@ if ((globalThis.process || binding.process).argv.includes("--profile-electron-in
         __dirname: false,
         __filename: false
       },
+      performance: { hints: false },
       optimization: {
-        minimize: env.mode === 'production',
+        minimize: production,
+        // These bundles are Electron's own runtime; leave the app's
+        // process.env.NODE_ENV alone.
+        nodeEnv: false,
         minimizer: [
           new TerserPlugin({
             terserOptions: {


### PR DESCRIPTION
#### Description of Change

webpack ran in development mode for every build and release builds only added the minimizer. It now always runs in production mode (deterministic numeric module ids, scope hoisting, unused-export removal), so testing builds and CI exercise the same module graph as releases; only minification stays release-only. `process.env.NODE_ENV` in app code is left alone (`optimization.nodeEnv: false`).

Minified js2c bundle sizes:

| bundle | before | after |
|---|---|---|
| sandbox_bundle | 135.5 KB | 127.0 KB |
| preload_realm_bundle | 107.3 KB | 100.7 KB |
| browser_init | 156.6 KB | 149.2 KB |
| renderer_init | 36.8 KB | 33.2 KB |
| utility_init | 21.8 KB | 20.6 KB |
| worker_init | 13.5 KB | 11.4 KB |
| isolated_bundle | 11.8 KB | 11.3 KB |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: none
