### PR TITLE
perf: don't load WHATWG streams or the desktop-name helper at startup

### DIFF
--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -2,9 +2,13 @@ import { ProtocolRequest, session } from 'electron/main';
 
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
 
-import type { ReadableStreamDefaultReader } from 'stream/web';
+import type { ReadableStream as ReadableStreamType, ReadableStreamDefaultReader } from 'stream/web';
+
+// `stream/web` evaluates all of Node's WHATWG streams; requiring it lazily
+// keeps that off the startup path of apps that never call protocol.handle().
+type ReadableStream<R = any> = ReadableStreamType<R>;
+const webStreams = () => require('stream/web') as typeof import('stream/web');
 
 // Global protocol APIs.
 const { registerSchemesAsPrivileged, getStandardSchemes, Protocol } =
@@ -17,7 +21,7 @@ const isBuiltInScheme = (scheme: string) => ['http', 'https', 'file'].includes(s
 
 function makeStreamFromPipe(pipe: any): ReadableStream<Uint8Array> {
   const buf = new Uint8Array(1024 * 1024 /* 1 MB */);
-  return new ReadableStream({
+  return new (webStreams().ReadableStream)({
     async pull(controller) {
       try {
         const rv = await pipe.read(buf);
@@ -62,7 +66,7 @@ function convertToRequestBody(uploadData: ProtocolRequest['uploadData']): Reques
   // Use Node's web stream types explicitly to avoid DOM lib vs Node lib structural mismatches.
   // Generic <Uint8Array> ensures reader.read() returns value?: Uint8Array consistent with enqueue.
   let current: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  return new ReadableStream<Uint8Array>({
+  return new (webStreams().ReadableStream)<Uint8Array>({
     async pull(controller) {
       if (current) {
         const { done, value } = await current.read();
@@ -114,7 +118,7 @@ function validateResponse(res: Response) {
 
   if (exists('body')) {
     if (typeof res.body !== 'object') return false;
-    if (res.body !== null && !(res.body instanceof ReadableStream)) return false;
+    if (res.body !== null && !(res.body instanceof webStreams().ReadableStream)) return false;
   }
 
   return true;
@@ -163,7 +167,7 @@ Protocol.prototype.handle = function (
         method: preq.method,
         referrer: preq.referrer,
         body,
-        duplex: body instanceof ReadableStream ? 'half' : undefined
+        duplex: body instanceof webStreams().ReadableStream ? 'half' : undefined
       } as any);
       // The origin that issued the request, if web content did; not something
       // a standard Request can carry, so it is attached as an own property.

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -1,5 +1,4 @@
 import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
-import { defaultDesktopName } from '@electron/internal/browser/desktop-name';
 
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
@@ -133,7 +132,11 @@ if (packageJson.productName != null) {
   app.name = `${packageJson.name}`.trim();
 }
 
-app.setDesktopName(packageJson.desktopName || defaultDesktopName(app.name));
+if (process.platform === 'linux') {
+  const { defaultDesktopName } =
+    require('@electron/internal/browser/desktop-name') as typeof import('@electron/internal/browser/desktop-name');
+  app.setDesktopName(packageJson.desktopName || defaultDesktopName(app.name));
+}
 
 // Set v8 flags, deliberately lazy load so that apps that do not use this
 // feature do not pay the price

--- a/lib/utility/init.ts
+++ b/lib/utility/init.ts
@@ -2,7 +2,6 @@ import LanguageModelUtility from '@electron/internal/utility/api/language-model-
 import { ParentPort } from '@electron/internal/utility/parent-port';
 
 import { EventEmitter } from 'events';
-import { ReadableStream } from 'stream/web';
 import { pathToFileURL } from 'url';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
@@ -11,7 +10,13 @@ const entryScript: string = v8Util.getHiddenValue(process, '_serviceStartupScrip
 process.argv.splice(1, 0, entryScript);
 
 // These are used by C++ to more easily identify these objects.
-v8Util.setHiddenValue(global, 'isReadableStream', (val: unknown) => val instanceof ReadableStream);
+// `stream/web` is required on first use rather than at startup: it evaluates
+// all of Node's WHATWG streams.
+v8Util.setHiddenValue(
+  global,
+  'isReadableStream',
+  (val: unknown) => val instanceof (require('stream/web') as typeof import('stream/web')).ReadableStream
+);
 v8Util.setHiddenValue(global, 'isLanguageModel', (val: unknown) => val instanceof LanguageModelUtility);
 v8Util.setHiddenValue(
   global,


### PR DESCRIPTION
#### Description of Change

`lib/browser/api/protocol.ts` (required by browser init) and `lib/utility/init.ts` imported `stream/web` at the top level, which evaluates all of Node's `internal/webstreams` on every app launch and every `utilityProcess.fork()` whether or not `protocol.handle()` is used. It is now required where it is used. The default desktop name is only computed on Linux, the only platform that uses it.

Release build, Linux x64, medians:

| | before | after |
|---|---|---|
| builtin modules loaded before `main.js` | 195 | 185 |
| `process.uptime()` at first line of `main.js` | 19.3 ms | 18.5 ms |
| `utilityProcess.fork()` → first message | 42.2 ms | 40.2 ms |
| utility process uptime at first message | 10.8 ms | 9.5 ms |

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes
Notes: none
